### PR TITLE
refactor: remove jemalloc dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,7 +28,6 @@ Build-Depends: cmake (>= 3.4~),
                wlr-protocols,
                treeland-protocols,
                libpam0g-dev,
-               libjemalloc-dev,
 Standards-Version: 4.6.0
 Section: dde
 Homepage: https://github.com/linuxdeepin/treeland.git

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -25,7 +25,6 @@
   pam,
   libxcrypt,
   libinput,
-  jemalloc,
   nixos-artwork,
 }:
 
@@ -83,7 +82,6 @@ stdenv.mkDerivation (finalAttrs: {
     pam
     libxcrypt
     libinput
-    jemalloc
   ];
 
   cmakeFlags = [

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,6 @@ pkg_search_module(WAYLAND REQUIRED IMPORTED_TARGET wayland-server)
 pkg_search_module(LIBINPUT REQUIRED IMPORTED_TARGET libinput)
 pkg_search_module(XCB REQUIRED IMPORTED_TARGET xcb)
 pkg_check_modules(PAM REQUIRED IMPORTED_TARGET pam)
-pkg_check_modules(JEMALLOC REQUIRED IMPORTED_TARGET jemalloc)
 # qt_finalize_target will collect all executable's private dependencies that are CMake targets
 
 qt_add_dbus_adaptor(DBUS_ADAPTOR "${CMAKE_SOURCE_DIR}/misc/dbus/org.deepin.compositor1.xml" "core/treeland.h" Treeland::Treeland)
@@ -279,7 +278,6 @@ target_link_libraries(libtreeland
         PkgConfig::PIXMAN
         PkgConfig::WAYLAND
         PkgConfig::LIBINPUT
-        PkgConfig::JEMALLOC
         $<$<NOT:$<BOOL:${DISABLE_DDM}>>:DDM::Auth>
         $<$<NOT:$<BOOL:${DISABLE_DDM}>>:DDM::Common>
         $<$<NOT:$<BOOL:${DISABLE_DDM}>>:PkgConfig::PAM>


### PR DESCRIPTION
1. Removed jemalloc from the build dependencies in debian/control
2. Eliminated jemalloc reference in nix/default.nix
3. Deleted pkg_check_modules(JEMALLOC) call in src/CMakeLists.txt
4. Removed PkgConfig::JEMALLOC from target_link_libraries in src/ CMakeLists.txt
5. This change simplifies the build process and reduces external dependencies

重构：移除jemalloc依赖

1. 从debian/control中删除jemalloc的构建依赖
2. 在nix/default.nix中消除对jemalloc的引用
3. 删除src/CMakeLists.txt中的pkg_check_modules(JEMALLOC)调用
4. 从src/CMakeLists.txt的target_link_libraries中移除PkgConfig::JEMALLOC
5. 此更改简化了构建过程并减少了外部依赖项

## Summary by Sourcery

Remove jemalloc dependency and simplify the build process by dropping all references to jemalloc in Debian, Nix, and CMake configurations.

Build:
- Remove jemalloc from debian/control build dependencies
- Eliminate jemalloc reference in nix/default.nix
- Delete pkg_check_modules(JEMALLOC) and target_link_libraries reference in CMakeLists.txt