### PR TITLE
Fix: use sizeFromSurface & resizeBySurface when drag resizing

### DIFF
--- a/src/treeland/quick/qml/StackToplevelHelper.qml
+++ b/src/treeland/quick/qml/StackToplevelHelper.qml
@@ -74,8 +74,7 @@ Item {
         value: {
             if (!surface.effectiveVisible)
                 return SurfaceItem.ManualResize
-            if (Helper.resizingItem === surface
-                    || stateTransition.running
+            if ( stateTransition.running
                     || waylandSurface.isMaximized)
                 return SurfaceItem.SizeToSurface
             return SurfaceItem.SizeFromSurface

--- a/src/treeland/quick/utils/helper.cpp
+++ b/src/treeland/quick/utils/helper.cpp
@@ -460,7 +460,7 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *watched, QInputEvent *even
 
                 if (surface->checkNewSize(geo.size().toSize())) {
                     surfaceItem->setPosition(geo.topLeft());
-                    surfaceItem->setSize(geo.size());
+                    surfaceItem->resizeSurface(geo.size().toSize());
                 }
             }
 


### PR DESCRIPTION
fix https://github.com/linuxdeepin/treeland/issues/183.
otherwise contentItem will change size before client committed so stretch.
depends on https://github.com/vioken/waylib/pull/308