### PR TITLE
chore(debian): update version to 0.5.21

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+treeland (0.5.21) unstable; urgency=medium
+
+  * fix: inputted password and capsIndicator button are covered
+
+ -- rewine <luhongxu@deepin.org>  Thu, 17 Apr 2025 15:17:48 +0800
+
 treeland (0.5.20) unstable; urgency=medium
 
   * fix: activeColor not saved to dconfig


### PR DESCRIPTION
Log: update version

## Summary by Sourcery

Chores:
- Bump the Debian package version number to 0.5.21 in the changelog