### PR TITLE
fix: dock crash

### DIFF
--- a/src/treeland/quick/protocols/foreigntoplevelmanagerv1.cpp
+++ b/src/treeland/quick/protocols/foreigntoplevelmanagerv1.cpp
@@ -169,7 +169,7 @@ public:
         wl_client_get_credentials(client, &pid, nullptr, nullptr);
         handle->setPid(pid);
 
-        handle->setIdentifier(*reinterpret_cast<const uint32_t *>(surface->handle()->handle()));
+        handle->setIdentifier(*reinterpret_cast<const uint32_t *>(surface->surface()->handle()->handle()));
 
         Q_EMIT surface->titleChanged();
         Q_EMIT surface->appIdChanged();


### PR DESCRIPTION
send wrong identifier. why two xdgsurface of one program has the same wlr_xdg_surface resource.

Issue: https://github.com/linuxdeepin/developer-center/issues/6885

Log: