### PR TITLE
feat: add popup surface container for handling popup windows

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -3,6 +3,7 @@
   lib,
   nix-filter,
   cmake,
+  ninja,
   extra-cmake-modules,
   pkg-config,
   wayland-scanner,
@@ -56,6 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
+    ninja
     extra-cmake-modules
     pkg-config
     wayland-scanner

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,6 +79,8 @@ qt_add_qml_module(libtreeland
         config/treelandconfig.h
         core/layersurfacecontainer.cpp
         core/layersurfacecontainer.h
+        core/popupsurfacecontainer.cpp
+        core/popupsurfacecontainer.h
         core/qmlengine.cpp
         core/qmlengine.h
         core/rootsurfacecontainer.cpp

--- a/src/core/popupsurfacecontainer.cpp
+++ b/src/core/popupsurfacecontainer.cpp
@@ -1,0 +1,49 @@
+// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "popupsurfacecontainer.h"
+
+#include "surface/surfacewrapper.h"
+
+#include <QLoggingCategory>
+
+Q_LOGGING_CATEGORY(qLcPopupContainer, "treeland.shell.popupContainer")
+
+PopupSurfaceContainer::PopupSurfaceContainer(SurfaceContainer *parent)
+    : SurfaceContainer(parent)
+{
+    setAcceptedMouseButtons(Qt::AllButtons);
+}
+
+void PopupSurfaceContainer::mousePressEvent(QMouseEvent *event)
+{
+    // Filter surfaces to only include XdgPopup type surfaces
+    QList<SurfaceWrapper *> xdgPopupSurfaces;
+    for (auto surface : std::as_const(surfaces())) {
+        if (surface->type() == SurfaceWrapper::Type::XdgPopup) {
+            xdgPopupSurfaces.append(surface);
+        }
+    }
+
+    if (!xdgPopupSurfaces.isEmpty()) {
+        qCDebug(qLcPopupContainer) << "Intercepting mouse press event due to active popup surfaces";
+        // If surfaces are not empty, intercept the mouse press event to prevent it from reaching
+        // lower z-index components
+        event->accept();
+        // Get all surfaces in this container and close them
+        for (auto surface : xdgPopupSurfaces) {
+            // Maybe the surface is removed by it's parent surface
+            if (!surfaces().contains(surface)) {
+                continue;
+            }
+            if (!surface->shellSurface()) {
+                qCCritical(qLcPopupContainer) << "Ignore invalid popup surface:" << surface;
+                continue;
+            }
+            surface->requestClose();
+        }
+        return;
+    }
+
+    SurfaceContainer::mousePressEvent(event);
+}

--- a/src/core/popupsurfacecontainer.h
+++ b/src/core/popupsurfacecontainer.h
@@ -1,0 +1,19 @@
+// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include "surface/surfacecontainer.h"
+
+#include <QMouseEvent>
+
+class PopupSurfaceContainer : public SurfaceContainer
+{
+    Q_OBJECT
+
+public:
+    explicit PopupSurfaceContainer(SurfaceContainer *parent = nullptr);
+
+protected:
+    void mousePressEvent(QMouseEvent *event) override;
+};

--- a/src/core/qml/WindowMenu.qml
+++ b/src/core/qml/WindowMenu.qml
@@ -7,6 +7,7 @@ import org.deepin.dtk 1.0 as D
 
 D.Menu {
     id: menu
+    modal: true
 
     property SurfaceWrapper surface: null
 

--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -4,6 +4,7 @@
 #include "shellhandler.h"
 
 #include "core/qmlengine.h"
+#include "popupsurfacecontainer.h"
 #include "layersurfacecontainer.h"
 #include "modules/dde-shell/ddeshellmanagerinterfacev1.h"
 #include "rootsurfacecontainer.h"
@@ -43,7 +44,7 @@ ShellHandler::ShellHandler(RootSurfaceContainer *rootContainer)
     , m_workspace(new Workspace(rootContainer))
     , m_topContainer(new LayerSurfaceContainer(rootContainer))
     , m_overlayContainer(new LayerSurfaceContainer(rootContainer))
-    , m_popupContainer(new SurfaceContainer(rootContainer))
+    , m_popupContainer(new PopupSurfaceContainer(rootContainer))
 {
     m_backgroundContainer->setZ(RootSurfaceContainer::BackgroundZOrder);
     m_bottomContainer->setZ(RootSurfaceContainer::BottomZOrder);

--- a/src/core/shellhandler.h
+++ b/src/core/shellhandler.h
@@ -16,6 +16,7 @@ class RootSurfaceContainer;
 class LayerSurfaceContainer;
 class Workspace;
 class SurfaceContainer;
+class PopupSurfaceContainer;
 class QmlEngine;
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
@@ -103,6 +104,6 @@ private:
     Workspace *m_workspace = nullptr;
     LayerSurfaceContainer *m_topContainer = nullptr;
     LayerSurfaceContainer *m_overlayContainer = nullptr;
-    SurfaceContainer *m_popupContainer = nullptr;
+    PopupSurfaceContainer *m_popupContainer = nullptr;
     QObject *m_windowMenu = nullptr;
 };


### PR DESCRIPTION
1. Added ninja build tool to nativeBuildInputs in nix/default.nix to support faster builds
2. Added popupsurfacecontainer files to CMakeLists.txt for proper compilation
3. Created new PopupSurfaceContainer class to handle popup surfaces with mouse event detection
4. Modified WindowMenu.qml to set modal property ensuring proper popup behavior
5. Updated ShellHandler to use PopupSurfaceContainer instead of generic SurfaceContainer

The changes implement a specialized container for handling popup surfaces with proper event handling and closure logic. The PopupSurfaceContainer class provides specific functionality for managing popup windows, including detecting mouse release events outside popup areas and closing popups accordingly. This improves the user experience by ensuring popups are properly dismissed when users interact outside their boundaries.

## Summary by Sourcery

Introduce a dedicated PopupSurfaceContainer for handling popup windows with appropriate event interception and closure logic, update build configuration, and improve QML popup behavior.

New Features:
- Add PopupSurfaceContainer class to manage popup surfaces by intercepting mouse events and auto-dismissing popups

Enhancements:
- Switch ShellHandler to use PopupSurfaceContainer instead of a generic SurfaceContainer
- Enable modal behavior in WindowMenu.qml for proper popup interaction

Build:
- Add ninja to nativeBuildInputs in nix/default.nix for faster native builds
- Include popupsurfacecontainer implementation files in CMakeLists.txt