### PR TITLE
Revert "fix: should not maximize when client set maxsize"

### DIFF
--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -533,12 +533,8 @@ void SurfaceWrapper::setSurfaceState(State newSurfaceState)
     QRectF targetGeometry;
 
     if (newSurfaceState == State::Maximized) {
-        if (!shellSurface()->maxSize().isEmpty())
-            return;
         targetGeometry = m_maximizedGeometry;
     } else if (newSurfaceState == State::Fullscreen) {
-        if (!shellSurface()->maxSize().isEmpty())
-            return;
         targetGeometry = m_fullscreenGeometry;
     } else if (newSurfaceState == State::Normal) {
         targetGeometry = m_normalGeometry;


### PR DESCRIPTION
This reverts commit 0d21c9310021c1cd7ded958e6a5e59aa053e9fae. which broken maximize of firefox

## Summary by Sourcery

Bug Fixes:
- Remove early return checks on shellSurface()->maxSize() in setSurfaceState to allow maximized and fullscreen states regardless of client maxSize.