### PR TITLE
Feat activated surface auto transition

### DIFF
--- a/src/greeter/Center.qml
+++ b/src/greeter/Center.qml
@@ -8,7 +8,7 @@ import org.deepin.dtk 1.0 as D
 import TreeLand
 import TreeLand.Utils
 
-Item {
+FocusScope {
     id: root
 
     property UserInput loginGroup: userInput
@@ -111,18 +111,22 @@ Item {
         }
     }
 
-    Item {
+    FocusScope {
         id: right
         anchors.left: quickActions.right
         anchors.right: parent.right
         anchors.top: parent.top
         anchors.bottom: parent.bottom
 
+        focus: true
+
         UserInput {
             id: userInput
             anchors.verticalCenter: parent.verticalCenter
             anchors.left: parent.left
             anchors.leftMargin: parent.width / 6
+
+            focus: true
         }
 
         //TODO: abstract ot a Button type

--- a/src/greeter/Greeter.qml
+++ b/src/greeter/Greeter.qml
@@ -6,7 +6,7 @@ import QtQuick.Layouts
 
 import TreeLand.Greeter
 
-Item {
+FocusScope {
     id: root
     clip: true
 
@@ -53,6 +53,8 @@ Item {
         anchors.topMargin: 50
         anchors.rightMargin: 50
         anchors.bottomMargin: 50
+
+        focus: true
     }
 
 

--- a/src/greeter/UserInput.qml
+++ b/src/greeter/UserInput.qml
@@ -125,7 +125,7 @@ Item {
             height: 30
             anchors.horizontalCenter: parent.horizontalCenter
             echoMode: showPasswordBtn.hiddenPWD ? TextInput.Password : TextInput.Normal
-            focus: true
+            focus: loginGroup.activeFocus   // whenever logingrp becomes activeFocus, first focus this child
             rightPadding: 24
             maximumLength: 510
             placeholderText: qsTr("Please enter password")
@@ -274,13 +274,6 @@ Item {
 
     Component.onCompleted: {
         updateUser()
-        passwordField.forceActiveFocus()
-    }
-
-    onVisibleChanged: {
-        if (visible === true) {
-            passwordField.forceActiveFocus()
-        }
     }
 
     function updateHintMsg(msg) {
@@ -293,6 +286,7 @@ Item {
 
     function userAuthFailed() {
         passwordField.selectAll()
-        passwordField.forceActiveFocus()
+        if(loginGroup.activeFocus)
+            passwordField.forceActiveFocus()
     }
 }

--- a/src/greeter/UserInput.qml
+++ b/src/greeter/UserInput.qml
@@ -125,7 +125,6 @@ Item {
             height: 30
             anchors.horizontalCenter: parent.horizontalCenter
             echoMode: showPasswordBtn.hiddenPWD ? TextInput.Password : TextInput.Normal
-            focus: loginGroup.activeFocus   // whenever logingrp becomes activeFocus, first focus this child
             rightPadding: 24
             maximumLength: 510
             placeholderText: qsTr("Please enter password")
@@ -276,6 +275,10 @@ Item {
         updateUser()
     }
 
+    onActiveFocusChanged: {
+        if (activeFocus) passwordField.forceActiveFocus()
+    }
+
     function updateHintMsg(msg) {
         hintText.text = msg
     }
@@ -286,7 +289,7 @@ Item {
 
     function userAuthFailed() {
         passwordField.selectAll()
-        if(loginGroup.activeFocus)
+        if (loginGroup.activeFocus)
             passwordField.forceActiveFocus()
     }
 }

--- a/src/treeland/quick/qml/LayerSurface.qml
+++ b/src/treeland/quick/qml/LayerSurface.qml
@@ -7,7 +7,7 @@ import QtQuick.Particles
 import TreeLand
 import TreeLand.Utils
 
-Item {
+FocusScope {
     property alias waylandSurface: surfaceItem.surface
     property bool anchorWidth: false
     property bool anchorHeight: false
@@ -27,6 +27,7 @@ Item {
 
     LayerSurfaceItem {
         anchors.centerIn: parent
+        focus: true
 
         id: surfaceItem
 
@@ -239,8 +240,6 @@ Item {
         function onActivateChanged() {
             if (waylandSurface.isActivated && surfaceItem.effectiveVisible) {
                 surfaceItem.forceActiveFocus()
-            } else {
-                surfaceItem.focus = false
             }
         }
     }

--- a/src/treeland/quick/qml/Main.qml
+++ b/src/treeland/quick/qml/Main.qml
@@ -283,11 +283,28 @@ Item {
 
         EventJunkman {
             anchors.fill: parent
+            focus: false
+        }
+
+        onActiveFocusItemChanged: {
+            // in case unexpected behavior happens
+            if (activeFocusItem === renderWindow.contentItem) {
+                console.warn('focusOnroot')
+                // manually pick one child to focus
+                for(let item of renderWindow.contentItem.children) {
+                    if (item.focus) {
+                        item.forceActiveFocus()
+                        return
+                    }
+                }
+                console.exception('no active focus !!!')
+            }
         }
 
         Item {
             id: outputLayout
-
+            objectName: "outputlayout"
+            focus: greeter.visible
             DynamicCreatorComponent {
                 id: outputDelegateCreator
                 creator: QmlHelper.outputManager
@@ -334,31 +351,38 @@ Item {
                 id: greeter
                 z: 1
                 visible: !TreeLand.testMode
+                enabled: visible
+                focus: enabled
                 anchors.fill: renderWindow.activeOutputDelegate
             }
         }
 
-        ColumnLayout {
+        FocusScope {
             id: workspaceLoader
             anchors.fill: parent
             visible: !greeter.visible
-
-            Item {
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-
-                Loader {
-                    id: stackLayout
-                    anchors.fill: parent
-                    sourceComponent: StackWorkspace {
-                        activeOutputDelegate: renderWindow.activeOutputDelegate
+            enabled: visible
+            focus: enabled
+            ColumnLayout {
+                FocusScope {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    focus: true
+                    activeFocusOnTab: true
+                    Loader {
+                        id: stackLayout
+                        anchors.fill: parent
+                        sourceComponent: StackWorkspace {
+                            focus: stackLayout.active
+                            activeOutputDelegate: renderWindow.activeOutputDelegate
+                        }
                     }
-                }
 
-                Loader {
-                    active: !stackLayout.active
-                    anchors.fill: parent
-                    sourceComponent: TiledWorkspace { }
+                    Loader {
+                        active: !stackLayout.active
+                        anchors.fill: parent
+                        sourceComponent: TiledWorkspace { }
+                    }
                 }
             }
         }

--- a/src/treeland/quick/qml/Main.qml
+++ b/src/treeland/quick/qml/Main.qml
@@ -364,6 +364,7 @@ Item {
             enabled: visible
             focus: enabled
             ColumnLayout {
+                anchors.fill: parent
                 FocusScope {
                     objectName: "loadercontainer"
                     Layout.fillWidth: true

--- a/src/treeland/quick/qml/Main.qml
+++ b/src/treeland/quick/qml/Main.qml
@@ -304,7 +304,6 @@ Item {
         Item {
             id: outputLayout
             objectName: "outputlayout"
-            focus: greeter.visible
             DynamicCreatorComponent {
                 id: outputDelegateCreator
                 creator: QmlHelper.outputManager
@@ -350,7 +349,7 @@ Item {
             Greeter {
                 id: greeter
                 z: 1
-                visible: !TreeLand.testMode
+                visible: { visible = !TreeLand.testMode }
                 enabled: visible
                 focus: enabled
                 anchors.fill: renderWindow.activeOutputDelegate
@@ -359,12 +358,14 @@ Item {
 
         FocusScope {
             id: workspaceLoader
+            objectName: "workspaceLoader"
             anchors.fill: parent
             visible: !greeter.visible
             enabled: visible
             focus: enabled
             ColumnLayout {
                 FocusScope {
+                    objectName: "loadercontainer"
                     Layout.fillWidth: true
                     Layout.fillHeight: true
                     focus: true
@@ -372,6 +373,7 @@ Item {
                     Loader {
                         id: stackLayout
                         anchors.fill: parent
+                        focus: true
                         sourceComponent: StackWorkspace {
                             focus: stackLayout.active
                             activeOutputDelegate: renderWindow.activeOutputDelegate

--- a/src/treeland/quick/qml/MultitaskView.qml
+++ b/src/treeland/quick/qml/MultitaskView.qml
@@ -62,11 +62,14 @@ Item {
                         Layout.preferredWidth: contentItem.childrenRect.width
                         Layout.maximumWidth: parent.width
                         Layout.alignment: Qt.AlignHCenter
-                        delegate: Item {
+                        delegate: Rectangle {
                             required property int wsid
                             required property int index
                             height: workspacesList.height
                             width: height * outputPlacementItem.width / outputPlacementItem.height
+                            border.width: workspaceManager.workspacesById.get(wsid).isCurrentWorkspace ? 2 : 0
+                            border.color: "blue"
+                            color: "transparent"
                             Item {
                                 anchors {
                                     fill: parent

--- a/src/treeland/quick/qml/StackToplevelHelper.qml
+++ b/src/treeland/quick/qml/StackToplevelHelper.qml
@@ -216,7 +216,7 @@ Item {
             } else {
                 surface.visible = true;
 
-                if (surface.effectiveVisible)
+                if (surface.parent.isCurrentWorkspace)
                     Helper.activatedSurface = waylandSurface
 
                 if (showNewAnimation) {

--- a/src/treeland/quick/qml/StackToplevelHelper.qml
+++ b/src/treeland/quick/qml/StackToplevelHelper.qml
@@ -168,7 +168,8 @@ Item {
                     }
 
                     surface.focus = activated
-                    Helper.activatedSurface = activated ? waylandSurface : null
+                    if (activated)
+                        Helper.activatedSurface = waylandSurface
                 }
 
                 function onRequestFullscreen(fullscreen) {
@@ -240,6 +241,8 @@ Item {
             }
             workspace().surfaces.removeIf((val) => val.item === surface)
             QmlHelper.workspaceManager.allSurfaces.removeIf((val) => val.item === surface)
+            if (Helper.activatedSurface === waylandSurface)
+                surface.parent.selectSurfaceToActivate()
         }
     }
 
@@ -366,11 +369,12 @@ Item {
             return
 
         surface.focus = false;
-        if (Helper.activatedSurface === surface)
-            Helper.activatedSurface = null;
-
         surface.visible = false;
         waylandSurface.setMinimize(true)
+
+        if (Helper.activatedSurface === waylandSurface) {
+            surface.parent.selectSurfaceToActivate()
+        }
     }
 
     function cancelMinimize () {

--- a/src/treeland/quick/qml/StackToplevelHelper.qml
+++ b/src/treeland/quick/qml/StackToplevelHelper.qml
@@ -130,8 +130,10 @@ Item {
                 // Apply the WSurfaceItem's size to wl_surface
                 surface.resize(SurfaceItem.SizeToSurface)
 
+                // process defered visible change after mapped
+                // TODO whatif layersurface set exclusive focus?
                 if (waylandSurface && waylandSurface.isActivated)
-                    surface.forceActiveFocus()
+                    Helper.activatedSurface = surface
             } else {
                 Helper.cancelMoveResize(surface)
             }
@@ -292,10 +294,9 @@ Item {
         function onActivateChanged() {
             if (waylandSurface.isActivated) {
                 WaylibHelper.itemStackToTop(surface)
-                if (surface.effectiveVisible)
-                    surface.forceActiveFocus()
-            } else {
-                surface.focus = false
+                if (surface.effectiveVisible) {
+                    Helper.activatedSurface = waylandSurface
+                }
             }
         }
 

--- a/src/treeland/quick/qml/StackWorkspace.qml
+++ b/src/treeland/quick/qml/StackWorkspace.qml
@@ -68,11 +68,17 @@ Item {
     property int currentWorkspaceId: 0
 
     // activated workspace driven by surface activation
-    property Item activatedSurfaceItem: getSurfaceItemFromWaylandSurface(Helper.activatedSurface)?.item
+    property Item activatedSurfaceItem:
+        getSurfaceItemFromWaylandSurface(Helper.activatedSurface)?.item || null // cannot assign [undefined] to QQuickItem*, need to assign null
     onActivatedSurfaceItemChanged: {
         if (activatedSurfaceItem?.parent?.workspaceRelativeId !== undefined)
             currentWorkspaceId = activatedSurfaceItem.parent.workspaceRelativeId
     }
+
+    // activated surface driven by workspace change
+    onCurrentWorkspaceIdChanged: 
+        if (activatedSurfaceItem?.parent?.workspaceRelativeId !== currentWorkspaceId)
+            workspaceManager.workspacesById.get(workspaceManager.layoutOrder.get(currentWorkspaceId).wsid).selectSurfaceToActivate()
 
     FocusScope {
         anchors.fill: parent

--- a/src/treeland/quick/qml/StackWorkspace.qml
+++ b/src/treeland/quick/qml/StackWorkspace.qml
@@ -119,9 +119,10 @@ FocusScope {
                 objectName: `ToplevelContainer ${wsid}`
                 required property int index
                 required property int wsid
+                property bool isCurrentWorkspace: workspaceRelativeId === currentWorkspaceId
                 workspaceId: wsid
                 workspaceRelativeId: index
-                visible: workspaceRelativeId === currentWorkspaceId
+                visible: isCurrentWorkspace
                 focus: visible
                 anchors.fill: parent
                 Component.onCompleted: {

--- a/src/treeland/quick/qml/StackWorkspace.qml
+++ b/src/treeland/quick/qml/StackWorkspace.qml
@@ -11,7 +11,7 @@ import TreeLand.Utils
 import TreeLand.Protocols
 import org.deepin.dtk 1.0 as D
 
-Item {
+FocusScope {
     id: root
     function getSurfaceItemFromWaylandSurface(surface) {
         let finder = function(props) {
@@ -84,6 +84,7 @@ Item {
         anchors.fill: parent
         visible: !multitaskView.active
         enabled: !switcher.visible && !multitaskView.active
+        focus: enabled
         opacity: if (switcher.visible || dockPreview.previewing) switcherHideOpacity
             else 1
         z: 0
@@ -121,6 +122,7 @@ Item {
                 workspaceId: wsid
                 workspaceRelativeId: index
                 visible: workspaceRelativeId === currentWorkspaceId
+                focus: visible
                 anchors.fill: parent
                 Component.onCompleted: {
                     workspaceManager.workspacesById.set(workspaceId, this)
@@ -172,6 +174,7 @@ Item {
                 bottomPadding: decoration.enable ? decoration.bottomMargin : 0
                 leftPadding: decoration.enable ? decoration.leftMargin : 0
                 rightPadding: decoration.enable ? decoration.rightMargin : 0
+                focus: this.waylandSurface === Helper.activatedSurface
 
                 OutputLayoutItem {
                     anchors.fill: parent
@@ -387,8 +390,6 @@ Item {
                 required property int workspaceId
                 parent: QmlHelper.workspaceManager.workspacesById.get(workspaceId)
 
-                Component.onCompleted: console.log('xwayland',this,'created to',workspaceId,parent)
-
                 surface: waylandSurface
                 parentSurfaceItem: surfaceParent ? surfaceParent.item : null
                 z: waylandSurface.bypassManager ? 1 : 0 // TODO: make to enum type
@@ -536,6 +537,7 @@ Item {
             id: layerSurface
             creator: layerComponent
             activeOutputItem: activeOutputDelegate
+            focus: Helper.activatedSurface === this.waylandSurface
         }
     }
 
@@ -546,6 +548,7 @@ Item {
         enabled: !multitaskView.active
         model: workspaceManager.workspacesById.get(workspaceManager.layoutOrder.get(currentWorkspaceId).wsid).surfaces
         visible: false // dbgswtchr.checked
+        focus: false
         activeOutput: activeOutputDelegate
         onSurfaceActivated: (surface) => {
             surface.cancelMinimize()
@@ -572,10 +575,12 @@ Item {
     Loader {
         id: multitaskView
         active: false
+        focus: false
         anchors.fill: parent
         sourceComponent: Component {
             MultitaskView {
                 anchors.fill: parent
+                focus: false
                 currentWorkspaceId: root.currentWorkspaceId
                 setCurrentWorkspaceId: (id) => root.currentWorkspaceId = id
                 onVisibleChanged: {

--- a/src/treeland/quick/qml/ToplevelContainer.qml
+++ b/src/treeland/quick/qml/ToplevelContainer.qml
@@ -80,4 +80,11 @@ Item {
             }
         }
     }
+
+    function selectSurfaceToActivate() {
+        const nextIndex = surfacesModel.findIf( (data) => !data.item.waylandSurface.isMinimized )
+        if (nextIndex >= 0)
+            Helper.activatedSurface = surfacesModel.get(nextIndex).item.waylandSurface
+        else Helper.activatedSurface = null
+    }
 }

--- a/src/treeland/quick/qml/ToplevelContainer.qml
+++ b/src/treeland/quick/qml/ToplevelContainer.qml
@@ -9,7 +9,7 @@ import TreeLand.Protocols
 import TreeLand.Utils
 import TreeLand.Protocols
 
-Item {
+FocusScope {
     id: root
     required property int workspaceId
     required property int workspaceRelativeId

--- a/src/treeland/quick/qml/WindowDecoration.qml
+++ b/src/treeland/quick/qml/WindowDecoration.qml
@@ -123,6 +123,7 @@ D.RoundRectangle {
 
         DragHandler {
             target: root.parent
+            onActiveChanged: if (active) Helper.activatedSurface = surface
             cursorShape: active ? Qt.DragMoveCursor : Qt.ArrowCursor
         }
 

--- a/src/treeland/quick/qml/WindowDecoration.qml
+++ b/src/treeland/quick/qml/WindowDecoration.qml
@@ -18,7 +18,7 @@ D.RoundRectangle {
 
     signal requestMove
     signal requestMinimize
-    signal requestToggleMaximize(var max)
+    signal requestMaximize(var max)
     signal requestClose
     signal requestResize(var edges)
 
@@ -117,7 +117,7 @@ D.RoundRectangle {
                 Helper.activatedSurface = surface
             }
             onDoubleTapped: {
-                root.requestToggleMaximize(!surface.isMaximized)
+                root.requestMaximize(!surface.isMaximized)
             }
         }
 
@@ -178,7 +178,7 @@ D.RoundRectangle {
                     height: titlebar.height
 
                     onClicked: {
-                        root.requestToggleMaximize(!surface.isMaximized)
+                        root.requestMaximize(!surface.isMaximized)
                     }
                 }
             }


### PR DESCRIPTION
- when current activated is minimize / closed
- when active workspace is changed
- https://github.com/linuxdeepin/treeland/pull/180 is merged to this
> Reduce use of `forceActiveFocus`, use focusscope etc. to automatically pass focus along the item tree. Currently uses of `forceActiveFocus` lacks checking, may result in:
> 
> * passwordinput failed to get focus, but unset workspace's focus so focus is set to root content item
> * greeter shows but later some surface becomes mapped so focus is robbed
> 
> Also fix that focus get lost when only there's one surface after switcher or some treeland controls get focus
> 
> based on [vioken/waylib#285](https://github.com/vioken/waylib/pull/285)

