### PR TITLE
fix: item focus not auto select

### DIFF
--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -28,7 +28,7 @@ Item {
     Binding {
         target: Helper.seat
         property: "keyboardFocus"
-        value: Helper.getFocusSurfaceFrom(renderWindow.activeFocusItem)
+        value: Helper.activatedSurface?.surface || null
     }
 
     OutputRenderWindow {
@@ -51,17 +51,9 @@ Item {
         }
 
         onActiveFocusItemChanged: {
-            // in case unexpected behavior happens
+            // Focus does not return to the workspace when a popup is closed from within QML
             if (activeFocusItem === renderWindow.contentItem) {
-                console.warn('focusOnroot')
-                // manually pick one child to focus
-                for(let item of renderWindow.contentItem.children) {
-                    if (item.focus) {
-                        item.forceActiveFocus()
-                        return
-                    }
-                }
-                console.exception('no active focus !!!')
+                workspaceLoader.forceActiveFocus()
             }
         }
 

--- a/src/qml/StackWorkspace.qml
+++ b/src/qml/StackWorkspace.qml
@@ -108,6 +108,7 @@ FocusScope {
             model: workspaceManager.layoutOrder
             anchors.fill: parent
             delegate: ToplevelContainer {
+                id: container
                 objectName: `ToplevelContainer ${wsid}`
                 required property int index
                 required property int wsid
@@ -120,6 +121,34 @@ FocusScope {
                 Component.onCompleted: {
                     workspaceManager.workspacesById.set(workspaceId, this)
                 }
+
+                Connections {
+                    target: Helper
+                    function onActivatedSurfaceChanged() {
+                        // FIXME:When the layershell is closed, the focus cannot
+                        //       be returned to the workspace. because the two are parallel layers.
+                        if (!Helper.activatedSurface && container.visible) {
+                            container.forceActiveFocus()
+                        }
+                    }
+                }
+            }
+        }
+
+        DynamicCreatorComponent {
+            id: layerComponent
+            creator: Helper.layerShellCreator
+            autoDestroy: false
+
+            onObjectRemoved: function (obj) {
+                obj.doDestroy()
+            }
+
+            LayerSurface {
+                id: layerSurface
+                creator: layerComponent
+                activeOutputItem: activeOutputDelegate
+                focus: Helper.activatedSurface === this.waylandSurface
             }
         }
 
@@ -327,23 +356,6 @@ FocusScope {
                 }
 
             }
-        }
-    }
-
-    DynamicCreatorComponent {
-        id: layerComponent
-        creator: Helper.layerShellCreator
-        autoDestroy: false
-
-        onObjectRemoved: function (obj) {
-            obj.doDestroy()
-        }
-
-        LayerSurface {
-            id: layerSurface
-            creator: layerComponent
-            activeOutputItem: activeOutputDelegate
-            focus: Helper.activatedSurface === this.waylandSurface
         }
     }
 

--- a/src/utils/helper.cpp
+++ b/src/utils/helper.cpp
@@ -615,7 +615,8 @@ std::pair<WOutput *, OutputInfo *> Helper::getFirstOutputOfSurface(WToplevelSurf
     return std::make_pair(nullptr, nullptr);
 }
 
-bool Helper::selectSurfaceToActivate(WToplevelSurface *surface) const {
+bool Helper::selectSurfaceToActivate(WToplevelSurface *surface) const
+{
     if (!surface) {
         return false;
     }
@@ -895,7 +896,7 @@ WToplevelSurface *Helper::activatedSurface() const
 
 void Helper::setActivateSurface(WToplevelSurface *newActivate)
 {
-    qDebug() << "setActivateSurf" << newActivate;
+    qCDebug(HelperDebugLog) << newActivate;
     if (newActivate) {
         wl_client *client = newActivate->surface()->handle()->handle()->resource->client;
         pid_t pid;
@@ -921,8 +922,10 @@ void Helper::setActivateSurface(WToplevelSurface *newActivate)
     if (newActivate && newActivate->doesNotAcceptFocus())
         return;
 
-    if (m_activateSurface) {
+    if (m_activateSurface && m_activateSurface->isActivated()) {
         if (newActivate) {
+            qCDebug(HelperDebugLog)
+                << "newActivate keyboardFocusPriority " << newActivate->keyboardFocusPriority();
             if (m_activateSurface->keyboardFocusPriority() > newActivate->keyboardFocusPriority())
                 return;
         } else {
@@ -931,10 +934,14 @@ void Helper::setActivateSurface(WToplevelSurface *newActivate)
         }
         m_activateSurface->setActivate(false);
     }
-    m_activateSurface = newActivate;
 
     static QMetaObject::Connection invalidCheck;
     disconnect(invalidCheck);
+
+    m_activateSurface = newActivate;
+
+    qCDebug(HelperDebugLog) << "Surface: " << newActivate << " is activated";
+
     invalidCheck =
         connect(newActivate, &WToplevelSurface::aboutToBeInvalidated, this, [newActivate, this] {
             newActivate->setActivate(false);


### PR DESCRIPTION
The focus can only be updated between the upper and lower levels, but the layershell is not managed by the workspace, so we need to manually update the status.

When using qml popup, the focus will return to the root window and need to be manually updated to the workspace.

Log: