### PR TITLE
Fix initialize focuswin

### DIFF
--- a/src/treeland/quick/qml/Main.qml
+++ b/src/treeland/quick/qml/Main.qml
@@ -444,5 +444,7 @@ Item {
                 greeter.active = !TreeLand.testMode
             }
         }
+
+        Component.onCompleted: seat0.setKeyboardFocusWindow(this)
     }
 }


### PR DESCRIPTION
set seat's keyboard focuswin on renderwindow initialize, so that keyevent can be received even if no mousemove happens