### PR TITLE
Fix winpreview activate bahavior

### DIFF
--- a/src/treeland/quick/qml/WindowsSwitcher.qml
+++ b/src/treeland/quick/qml/WindowsSwitcher.qml
@@ -39,6 +39,7 @@ Item {
     }
 
     function show() {
+        // current may be in intermediate state, make sure current is in range
         if (current >= model.count || current < 0) {
             return
         }
@@ -64,7 +65,10 @@ Item {
         }
     }
     
-    onCurrentChanged: show()
+    onCurrentChanged: {
+        // change may be triggered by: click, keyboard navigation
+        show()
+    }
 
     Loader {
         id: context
@@ -87,7 +91,11 @@ Item {
                 }
             }
         }
-        onCountChanged: if (visible) indicatorPlane.calcLayout()
+        onCountChanged: if (visible) {
+            // in case a window exited when previewing
+            current = Math.max(Math.min(current, model.count - 1), 0)
+            indicatorPlane.calcLayout()
+        }
     }
 
     property int spacing: 10

--- a/src/treeland/quick/qml/WindowsSwitcher.qml
+++ b/src/treeland/quick/qml/WindowsSwitcher.qml
@@ -28,7 +28,7 @@ Item {
     function previous() {
         current = current - 1
         if (current < 0) {
-            current = 0
+            current = Math.max(0, model.count - 1)
         }
     }
     function next() {
@@ -39,7 +39,7 @@ Item {
     }
 
     function show() {
-        if (model.count < 1) {
+        if (current >= model.count || current < 0) {
             return
         }
 
@@ -49,17 +49,18 @@ Item {
         context.anchors.fill = root
         context.sourceComponent = contextComponent
         context.item.start(source)
-        surfaceActivated(source)
     }
 
     function stop() {
         if (context.item) {
             context.item.stop()
         }
-        // adjust win stack
+        const source = model.get(current).source
+        // activated window changed
         if (current != 0) {
-            // console.log('adjust', current, 'to first')
+            // adjust window stack
             model.move(current, 0, 1)
+            surfaceActivated(source)
         }
     }
     


### PR DESCRIPTION
Referring to kwin/mutter standard behavior, shoudn't actually activate win when previewing / in switching.