### PR TITLE
fix: add [[maybe_unused]] attribute to unused parameters

### DIFF
--- a/src/modules/dde-shell/ddeshellmanagerinterfacev1.cpp
+++ b/src/modules/dde-shell/ddeshellmanagerinterfacev1.cpp
@@ -229,14 +229,14 @@ DDEShellManagerInterfaceV1::DDEShellManagerInterfaceV1(QObject *parent)
 
 DDEShellManagerInterfaceV1::~DDEShellManagerInterfaceV1() = default;
 
-void DDEShellManagerInterfaceV1::checkRegionalConflict(const QRegion &region) { }
+void DDEShellManagerInterfaceV1::checkRegionalConflict([[maybe_unused]] const QRegion &region) { }
 
 void DDEShellManagerInterfaceV1::create(WServer *server)
 {
     d->init(server->handle()->handle(), TREELAND_DDE_SHELL_MANAGER_V1_VERSION);
 }
 
-void DDEShellManagerInterfaceV1::destroy(WServer *server)
+void DDEShellManagerInterfaceV1::destroy([[maybe_unused]] WServer *server)
 {
     d = nullptr;
 }
@@ -271,46 +271,44 @@ public:
     bool acceptKeyboardFocus = true;
 
 protected:
-    void treeland_dde_shell_surface_v1_destroy_resource(Resource *resource) override;
-    void treeland_dde_shell_surface_v1_destroy(Resource *resource) override;
-    void treeland_dde_shell_surface_v1_set_surface_position(Resource *resource,
+    void treeland_dde_shell_surface_v1_destroy_resource([[maybe_unused]] Resource *resource) override;
+    void treeland_dde_shell_surface_v1_destroy([[maybe_unused]] Resource *resource) override;
+    void treeland_dde_shell_surface_v1_set_surface_position([[maybe_unused]] Resource *resource,
                                                             int32_t x,
                                                             int32_t y) override;
     void treeland_dde_shell_surface_v1_set_role(Resource *resource, uint32_t value) override;
-    void treeland_dde_shell_surface_v1_set_auto_placement(Resource *resource,
+    void treeland_dde_shell_surface_v1_set_auto_placement([[maybe_unused]] Resource *resource,
                                                           uint32_t y_offset) override;
-    void treeland_dde_shell_surface_v1_set_skip_switcher(Resource *resource,
+    void treeland_dde_shell_surface_v1_set_skip_switcher([[maybe_unused]] Resource *resource,
                                                          uint32_t skip) override;
-    void treeland_dde_shell_surface_v1_set_skip_dock_preview(Resource *resource,
+    void treeland_dde_shell_surface_v1_set_skip_dock_preview([[maybe_unused]] Resource *resource,
                                                              uint32_t skip) override;
-    void treeland_dde_shell_surface_v1_set_skip_muti_task_view(Resource *resource,
+    void treeland_dde_shell_surface_v1_set_skip_muti_task_view([[maybe_unused]] Resource *resource,
                                                                uint32_t skip) override;
-    void treeland_dde_shell_surface_v1_set_accept_keyboard_focus(Resource *resource,
+    void treeland_dde_shell_surface_v1_set_accept_keyboard_focus([[maybe_unused]] Resource *resource,
                                                                  uint32_t accept) override;
 };
 
 DDEShellSurfaceInterfacePrivate::DDEShellSurfaceInterfacePrivate(DDEShellSurfaceInterface *_q,
                                                                  wl_resource *surface,
                                                                  wl_resource *resource)
-    : q(_q)
+    : QtWaylandServer::treeland_dde_shell_surface_v1(resource)
+    , q(_q)
     , surfaceResource(surface)
-    , QtWaylandServer::treeland_dde_shell_surface_v1(resource)
 {
 }
 
-void DDEShellSurfaceInterfacePrivate::treeland_dde_shell_surface_v1_destroy_resource(
-    Resource *resource)
+void DDEShellSurfaceInterfacePrivate::treeland_dde_shell_surface_v1_destroy_resource([[maybe_unused]] Resource *resource)
 {
     delete q;
 }
 
-void DDEShellSurfaceInterfacePrivate::treeland_dde_shell_surface_v1_destroy(Resource *resource)
+void DDEShellSurfaceInterfacePrivate::treeland_dde_shell_surface_v1_destroy([[maybe_unused]] Resource *resource)
 {
     wl_resource_destroy(resource->handle);
 }
 
-void DDEShellSurfaceInterfacePrivate::treeland_dde_shell_surface_v1_set_surface_position(
-    Resource *resource,
+void DDEShellSurfaceInterfacePrivate::treeland_dde_shell_surface_v1_set_surface_position([[maybe_unused]] Resource *resource,
     int32_t x,
     int32_t y)
 {
@@ -348,8 +346,7 @@ void DDEShellSurfaceInterfacePrivate::treeland_dde_shell_surface_v1_set_role(Res
     Q_EMIT q->roleChanged(newRole);
 }
 
-void DDEShellSurfaceInterfacePrivate::treeland_dde_shell_surface_v1_set_auto_placement(
-    Resource *resource,
+void DDEShellSurfaceInterfacePrivate::treeland_dde_shell_surface_v1_set_auto_placement([[maybe_unused]] Resource *resource,
     uint32_t y_offset)
 {
     if (y_offset == yOffset) {
@@ -360,8 +357,7 @@ void DDEShellSurfaceInterfacePrivate::treeland_dde_shell_surface_v1_set_auto_pla
     Q_EMIT q->yOffsetChanged(y_offset);
 }
 
-void DDEShellSurfaceInterfacePrivate::treeland_dde_shell_surface_v1_set_skip_switcher(
-    Resource *resource,
+void DDEShellSurfaceInterfacePrivate::treeland_dde_shell_surface_v1_set_skip_switcher([[maybe_unused]] Resource *resource,
     uint32_t skip)
 {
     if (skip == skipSwitcher) {
@@ -372,8 +368,7 @@ void DDEShellSurfaceInterfacePrivate::treeland_dde_shell_surface_v1_set_skip_swi
     Q_EMIT q->skipSwitcherChanged(skip);
 }
 
-void DDEShellSurfaceInterfacePrivate::treeland_dde_shell_surface_v1_set_skip_dock_preview(
-    Resource *resource,
+void DDEShellSurfaceInterfacePrivate::treeland_dde_shell_surface_v1_set_skip_dock_preview([[maybe_unused]] Resource *resource,
     uint32_t skip)
 {
     if (skip == skipDockPreView) {
@@ -384,8 +379,7 @@ void DDEShellSurfaceInterfacePrivate::treeland_dde_shell_surface_v1_set_skip_doc
     Q_EMIT q->skipDockPreViewChanged(skip);
 }
 
-void DDEShellSurfaceInterfacePrivate::treeland_dde_shell_surface_v1_set_skip_muti_task_view(
-    Resource *resource,
+void DDEShellSurfaceInterfacePrivate::treeland_dde_shell_surface_v1_set_skip_muti_task_view([[maybe_unused]] Resource *resource,
     uint32_t skip)
 {
     if (skip == skipMutiTaskView) {
@@ -396,8 +390,7 @@ void DDEShellSurfaceInterfacePrivate::treeland_dde_shell_surface_v1_set_skip_mut
     Q_EMIT q->skipMutiTaskViewChanged(skip);
 }
 
-void DDEShellSurfaceInterfacePrivate::treeland_dde_shell_surface_v1_set_accept_keyboard_focus(
-    Resource *resource,
+void DDEShellSurfaceInterfacePrivate::treeland_dde_shell_surface_v1_set_accept_keyboard_focus([[maybe_unused]] Resource *resource,
     uint32_t accept)
 {
     if (accept == acceptKeyboardFocus) {
@@ -490,8 +483,8 @@ public:
     wl_resource *seatResouce{ nullptr };
 
 protected:
-    void treeland_dde_active_v1_destroy_resource(Resource *resource) override;
-    void treeland_dde_active_v1_destroy(Resource *resource) override;
+    void treeland_dde_active_v1_destroy_resource([[maybe_unused]] Resource *resource) override;
+    void treeland_dde_active_v1_destroy([[maybe_unused]] Resource *resource) override;
 };
 
 DDEActiveInterfacePrivate::DDEActiveInterfacePrivate(DDEActiveInterface *_q,
@@ -503,12 +496,12 @@ DDEActiveInterfacePrivate::DDEActiveInterfacePrivate(DDEActiveInterface *_q,
 {
 }
 
-void DDEActiveInterfacePrivate::treeland_dde_active_v1_destroy_resource(Resource *resource)
+void DDEActiveInterfacePrivate::treeland_dde_active_v1_destroy_resource([[maybe_unused]] Resource *resource)
 {
     delete q;
 }
 
-void DDEActiveInterfacePrivate::treeland_dde_active_v1_destroy(Resource *resource)
+void DDEActiveInterfacePrivate::treeland_dde_active_v1_destroy([[maybe_unused]] Resource *resource)
 {
     wl_resource_destroy(resource->handle);
 }
@@ -596,7 +589,7 @@ public:
     bool overlapped{ false };
 
 protected:
-    void treeland_window_overlap_checker_destroy_resource(Resource *resource) override;
+    void treeland_window_overlap_checker_destroy_resource([[maybe_unused]] Resource *resource) override;
 
     void treeland_window_overlap_checker_update(Resource *resource,
                                                 int32_t width,
@@ -650,8 +643,7 @@ WindowOverlapCheckerInterfacePrivate::WindowOverlapCheckerInterfacePrivate(
 {
 }
 
-void WindowOverlapCheckerInterfacePrivate::treeland_window_overlap_checker_destroy_resource(
-    Resource *resource)
+void WindowOverlapCheckerInterfacePrivate::treeland_window_overlap_checker_destroy_resource([[maybe_unused]] Resource *resource)
 {
     s_conflictList.remove(q);
     delete q;
@@ -710,9 +702,9 @@ public:
     MultiTaskViewInterface *q;
 
 protected:
-    void treeland_multitaskview_v1_destroy_resource(Resource *resource) override;
-    void treeland_multitaskview_v1_destroy(Resource *resource) override;
-    void treeland_multitaskview_v1_toggle(Resource *resource) override;
+    void treeland_multitaskview_v1_destroy_resource([[maybe_unused]] Resource *resource) override;
+    void treeland_multitaskview_v1_destroy([[maybe_unused]] Resource *resource) override;
+    void treeland_multitaskview_v1_toggle([[maybe_unused]] Resource *resource) override;
 };
 
 MultiTaskViewInterfacePrivate::MultiTaskViewInterfacePrivate(MultiTaskViewInterface *_q,
@@ -722,17 +714,17 @@ MultiTaskViewInterfacePrivate::MultiTaskViewInterfacePrivate(MultiTaskViewInterf
 {
 }
 
-void MultiTaskViewInterfacePrivate::treeland_multitaskview_v1_destroy_resource(Resource *resource)
+void MultiTaskViewInterfacePrivate::treeland_multitaskview_v1_destroy_resource([[maybe_unused]] Resource *resource)
 {
     delete q;
 }
 
-void MultiTaskViewInterfacePrivate::treeland_multitaskview_v1_destroy(Resource *resource)
+void MultiTaskViewInterfacePrivate::treeland_multitaskview_v1_destroy([[maybe_unused]] Resource *resource)
 {
     wl_resource_destroy(resource->handle);
 }
 
-void MultiTaskViewInterfacePrivate::treeland_multitaskview_v1_toggle(Resource *resource)
+void MultiTaskViewInterfacePrivate::treeland_multitaskview_v1_toggle([[maybe_unused]] Resource *resource)
 {
     Q_EMIT q->toggle();
 }
@@ -752,9 +744,9 @@ public:
     WindowPickerInterface *q;
 
 protected:
-    void treeland_window_picker_v1_destroy_resource(Resource *resource) override;
-    void treeland_window_picker_v1_destroy(Resource *resource) override;
-    void treeland_window_picker_v1_pick(Resource *resource, const QString &hint) override;
+    void treeland_window_picker_v1_destroy_resource([[maybe_unused]] Resource *resource) override;
+    void treeland_window_picker_v1_destroy([[maybe_unused]] Resource *resource) override;
+    void treeland_window_picker_v1_pick([[maybe_unused]] Resource *resource, const QString &hint) override;
 };
 
 WindowPickerInterfacePrivate::WindowPickerInterfacePrivate(WindowPickerInterface *_q,
@@ -764,19 +756,19 @@ WindowPickerInterfacePrivate::WindowPickerInterfacePrivate(WindowPickerInterface
 {
 }
 
-void WindowPickerInterfacePrivate::treeland_window_picker_v1_destroy_resource(Resource *resource)
+void WindowPickerInterfacePrivate::treeland_window_picker_v1_destroy_resource([[maybe_unused]] Resource *resource)
 {
     Q_EMIT q->beforeDestroy();
     delete q;
 }
 
-void WindowPickerInterfacePrivate::treeland_window_picker_v1_destroy(Resource *resource)
+void WindowPickerInterfacePrivate::treeland_window_picker_v1_destroy([[maybe_unused]] Resource *resource)
 {
     wl_resource_destroy(resource->handle);
 }
 
-void WindowPickerInterfacePrivate::treeland_window_picker_v1_pick(Resource *resource,
-                                                                  const QString &hint)
+void WindowPickerInterfacePrivate::treeland_window_picker_v1_pick([[maybe_unused]] Resource *resource,
+    const QString &hint)
 {
     Q_EMIT q->pick(hint);
 }
@@ -801,24 +793,24 @@ public:
     LockScreenInterface *q;
 
 protected:
-    void treeland_lockscreen_v1_destroy_resource(Resource *resource) override;
-    void treeland_lockscreen_v1_destroy(Resource *resource) override;
-    virtual void treeland_lockscreen_v1_lock(Resource *resource) override;
-    virtual void treeland_lockscreen_v1_shutdown(Resource *resource) override;
-    virtual void treeland_lockscreen_v1_switch_user(Resource *resource) override;
+    void treeland_lockscreen_v1_destroy_resource([[maybe_unused]] Resource *resource) override;
+    void treeland_lockscreen_v1_destroy([[maybe_unused]] Resource *resource) override;
+    virtual void treeland_lockscreen_v1_lock([[maybe_unused]] Resource *resource) override;
+    virtual void treeland_lockscreen_v1_shutdown([[maybe_unused]] Resource *resource) override;
+    virtual void treeland_lockscreen_v1_switch_user([[maybe_unused]] Resource *resource) override;
 };
 
-void LockScreenInterfacePrivate::treeland_lockscreen_v1_lock(Resource *resource)
+void LockScreenInterfacePrivate::treeland_lockscreen_v1_lock([[maybe_unused]] Resource *resource)
 {
     Q_EMIT q->lock();
 }
 
-void LockScreenInterfacePrivate::treeland_lockscreen_v1_shutdown(Resource *resource)
+void LockScreenInterfacePrivate::treeland_lockscreen_v1_shutdown([[maybe_unused]] Resource *resource)
 {
     Q_EMIT q->shutdown();
 }
 
-void LockScreenInterfacePrivate::treeland_lockscreen_v1_switch_user(Resource *resource)
+void LockScreenInterfacePrivate::treeland_lockscreen_v1_switch_user([[maybe_unused]] Resource *resource)
 {
     Q_EMIT q->switchUser();
 }
@@ -830,12 +822,12 @@ LockScreenInterfacePrivate::LockScreenInterfacePrivate(LockScreenInterface *_q,
 {
 }
 
-void LockScreenInterfacePrivate::treeland_lockscreen_v1_destroy_resource(Resource *resource)
+void LockScreenInterfacePrivate::treeland_lockscreen_v1_destroy_resource([[maybe_unused]] Resource *resource)
 {
     delete q;
 }
 
-void LockScreenInterfacePrivate::treeland_lockscreen_v1_destroy(Resource *resource)
+void LockScreenInterfacePrivate::treeland_lockscreen_v1_destroy([[maybe_unused]] Resource *resource)
 {
     wl_resource_destroy(resource->handle);
 }

--- a/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
+++ b/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
@@ -98,7 +98,7 @@ void ForeignToplevelV1::addSurface(SurfaceWrapper *wrapper)
     connect(handle,
             &treeland_foreign_toplevel_handle_v1::requestActivate,
             wrapper,
-            [wrapper, this](treeland_foreign_toplevel_handle_v1_activated_event *event) {
+            [wrapper, this]([[maybe_unused]] treeland_foreign_toplevel_handle_v1_activated_event *event) {
                 Helper::instance()->forceActivateSurface(wrapper);
             });
 

--- a/src/modules/foreign-toplevel/impl/foreign_toplevel_manager_impl.cpp
+++ b/src/modules/foreign-toplevel/impl/foreign_toplevel_manager_impl.cpp
@@ -56,7 +56,7 @@ static void treeland_dock_preview_context_handle_show(struct wl_client *client,
                                                       int32_t x,
                                                       int32_t y,
                                                       uint32_t direction);
-static void treeland_dock_preview_context_handle_show_tooltip(struct wl_client *client,
+static void treeland_dock_preview_context_handle_show_tooltip([[maybe_unused]] struct wl_client *client,
                                                               struct wl_resource *resource,
                                                               const char *tooltip,
                                                               int32_t x,
@@ -185,7 +185,7 @@ static void toplevel_send_fullscreen_event(struct wl_resource *resource,
     Q_EMIT toplevel->requestFullscreen(&event);
 }
 
-static void treeland_dock_preview_context_handle_show_tooltip(struct wl_client *client,
+static void treeland_dock_preview_context_handle_show_tooltip([[maybe_unused]] struct wl_client *client,
                                                               struct wl_resource *resource,
                                                               const char *tooltip,
                                                               int32_t x,
@@ -644,7 +644,7 @@ static void treeland_dock_preview_context_handle_show([[maybe_unused]] struct wl
     std::vector<uint32_t> s;
     const uint32_t *data = reinterpret_cast<const uint32_t *>(surfaces->data);
     const size_t count = surfaces->size / sizeof(uint32_t);
-    for (int i = 0; i != count; ++i) {
+    for (size_t i = 0; i != count; ++i) {
         s.push_back(data[i]);
     }
 

--- a/src/modules/personalization/impl/personalization_manager_impl.cpp
+++ b/src/modules/personalization/impl/personalization_manager_impl.cpp
@@ -31,11 +31,11 @@ static void set_background_type([[maybe_unused]] struct wl_client *client,
                                 struct wl_resource *resource,
                                 int32_t type);
 
-static void set_round_corner_radius(struct wl_client *client,
+static void set_round_corner_radius([[maybe_unused]] struct wl_client *client,
                                     struct wl_resource *resource,
                                     int32_t radius);
 
-static void set_shadow(struct wl_client *client,
+static void set_shadow([[maybe_unused]] struct wl_client *client,
                        struct wl_resource *resource,
                        int32_t radius,
                        int32_t offset_x,
@@ -45,7 +45,7 @@ static void set_shadow(struct wl_client *client,
                        int32_t b,
                        int32_t a);
 
-static void set_border(struct wl_client *client,
+static void set_border([[maybe_unused]] struct wl_client *client,
                        struct wl_resource *resource,
                        int32_t width,
                        int32_t r,
@@ -53,7 +53,7 @@ static void set_border(struct wl_client *client,
                        int32_t b,
                        int32_t a);
 
-static void set_titlebar(struct wl_client *client, struct wl_resource *resource, int32_t mode);
+static void set_titlebar([[maybe_unused]] struct wl_client *client, struct wl_resource *resource, int32_t mode);
 
 static void on_destroy([[maybe_unused]] struct wl_client *client, struct wl_resource *resource)
 {
@@ -116,7 +116,7 @@ static void set_background_type([[maybe_unused]] struct wl_client *client,
     }
 }
 
-static void set_round_corner_radius(struct wl_client *client,
+static void set_round_corner_radius([[maybe_unused]] struct wl_client *client,
                                     struct wl_resource *resource,
                                     int32_t radius)
 {
@@ -126,7 +126,7 @@ static void set_round_corner_radius(struct wl_client *client,
     }
 }
 
-static void set_shadow(struct wl_client *client,
+static void set_shadow([[maybe_unused]] struct wl_client *client,
                        struct wl_resource *resource,
                        int32_t radius,
                        int32_t offset_x,
@@ -142,7 +142,7 @@ static void set_shadow(struct wl_client *client,
     }
 }
 
-static void set_border(struct wl_client *client,
+static void set_border([[maybe_unused]] struct wl_client *client,
                        struct wl_resource *resource,
                        int32_t width,
                        int32_t r,
@@ -156,7 +156,7 @@ static void set_border(struct wl_client *client,
     }
 }
 
-static void set_titlebar(struct wl_client *client, struct wl_resource *resource, int32_t mode)
+static void set_titlebar([[maybe_unused]] struct wl_client *client, struct wl_resource *resource, int32_t mode)
 {
     if (auto *window = personalization_window_context_v1::from_resource(resource)) {
         window->states.setFlag(
@@ -179,7 +179,7 @@ void set_fd(struct wl_client *client,
 
 void set_identifier(struct wl_client *client, struct wl_resource *resource, const char *identifier);
 
-void set_output(struct wl_client *client, struct wl_resource *resource, const char *output);
+void set_output([[maybe_unused]] struct wl_client *client, struct wl_resource *resource, const char *output);
 
 void set_on(struct wl_client *client, struct wl_resource *resource, uint32_t options);
 
@@ -234,15 +234,50 @@ static void personalization_wallpaper_context_resource_destroy(struct wl_resourc
     wl_list_remove(wl_resource_get_link(resource));
 }
 
-void set_cursor_theme(struct wl_client *client, struct wl_resource *resource, const char *name);
+void set_cursor_theme([[maybe_unused]] struct wl_client *client, struct wl_resource *resource, const char *name)
+{
+    auto *cursor = personalization_cursor_context_v1::from_resource(resource);
+    if (!cursor)
+        return;
 
-void get_cursor_theme(struct wl_client *client, struct wl_resource *resource);
+    cursor->setTheme(name);
+}
 
-void set_cursor_size(struct wl_client *client, struct wl_resource *resource, uint32_t size);
+void get_cursor_theme([[maybe_unused]] struct wl_client *client, struct wl_resource *resource)
+{
+    auto *cursor = personalization_cursor_context_v1::from_resource(resource);
+    if (!cursor)
+        return;
 
-void get_cursor_size(struct wl_client *client, struct wl_resource *resource);
+    Q_EMIT cursor->get_theme(cursor);
+}
 
-void cursor_commit(struct wl_client *client, struct wl_resource *resource);
+void set_cursor_size([[maybe_unused]] struct wl_client *client, struct wl_resource *resource, uint32_t size)
+{
+    auto *cursor = personalization_cursor_context_v1::from_resource(resource);
+    if (!cursor)
+        return;
+
+    cursor->setSize(QSize(size, size));
+}
+
+void get_cursor_size([[maybe_unused]] struct wl_client *client, struct wl_resource *resource)
+{
+    auto *cursor = personalization_cursor_context_v1::from_resource(resource);
+    if (!cursor)
+        return;
+
+    Q_EMIT cursor->get_size(cursor);
+}
+
+void cursor_commit([[maybe_unused]] struct wl_client *client, struct wl_resource *resource)
+{
+    auto *cursor = personalization_cursor_context_v1::from_resource(resource);
+    if (!cursor)
+        return;
+
+    Q_EMIT cursor->commit(cursor);
+}
 
 static void personalization_cursor_context_destroy([[maybe_unused]] struct wl_client *client,
                                                    struct wl_resource *resource)
@@ -486,7 +521,7 @@ void set_identifier(struct wl_client *client [[maybe_unused]],
     wallpaper->identifier = identifier;
 }
 
-void set_output(struct wl_client *client, struct wl_resource *resource, const char *output)
+void set_output([[maybe_unused]] struct wl_client *client, struct wl_resource *resource, const char *output)
 {
     auto *wallpaper = personalization_wallpaper_context_v1::from_resource(resource);
     if (!wallpaper)
@@ -533,51 +568,6 @@ void set_isdark(struct wl_client *client [[maybe_unused]],
         return;
 
     wallpaper->isdark = isdark;
-}
-
-void set_cursor_theme(struct wl_client *client, struct wl_resource *resource, const char *name)
-{
-    auto *cursor = personalization_cursor_context_v1::from_resource(resource);
-    if (!cursor)
-        return;
-
-    cursor->setTheme(name);
-}
-
-void get_cursor_theme(struct wl_client *client, struct wl_resource *resource)
-{
-    auto *cursor = personalization_cursor_context_v1::from_resource(resource);
-    if (!cursor)
-        return;
-
-    Q_EMIT cursor->get_theme(cursor);
-}
-
-void set_cursor_size(struct wl_client *client, struct wl_resource *resource, uint32_t size)
-{
-    auto *cursor = personalization_cursor_context_v1::from_resource(resource);
-    if (!cursor)
-        return;
-
-    cursor->setSize(QSize(size, size));
-}
-
-void get_cursor_size(struct wl_client *client, struct wl_resource *resource)
-{
-    auto *cursor = personalization_cursor_context_v1::from_resource(resource);
-    if (!cursor)
-        return;
-
-    Q_EMIT cursor->get_size(cursor);
-}
-
-void cursor_commit(struct wl_client *client, struct wl_resource *resource)
-{
-    auto *cursor = personalization_cursor_context_v1::from_resource(resource);
-    if (!cursor)
-        return;
-
-    Q_EMIT cursor->commit(cursor);
 }
 
 static void treeland_personalization_manager_bind(struct wl_client *client,

--- a/src/modules/primary-output/outputmanagement.cpp
+++ b/src/modules/primary-output/outputmanagement.cpp
@@ -25,7 +25,7 @@ void PrimaryOutputV1::create(WServer *server)
             &PrimaryOutputV1::requestSetPrimaryOutput);
 }
 
-void PrimaryOutputV1::destroy(WServer *server) { }
+void PrimaryOutputV1::destroy([[maybe_unused]] WServer *server) { }
 
 wl_global *PrimaryOutputV1::global() const
 {

--- a/src/modules/shortcut/shortcutmanager.cpp
+++ b/src/modules/shortcut/shortcutmanager.cpp
@@ -59,7 +59,7 @@ void ShortcutV1::create(WServer *server)
     connect(m_manager, &treeland_shortcut_manager_v1::newContext, this, &ShortcutV1::onNewContext);
 }
 
-void ShortcutV1::destroy(WServer *server) { }
+void ShortcutV1::destroy([[maybe_unused]] WServer *server) { }
 
 wl_global *ShortcutV1::global() const
 {

--- a/src/modules/virtual-output/impl/virtual_output_manager_impl.cpp
+++ b/src/modules/virtual-output/impl/virtual_output_manager_impl.cpp
@@ -35,7 +35,7 @@ static void virtual_output_manager_handle_get_virtual_output(
     [[maybe_unused]] struct wl_client *client,
     struct wl_resource *resource,
     const char *name,
-    uint32_t id);
+    [[maybe_unused]] uint32_t id);
 
 static void virtual_output_handle_destroy([[maybe_unused]] struct wl_client *client,
                                           struct wl_resource *resource);
@@ -185,7 +185,7 @@ static void virtual_output_manager_handle_get_virtual_output(
     [[maybe_unused]] struct wl_client *client,
     struct wl_resource *resource,
     const char *name,
-    uint32_t id)
+    [[maybe_unused]] uint32_t id)
 {
     auto *manager = virtual_output_manager_from_resource(resource);
     for (int i = 0; i < manager->virtual_output.size(); ++i) {

--- a/src/modules/virtual-output/virtualoutputmanager.cpp
+++ b/src/modules/virtual-output/virtualoutputmanager.cpp
@@ -71,7 +71,7 @@ void VirtualOutputV1::create(WServer *server)
             &VirtualOutputV1::onVirtualOutputDestroy);
 }
 
-void VirtualOutputV1::destroy(WServer *server) { }
+void VirtualOutputV1::destroy([[maybe_unused]] WServer *server) { }
 
 wl_global *VirtualOutputV1::global() const
 {

--- a/src/modules/wallpaper-color/wallpapercolor.cpp
+++ b/src/modules/wallpaper-color/wallpapercolor.cpp
@@ -23,7 +23,7 @@ void WallpaperColorV1::create(WServer *server)
     m_handle = wallpaper_color_manager_v1::create(server->handle());
 }
 
-void WallpaperColorV1::destroy(WServer *server) { }
+void WallpaperColorV1::destroy([[maybe_unused]] WServer *server) { }
 
 wl_global *WallpaperColorV1::global() const
 {

--- a/src/modules/window-management/windowmanagement.cpp
+++ b/src/modules/window-management/windowmanagement.cpp
@@ -63,7 +63,7 @@ void WindowManagementV1::create(WServer *server)
     });
 }
 
-void WindowManagementV1::destroy(WServer *server) { }
+void WindowManagementV1::destroy([[maybe_unused]] WServer *server) { }
 
 wl_global *WindowManagementV1::global() const
 {


### PR DESCRIPTION
1. Added [[maybe_unused]] attribute to multiple function parameters across various modules
2. This resolves compiler warnings about unused variables in Wayland interface implementations
3. The changes affect DDE shell interfaces, foreign toplevel handling, personalization manager, output management, and other components
4. Modern C++ compilers can now properly ignore these parameters without generating unnecessary warnings

fix: 为未使用的参数添加 [[maybe_unused]] 属性

1. 在多个模块的函数参数中添加了 [[maybe_unused]] 属性
2. 这解决了Wayland接口实现中关于未使用变量的编译器警告问题
3. 修改涉及DDE shell接口、外部顶层窗口处理、个性化管理器、输出管理以及其 他组件
4. 现代C++编译器现在可以正确忽略这些参数，而不会生成不必要的警告

## Summary by Sourcery

Add [[maybe_unused]] to unused parameters across multiple Wayland interface modules to silence compiler warnings, consolidate duplicate cursor methods in the personalization manager, and correct loop index types for consistency.

Bug Fixes:
- Suppress compiler warnings for unused function parameters in various modules by marking them with [[maybe_unused]].

Enhancements:
- Unify and remove duplicate personalization cursor context method implementations.
- Fix mismatched loop index type in the foreign toplevel preview iteration.