### PR TITLE
Feat: spawning window layout rule

### DIFF
--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -457,6 +457,10 @@ Item {
             }
         }
 
-        Component.onCompleted: seat0.setKeyboardFocusWindow(this)
+        Component.onCompleted: {
+            QmlHelper.renderWindow = this
+            QmlHelper.cursor = cursor1
+            seat0.setKeyboardFocusWindow(this)
+        }
     }
 }

--- a/src/qml/StackWorkspace.qml
+++ b/src/qml/StackWorkspace.qml
@@ -85,6 +85,7 @@ FocusScope {
     onActivatedSurfaceItemChanged: {
         if (activatedSurfaceItem?.parent?.workspaceRelativeId !== undefined)
             currentWorkspaceId = activatedSurfaceItem.parent.workspaceRelativeId
+        QmlHelper.winposManager.updateSeq(Helper.activatedSurface.appId, activatedSurfaceItem)
     }
 
     // activated surface driven by workspace change

--- a/src/qml/StackWorkspace.qml
+++ b/src/qml/StackWorkspace.qml
@@ -175,6 +175,13 @@ FocusScope {
                     }
                 }
 
+                function move(pos) {
+                    isMoveResizing = true
+                    x = pos.x
+                    y = pos.y
+                    isMoveResizing = false
+                }
+
                 required property int workspaceId
                 // put here, otherwise may initialize late
                 parent: QmlHelper.workspaceManager.workspacesById.get(workspaceId)
@@ -197,11 +204,9 @@ FocusScope {
                         outputCounter++
 
                         if (outputCounter == 1) {
+                            const pos = QmlHelper.winposManager.nextPos(waylandSurface.appId, toplevelSurfaceItem.parent, toplevelSurfaceItem)
                             let outputDelegate = output.OutputItem.item
-                            toplevelSurfaceItem.x = outputDelegate.x
-                                    + (outputDelegate.width - toplevelSurfaceItem.width) / 2
-                            toplevelSurfaceItem.y = outputDelegate.y
-                                    + (outputDelegate.height - toplevelSurfaceItem.height) / 2
+                            toplevelSurfaceItem.move(pos)
 
                             if (Helper.clientName(waylandSurface.surface) === "dde-desktop") {
                                 toplevelSurfaceItem.x = outputDelegate.x
@@ -220,6 +225,11 @@ FocusScope {
                         waylandSurface.surface.leaveOutput(output)
                         Helper.onSurfaceLeaveOutput(waylandSurface, toplevelSurfaceItem, output)
                         outputCounter--
+                        
+                        if (outputCounter == 0) {
+                            const pos = QmlHelper.winposManager.nextPos(waylandSurface.appId, toplevelSurfaceItem.parent, toplevelSurfaceItem)
+                            toplevelSurfaceItem.move(pos)
+                        }
                     }
                 }
 
@@ -416,6 +426,12 @@ FocusScope {
                             ? XWaylandSurfaceItem.PositionToSurface
                             : XWaylandSurfaceItem.PositionFromSurface
                 }
+                function move(pos) {
+                    isMoveResizing = true
+                    x = pos.x
+                    y = pos.y
+                    isMoveResizing = false
+                }
 
                 topPadding: decoration.enable ? decoration.topMargin : 0
                 bottomPadding: decoration.enable ? decoration.bottomMargin : 0
@@ -466,10 +482,8 @@ FocusScope {
                                 xwaylandSurfaceItem.waylandSurface.windowTypes === XWaylandSurface.NET_WM_WINDOW_TYPE_NORMAL) {
                             let outputDelegate = output.OutputItem.item
                             forcePositionToSurface = true
-                            xwaylandSurfaceItem.x = outputDelegate.x
-                                   + (outputDelegate.width - xwaylandSurfaceItem.width) / 2
-                            xwaylandSurfaceItem.y = outputDelegate.y
-                                   + (outputDelegate.height - xwaylandSurfaceItem.height) / 2
+                            const pos = QmlHelper.winposManager.nextPos(`xwayland_${waylandSurface.appId}`, xwaylandSurfaceItem.parent, xwaylandSurfaceItem)
+                            xwaylandSurfaceItem.move(pos)
                             forcePositionToSurface = false
                         }
                     }
@@ -478,6 +492,9 @@ FocusScope {
                             xwaylandSurfaceItem.waylandSurface.surface.leaveOutput(output);
                         Helper.onSurfaceLeaveOutput(waylandSurface, xwaylandSurfaceItem, output)
                         outputCounter--
+                        if (outputCounter == 0 &&
+                            xwaylandSurfaceItem.waylandSurface.windowTypes === XWaylandSurface.NET_WM_WINDOW_TYPE_NORMAL)
+                            xwaylandSurfaceItem.move(QmlHelper.winposManager.nextPos(`xwayland_${waylandSurface.appId}`, xwaylandSurfaceItem.parent, xwaylandSurfaceItem))
                     }
                 }
 

--- a/src/qml/StackWorkspace.qml
+++ b/src/qml/StackWorkspace.qml
@@ -242,6 +242,8 @@ FocusScope {
                     decoration: decoration
                 }
 
+                property bool isMoveResizing: Helper.resizingItem == toplevelSurfaceItem || Helper.movingItem == toplevelSurfaceItem
+                
                 states: [
                     State {
                         name: "maximize"
@@ -486,6 +488,8 @@ FocusScope {
                     creator: xwaylandComponent
                     decoration: decoration
                 }
+
+                property bool isMoveResizing: Helper.resizingItem == xwaylandSurfaceItem || Helper.movingItem == xwaylandSurfaceItem
 
                 states: [
                     State {

--- a/src/qml/WindowDecoration.qml
+++ b/src/qml/WindowDecoration.qml
@@ -128,7 +128,12 @@ D.RoundRectangle {
         DragHandler {
             enabled: moveable
             target: root.parent
-            onActiveChanged: if (active) Helper.activatedSurface = surface
+            onActiveChanged: if (active) {
+                Helper.activatedSurface = surface
+                Helper.movingItem = root.parent
+            } else {
+                Helper.movingItem = null
+            }
             cursorShape: active ? Qt.DragMoveCursor : Qt.ArrowCursor
         }
 

--- a/src/utils/helper.h
+++ b/src/utils/helper.h
@@ -36,7 +36,7 @@ class Helper : public WSeatEventFilter
     Q_OBJECT
     Q_PROPERTY(WToplevelSurface* activatedSurface READ activatedSurface WRITE setActivateSurface NOTIFY activatedSurfaceChanged FINAL)
     Q_PROPERTY(WSurfaceItem* resizingItem READ resizingItem NOTIFY resizingItemChanged FINAL)
-    Q_PROPERTY(WSurfaceItem *movingItem READ movingItem NOTIFY movingItemChanged FINAL)
+    Q_PROPERTY(WSurfaceItem *movingItem READ movingItem WRITE setMovingItem NOTIFY movingItemChanged FINAL)
     Q_PROPERTY(QString socketFile READ socketFile WRITE setSocketFile NOTIFY socketFileChanged FINAL)
     Q_PROPERTY(QString currentUser READ currentUser WRITE setCurrentUser FINAL)
     Q_PROPERTY(bool switcherOn MEMBER m_switcherOn NOTIFY switcherOnChanged FINAL)


### PR DESCRIPTION
-  initial win pos
  - follow cursor's output
  - policies
    - start from cursor pos, stacking following down-right line
    - center then scatter at corners
  - [x] TODO: XWayland surface item lacks class or id