### PR TITLE
Winlayout restore on output changes

### DIFF
--- a/src/qml/StackToplevelHelper.qml
+++ b/src/qml/StackToplevelHelper.qml
@@ -30,6 +30,7 @@ Item {
     property bool isFullScreen: waylandSurface && waylandSurface.isFullScreen && outputCoordMapper
     property bool showCloseAnimation: false
     property bool showNewAnimation: true
+    onIsMaximizeChanged: console.log(`${surface} isMaximize changed, ${waylandSurface.isMaximized}, ${outputCoordMapper}`)
 
     // For Maximize
     property rect maximizeRect: outputCoordMapper ? Qt.rect(

--- a/src/qml/StackWorkspace.qml
+++ b/src/qml/StackWorkspace.qml
@@ -296,10 +296,10 @@ FocusScope {
                 }
                 function move(pos) {
                     forcePositionToSurface = true
-                    isMoveResizing = true
+                    manualMoveResizing = true
                     surfaceItem.x = pos.x
                     surfaceItem.y = pos.y
-                    isMoveResizing = false
+                    manualMoveResizing = false
                     forcePositionToSurface = false
                 }
 


### PR DESCRIPTION
Impl basic winlayout restore on output changes.
- outputs environment
  - use the set of outputs as hash-key
- state restore
  - only restore the surfaces that has a matched state
  - use intermediate state for transition animating