### PR TITLE
fix: can't load plugin in debug build

### DIFF
--- a/src/core/treeland.cpp
+++ b/src/core/treeland.cpp
@@ -310,7 +310,14 @@ Treeland::Treeland()
     QDBusConnection::sessionBus().registerObject("/org/deepin/Compositor1", this);
 
 #ifdef QT_DEBUG
-    d->loadPlugin(QStringLiteral(TREELAND_PLUGINS_OUTPUT_PATH));
+    QDir dir(QStringLiteral(TREELAND_PLUGINS_OUTPUT_PATH));
+    if (dir.exists() && dir.isReadable()) {
+        d->loadPlugin(QStringLiteral(TREELAND_PLUGINS_OUTPUT_PATH));
+    } else {
+        qInfo() << "The Treeland plugin build directory is inaccessible, failback to the "
+                   "installation directory";
+        d->loadPlugin(QStringLiteral(TREELAND_PLUGINS_INSTALL_PATH));
+    }
 #else
     d->loadPlugin(QStringLiteral(TREELAND_PLUGINS_INSTALL_PATH));
 #endif


### PR DESCRIPTION
Log: ddm is started as user dde and cannot access other users' home directories
Fix: https://github.com/linuxdeepin/treeland/issues/388