### PR TITLE
fix: Show desktop crash

### DIFF
--- a/src/modules/primary-output/impl/output_manager_impl.cpp
+++ b/src/modules/primary-output/impl/output_manager_impl.cpp
@@ -80,6 +80,11 @@ static treeland_output_manager_v1 *output_manager_from_resource(wl_resource *res
     return manager;
 }
 
+static void output_manager_resource_destroy(struct wl_resource *resource)
+{
+    wl_list_remove(wl_resource_get_link(resource));
+}
+
 static void output_manager_bind(wl_client *client, void *data, uint32_t version, uint32_t id)
 {
     auto *manager = static_cast<treeland_output_manager_v1 *>(data);
@@ -90,7 +95,11 @@ static void output_manager_bind(wl_client *client, void *data, uint32_t version,
         wl_client_post_no_memory(client);
         return;
     }
-    wl_resource_set_implementation(resource, &output_manager_impl, manager, nullptr);
+
+    wl_resource_set_implementation(resource,
+                                   &output_manager_impl,
+                                   manager,
+                                   output_manager_resource_destroy);
     wl_list_insert(&manager->resources, wl_resource_get_link(resource));
 
     treeland_output_manager_v1_send_primary_output(resource, manager->primary_output_name);

--- a/src/modules/window-management/impl/window_management_impl.cpp
+++ b/src/modules/window-management/impl/window_management_impl.cpp
@@ -80,6 +80,11 @@ static treeland_window_management_v1 *treeland_window_management_from_resource(w
     return manager;
 }
 
+static void treeland_window_management_resource_destroy(struct wl_resource *resource)
+{
+    wl_list_remove(wl_resource_get_link(resource));
+}
+
 static void treeland_window_management_bind(wl_client *client, void *data, uint32_t version, uint32_t id)
 {
     auto *manager = static_cast<treeland_window_management_v1 *>(data);
@@ -90,7 +95,11 @@ static void treeland_window_management_bind(wl_client *client, void *data, uint3
         wl_client_post_no_memory(client);
         return;
     }
-    wl_resource_set_implementation(resource, &window_management_impl, manager, nullptr);
+
+    wl_resource_set_implementation(resource,
+                                   &window_management_impl,
+                                   manager,
+                                   treeland_window_management_resource_destroy);
     wl_list_insert(&manager->resources, wl_resource_get_link(resource));
 
     treeland_window_management_v1_send_show_desktop(resource, manager->state);


### PR DESCRIPTION
The failure of wl_resource_set_implementation to destroy results in a request crash on the client.