### PR TITLE
Fix: not destroyObject when not show closeAnimation

### DIFF
--- a/src/treeland/quick/qml/LayerSurface.qml
+++ b/src/treeland/quick/qml/LayerSurface.qml
@@ -16,6 +16,7 @@ Item {
     property CoordMapper outputCoordMapper
     property bool mapped: waylandSurface.surface && waylandSurface.surface.mapped && waylandSurface.WaylandSocket.rootSocket.enabled
     property bool pendingDestroy: false
+    property bool showCloseAnimation: false
 
     property alias surfaceItem: surfaceItem
 
@@ -88,16 +89,13 @@ Item {
             if (!waylandSurface.WaylandSocket.rootSocket.enabled) {
                surface.visible = false
             } else {
-                let showCloseAnimation = false
+                // if don't show CloseAnimation will destroyObject in doDestroy, here is too early
                 if (showCloseAnimation) {
                     // do animation for window close
                     closeAnimation.parent = root.parent
                     closeAnimation.anchors.fill = root
                     closeAnimation.sourceComponent = closeAnimationComponent
                     closeAnimation.item.start(root)
-                } else {
-                    if (pendingDestroy)
-                        creator.destroyObject(root)
                 }
             }
         }
@@ -113,6 +111,10 @@ Item {
 
         // unbind some properties
         mapped = false
+
+        if (!showCloseAnimation) {
+            creator.destroyObject(surface)
+        }
     }
 
     function getPrimaryOutputItem() {

--- a/src/treeland/quick/qml/StackToplevelHelper.qml
+++ b/src/treeland/quick/qml/StackToplevelHelper.qml
@@ -26,6 +26,7 @@ Item {
     property bool pendingDestroy: false
     property bool isMaximize: waylandSurface && waylandSurface.isMaximized && outputCoordMapper
     property bool isFullScreen: waylandSurface && waylandSurface.isFullScreen && outputCoordMapper
+    property bool showCloseAnimation: false
 
     // For Maximize
     function getMaximizeX() {
@@ -221,16 +222,13 @@ Item {
             if (!waylandSurface.WaylandSocket.rootSocket.enabled) {
                 surface.visible = false;
             } else {
-                // do animation for window close
-                let showCloseAnimation = false
+                // if don't show CloseAnimation will destroyObject in doDestroy, here is too early
                 if (showCloseAnimation) {
+                    // do animation for window close
                     closeAnimation.parent = surface.parent
                     closeAnimation.anchors.fill = surface
                     closeAnimation.sourceComponent = closeAnimationComponent
                     closeAnimation.item.start(surface)
-                } else {
-                    if (pendingDestroy)
-                        creator.destroyObject(surface)
                 }
             }
             switcherModel.removeSurface(surface)
@@ -253,6 +251,10 @@ Item {
         mapped = false
         surface.states = null
         surface.transitions = null
+
+        if (!showCloseAnimation) {
+            creator.destroyObject(surface)
+        }
     }
 
     function getPrimaryOutputItem() {


### PR DESCRIPTION
log: client will unmap before destory, pendingDestroy not set if don't wait CloseAnimation