### PR TITLE
Fix: create inputpopup out of workspace

### DIFF
--- a/src/treeland/quick/qml/Main.qml
+++ b/src/treeland/quick/qml/Main.qml
@@ -93,7 +93,7 @@ Item {
             }
 
             eventFilter: Helper
-            keyboardFocus: Helper.activatedSurface?.surface
+            keyboardFocus: Helper.activatedSurface?.surface || null
         }
 
         XdgShell {

--- a/src/treeland/quick/qml/StackWorkspace.qml
+++ b/src/treeland/quick/qml/StackWorkspace.qml
@@ -130,6 +130,21 @@ FocusScope {
                 }
             }
         }
+
+        DynamicCreatorComponent {
+            id: inputPopupComponent
+            creator: QmlHelper.inputPopupSurfaceManager
+
+            InputPopupSurface {
+                required property InputMethodHelper inputMethodHelper
+                required property WaylandInputPopupSurface popupSurface
+
+                id: inputPopupSurface
+                surface: popupSurface
+                helper: inputMethodHelper
+            }
+        }
+
     }
 
     Item {
@@ -509,20 +524,6 @@ FocusScope {
                         }
                     }
                 ]
-            }
-        }
-
-        DynamicCreatorComponent {
-            id: inputPopupComponent
-            creator: QmlHelper.inputPopupSurfaceManager
-
-            InputPopupSurface {
-                required property InputMethodHelper inputMethodHelper
-                required property WaylandInputPopupSurface popupSurface
-
-                id: inputPopupSurface
-                surface: popupSurface
-                helper: inputMethodHelper
             }
         }
     }


### PR DESCRIPTION
Input popup is missing due to the introduce of workspace
it's created following keyboardfocus,
when surface moved between workspaces, it follows.