### PR TITLE
feat: better Alt+Tab window switcher

### DIFF
--- a/src/treeland/quick/qml/CMakeLists.txt
+++ b/src/treeland/quick/qml/CMakeLists.txt
@@ -25,6 +25,7 @@ qt_add_qml_module(treeland-qml
         WindowsSwitcher.qml
         WindowsSwitcherPreview.qml
         DockPreview.qml
+        EQHGrid.qml
     RESOURCE_PREFIX
         /qt/qml
     OUTPUT_DIRECTORY

--- a/src/treeland/quick/qml/EQHGrid.qml
+++ b/src/treeland/quick/qml/EQHGrid.qml
@@ -1,0 +1,100 @@
+// Copyright (C) 2023 Dingyuan Zhang <zhangdingyuan@uniontech.com>.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+import QtQuick
+import QtQuick.Layouts
+
+ColumnLayout {
+    id: eqhgrid // equal height grid
+
+    required property int minH
+    required property int maxH
+    required property int maxW
+    required property int availH
+    required property int availW
+    required property ListModel model
+    required property Component delegate
+    
+    property int rowHeight: 0
+    property int padding: 8
+    property var rows: []
+    spacing: 10
+    onRowsChanged: console.log('rows', rows.length, rowHeight)
+
+    Component.onCompleted: console.log('eqhgrid',availH,availW, mapToGlobal(0, 0), width,
+                                       height, rows, delegate)
+
+    Repeater {
+        model: rows
+        RowLayout {
+            id: row
+            width: eqhgrid.width
+            Layout.alignment: Qt.AlignHCenter
+            property int baseIdx: {
+                var idx = 0
+                for (var i = 0; i < index; i++)
+                    idx += rows[i].length
+                return idx
+            }
+            Repeater {
+                model: modelData
+                delegate: Loader {
+                    required property int index
+                    required property var modelData
+                    property int globalIndex: index + row.baseIdx
+                    sourceComponent: eqhgrid.delegate
+                }
+            }
+        }
+    }
+    property var getRatio: (d)=>d.source.width / d.source.height
+    function calcLayout() {
+        function tryLayout(rowH, div) {
+            var nrows = 1
+            var acc = 0
+            var rowstmp = []
+            var currow = []
+            for (var i = 0; i < model.count; i++) {
+                var win = model.get(i)
+                var ratio = getRatio(win)
+                var curW = Math.min(maxW, ratio * rowH)
+                console.log('curW', curW,ratio)
+                var wwin = {
+                    "dw": curW
+                }
+                Object.assign(wwin, win)
+                acc += curW
+                if (acc <= availW)
+                    currow.push(wwin)
+                else {
+                    acc = curW
+                    nrows++
+                    console.log('cur', currow, 'tmp', rowstmp)
+                    rowstmp.push(currow)
+                    currow = [wwin]
+                    if (nrows > div)
+                        break
+                }
+                console.info(acc)
+            }
+            if (nrows <= div) {
+                if (currow.length)
+                    rowstmp.push(currow)
+                rowHeight = rowH
+                rows = rowstmp
+                console.log('calcover', nrows, rowH, rows)
+                return true
+            }
+            return false
+        }
+
+        for (var div = 1; availH / div >= minH; div++) {
+            // return if width satisfies
+            console.log('div=', div,availH,availW,maxH,maxW)
+            var rowH = Math.min(availH / div, maxH)
+            if (tryLayout(rowH, div))
+                return
+        }
+        tryLayout(minH, 999)
+        console.warn('cannot layout')
+    }
+}

--- a/src/treeland/quick/qml/Main.qml
+++ b/src/treeland/quick/qml/Main.qml
@@ -338,7 +338,9 @@ Item {
                 Loader {
                     id: stackLayout
                     anchors.fill: parent
-                    sourceComponent: StackWorkspace { }
+                    sourceComponent: StackWorkspace {
+                        outputRenderWindow: renderWindow
+                    }
                 }
 
                 Loader {

--- a/src/treeland/quick/qml/StackWorkspace.qml
+++ b/src/treeland/quick/qml/StackWorkspace.qml
@@ -61,7 +61,12 @@ Item {
 
     required property OutputRenderWindow outputRenderWindow
     readonly property real switcherHideOpacity: 0.3
-
+    Item {
+        // TODO: some surfaces like layersurface should not be opacity 
+        id: allWins
+        anchors.fill: parent
+        enabled: !switcher.visible
+        opacity: switcher.visible?switcherHideOpacity:1
     DynamicCreatorComponent {
         id: toplevelComponent
         creator: QmlHelper.xdgSurfaceManager
@@ -93,7 +98,7 @@ Item {
                     return 0
                 }
             }
-            opacity: switcher.visible?switcherHideOpacity:1
+            // opacity: switcher.visible&&!activeFocus?switcherHideOpacity:1
 
             topPadding: decoration.enable ? decoration.topMargin : 0
             bottomPadding: decoration.enable ? decoration.bottomMargin : 0
@@ -333,7 +338,7 @@ Item {
                         ? XWaylandSurfaceItem.PositionToSurface
                         : XWaylandSurfaceItem.PositionFromSurface
             }
-            opacity: switcher.visible?switcherHideOpacity:1
+            // opacity: switcher.visible&&!activeFocus?switcherHideOpacity:1
 
             topPadding: decoration.enable ? decoration.topMargin : 0
             bottomPadding: decoration.enable ? decoration.bottomMargin : 0
@@ -455,13 +460,15 @@ Item {
             helper: inputMethodHelper
         }
     }
+    }
 
     WindowsSwitcher {
         id: switcher
         z: 100 + 1
-        anchors.fill: activeOutputBox
+        anchors.fill: parent
         visible: dbgswtchr.checked
         activeOutput: outputRenderWindow.activeOutputDelegate
+        // allWins: allWins
         onSurfaceActivated: (surface) => {
             surface.cancelMinimize()
             Helper.activatedSurface = surface.waylandSurface

--- a/src/treeland/quick/qml/StackWorkspace.qml
+++ b/src/treeland/quick/qml/StackWorkspace.qml
@@ -454,10 +454,18 @@ Item {
         id: switcher
         z: 100 + 1
         anchors.fill: parent
-        visible: false
+        visible: dbgswtchr.checked
         onSurfaceActivated: (surface) => {
             surface.cancelMinimize()
             Helper.activatedSurface = surface.waylandSurface
+        }
+    }
+
+    Switch {
+        id: dbgswtchr
+        anchors {
+            bottom: parent.bottom
+            left: parent.left
         }
     }
 

--- a/src/treeland/quick/qml/StackWorkspace.qml
+++ b/src/treeland/quick/qml/StackWorkspace.qml
@@ -59,12 +59,16 @@ Item {
         return null
     }
 
+    required property OutputRenderWindow outputRenderWindow
+    readonly property real switcherHideOpacity: 0.3
+
     DynamicCreatorComponent {
         id: toplevelComponent
         creator: QmlHelper.xdgSurfaceManager
         chooserRole: "type"
         chooserRoleValue: "toplevel"
         autoDestroy: false
+
 
         onObjectRemoved: function (obj) {
             obj.doDestroy()
@@ -89,6 +93,7 @@ Item {
                     return 0
                 }
             }
+            opacity: switcher.visible?switcherHideOpacity:1
 
             topPadding: decoration.enable ? decoration.topMargin : 0
             bottomPadding: decoration.enable ? decoration.bottomMargin : 0
@@ -328,6 +333,7 @@ Item {
                         ? XWaylandSurfaceItem.PositionToSurface
                         : XWaylandSurfaceItem.PositionFromSurface
             }
+            opacity: switcher.visible?switcherHideOpacity:1
 
             topPadding: decoration.enable ? decoration.topMargin : 0
             bottomPadding: decoration.enable ? decoration.bottomMargin : 0
@@ -453,8 +459,9 @@ Item {
     WindowsSwitcher {
         id: switcher
         z: 100 + 1
-        anchors.fill: parent
+        anchors.fill: activeOutputBox
         visible: dbgswtchr.checked
+        activeOutput: outputRenderWindow.activeOutputDelegate
         onSurfaceActivated: (surface) => {
             surface.cancelMinimize()
             Helper.activatedSurface = surface.waylandSurface

--- a/src/treeland/quick/qml/WindowsSwitcher.qml
+++ b/src/treeland/quick/qml/WindowsSwitcher.qml
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import QtQuick
+import QtQuick.Layouts
 import Waylib.Server
 import TreeLand
 
@@ -14,6 +15,7 @@ Item {
 
     onVisibleChanged: {
         if (visible) {
+            calcLayout()
             next()
         }
         else {
@@ -79,37 +81,147 @@ Item {
                 }
             }
         }
+        // onCountChanged: calcLayout()
+    }
+    // Component.onCompleted: calcLayout()
+    property int spacing: 10
+    property var rows: []
+    property int rowHeight: 0
+    property int padding: 8
+    onRowsChanged: console.log('rows', rows.length, rowHeight)
+    ColumnLayout {
+        id: eqhgrid // equal height grid
+        anchors.centerIn: parent
+        Repeater {
+            model: rows
+            RowLayout {
+                width: eqhgrid.width
+                Layout.alignment: Qt.AlignHCenter
+                property int baseIdx: {
+                    var idx = 0
+                    for (var i = 0; i < index; i++)
+                        idx += rows[i].length
+                    return idx
+                }
+                Repeater {
+                    model: modelData
+                    Rectangle {
+                        property XdgSurface source: modelData.source
+                        width: source.width / source.height * rowHeight + 2 * root.padding
+                        height: col.height + 2 * root.padding
+                        property int globalIdx: index + parent.baseIdx
+                        Component.onCompleted: console.log('item', modelData,
+                                                           index, globalIdx)
+                        border.color: "blue"
+                        border.width: globalIdx == root.current ? 2 : 0
+                        radius: 8
+                        Column {
+                            anchors {
+                                left: parent.left
+                                right: parent.right
+                                top: parent.top
+                                margins: root.padding
+                            }
+                            id: col
+                            RowLayout {
+                                width: parent.width
+                                Rectangle {
+                                    height: width
+                                    width: 24
+                                    color: "yellow"
+                                }
+                                Text {
+                                    Layout.fillWidth: true
+                                    text: "test title ttttttttttttttttttttttt"
+                                    elide: Qt.ElideRight
+                                }
+                            }
+                            Item {
+                                id: thumb
+                                width: parent.width
+                                height: source.height * width / source.width
+                                clip: true
+                                visible: true
+                                ShaderEffectSource {
+                                    anchors.centerIn: parent
+                                    width: parent.width
+                                    height: source.height * width / source.width
+                                    live: true
+                                    hideSource: visible
+                                    smooth: true
+                                    sourceItem: source
+                                }
+                                Component.onCompleted: console.log('thumb',source)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    function calcLayout() {
+        console.warn('calcLayout')
+        var minH = 100, maxH = 200
+        function tryLayout(rowH, div) {
+            var nrows = 1
+            var acc = 0
+            var rowstmp = []
+            var currow = []
+            for (var i = 0; i < model.count; i++) {
+                var win = model.get(i)
+                console.log('win',i,'=',win,win.source,win.source.width)
+                var ratio = win.source.width / win.source.height
+                acc += ratio
+                if (acc * rowH <= root.width)
+                    currow.push(win)
+                else {
+                    acc = ratio
+                    nrows++
+                    console.log('cur', currow, 'tmp', rowstmp)
+                    rowstmp.push(currow)
+                    currow = [win]
+                    if (nrows > div)
+                        break
+                }
+                console.info(acc)
+            }
+            if (nrows <= div) {
+                if (currow.length)
+                    rowstmp.push(currow)
+                rowHeight = rowH
+                rows = rowstmp
+                console.log('calcover', nrows, rowH)
+                return true
+            }
+            return false
+        }
+
+        for (var div = 1; root.height / div >= minH; div++) {
+            // return if width satisfies
+            console.log('div=', div)
+            var rowH = Math.min(root.height / div, maxH)
+            if (tryLayout(rowH, div))
+                return
+        }
+        tryLayout(minH, 999)
+        console.warn('cannot layout')
     }
 
     Rectangle {
-        width: switcher.width
-        height: switcher.height
+        width: eqhgrid.width
+        height: eqhgrid.height
         anchors.centerIn: parent
         radius: 10
         opacity: 0.4
     }
 
-    Row {
-        anchors.centerIn: parent
-        id: switcher
-        Repeater {
-            model: model
-            Item {
-                required property XdgSurface source
-                width: 180
-                height: 160
-                clip: true
-                visible: true
-                ShaderEffectSource {
-                    anchors.centerIn: parent
-                    width: 150
-                    height: Math.min(source.height * width / source.width, width)
-                    live: true
-                    hideSource: visible
-                    smooth: true
-                    sourceItem: source
-                }
-            }
-        }
-    }
+    // Row {
+    //     anchors.centerIn: parent
+    //     id: switcher
+    //     Repeater {
+    //         model: model
+    //         
+    //     }
+    // }
 }

--- a/src/treeland/quick/qml/WindowsSwitcher.qml
+++ b/src/treeland/quick/qml/WindowsSwitcher.qml
@@ -136,6 +136,14 @@ Item {
             }
         }
 
+        Rectangle {
+            width: flickable.width + 2 * padding
+            height: flickable.height + 2 * padding
+            anchors.centerIn: flickable
+            radius: 10
+            opacity: 0.4
+        }
+
         Flickable {
             id: flickable
             width: eqhgrid.width
@@ -177,6 +185,7 @@ Item {
                                                                 index, globalIdx,height,width)
                                 border.color: "blue"
                                 border.width: highlighted ? 2 : 0
+                                color: Qt.rgba(255,255,255,.2)
                                 radius: 8
                                 onHighlightedChanged: {
                                     // auto scroll to current highlight
@@ -195,23 +204,31 @@ Item {
                                     }
                                 }
                                 Column {
+                                    id: col
                                     anchors {
                                         left: parent.left
                                         right: parent.right
                                         top: parent.top
-                                        margins: padding
+                                        margins: root.padding
                                     }
-                                    id: col
+                                    spacing: 5
+
                                     RowLayout {
                                         width: parent.width
                                         Rectangle {
                                             height: width
                                             width: 24
                                             color: "yellow"
+                                            radius: 5
                                         }
                                         Text {
                                             Layout.fillWidth: true
-                                            text: "test title ttttttttttttttttttttttt"
+                                            text: {
+                                                const xdg=source.waylandSurface
+                                                const wholeTitle=xdg.appId?.length?`${xdg.title} - ${xdg.appId}`:xdg.title
+                                                console.log(wholeTitle)
+                                                wholeTitle
+                                            }
                                             elide: Qt.ElideRight
                                         }
                                     }
@@ -296,14 +313,6 @@ Item {
             }
             tryLayout(minH, 999)
             console.warn('cannot layout')
-        }
-
-        Rectangle {
-            width: flickable.width
-            height: flickable.height
-            anchors.centerIn: parent
-            radius: 10
-            opacity: 0.4
         }
     }
 }

--- a/src/treeland/quick/qml/WindowsSwitcher.qml
+++ b/src/treeland/quick/qml/WindowsSwitcher.qml
@@ -158,161 +158,101 @@ Item {
             }
             clip: true
 
-            ColumnLayout {
-                id: eqhgrid // equal height grid
+            EQHGrid {
+                id: eqhgrid
+                model: model
+                minH: 100
+                maxH: 200
+                maxW: indicatorPlane.width * maxH / indicatorPlane.height
+                availW: indicatorPlane.width * .7
+                availH: indicatorPlane.height * .7
                 anchors.centerIn: parent
-                Component.onCompleted: console.log('eqhgrid',mapToGlobal(0,0),width,height,rows)
-                Repeater {
-                    model: rows
-                    RowLayout {
-                        width: eqhgrid.width
-                        Layout.alignment: Qt.AlignHCenter
-                        property int baseIdx: {
-                            var idx = 0
-                            for (var i = 0; i < index; i++)
-                                idx += rows[i].length
-                            return idx
-                        }
-                        Repeater {
-                            model: modelData
-                            Rectangle {
-                                property XdgSurface source: modelData.source
-                                property bool highlighted: globalIdx == root.current 
-                                width: modelData.dw + 2 * padding
-                                height: col.height + 2 * padding
-                                property int globalIdx: index + parent.baseIdx
-                                Component.onCompleted: console.log('item', modelData,
-                                                                index, globalIdx,height,width)
-                                border.color: "blue"
-                                border.width: highlighted ? 2 : 0
-                                color: Qt.rgba(255,255,255,.2)
-                                radius: 8
-                                onHighlightedChanged: {
-                                    // auto scroll to current highlight
-                                    if (highlighted) {
-                                        console.log('highlighted',
-                                                    flickable.contentY,
-                                                    mapToItem(flickable, 0, 0),
-                                                    mapFromItem(flickable, 0, 0))
-                                        flickable.contentY = Math.min(
-                                                    Math.max(
-                                                        mapToItem(
-                                                            eqhgrid, 0,
-                                                            height).y - flickable.height,
-                                                        flickable.contentY),
-                                                    mapToItem(eqhgrid, 0, 0).y)
-                                    }
-                                }
-                                Column {
-                                    id: col
-                                    anchors {
-                                        left: parent.left
-                                        right: parent.right
-                                        top: parent.top
-                                        margins: root.padding
-                                    }
-                                    spacing: 5
+                delegate: Rectangle {
+                    property XdgSurface source: modelData.source
+                    property bool highlighted: globalIndex == root.current 
 
-                                    RowLayout {
-                                        width: parent.width
-                                        Rectangle {
-                                            height: width
-                                            width: 24
-                                            color: "yellow"
-                                            radius: 5
-                                        }
-                                        Text {
-                                            Layout.fillWidth: true
-                                            text: {
-                                                const xdg=source.waylandSurface
-                                                const wholeTitle=xdg.appId?.length?`${xdg.title} - ${xdg.appId}`:xdg.title
-                                                console.log(wholeTitle)
-                                                wholeTitle
-                                            }
-                                            elide: Qt.ElideRight
-                                        }
-                                    }
-                                    Item {
-                                        id: thumb
-                                        width: parent.width
-                                        height: source.height * width / source.width
-                                        clip: true
-                                        visible: true
-                                        ShaderEffectSource {
-                                            anchors.centerIn: parent
-                                            width: parent.width
-                                            height: source.height * width / source.width
-                                            live: true
-                                            hideSource: false
-                                            smooth: true
-                                            sourceItem: source
-                                        }
-                                        Component.onCompleted: console.log('thumb',source)
-                                    }
-                                }
-                                TapHandler {
-                                    onTapped: {
-                                        console.log('tapped idx',globalIdx)
-                                        root.current = globalIdx
-                                    }
-                                }
+                    width: modelData.dw + 2 * padding
+                    height: col.height + 2 * padding
+                    border.color: "blue"
+                    border.width: highlighted ? 2 : 0
+                    color: Qt.rgba(255,255,255,.2)
+                    radius: 8
+                    Component.onCompleted: console.log('item', modelData,
+                                                    index, globalIndex,height,width)
+                    onHighlightedChanged: {
+                        // auto scroll to current highlight
+                        if (highlighted) {
+                            console.log('highlighted',
+                                        flickable.contentY,
+                                        mapToItem(flickable, 0, 0),
+                                        mapFromItem(flickable, 0, 0))
+                            flickable.contentY = Math.min(
+                                        Math.max(
+                                            mapToItem(
+                                                eqhgrid, 0,
+                                                height).y - flickable.height,
+                                            flickable.contentY),
+                                        mapToItem(eqhgrid, 0, 0).y)
+                        }
+                    }
+                    Column {
+                        id: col
+                        anchors {
+                            left: parent.left
+                            right: parent.right
+                            top: parent.top
+                            margins: root.padding
+                        }
+                        spacing: 5
+
+                        RowLayout {
+                            width: parent.width
+                            Rectangle {
+                                height: width
+                                width: 24
+                                color: "yellow"
+                                radius: 5
                             }
+                            Text {
+                                Layout.fillWidth: true
+                                text: {
+                                    const xdg=source.waylandSurface
+                                    const wholeTitle=xdg.appId?.length?`${xdg.title} - ${xdg.appId}`:xdg.title
+                                    console.log(wholeTitle)
+                                    wholeTitle
+                                }
+                                elide: Qt.ElideRight
+                            }
+                        }
+                        Item {
+                            id: thumb
+                            width: parent.width
+                            height: source.height * width / source.width
+                            clip: true
+                            visible: true
+                            ShaderEffectSource {
+                                anchors.centerIn: parent
+                                width: parent.width
+                                height: source.height * width / source.width
+                                live: true
+                                hideSource: false
+                                smooth: true
+                                sourceItem: source
+                            }
+                            Component.onCompleted: console.log('thumb',source)
+                        }
+                    }
+                    TapHandler {
+                        onTapped: {
+                            console.log('tapped idx',globalIndex)
+                            root.current = globalIndex
                         }
                     }
                 }
             }
         }
-
-        function calcLayout() {
-            var minH = 100, maxH = 200, maxW = indicatorPlane.width * maxH / indicatorPlane.height, totMaxWidth = indicatorPlane.width * 0.7
-            function tryLayout(rowH, div) {
-                var nrows = 1
-                var acc = 0
-                var rowstmp = []
-                var currow = []
-                for (var i = 0; i < model.count; i++) {
-                    var win = model.get(i)
-                    var ratio = win.source.width / win.source.height
-                    var curW = Math.min(maxW, ratio * rowH)
-                    console.log('curW', curW)
-                    var wwin = {
-                        "dw": curW
-                    }
-                    Object.assign(wwin, win)
-                    acc += curW
-                    if (acc <= totMaxWidth)
-                        currow.push(wwin)
-                    else {
-                        acc = curW
-                        nrows++
-                        console.log('cur', currow, 'tmp', rowstmp)
-                        rowstmp.push(currow)
-                        currow = [wwin]
-                        if (nrows > div)
-                            break
-                    }
-                    console.info(acc)
-                }
-                if (nrows <= div) {
-                    if (currow.length)
-                        rowstmp.push(currow)
-                    rowHeight = rowH
-                    rows = rowstmp
-                    console.log('calcover', nrows, rowH,rows)
-                    return true
-                }
-                return false
-            }
-
-            for (var div = 1; indicatorPlane.height / div >= minH; div++) {
-                // return if width satisfies
-                console.log('div=', div)
-                var rowH = Math.min(indicatorPlane.height / div, maxH)
-                if (tryLayout(rowH, div))
-                    return
-            }
-            tryLayout(minH, 999)
-            console.warn('cannot layout')
+        function calcLayout(){
+            eqhgrid.calcLayout()
         }
     }
 }

--- a/src/treeland/quick/qml/WindowsSwitcher.qml
+++ b/src/treeland/quick/qml/WindowsSwitcher.qml
@@ -11,6 +11,7 @@ Item {
     property alias model: model
     property var current: 0
     required property OutputDelegate activeOutput
+    // required property var allWins
 
     signal surfaceActivated(surface: XdgSurface)
 
@@ -18,6 +19,7 @@ Item {
         if (visible) {
             indicator.calcLayout()
             next()
+            // console.log('liveview',allWins,allWins.width,allWins.height,workspaceLiveView.width,workspaceLiveView.height,workspaceLiveView.z)
         }
         else {
             stop()
@@ -60,6 +62,20 @@ Item {
             context.item.stop()
         }
     }
+
+    // invisible impl, makes cursor style also not changed
+    // ShaderEffectSource {
+    //     id: workspaceLiveView
+    //     anchors{
+    //         fill: parent
+    //         margins: 50
+    //     }
+    //     live: true
+    //     hideSource: false
+    //     smooth: true
+    //     sourceItem: allWins
+    //     // opacity: .3
+    // }
 
     Loader {
         id: context

--- a/src/treeland/quick/qml/WindowsSwitcher.qml
+++ b/src/treeland/quick/qml/WindowsSwitcher.qml
@@ -17,7 +17,7 @@ Item {
 
     onVisibleChanged: {
         if (visible) {
-            indicator.calcLayout()
+            indicatorPlane.calcLayout()
             next()
             // console.log('liveview',allWins,allWins.width,allWins.height,workspaceLiveView.width,workspaceLiveView.height,workspaceLiveView.z)
         }
@@ -31,16 +31,12 @@ Item {
         if (current < 0) {
             current = 0
         }
-
-        show();
     }
     function next() {
         current = current + 1
         if (current >= model.count) {
             current = 0
         }
-
-        show();
     }
 
     function show() {
@@ -62,6 +58,8 @@ Item {
             context.item.stop()
         }
     }
+    
+    onCurrentChanged: show()
 
     // invisible impl, makes cursor style also not changed
     // ShaderEffectSource {
@@ -98,7 +96,7 @@ Item {
                 }
             }
         }
-        onCountChanged: if(visible)indicator.calcLayout()
+        onCountChanged: if(visible)indicatorPlane.calcLayout()
     }
 
     property int spacing: 10
@@ -108,9 +106,9 @@ Item {
     onRowsChanged: console.log('rows', rows.length, rowHeight)
 
     Item {
-        id: indicator
+        id: indicatorPlane
         
-        // currently use binding, so indicator follows mouse/active output
+        // currently use binding, so indicatorPlane follows mouse/active output
         x: {
             const coord=parent.mapFromItem(activeOutput,0,0)
             console.log('coord',coord,width,height)
@@ -123,9 +121,18 @@ Item {
         width: activeOutput?.width
         height: activeOutput?.height
         Component.onCompleted: console.log('box hw',activeOutput,width,height)
+        
+        MouseArea {
+            anchors.fill: parent
+            onClicked: {
+                console.log('out')
+                root.visible = false
+            }
+        }
+
         Flickable {
             id: flickable
-            width: parent.width * 0.6
+            width: eqhgrid.width
             height: Math.min(eqhgrid.height, parent.height * 0.7)
             anchors.centerIn: parent
             contentHeight: eqhgrid.height
@@ -220,6 +227,12 @@ Item {
                                         Component.onCompleted: console.log('thumb',source)
                                     }
                                 }
+                                TapHandler {
+                                    onTapped: {
+                                        console.log('tapped idx',globalIdx)
+                                        root.current = globalIdx
+                                    }
+                                }
                             }
                         }
                     }
@@ -228,7 +241,7 @@ Item {
         }
 
         function calcLayout() {
-            var minH = 100, maxH = 200, maxW = indicator.width * maxH / indicator.height, totMaxWidth = indicator.width * 0.7
+            var minH = 100, maxH = 200, maxW = indicatorPlane.width * maxH / indicatorPlane.height, totMaxWidth = indicatorPlane.width * 0.7
             function tryLayout(rowH, div) {
                 var nrows = 1
                 var acc = 0
@@ -268,10 +281,10 @@ Item {
                 return false
             }
 
-            for (var div = 1; indicator.height / div >= minH; div++) {
+            for (var div = 1; indicatorPlane.height / div >= minH; div++) {
                 // return if width satisfies
                 console.log('div=', div)
-                var rowH = Math.min(indicator.height / div, maxH)
+                var rowH = Math.min(indicatorPlane.height / div, maxH)
                 if (tryLayout(rowH, div))
                     return
             }

--- a/src/treeland/quick/qml/WindowsSwitcher.qml
+++ b/src/treeland/quick/qml/WindowsSwitcher.qml
@@ -17,6 +17,7 @@ Item {
 
     onVisibleChanged: {
         if (visible) {
+            current = 0
             indicatorPlane.calcLayout()
             next()
             // console.log('liveview',allWins,allWins.width,allWins.height,workspaceLiveView.width,workspaceLiveView.height,workspaceLiveView.z)
@@ -56,6 +57,11 @@ Item {
     function stop() {
         if (context.item) {
             context.item.stop()
+        }
+        // adjust win stack
+        if(current!=0) {
+            console.log('adjust',current,'to first')
+            model.move(current,0,1)
         }
     }
     

--- a/src/treeland/quick/qml/WindowsSwitcher.qml
+++ b/src/treeland/quick/qml/WindowsSwitcher.qml
@@ -123,71 +123,102 @@ Item {
         width: activeOutput?.width
         height: activeOutput?.height
         Component.onCompleted: console.log('box hw',activeOutput,width,height)
-
-        ColumnLayout {
-            id: eqhgrid // equal height grid
+        Flickable {
+            id: flickable
+            width: parent.width * 0.6
+            height: Math.min(eqhgrid.height, parent.height * 0.7)
             anchors.centerIn: parent
-            Component.onCompleted: console.log('eqhgrid',mapToGlobal(0,0),width,height,rows)
-            Repeater {
-                model: rows
-                RowLayout {
-                    width: eqhgrid.width
-                    Layout.alignment: Qt.AlignHCenter
-                    property int baseIdx: {
-                        var idx = 0
-                        for (var i = 0; i < index; i++)
-                            idx += rows[i].length
-                        return idx
-                    }
-                    Repeater {
-                        model: modelData
-                        Rectangle {
-                            property XdgSurface source: modelData.source
-                            width: modelData.dw + 2 * padding
-                            height: col.height + 2 * padding
-                            property int globalIdx: index + parent.baseIdx
-                            Component.onCompleted: console.log('item', modelData,
-                                                            index, globalIdx,height,width)
-                            border.color: "blue"
-                            border.width: globalIdx == root.current ? 2 : 0
-                            radius: 8
-                            Column {
-                                anchors {
-                                    left: parent.left
-                                    right: parent.right
-                                    top: parent.top
-                                    margins: padding
-                                }
-                                id: col
-                                RowLayout {
-                                    width: parent.width
-                                    Rectangle {
-                                        height: width
-                                        width: 24
-                                        color: "yellow"
+            contentHeight: eqhgrid.height
+            boundsBehavior: Flickable.StopAtBounds
+            Behavior on contentY {
+                NumberAnimation {
+                    duration: 200
+                }
+            }
+            clip: true
+
+            ColumnLayout {
+                id: eqhgrid // equal height grid
+                anchors.centerIn: parent
+                Component.onCompleted: console.log('eqhgrid',mapToGlobal(0,0),width,height,rows)
+                Repeater {
+                    model: rows
+                    RowLayout {
+                        width: eqhgrid.width
+                        Layout.alignment: Qt.AlignHCenter
+                        property int baseIdx: {
+                            var idx = 0
+                            for (var i = 0; i < index; i++)
+                                idx += rows[i].length
+                            return idx
+                        }
+                        Repeater {
+                            model: modelData
+                            Rectangle {
+                                property XdgSurface source: modelData.source
+                                property bool highlighted: globalIdx == root.current 
+                                width: modelData.dw + 2 * padding
+                                height: col.height + 2 * padding
+                                property int globalIdx: index + parent.baseIdx
+                                Component.onCompleted: console.log('item', modelData,
+                                                                index, globalIdx,height,width)
+                                border.color: "blue"
+                                border.width: highlighted ? 2 : 0
+                                radius: 8
+                                onHighlightedChanged: {
+                                    // auto scroll to current highlight
+                                    if (highlighted) {
+                                        console.log('highlighted',
+                                                    flickable.contentY,
+                                                    mapToItem(flickable, 0, 0),
+                                                    mapFromItem(flickable, 0, 0))
+                                        flickable.contentY = Math.min(
+                                                    Math.max(
+                                                        mapToItem(
+                                                            eqhgrid, 0,
+                                                            height).y - flickable.height,
+                                                        flickable.contentY),
+                                                    mapToItem(eqhgrid, 0, 0).y)
                                     }
-                                    Text {
-                                        Layout.fillWidth: true
-                                        text: "test title ttttttttttttttttttttttt"
-                                        elide: Qt.ElideRight
-                                    }
                                 }
-                                Item {
-                                    id: thumb
-                                    width: parent.width
-                                    height: source.height * width / source.width
-                                    clip: true
-                                    visible: true
-                                    ShaderEffectSource {
-                                        anchors.centerIn: parent
+                                Column {
+                                    anchors {
+                                        left: parent.left
+                                        right: parent.right
+                                        top: parent.top
+                                        margins: padding
+                                    }
+                                    id: col
+                                    RowLayout {
+                                        width: parent.width
+                                        Rectangle {
+                                            height: width
+                                            width: 24
+                                            color: "yellow"
+                                        }
+                                        Text {
+                                            Layout.fillWidth: true
+                                            text: "test title ttttttttttttttttttttttt"
+                                            elide: Qt.ElideRight
+                                        }
+                                    }
+                                    Item {
+                                        id: thumb
                                         width: parent.width
                                         height: source.height * width / source.width
-                                        live: true
-                                        hideSource: false
-                                        smooth: true
-                                        sourceItem: source
+                                        clip: true
+                                        visible: true
+                                        ShaderEffectSource {
+                                            anchors.centerIn: parent
+                                            width: parent.width
+                                            height: source.height * width / source.width
+                                            live: true
+                                            hideSource: false
+                                            smooth: true
+                                            sourceItem: source
+                                        }
+                                        Component.onCompleted: console.log('thumb',source)
                                     }
-                                    Component.onCompleted: console.log('thumb',source)
                                 }
                             }
                         }
@@ -249,8 +280,8 @@ Item {
         }
 
         Rectangle {
-            width: eqhgrid.width
-            height: eqhgrid.height
+            width: flickable.width
+            height: flickable.height
             anchors.centerIn: parent
             radius: 10
             opacity: 0.4


### PR DESCRIPTION
features include:
- indicator
  - win11-like equal-height-grid layout of window thumbnails
  - indicator follows screen not whole virtual desktop scene
  - tap & scroll interaction of the indicator
- current window preview
  - opaque not-focused windows
  - fix the bug that windows still receiving input when switcher shows