### PR TITLE
feat: implement ext-foreign-toplevel-list

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -756,14 +756,17 @@ void Helper::onSurfaceWrapperAdded(SurfaceWrapper *wrapper)
 
     if (!wrapper->skipDockPreView()) {
         m_foreignToplevel->addSurface(wrapper->shellSurface());
+        m_extForeignToplevelListV1->addSurface(wrapper->shellSurface());
         m_treelandForeignToplevel->addSurface(wrapper);
     }
     connect(wrapper, &SurfaceWrapper::skipDockPreViewChanged, this, [this, wrapper] {
         if (wrapper->skipDockPreView()) {
             m_foreignToplevel->removeSurface(wrapper->shellSurface());
+            m_extForeignToplevelListV1->removeSurface(wrapper->shellSurface());
             m_treelandForeignToplevel->removeSurface(wrapper);
         } else {
             m_foreignToplevel->addSurface(wrapper->shellSurface());
+            m_extForeignToplevelListV1->addSurface(wrapper->shellSurface());
             m_treelandForeignToplevel->addSurface(wrapper);
         }
     });
@@ -773,6 +776,7 @@ void Helper::onSurfaceWrapperAboutToRemove(SurfaceWrapper *wrapper)
 {
     if (!wrapper->skipDockPreView()) {
         m_foreignToplevel->removeSurface(wrapper->shellSurface());
+        m_extForeignToplevelListV1->removeSurface(wrapper->shellSurface());
         m_treelandForeignToplevel->removeSurface(wrapper);
     }
 }
@@ -860,6 +864,7 @@ void Helper::init()
     m_shellHandler->initInputMethodHelper(m_server, m_seat);
 
     m_foreignToplevel = m_server->attach<WForeignToplevel>();
+    m_extForeignToplevelListV1 = m_server->attach<WExtForeignToplevelListV1>();
     m_treelandForeignToplevel = m_server->attach<ForeignToplevelV1>();
     Q_ASSERT(m_treelandForeignToplevel);
     qmlRegisterSingletonInstance<ForeignToplevelV1>("Treeland.Protocols",

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -13,6 +13,7 @@
 #include <wqmlcreator.h>
 #include <wseat.h>
 #include <wxdgdecorationmanager.h>
+#include <wextforeigntoplevellistv1.h>
 
 Q_MOC_INCLUDE(<wtoplevelsurface.h>)
 Q_MOC_INCLUDE(<wxdgsurface.h>)
@@ -48,6 +49,7 @@ class WSurface;
 class WToplevelSurface;
 class WSurfaceItem;
 class WForeignToplevel;
+class WExtForeignToplevelListV1;
 class WOutputManagerV1;
 class WLayerSurface;
 WAYLIB_SERVER_END_NAMESPACE
@@ -311,6 +313,7 @@ private:
     WXWayland *m_defaultXWayland = nullptr;
     WXdgDecorationManager *m_xdgDecorationManager = nullptr;
     WForeignToplevel *m_foreignToplevel = nullptr;
+    WExtForeignToplevelListV1 *m_extForeignToplevelListV1 = nullptr;
     ForeignToplevelV1 *m_treelandForeignToplevel = nullptr;
     ShortcutV1 *m_shortcut = nullptr;
     PersonalizationV1 *m_personalization = nullptr;


### PR DESCRIPTION
Log: need https://github.com/vioken/waylib/pull/640

## Summary by Sourcery

Add support for the ext_foreign_toplevel_list_v1 protocol by wiring up WExtForeignToplevelListV1 in the Helper class and propagating surface additions and removals to it.

New Features:
- Attach WExtForeignToplevelListV1 to the server alongside existing foreign toplevel handlers.
- Forward surface add and remove calls to the ext_foreign_toplevel_list_v1 protocol in onSurfaceWrapperAdded, skipDockPreViewChanged, and onSurfaceWrapperAboutToRemove.