### PR TITLE
feat: supports enable debug menu bar view on runtime

### DIFF
--- a/src/output/output.h
+++ b/src/output/output.h
@@ -74,9 +74,7 @@ public:
     QRectF validGeometry() const;
     WOutputViewport *screenViewport() const;
     void updatePositionFromLayout();
-#ifdef QT_DEBUG
-    QQuickItem *outputMenuBar() const;
-#endif
+    QQuickItem *debugMenuBar() const;
 
     static double calcPreferredScale(double widthPx,
                                      double heightPx,
@@ -132,9 +130,7 @@ private:
     Output *m_proxy = nullptr;
     SurfaceFilterModel *minimizedSurfaces;
     QPointer<QQuickItem> m_taskBar;
-#ifdef QT_DEBUG
-    QPointer<QQuickItem> m_menuBar;
-#endif
+    QPointer<QQuickItem> m_debugMenuBar;
     WOutputViewport *m_outputViewport = nullptr;
 
     QMargins m_exclusiveZone;

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -171,7 +171,7 @@ public:
 
     WSeat *seat() const;
 
-    void toggleOutputMenuBar(bool show);
+    bool toggleDebugMenuBar();
 
     QString cursorTheme() const;
     QSize cursorSize() const;

--- a/src/utils/cmdline.cpp
+++ b/src/utils/cmdline.cpp
@@ -20,9 +20,10 @@ CmdLine::CmdLine()
     , m_lockScreen(std::make_unique<QCommandLineOption>("lockscreen",
                                                         "use lockscreen, need DDM auth socket"))
     , m_tryExec("try-exec", "Only try exec, don't show on screen")
+    , m_disableDebugView("disable-debug-view", "Disable debug view")
 {
     m_parser->addHelpOption();
-    m_parser->addOptions({ *m_run.get(), *m_lockScreen.get(), m_tryExec });
+    m_parser->addOptions({ *m_run.get(), *m_lockScreen.get(), m_tryExec, m_disableDebugView});
     m_parser->process(*QCoreApplication::instance());
 }
 
@@ -124,6 +125,11 @@ std::optional<QStringList> CmdLine::unescapeExecArgs(const QString &str) noexcep
 bool CmdLine::tryExec() const
 {
     return m_parser->isSet(m_tryExec);
+}
+
+bool CmdLine::disableDebugView() const
+{
+    return m_parser->isSet(m_disableDebugView);
 }
 
 std::optional<QString> CmdLine::run() const

--- a/src/utils/cmdline.h
+++ b/src/utils/cmdline.h
@@ -26,6 +26,7 @@ public:
     bool useLockScreen() const;
     std::optional<QStringList> unescapeExecArgs(const QString &str) noexcept;
     bool tryExec() const;
+    bool disableDebugView() const;
 
 private:
     CmdLine();
@@ -37,4 +38,5 @@ private:
     std::unique_ptr<QCommandLineOption> m_run;
     std::unique_ptr<QCommandLineOption> m_lockScreen;
     QCommandLineOption m_tryExec;
+    QCommandLineOption m_disableDebugView;
 };


### PR DESCRIPTION
Add shortcut Ctrl+Shift+Meta+F11 to toggle the debug view. If you wnat to disable the shortcut, please with --disable-debug-view to start treeland.

## Summary by Sourcery

Adds the ability to toggle the debug menu bar at runtime using a keyboard shortcut and a command-line option to disable it.

New Features:
- Adds a debug menu bar that can be toggled at runtime using the shortcut Ctrl+Shift+Meta+F11.
- Adds a command-line option `--disable-debug-view` to disable the debug view.