### PR TITLE
Fix: keyboardfocus should not follow activeItem

### DIFF
--- a/src/treeland/quick/qml/Main.qml
+++ b/src/treeland/quick/qml/Main.qml
@@ -93,7 +93,7 @@ Item {
             }
 
             eventFilter: Helper
-            keyboardFocus: Helper.getFocusSurfaceFrom(renderWindow.activeFocusItem)
+            keyboardFocus: Helper.activatedSurface?.surface
         }
 
         XdgShell {


### PR DESCRIPTION
activated surface may lose focus in qt when other view is on, so use activatedsurface to check