### PR TITLE
chore: remove special libexec dir

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -14,8 +14,7 @@ export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
 include /usr/share/dpkg/architecture.mk
 
-DDM_CMAKE_ARGS = -DCMAKE_INSTALL_LIBEXECDIR=/usr/lib/${DEB_HOST_MULTIARCH}/ddm \
-	    -DDBUS_CONFIG_FILENAME="ddm_org.freedesktop.DisplayManager.conf"
+DDM_CMAKE_ARGS = -DDBUS_CONFIG_FILENAME="ddm_org.freedesktop.DisplayManager.conf"
 
 ifneq ($(DEB_HOST_ARCH_OS),linux)
   DDM_CMAKE_ARGS += -DNO_SYSTEMD=ON -DENABLE_JOURNALD=OFF


### PR DESCRIPTION
use debian default libexec dir

Log: