### PR TITLE
fix: cannot use treeland user session mode

### DIFF
--- a/debian/treeland-wayland-session.install
+++ b/debian/treeland-wayland-session.install
@@ -1,1 +1,2 @@
 usr/share/wayland-sessions/treeland-user.desktop
+usr/bin/treeland-user-wrapper

--- a/misc/systemd/dde-session-pre.target.wants/treeland.service.in
+++ b/misc/systemd/dde-session-pre.target.wants/treeland.service.in
@@ -20,7 +20,7 @@ PartOf=dde-session-pre.target
 Before=dde-session-pre.target
 
 [Service]
-ExecCondition=/bin/sh -c 'test "$XDG_SESSION_DESKTOP" = "treeland-user" || exit 2'
+ExecCondition=/bin/sh -c 'test "$TREELAND_RUN_MODE" = "user" || exit 2'
 Type=dbus
 BusName=org.deepin.Compositor1
 UnsetEnvironment=DISPLAY
@@ -28,6 +28,7 @@ UnsetEnvironment=WAYLAND_DISPLAY
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/treeland
 ExecStartPost=-/usr/bin/systemctl --user set-environment XDG_SESSION_DESKTOP=Treeland
 ExecStop=-/usr/bin/systemctl --user unset-environment XDG_SESSION_DESKTOP
+ExecStop=-/usr/bin/systemctl --user unset-environment TREELAND_RUN_MODE
 Slice=session.slice
 Restart=on-failure
 RestartSec=1s

--- a/misc/systemd/dde-session-shutdown.target.wants/treeland-session-shutdown.service
+++ b/misc/systemd/dde-session-shutdown.target.wants/treeland-session-shutdown.service
@@ -2,8 +2,9 @@
 Description=Treeland shutdown session service
 
 [Service]
-ExecCondition=/bin/sh -c 'test "$XDG_SESSION_DESKTOP" = "treeland-user" || exit 2'
+ExecCondition=/bin/sh -c 'test "$TREELAND_RUN_MODE" = "user" || exit 2'
 Type=oneshot
 ExecStart=/usr/bin/systemctl --user unset-environment XDG_SESSION_DESKTOP
 ExecStart=/usr/bin/systemctl --user unset-environment DESKTOP_SESSION
 ExecStart=/usr/bin/systemctl --user unset-environment XDG_SESSION_TYPE
+ExecStart=/usr/bin/systemctl --user unset-environment TREELAND_RUN_MODE

--- a/misc/wayland-sessions/CMakeLists.txt
+++ b/misc/wayland-sessions/CMakeLists.txt
@@ -1,5 +1,6 @@
 configure_file(treeland-user.desktop.in treeland-user.desktop)
 configure_file(treeland.desktop.in treeland.desktop)
+configure_file(treeland-user-wrapper.in treeland-user-wrapper)
 
 install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/treeland.desktop
@@ -9,4 +10,9 @@ install(FILES
 install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/treeland-user.desktop
     DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/wayland-sessions"
+)
+
+install(PROGRAMS
+    ${CMAKE_CURRENT_BINARY_DIR}/treeland-user-wrapper
+    DESTINATION "${CMAKE_INSTALL_BINDIR}"
 )

--- a/misc/wayland-sessions/treeland-user-wrapper.in
+++ b/misc/wayland-sessions/treeland-user-wrapper.in
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export TREELAND_RUN_MODE=user
+
+exec ${CMAKE_INSTALL_FULL_BINDIR}/dde-session

--- a/misc/wayland-sessions/treeland-user.desktop.in
+++ b/misc/wayland-sessions/treeland-user.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Treeland
 Comment=This session is DDE single wayland
-Exec=${CMAKE_INSTALL_FULL_BINDIR}/dde-session
+Exec=${CMAKE_INSTALL_FULL_BINDIR}/treeland-user-wrapper
 TryExec=${CMAKE_INSTALL_FULL_BINDIR}/treeland
 Type=Application
 DesktopNames=Treeland

--- a/src/modules/personalization/personalizationmanager.cpp
+++ b/src/modules/personalization/personalizationmanager.cpp
@@ -83,7 +83,7 @@ PersonalizationV1::PersonalizationV1(QObject *parent)
     PERSONALIZATION_MANAGER = this;
 
     // When not use ddm, set uid by self
-    if (qgetenv("XDG_SESSION_DESKTOP") == "treeland-user") {
+    if (qgetenv("TREELAND_RUN_MODE") == "user") {
         setUserId(getgid());
     }
 }


### PR DESCRIPTION
DM will store the desktop file name used for startup in DESKTOP_SESSION, and treeland-user.service should use this environment variable to determine whether it is treeland user session mode.

Log:

## Summary by Sourcery

Add a wrapper script for treeland user sessions and switch session mode detection to a dedicated environment variable.

Bug Fixes:
- Use TREELAND_RUN_MODE instead of XDG_SESSION_DESKTOP to detect treeland user session mode

Enhancements:
- Introduce treeland-user-wrapper script to launch treeland-user sessions

Build:
- Configure and install treeland-user-wrapper via CMakeLists.txt