### PR TITLE
WIP: add shortcut

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,6 +116,8 @@ qt_add_qml_module(libtreeland
         input/inputdevice.h
         input/togglablegesture.cpp
         input/togglablegesture.h
+        input/globalshortcut.h
+        input/globalshortcut.cpp
         interfaces/baseplugininterface.h
         interfaces/lockscreeninterface.h
         interfaces/multitaskviewinterface.h

--- a/src/input/globalshortcut.cpp
+++ b/src/input/globalshortcut.cpp
@@ -1,0 +1,67 @@
+// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "globalshortcut.h"
+
+#include <QHash>
+#include <QKeySequence>
+
+namespace Treeland {
+class GlobalShortcutPrivate : public QObject
+{
+    Q_OBJECT
+    Q_DECLARE_PUBLIC(GlobalShortcut)
+
+    GlobalShortcut *q_ptr;
+    QHash<const QAction*, QList<QKeySequence>> shortcuts;
+
+public:
+    explicit GlobalShortcutPrivate(GlobalShortcut *parent)
+        : q_ptr(parent)
+    {
+    }
+
+    void init()
+    {
+        // Initialization code for global shortcuts can go here.
+    }
+};
+
+bool GlobalShortcut::setShortcut(QAction *action, const QList<QKeySequence> &shortcut)
+{
+    Q_D(GlobalShortcut);
+    if (!action || shortcut.isEmpty()) {
+        return false;
+    }
+    d->shortcuts[action] = shortcut;
+    return true;
+}
+
+QList<QKeySequence> GlobalShortcut::shortcut(const QAction *action) const
+{
+    Q_D(const GlobalShortcut);
+    return d->shortcuts.value(action);
+}
+
+bool GlobalShortcut::hasShortcut(const QAction *action) const
+{
+    Q_D(const GlobalShortcut);
+    return d->shortcuts.contains(action);
+}
+
+void GlobalShortcut::removeAllShortcuts(QAction *action)
+{
+    Q_D(GlobalShortcut);
+    d->shortcuts.remove(action);
+}
+
+GlobalShortcut::GlobalShortcut(QObject *parent)
+    : QObject(parent)
+    , d_ptr(new GlobalShortcutPrivate(this))
+{
+    Q_D(GlobalShortcut);
+    d->init();
+}
+} // namespace Treeland
+
+#include "globalshortcut.moc"

--- a/src/input/globalshortcut.h
+++ b/src/input/globalshortcut.h
@@ -1,0 +1,29 @@
+// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <QObject>
+
+class QAction;
+
+namespace Treeland {
+
+class GlobalShortcutPrivate;
+
+class GlobalShortcut : public QObject
+{
+    Q_OBJECT
+    Q_DECLARE_PRIVATE(GlobalShortcut)
+public:
+    explicit GlobalShortcut(QObject *parent = nullptr);
+
+    bool setShortcut(QAction *action, const QList<QKeySequence> &shortcut);
+    QList<QKeySequence> shortcut(const QAction *action) const;
+    bool hasShortcut(const QAction *action) const;
+    void removeAllShortcuts(QAction *action);
+
+private:
+    GlobalShortcutPrivate *d_ptr;
+};
+} // namespace Treeland


### PR DESCRIPTION
## Summary by Sourcery

Introduce a GlobalShortcut class in the Treeland input module to manage application-wide keyboard shortcuts mapping QActions to key sequences.

New Features:
- Add GlobalShortcut class with methods to set, retrieve, check, and remove shortcuts for QActions.

Build:
- Include globalshortcut.h and globalshortcut.cpp in the CMakeLists for the input module.