### PR TITLE
fix: Treeland does not exit when logging out of session

### DIFF
--- a/misc/systemd/dde-session-pre.target.wants/treeland.service.in
+++ b/misc/systemd/dde-session-pre.target.wants/treeland.service.in
@@ -28,7 +28,6 @@ UnsetEnvironment=WAYLAND_DISPLAY
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/treeland
 ExecStartPost=-/usr/bin/systemctl --user set-environment XDG_SESSION_DESKTOP=Treeland
 ExecStop=-/usr/bin/systemctl --user unset-environment XDG_SESSION_DESKTOP
-ExecStop=-/usr/bin/systemctl --user unset-environment TREELAND_RUN_MODE
 Slice=session.slice
 Restart=on-failure
 RestartSec=1s


### PR DESCRIPTION
only treeland-session-shutdown.service can be clean TREELAND_RUN_MODE.

treeland-session-shutdown.service need TREELAND_RUN_MODE env, but environment unset before treeland service stop.

Log: