### PR TITLE
chore: configure translation files and update Chinese translations

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,26 @@
+[main]
+host = https://www.transifex.com
+
+[o:linuxdeepin:p:treeland:r:f56f82288bfe7a231b1be25f7b0cb008]
+file_filter = translations/treeland.<lang>.ts
+source_file = translations/treeland.en_US.ts
+source_lang = en_US
+type = QT
+
+[o:linuxdeepin:p:treeland:r:b675317802ed042606e0660179b6b04f]
+file_filter = src/plugins/lockscreen/translations/lockscreen.<lang>.ts
+source_file = src/plugins/lockscreen/translations/lockscreen.en_US.ts
+source_lang = en_US
+type = QT
+
+[o:linuxdeepin:p:treeland:r:7309e9da01b4b7fbf5c2ac9c2a2d23a6]
+file_filter = src/plugins/multitaskview/translations/multitaskview.<lang>.ts
+source_file = src/plugins/multitaskview/translations/multitaskview.en_US.ts
+source_lang = en_US
+type = QT
+
+[o:linuxdeepin:p:treeland:r:1eff66bc82bf8f288b9c56e8c724ea20]
+file_filter = examples/test_set_treeland_wallpaper/translations/wallpaper.<lang>.ts
+source_file = examples/test_set_treeland_wallpaper/translations/wallpaper.en_US.ts
+source_lang = en_US
+type = QT

--- a/examples/test_set_treeland_wallpaper/translations/wallpaper.zh_CN.ts
+++ b/examples/test_set_treeland_wallpaper/translations/wallpaper.zh_CN.ts
@@ -54,7 +54,7 @@
     <message>
         <location filename="../WallpaperSetting.qml" line="111"/>
         <source>Please choose a file</source>
-        <translation type="unfinished">请选择文件</translation>
+        <translation>请选择文件</translation>
     </message>
     <message>
         <location filename="../WallpaperSetting.qml" line="126"/>
@@ -64,7 +64,7 @@
     <message>
         <location filename="../WallpaperSetting.qml" line="135"/>
         <source>Add Directory</source>
-        <translation type="unfinished">添加目录</translation>
+        <translation>添加目录</translation>
     </message>
 </context>
 <context>

--- a/src/plugins/lockscreen/translations/lockscreen.zh_CN.ts
+++ b/src/plugins/lockscreen/translations/lockscreen.zh_CN.ts
@@ -37,7 +37,7 @@
     <message>
         <location filename="../qml/ControlAction.qml" line="55"/>
         <source>Power</source>
-        <translation type="unfinished">电源</translation>
+        <translation>电源</translation>
     </message>
     <message>
         <source>lock</source>
@@ -64,7 +64,7 @@
     <message>
         <location filename="../qml/LockView.qml" line="176"/>
         <source>Password is incorrect.</source>
-        <translation type="unfinished">密码错误</translation>
+        <translation>密码错误</translation>
     </message>
 </context>
 <context>
@@ -106,17 +106,17 @@
     <message>
         <location filename="../qml/ShutdownView.qml" line="32"/>
         <source>lock</source>
-        <translation type="unfinished">锁定</translation>
+        <translation>锁定</translation>
     </message>
     <message>
         <location filename="../qml/ShutdownView.qml" line="37"/>
         <source>switch user</source>
-        <translation type="unfinished">切换帐户</translation>
+        <translation>切换帐户</translation>
     </message>
     <message>
         <location filename="../qml/ShutdownView.qml" line="43"/>
         <source>Logout</source>
-        <translation type="unfinished">注销</translation>
+        <translation>注销</translation>
     </message>
 </context>
 <context>
@@ -140,7 +140,7 @@
     <message>
         <location filename="../qml/UserInput.qml" line="141"/>
         <source>Password</source>
-        <translation type="unfinished">密码</translation>
+        <translation>密码</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
1. Add .tx/config file to set up Transifex translation management with multiple resource configurations for different components
2. Update Simplified Chinese translations in wallpaper plugin by removing 'type="unfinished"' from several entries
3. Update Simplified Chinese translations in lockscreen plugin by removing 'type="unfinished"' from multiple translation tags

These changes improve translation management workflow through proper Transifex configuration and ensure the Chinese translations are marked as completed rather than unfinished.

chore: 配置翻译文件并更新中文翻译

1. 添加 .tx/config 文件，配置多个组件的 Transifex 翻译资源管理
2. 在壁纸插件中更新简体中文翻译，移除多个条目中的 'type="unfinished"'
3. 在锁屏插件中更新简体中文翻译，移除多个标签中的 'type="unfinished"'

这些更改通过正确的 Transifex 配置改进了翻译管理工作流程，并确保中文翻译
标记为已完成状态而非未完成状态。