### PR TITLE
fix: various compiler warnings

### DIFF
--- a/src/config/treelandconfig.h
+++ b/src/config/treelandconfig.h
@@ -205,10 +205,10 @@ private:
     uint32_t m_windowTitlebarHeight;
     QString m_cursorThemeName;
     QSize m_cursorSize;
+    qreal m_windowRadius;
     QString m_fontName;
     QString m_monoFontName;
     uint32_t m_fontSize;
-    qreal m_windowRadius;
     QString m_iconThemeName;
     QString m_defaultBackground;
 

--- a/src/modules/capture/capture.cpp
+++ b/src/modules/capture/capture.cpp
@@ -931,7 +931,7 @@ void CaptureSource::copyBuffer(qw_buffer *buffer)
     size_t stride;
     void *data;
     buffer->begin_data_ptr_access(WLR_BUFFER_DATA_PTR_ACCESS_WRITE, &data, &format, &stride);
-    Q_ASSERT(stride == width * 4); // For QImage
+    Q_ASSERT(stride == static_cast<size_t>(width) * 4); // For QImage
     QImage img = image().copy(cropRect());
     auto bufFormat = WTools::toImageFormat(format);
     if (image().format() != bufFormat) {

--- a/src/modules/dde-shell/ddeshellmanagerinterfacev1.cpp
+++ b/src/modules/dde-shell/ddeshellmanagerinterfacev1.cpp
@@ -259,7 +259,6 @@ public:
                                     wl_resource *resource);
 
     DDEShellSurfaceInterface *q;
-
     wl_resource *surfaceResource{ nullptr };
     std::optional<QPoint> surfacePos;
     std::optional<DDEShellSurfaceInterface::Role> role;
@@ -293,9 +292,9 @@ protected:
 DDEShellSurfaceInterfacePrivate::DDEShellSurfaceInterfacePrivate(DDEShellSurfaceInterface *_q,
                                                                  wl_resource *surface,
                                                                  wl_resource *resource)
-    : QtWaylandServer::treeland_dde_shell_surface_v1(resource)
+    : q(_q)
     , surfaceResource(surface)
-    , q(_q)
+    , QtWaylandServer::treeland_dde_shell_surface_v1(resource)
 {
 }
 

--- a/src/modules/foreign-toplevel/impl/foreign_toplevel_manager_impl.h
+++ b/src/modules/foreign-toplevel/impl/foreign_toplevel_manager_impl.h
@@ -67,7 +67,6 @@ Q_SIGNALS:
     void requestClose();
 };
 
-static void toplevel_handle_output_bind(struct wl_listener *listener, void *data);
 struct treeland_foreign_toplevel_handle_v1_maximized_event;
 struct treeland_foreign_toplevel_handle_v1_minimized_event;
 struct treeland_foreign_toplevel_handle_v1_activated_event;
@@ -132,8 +131,6 @@ private:
     void update_idle_source();
     void send_state();
     void send_output(QW_NAMESPACE::qw_output *output, bool enter);
-
-    friend void toplevel_handle_output_bind(struct wl_listener *listener, void *data);
 };
 
 struct wlr_seat;

--- a/src/modules/shortcut/impl/shortcut_manager_impl.cpp
+++ b/src/modules/shortcut/impl/shortcut_manager_impl.cpp
@@ -13,7 +13,6 @@ using QW_NAMESPACE::qw_display;
 
 static void treeland_shortcut_context_v1_destroy(struct wl_resource *resource);
 static treeland_shortcut_manager_v1 *shortcut_manager_from_resource(struct wl_resource *resource);
-static treeland_shortcut_context_v1 *shortcut_context_from_resource(struct wl_resource *resource);
 
 static void treeland_shortcut_context_destroy([[maybe_unused]] struct wl_client *client,
                                               struct wl_resource *resource)
@@ -120,17 +119,6 @@ static treeland_shortcut_manager_v1 *shortcut_manager_from_resource(struct wl_re
         static_cast<treeland_shortcut_manager_v1 *>(wl_resource_get_user_data(resource));
     assert(manager != nullptr);
     return manager;
-}
-
-static treeland_shortcut_context_v1 *shortcut_context_from_resource(struct wl_resource *resource)
-{
-    assert(wl_resource_instance_of(resource,
-                                   &treeland_shortcut_context_v1_interface,
-                                   &shortcut_context_impl));
-    auto *context =
-        static_cast<treeland_shortcut_context_v1 *>(wl_resource_get_user_data(resource));
-    assert(context != nullptr);
-    return context;
 }
 
 treeland_shortcut_manager_v1::~treeland_shortcut_manager_v1()


### PR DESCRIPTION
- Adjust member initialization order in `DDEShellSurfaceInterfacePrivate`
- Use `static_cast<size_t>` for type-safe assertion in `CaptureSource::copyBuffer`
- Reorder member variables in `treelandconfig.h` to match initialization order
- Remove unused static functions and redundant friend declarations