### PR TITLE
chore: configure transifex translation files

### DIFF
--- a/.tx/transifex.yaml
+++ b/.tx/transifex.yaml
@@ -1,0 +1,23 @@
+filters:
+  - filter_type: file
+    source_file: translations/treeland.en_US.ts
+    file_format: QT
+    source_language: en_US
+    translation_files_expression: translations/treeland.<lang>.ts
+  - filter_type: file
+    source_file: src/plugins/lockscreen/translations/lockscreen.en_US.ts
+    file_format: QT
+    source_language: en_US
+    translation_files_expression: src/plugins/lockscreen/translations/lockscreen.<lang>.ts
+  - filter_type: file
+    source_file: src/plugins/multitaskview/translations/multitaskview.en_US.ts
+    file_format: QT
+    source_language: en_US
+    translation_files_expression: src/plugins/multitaskview/translations/multitaskview.<lang>.ts
+  - filter_type: file
+    source_file: examples/test_set_treeland_wallpaper/translations/wallpaper.en_US.ts
+    file_format: QT
+    source_language: en_US
+    translation_files_expression: examples/test_set_treeland_wallpaper/translations/wallpaper.<lang>.ts
+settings:
+    pr_branch_name: transifex_update_<br_unique_id>

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -3,7 +3,7 @@ SPDX-PackageName = "treeland"
 SPDX-PackageDownloadLocation = "https://github.com/linuxdeepin/treeland"
 
 [[annotations]]
-path = [".github/**", ".obs/**.yml", "garnix.yaml"]
+path = [".github/**", ".obs/**.yml", "garnix.yaml", ".tx/*"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "None"
 SPDX-License-Identifier = "CC0-1.0"


### PR DESCRIPTION
1. Create configuration for Transifex localization workflow
2. Add four translation file filters for different modules:
   - Main treeland translations
   - Lockscreen plugin translations
   - Multitaskview plugin translations
   - Wallpaper example translations
3. Set up QT file format with proper source and target paths
4. Configure PR branch naming pattern for automated updates

chore: 配置 Transifex 翻译文件

1. 创建 Transifex 本地化工作流配置
2. 添加四个翻译文件过滤器，分别对应不同模块：
   - 主程序 treeland 的翻译
   - 锁屏插件 lockscreen 的翻译
   - 多任务视图插件 multitaskview 的翻译
   - 壁纸示例 wallpaper 的翻译
3. 设置 QT 文件格式及对应的源文件和目标路径
4. 配置用于自动化更新的 PR 分支命名规则

## Summary by Sourcery

Configure the Transifex localization workflow by adding a .tx/transifex.yaml file with QT translation file filters for core and plugin modules and setting up automated PR branch naming for updates.

Enhancements:
- Add file filters for Treeland, lockscreen, multitaskview, and wallpaper translation modules

CI:
- Configure PR branch naming pattern for automated Transifex updates

Chores:
- Initialize Transifex localization workflow configuration in .tx/transifex.yaml