### PR TITLE
fix: cannot export dbus services

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,11 +18,6 @@ DCORE_USE_NAMESPACE;
 
 int main(int argc, char *argv[])
 {
-#ifdef QT_DEBUG
-    DLogManager::registerConsoleAppender();
-#endif
-    DLogManager::registerJournalAppender();
-
     qw_log::init();
     WServer::initializeQPA();
     //    QQuickStyle::setStyle("Material");
@@ -35,6 +30,11 @@ int main(int argc, char *argv[])
     QGuiApplication app(argc, argv);
     app.setOrganizationName("deepin");
     app.setApplicationName("treeland");
+
+#ifdef QT_DEBUG
+    DLogManager::registerConsoleAppender();
+#endif
+    DLogManager::registerJournalAppender();
 
     CmdLine::ref();
 


### PR DESCRIPTION
I can't explain this phenomenon. As long as the DLog registration function is before QApplication, it is impossible to obtain all the contents registered by dbus.

DTK Team reported that other projects encountered the same problem and suspected that it was a Qt problem.

Log:

## Summary by Sourcery

Bug Fixes:
- Relocate DLogManager console and journal appender registration to occur after QApplication instantiation to ensure D-Bus registrations are applied correctly