### PR TITLE
fix: Treeland crash self-recovery is broken

### DIFF
--- a/misc/systemd/dde-session-pre.target.wants/treeland.service.in
+++ b/misc/systemd/dde-session-pre.target.wants/treeland.service.in
@@ -28,7 +28,6 @@ UnsetEnvironment=WAYLAND_DISPLAY
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/treeland
 ExecStartPost=-/usr/bin/systemctl --user set-environment XDG_SESSION_DESKTOP=Treeland
 ExecStop=-/usr/bin/systemctl --user unset-environment XDG_SESSION_DESKTOP
-ExecStop=-/usr/bin/systemctl --user unset-environment TREELAND_RUN_MODE
 Slice=session.slice
 Restart=on-failure
 RestartSec=1s


### PR DESCRIPTION
only treeland-session-shutdown.service can be clean TREELAND_RUN_MODE

Log:

## Summary by Sourcery

Restrict TREELAND_RUN_MODE to the shutdown service to restore Treeland’s self-recovery and update its systemd service configuration accordingly.

Bug Fixes:
- Restore Treeland crash self-recovery by fixing its run-mode handling.

Enhancements:
- Limit clean TREELAND_RUN_MODE to only treeland-session-shutdown.service.

Chores:
- Adjust treeland.service systemd unit file under dde-session-pre.target.wants.