### PR TITLE
chore: uses an OUTPUT_DIRECTORY end in the same target path

### DIFF
--- a/src/greeter/CMakeLists.txt
+++ b/src/greeter/CMakeLists.txt
@@ -50,6 +50,8 @@ qt_add_qml_module(greeterplugin
     RESOURCE_PREFIX
         /qt/qml
     QML_FILES ${QML_FILES}
+    OUTPUT_DIRECTORY
+        ${PROJECT_BINARY_DIR}/qt/qml/TreeLand/Greeter
 )
 
 qt_add_lupdate(greeterplugin

--- a/src/treeland/quick/protocols/CMakeLists.txt
+++ b/src/treeland/quick/protocols/CMakeLists.txt
@@ -14,6 +14,8 @@ qt_add_qml_module(treeland-quick-protocols
         qwpersonalizationmanager.cpp
     RESOURCE_PREFIX
         /qt/qml
+    OUTPUT_DIRECTORY
+        ${PROJECT_BINARY_DIR}/qt/qml/TreeLand/Protocols
 )
 
 target_sources(treeland-quick-protocols PUBLIC

--- a/src/treeland/quick/qml/CMakeLists.txt
+++ b/src/treeland/quick/qml/CMakeLists.txt
@@ -26,5 +26,7 @@ qt_add_qml_module(treeland-qml
         DockPreview.qml
     RESOURCE_PREFIX
         /qt/qml
+    OUTPUT_DIRECTORY
+        ${PROJECT_BINARY_DIR}/qt/qml/TreeLand
 )
 

--- a/src/treeland/quick/utils/CMakeLists.txt
+++ b/src/treeland/quick/utils/CMakeLists.txt
@@ -10,6 +10,9 @@ qt_add_qml_module(treeland-quick-utils
         dockpreviewfilter.cpp
     RESOURCE_PREFIX
         /qt/qml
+    OUTPUT_DIRECTORY
+        ${PROJECT_BINARY_DIR}/qt/qml/TreeLand/Utils
+
 )
 
 target_sources(treeland-quick-utils PUBLIC


### PR DESCRIPTION
log: cmake Warning: The greeterplugin target is a QML module with target path TreeLand/Greeter.
  It uses an OUTPUT_DIRECTORY of build/src/greeter, which should end in the same
  target path, but doesn't.  Tooling such as qmllint may not work correctly.