### PR TITLE
Fix can't start on VirtualBox

### DIFF
--- a/debian/treeland.install
+++ b/debian/treeland.install
@@ -1,4 +1,5 @@
 usr/bin/treeland
+usr/bin/treeland.sh
 usr/lib/systemd/user/*
 usr/lib/systemd/system/*
 usr/libexec/*

--- a/misc/systemd/treeland.service.in
+++ b/misc/systemd/treeland.service.in
@@ -11,6 +11,6 @@ After=seatd.service
 User=dde
 Environment=LIBSEAT_BACKEND=seatd
 Environment=DSG_APP_ID=org.deepin.dde.treeland
-ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/treeland --lockscreen
+ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/treeland.sh --lockscreen
 Restart=on-failure
 RestartSec=1s

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -305,6 +305,7 @@ target_link_libraries(${BIN_NAME} PRIVATE
 )
 
 install(TARGETS ${BIN_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+install(PROGRAMS treeland.sh DESTINATION "${CMAKE_INSTALL_BINDIR}")
 install(TARGETS libtreeland LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 # TODO: The qml plugin installation directory still needs to be adjusted
 install(DIRECTORY ${PROJECT_BINARY_DIR}/qt/qml/Treeland DESTINATION "${TREELAND_DATA_DIR}/qml/Treeland")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,8 @@ int main(int argc, char *argv[])
     CmdLine::ref();
 
     WRenderHelper::setupRendererBackend();
+    if (CmdLine::ref().tryExec())
+        return 0;
     Q_ASSERT(qw_buffer::get_objects().isEmpty());
 
     Treeland::Treeland treeland;

--- a/src/treeland.sh
+++ b/src/treeland.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+script_path=$(realpath $(dirname "$0"))
+cmd="$script_path/treeland $@"
+output=$($cmd --try-exec 2>&1)
+exit_code=$?
+
+if [ $exit_code -ne 0 ] && echo "$output" | grep -q "failed to create dri2 screen"; then
+    # In VirtualBox, if 3D acceleration is not enabled, calling `eglInitialize` will cause
+    # the program to crash. Therefore, a preliminary check is performed here: if `treeland`
+    # fails to exit normally, it falls back to pixman renderer mode.
+    export WLR_RENDERER=pixman
+    echo "Treeland crash, try fallback to software renderer."
+fi
+
+$cmd

--- a/src/utils/cmdline.cpp
+++ b/src/utils/cmdline.cpp
@@ -19,9 +19,10 @@ CmdLine::CmdLine()
     , m_run(std::make_unique<QCommandLineOption>(QStringList{ "r", "run" }, "run a process", "run"))
     , m_lockScreen(std::make_unique<QCommandLineOption>("lockscreen",
                                                         "use lockscreen, need DDM auth socket"))
+    , m_tryExec("try-exec", "Only try exec, don't show on screen")
 {
     m_parser->addHelpOption();
-    m_parser->addOptions({ *m_run.get(), *m_lockScreen.get() });
+    m_parser->addOptions({ *m_run.get(), *m_lockScreen.get(), m_tryExec });
     m_parser->process(*QCoreApplication::instance());
 }
 
@@ -118,6 +119,11 @@ std::optional<QStringList> CmdLine::unescapeExecArgs(const QString &str) noexcep
     }
 
     return execList;
+}
+
+bool CmdLine::tryExec() const
+{
+    return m_parser->isSet(m_tryExec);
 }
 
 std::optional<QString> CmdLine::run() const

--- a/src/utils/cmdline.h
+++ b/src/utils/cmdline.h
@@ -4,13 +4,13 @@
 #include <DSingleton>
 
 #include <QObject>
+#include <QCommandLineOption>
 
 #include <memory>
 #include <optional>
 
 class QCoreApplication;
 class QCommandLineParser;
-class QCommandLineOption;
 
 DCORE_USE_NAMESPACE
 
@@ -25,6 +25,7 @@ public:
     std::optional<QString> run() const;
     bool useLockScreen() const;
     std::optional<QStringList> unescapeExecArgs(const QString &str) noexcept;
+    bool tryExec() const;
 
 private:
     CmdLine();
@@ -35,4 +36,5 @@ private:
     std::unique_ptr<QCommandLineParser> m_parser;
     std::unique_ptr<QCommandLineOption> m_run;
     std::unique_ptr<QCommandLineOption> m_lockScreen;
+    QCommandLineOption m_tryExec;
 };


### PR DESCRIPTION
This is a workaround.
On the VirtualBox no 3D accelerate, eglInitialize will crash.

Depends https://github.com/vioken/waylib/pull/615