### PR TITLE
Refactor: Adopt qt hierachical focus management

### DIFF
--- a/src/greeter/Center.qml
+++ b/src/greeter/Center.qml
@@ -8,7 +8,7 @@ import org.deepin.dtk 1.0 as D
 import TreeLand
 import TreeLand.Utils
 
-Item {
+FocusScope {
     id: root
 
     property UserInput loginGroup: userInput
@@ -111,18 +111,22 @@ Item {
         }
     }
 
-    Item {
+    FocusScope {
         id: right
         anchors.left: quickActions.right
         anchors.right: parent.right
         anchors.top: parent.top
         anchors.bottom: parent.bottom
 
+        focus: true
+
         UserInput {
             id: userInput
             anchors.verticalCenter: parent.verticalCenter
             anchors.left: parent.left
             anchors.leftMargin: parent.width / 6
+
+            focus: true
         }
 
         //TODO: abstract ot a Button type

--- a/src/greeter/Greeter.qml
+++ b/src/greeter/Greeter.qml
@@ -6,7 +6,7 @@ import QtQuick.Layouts
 
 import TreeLand.Greeter
 
-Item {
+FocusScope {
     id: root
     clip: true
 
@@ -53,6 +53,8 @@ Item {
         anchors.topMargin: 50
         anchors.rightMargin: 50
         anchors.bottomMargin: 50
+
+        focus: true
     }
 
 

--- a/src/greeter/UserInput.qml
+++ b/src/greeter/UserInput.qml
@@ -125,7 +125,7 @@ Item {
             height: 30
             anchors.horizontalCenter: parent.horizontalCenter
             echoMode: showPasswordBtn.hiddenPWD ? TextInput.Password : TextInput.Normal
-            focus: true
+            focus: loginGroup.activeFocus   // whenever logingrp becomes activeFocus, first focus this child
             rightPadding: 24
             maximumLength: 510
             placeholderText: qsTr("Please enter password")
@@ -274,13 +274,6 @@ Item {
 
     Component.onCompleted: {
         updateUser()
-        passwordField.forceActiveFocus()
-    }
-
-    onVisibleChanged: {
-        if (visible === true) {
-            passwordField.forceActiveFocus()
-        }
     }
 
     function updateHintMsg(msg) {
@@ -293,6 +286,7 @@ Item {
 
     function userAuthFailed() {
         passwordField.selectAll()
-        passwordField.forceActiveFocus()
+        if(loginGroup.activeFocus)
+            passwordField.forceActiveFocus()
     }
 }

--- a/src/greeter/UserInput.qml
+++ b/src/greeter/UserInput.qml
@@ -125,7 +125,6 @@ Item {
             height: 30
             anchors.horizontalCenter: parent.horizontalCenter
             echoMode: showPasswordBtn.hiddenPWD ? TextInput.Password : TextInput.Normal
-            focus: loginGroup.activeFocus   // whenever logingrp becomes activeFocus, first focus this child
             rightPadding: 24
             maximumLength: 510
             placeholderText: qsTr("Please enter password")
@@ -276,6 +275,10 @@ Item {
         updateUser()
     }
 
+    onActiveFocusChanged: {
+        if (activeFocus) passwordField.forceActiveFocus()
+    }
+
     function updateHintMsg(msg) {
         hintText.text = msg
     }
@@ -286,7 +289,7 @@ Item {
 
     function userAuthFailed() {
         passwordField.selectAll()
-        if(loginGroup.activeFocus)
+        if (loginGroup.activeFocus)
             passwordField.forceActiveFocus()
     }
 }

--- a/src/treeland/quick/qml/LayerSurface.qml
+++ b/src/treeland/quick/qml/LayerSurface.qml
@@ -7,7 +7,7 @@ import QtQuick.Particles
 import TreeLand
 import TreeLand.Utils
 
-Item {
+FocusScope {
     property alias waylandSurface: surfaceItem.surface
     property bool anchorWidth: false
     property bool anchorHeight: false
@@ -27,6 +27,7 @@ Item {
 
     LayerSurfaceItem {
         anchors.centerIn: parent
+        focus: true
 
         id: surfaceItem
 
@@ -239,8 +240,6 @@ Item {
         function onActivateChanged() {
             if (waylandSurface.isActivated && surfaceItem.effectiveVisible) {
                 surfaceItem.forceActiveFocus()
-            } else {
-                surfaceItem.focus = false
             }
         }
     }

--- a/src/treeland/quick/qml/Main.qml
+++ b/src/treeland/quick/qml/Main.qml
@@ -295,7 +295,6 @@ Item {
         Item {
             id: outputLayout
             objectName: "outputlayout"
-            focus: greeter.visible
             DynamicCreatorComponent {
                 id: outputDelegateCreator
                 creator: QmlHelper.outputManager
@@ -341,7 +340,7 @@ Item {
             Greeter {
                 id: greeter
                 z: 1
-                visible: !TreeLand.testMode
+                visible: { visible = !TreeLand.testMode }
                 enabled: visible
                 focus: enabled
                 anchors.fill: renderWindow.activeOutputDelegate
@@ -350,12 +349,14 @@ Item {
 
         FocusScope {
             id: workspaceLoader
+            objectName: "workspaceLoader"
             anchors.fill: parent
             visible: !greeter.visible
             enabled: visible
             focus: enabled
             ColumnLayout {
                 FocusScope {
+                    objectName: "loadercontainer"
                     Layout.fillWidth: true
                     Layout.fillHeight: true
                     focus: true
@@ -363,6 +364,7 @@ Item {
                     Loader {
                         id: stackLayout
                         anchors.fill: parent
+                        focus: true
                         sourceComponent: StackWorkspace {
                             focus: stackLayout.active
                             activeOutputDelegate: renderWindow.activeOutputDelegate

--- a/src/treeland/quick/qml/Main.qml
+++ b/src/treeland/quick/qml/Main.qml
@@ -274,11 +274,28 @@ Item {
 
         EventJunkman {
             anchors.fill: parent
+            focus: false
+        }
+
+        onActiveFocusItemChanged: {
+            // in case unexpected behavior happens
+            if (activeFocusItem === renderWindow.contentItem) {
+                console.warn('focusOnroot')
+                // manually pick one child to focus
+                for(let item of renderWindow.contentItem.children) {
+                    if (item.focus) {
+                        item.forceActiveFocus()
+                        return
+                    }
+                }
+                console.exception('no active focus !!!')
+            }
         }
 
         Item {
             id: outputLayout
-
+            objectName: "outputlayout"
+            focus: greeter.visible
             DynamicCreatorComponent {
                 id: outputDelegateCreator
                 creator: QmlHelper.outputManager
@@ -325,31 +342,38 @@ Item {
                 id: greeter
                 z: 1
                 visible: !TreeLand.testMode
+                enabled: visible
+                focus: enabled
                 anchors.fill: renderWindow.activeOutputDelegate
             }
         }
 
-        ColumnLayout {
+        FocusScope {
             id: workspaceLoader
             anchors.fill: parent
             visible: !greeter.visible
-
-            Item {
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-
-                Loader {
-                    id: stackLayout
-                    anchors.fill: parent
-                    sourceComponent: StackWorkspace {
-                        activeOutputDelegate: renderWindow.activeOutputDelegate
+            enabled: visible
+            focus: enabled
+            ColumnLayout {
+                FocusScope {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    focus: true
+                    activeFocusOnTab: true
+                    Loader {
+                        id: stackLayout
+                        anchors.fill: parent
+                        sourceComponent: StackWorkspace {
+                            focus: stackLayout.active
+                            activeOutputDelegate: renderWindow.activeOutputDelegate
+                        }
                     }
-                }
 
-                Loader {
-                    active: !stackLayout.active
-                    anchors.fill: parent
-                    sourceComponent: TiledWorkspace { }
+                    Loader {
+                        active: !stackLayout.active
+                        anchors.fill: parent
+                        sourceComponent: TiledWorkspace { }
+                    }
                 }
             }
         }

--- a/src/treeland/quick/qml/StackToplevelHelper.qml
+++ b/src/treeland/quick/qml/StackToplevelHelper.qml
@@ -108,8 +108,10 @@ Item {
                 // Apply the WSurfaceItem's size to wl_surface
                 surface.resize(SurfaceItem.SizeToSurface)
 
+                // process defered visible change after mapped
+                // TODO whatif layersurface set exclusive focus?
                 if (waylandSurface && waylandSurface.isActivated)
-                    surface.forceActiveFocus()
+                    Helper.activatedSurface = surface
             } else {
                 Helper.cancelMoveResize(surface)
             }
@@ -141,7 +143,7 @@ Item {
                 cancelMinimize()
             }
 
-            surface.focus = activated
+            // surface.focus = activated
             Helper.activatedSurface = activated ? waylandSurface : null
         }
 
@@ -287,10 +289,9 @@ Item {
         function onActivateChanged() {
             if (waylandSurface.isActivated) {
                 WaylibHelper.itemStackToTop(surface)
-                if (surface.effectiveVisible)
-                    surface.forceActiveFocus()
-            } else {
-                surface.focus = false
+                if (surface.effectiveVisible) {
+                    Helper.activatedSurface = waylandSurface
+                }
             }
         }
 
@@ -359,7 +360,7 @@ Item {
             if (!surface.effectiveVisible)
                 return
 
-            surface.focus = false;
+            // TODO activate next in stack
             if (Helper.activatedSurface === surface)
                 Helper.activatedSurface = null;
 

--- a/src/treeland/quick/qml/StackWorkspace.qml
+++ b/src/treeland/quick/qml/StackWorkspace.qml
@@ -10,7 +10,7 @@ import TreeLand.Utils
 import TreeLand.Protocols
 import org.deepin.dtk 1.0 as D
 
-Item {
+FocusScope {
     id: root
     function getSurfaceItemFromWaylandSurface(surface) {
         let finder = function(props) {
@@ -60,6 +60,13 @@ Item {
         return null
     }
 
+    function dbgActivefocus(self) {
+        console.log(self, 'focus', activeFocus, self.children.some(surfaceItem => surfaceItem.waylandSurface === Helper.activatedSurface))
+        for (let item of self.children) {
+            console.log('child', item, item.focus, item.activeFocus)
+        }
+    }
+
     required property OutputDelegate activeOutputDelegate
     readonly property real switcherHideOpacity: 0.3
 
@@ -76,6 +83,7 @@ Item {
     FocusScope {
         anchors.fill: parent
         enabled: !switcher.visible && !multitaskView.active
+        focus: enabled
         opacity: if (switcher.visible || dockPreview.previewing) switcherHideOpacity
             else 1
         z: 0
@@ -113,6 +121,7 @@ Item {
                 workspaceId: wsid
                 workspaceRelativeId: index
                 visible: workspaceRelativeId === currentWorkspaceId
+                focus: visible
                 anchors.fill: parent
                 Component.onCompleted: {
                     workspaceManager.workspacesById.set(workspaceId, this)
@@ -164,6 +173,7 @@ Item {
                 bottomPadding: decoration.enable ? decoration.bottomMargin : 0
                 leftPadding: decoration.enable ? decoration.leftMargin : 0
                 rightPadding: decoration.enable ? decoration.rightMargin : 0
+                focus: this.waylandSurface === Helper.activatedSurface
 
                 OutputLayoutItem {
                     anchors.fill: parent
@@ -528,6 +538,7 @@ Item {
             id: layerSurface
             creator: layerComponent
             activeOutputItem: activeOutputDelegate
+            focus: Helper.activatedSurface === this.waylandSurface
         }
     }
 
@@ -538,6 +549,7 @@ Item {
         enabled: !multitaskView.active
         model: workspaceManager.workspacesById.get(workspaceManager.layoutOrder.get(currentWorkspaceId).wsid).surfaces
         visible: false // dbgswtchr.checked
+        focus: false
         activeOutput: activeOutputDelegate
         onSurfaceActivated: (surface) => {
             surface.cancelMinimize()
@@ -564,10 +576,12 @@ Item {
     Loader {
         id: multitaskView
         active: false
+        focus: false
         sourceComponent: Component {
             MultitaskView {
                 anchors.fill: parent
                 model: workspaceManager.workspacesById.get(workspaceManager.layoutOrder.get(currentWorkspaceId).wsid).surfaces
+                focus: false
                 onVisibleChanged: {
                     console.assert(!visible,'should be exit')
                     multitaskView.active = false

--- a/src/treeland/quick/qml/ToplevelContainer.qml
+++ b/src/treeland/quick/qml/ToplevelContainer.qml
@@ -9,7 +9,7 @@ import TreeLand.Protocols
 import TreeLand.Utils
 import TreeLand.Protocols
 
-Item {
+FocusScope {
     id: root
     required property int workspaceId
     required property int workspaceRelativeId


### PR DESCRIPTION
Reduce use of `forceActiveFocus`, use focusscope etc. to automatically pass focus along the item tree.
Currently uses of `forceActiveFocus` lacks checking, may result in:
- passwordinput failed to get focus, but unset workspace's focus so focus is set to root content item
- greeter shows but later some surface becomes mapped so focus is robbed

Also fix that focus get lost when only there's one surface after switcher or some treeland controls get focus

based on https://github.com/vioken/waylib/pull/285