### PR TITLE
chore: fix not found qtsvg in nixos

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
+watch_file nix/default.nix
 use flake

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
               export NIX_CFLAGS_COMPILE=$(echo $NIX_CFLAGS_COMPILE | sed 's/-DQT_NO_DEBUG//')
               #export QT_LOGGING_RULES="*.debug=true;qt.*.debug=false"
               #export WAYLAND_DEBUG=1
-              export QT_PLUGIN_PATH=${makeQtpluginPath (with pkgs.qt6; [ qtbase qtdeclarative qtquick3d qtimageformats qtwayland qt5compat ])}
+              export QT_PLUGIN_PATH=${makeQtpluginPath (with pkgs.qt6; [ qtbase qtdeclarative qtquick3d qtimageformats qtwayland qt5compat qtsvg ])}
               export QML2_IMPORT_PATH=${makeQmlpluginPath (with pkgs.qt6; [ qtdeclarative qtquick3d qt5compat ] 
                                                           ++ [ dde-nixos.packages.${system}.qt6.dtkdeclarative ] )}
               export QML_IMPORT_PATH=$QML2_IMPORT_PATH

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , nix-filter
-, fetchFromGitHub
 , cmake
 , extra-cmake-modules
 , pkg-config
@@ -12,6 +11,7 @@
 , qtquick3d
 , qtimageformats
 , qtwayland
+, qtsvg
 , dtkdeclarative
 , dtksystemsettings
 , waylib
@@ -24,7 +24,7 @@
 , nixos-artwork
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "treeland";
   version = "0.0.1";
 
@@ -64,6 +64,7 @@ stdenv.mkDerivation rec {
     qtquick3d
     qtimageformats
     qtwayland
+    qtsvg
     dtkdeclarative
     dtksystemsettings
     waylib
@@ -99,11 +100,12 @@ stdenv.mkDerivation rec {
     "-DDBUS_CONFIG_DIR=${placeholder "out"}/share/dbus-1/system.d"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "DDM is a fork of SDDM";
     homepage = "https://github.com/vioken/treeland";
-    license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    license = with lib.licenses; [ gpl3Only lgpl3Only asl20 ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ rewine ];
   };
-}
+})
 


### PR DESCRIPTION
log: treeland need qtsvg