### PR TITLE
fix: trigger resize on mode change

### DIFF
--- a/src/treeland/quick/qml/StackToplevelHelper.qml
+++ b/src/treeland/quick/qml/StackToplevelHelper.qml
@@ -82,6 +82,15 @@ Item {
         }
         restoreMode: Binding.RestoreNone
     }
+    // if surface mapped when not visible, it will change mode to sizefromsurf
+    // but mode change is not applied if no resize event happens afterwards, so trigger resize here
+    Connections {
+        target: surface
+        function onResizeModeChanged() {
+            if (surface.resizeMode != SurfaceItem.ManualResize)
+                surface.resize(surface.resizeMode)
+        }
+    }
 
     Loader {
         id: closeAnimation


### PR DESCRIPTION
if surface mapped when not visible, it will only change mode to sizefromsurf, but not applied, so has zero size