### PR TITLE
fix: greeter maybe not show when screen was pulled out

### DIFF
--- a/src/treeland/quick/qml/Main.qml
+++ b/src/treeland/quick/qml/Main.qml
@@ -304,6 +304,17 @@ Item {
                             renderWindow.activeOutputDelegate = outputDelegate
                         }
                     }
+
+                    Component.onDestruction: {
+                        if (renderWindow.activeOutputDelegate === outputDelegate) {
+                            for (const output of QmlHelper.layout.outputs) {
+                                if (output.lastActiveCursorItem && output !== outputDelegate) {
+                                    renderWindow.activeOutputDelegate = output
+                                    break
+                                }
+                            }
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
log: After a screen is pulled out, the cursor will automatically return to other screens and trigger the LastActiveCursorItemChanged signal. However, if the cursor is on two screens at the same time before the screen is pulled out and has not left the previous screen, the signal will not be triggered.