### PR TITLE
chore(debian): bump version to 0.5.20

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+treeland (0.5.20) unstable; urgency=medium
+
+  * fix: activeColor not saved to dconfig
+  * fix: send error output enter for layer shell
+  * chore: input popup should not use radius
+
+ -- rewine <luhongxu@deepin.org>  Mon, 10 Mar 2025 16:20:35 +0800
+
 treeland (0.5.19) unstable; urgency=medium
 
   * fix: can't set output's postion


### PR DESCRIPTION
Log: bump version to 0.5.17

## Summary by Sourcery

Chores:
- Bump the Debian package version to 0.5.20 in the changelog.