### PR TITLE
fix: cursor display abnormality

### DIFF
--- a/src/treeland/quick/qml/Main.qml
+++ b/src/treeland/quick/qml/Main.qml
@@ -39,9 +39,6 @@ Item {
             id: backend
 
             onOutputAdded: function(output) {
-                if (!backend.hasDrm)
-                    output.forceSoftwareCursor = true // Test
-
                 Helper.allowNonDrmOutputAutoChangeMode(output)
                 QmlHelper.outputManager.add({waylandOutput: output})
                 outputManagerV1.newOutput(output)


### PR DESCRIPTION
when there is no drm, the cursor is the native
Xorg or Wayland compositor rendering display.

Log: fixed rendering one more cursor
Issue: https://github.com/linuxdeepin/treeland/issues/265