### PR TITLE
Refactor shortcuts of winswitcher and one-shot kinds like multitaskview

### DIFF
--- a/src/treeland/quick/qml/Main.qml
+++ b/src/treeland/quick/qml/Main.qml
@@ -364,5 +364,27 @@ Item {
                 greeter.visible = true
             }
         }
+        
+        Shortcut {
+            sequences: ["Meta+S"]
+            context: Qt.ApplicationShortcut
+            onActivated: {
+                QmlHelper.shortcutManager.multitaskViewToggled()
+            }
+        }
+        Shortcut {
+            sequences: ["Meta+L"]
+            autoRepeat: false
+            context: Qt.ApplicationShortcut
+            onActivated: {
+                QmlHelper.shortcutManager.screenLocked()
+            }
+        }
+        Connections {
+            target: QmlHelper.shortcutManager
+            function onScreenLocked() {
+                greeter.visible = true
+            }
+        }
     }
 }

--- a/src/treeland/quick/qml/QmlHelper.qml
+++ b/src/treeland/quick/qml/QmlHelper.qml
@@ -13,6 +13,7 @@ Item {
     property DynamicCreator layerSurfaceManager: layerSurfaceManager
     property DynamicCreator xwaylandSurfaceManager: xwaylandSurfaceManager
     property DynamicCreator inputPopupSurfaceManager: inputPopupSurfaceManager
+    property alias shortcutManager: shortcutManager
 
     function printStructureObject(obj) {
         var json = ""
@@ -94,5 +95,11 @@ Item {
             console.info(`Input popup surface item ${obj} is removed, it's create from delegate ${delegate} with initial properties:`,
                          `\n${printStructureObject(properties)}`)
         }
+    }
+
+    QtObject {
+        id: shortcutManager
+        signal screenLocked
+        signal multitaskViewToggled
     }
 }

--- a/src/treeland/quick/qml/StackWorkspace.qml
+++ b/src/treeland/quick/qml/StackWorkspace.qml
@@ -467,11 +467,28 @@ Item {
         id: switcher
         z: 100 + 1
         anchors.fill: parent
+        enabled: !multitaskView.visible
         visible: false // dbgswtchr.checked
         activeOutput: activeOutputDelegate
         onSurfaceActivated: (surface) => {
             surface.cancelMinimize()
             Helper.activatedSurface = surface.waylandSurface
+        }
+        Binding {
+            target: Helper
+            property: "switcherEnabled"
+            value: switcher.enabled
+        }
+        Binding {
+            target: Helper
+            property: "switcherOn"
+            value: switcher.visible
+        }
+        Connections {
+            target: Helper
+            function onSwitcherOnChanged(on) {
+                if (!on) switcher.visible = false
+            }
         }
     }
 
@@ -520,13 +537,8 @@ Item {
     Connections {
         target: Helper
         function onSwitcherChanged(mode) {
+            switcher.visible = true // ensure, won't emit event if already visible
             switch (mode) {
-            case (Helper.Show):
-                switcher.visible = true
-                break
-            case (Helper.Hide):
-                switcher.visible = false
-                break
             case (Helper.Next):
                 switcher.next()
                 break

--- a/src/treeland/quick/qml/StackWorkspace.qml
+++ b/src/treeland/quick/qml/StackWorkspace.qml
@@ -467,7 +467,7 @@ Item {
         id: switcher
         z: 100 + 1
         anchors.fill: parent
-        enabled: !multitaskView.visible
+        enabled: !multitaskView.active
         visible: false // dbgswtchr.checked
         activeOutput: activeOutputDelegate
         onSurfaceActivated: (surface) => {
@@ -546,6 +546,12 @@ Item {
                 switcher.previous()
                 break
             }
+        }
+    }
+    Connections {
+        target: QmlHelper.shortcutManager
+        function onMultitaskViewToggled() {
+            multitaskView.active = !multitaskView.active
         }
     }
 }

--- a/src/treeland/quick/qml/WindowsSwitcher.qml
+++ b/src/treeland/quick/qml/WindowsSwitcher.qml
@@ -18,7 +18,7 @@ Item {
         if (visible) {
             current = 0
             indicatorPlane.calcLayout()
-            next()
+            show()
         }
         else {
             stop()

--- a/src/treeland/quick/utils/helper.h
+++ b/src/treeland/quick/utils/helper.h
@@ -36,6 +36,8 @@ class Helper : public WSeatEventFilter {
     Q_PROPERTY(WSurfaceItem *movingItem READ movingItem NOTIFY movingItemChanged FINAL)
     Q_PROPERTY(QString socketFile READ socketFile WRITE setSocketFile NOTIFY socketFileChanged FINAL)
     Q_PROPERTY(QString currentUser READ currentUser WRITE setCurrentUser FINAL)
+    Q_PROPERTY(bool switcherOn MEMBER m_switcherOn NOTIFY switcherOnChanged FINAL)
+    Q_PROPERTY(bool switcherEnabled MEMBER m_switcherEnabled FINAL)
     QML_ELEMENT
     QML_SINGLETON
 
@@ -43,8 +45,6 @@ public:
     explicit Helper(QObject *parent = nullptr);
 
     enum Switcher {
-        Hide,
-        Show,
         Next,
         Previous,
     };
@@ -102,7 +102,8 @@ Q_SIGNALS:
     void leftExclusiveMarginChanged();
     void rightExclusiveMarginChanged();
     void socketFileChanged();
-    void switcherChanged(Switcher mode);
+    void switcherChanged(Switcher action);
+    void switcherOnChanged(bool on);
 
 protected:
     bool beforeDisposeEvent(WSeat *seat, QWindow *watched, QInputEvent *event) override;
@@ -134,8 +135,9 @@ private:
 private:
     QString m_socketFile;
     QString m_currentUser;
-    Switcher m_switcherCurrentMode = Switcher::Hide;
     std::map<QString, std::vector<QAction*>> m_actions;
+    bool m_switcherOn = false;
+    bool m_switcherEnabled = true;
 };
 
 struct OutputInfo {


### PR DESCRIPTION
- Sync state between qml and C++. Now C++ only provides keyboard navigation events, state is maintained in qml.
- Using qml `ShortCut` type for trigger/toggle based shortcuts like multitaskview `Meta+S`, screenlock `Meta+L`.
suggests https://github.com/vioken/waylib/pull/287 for auto-repeat