### PR TITLE
chore: Use treeland-specific seatd service

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -44,6 +44,7 @@ Depends: qml6-module-qtquick-layouts,
          treeland-data (= ${source:Version}),
          xwayland,
          ${shlibs:Depends},
+Recommends: ddm,
 Description: a Wayland compositor based on wlroots and QML, designed with an attractive and elegant appearance.
 
 Package: treeland-dev

--- a/misc/systemd/treeland.service.in
+++ b/misc/systemd/treeland.service.in
@@ -4,8 +4,8 @@ PartOf=graphical.target
 StartLimitIntervalSec=30
 StartLimitBurst=2
 
-Requires=seatd.service
-After=seatd.service
+Requires=seatd-dde.service
+After=seatd-dde.service
 
 [Service]
 User=dde


### PR DESCRIPTION
This commit modifies the treeland systemd service file to use the `seatd-dde.service` instead of the generic `seatd.service`. This change is necessary because treeland now utilizes a dedicated seatd instance, `seatd-dde`, specifically configured for its requirements.  By switching to the dedicated service, treeland avoids potential conflicts or misconfigurations that could arise from sharing a common seatd instance with other applications or services.

chore: 使用 treeland 专用的 seatd 服务

此提交修改了 treeland systemd 服务文件，以使用 `seatd-dde.service` 而不 是通用的 `seatd.service`。 这一更改是必要的，因为 treeland 现在使用专门
为其需求配置的专用 seatd 实例 `seatd-dde`。 通过切换到专用服务，treeland 可以避免因与其他应用程序或服务共享通用 seatd 实例而可能引起的潜在冲突或
错误配置。

## Summary by Sourcery

Deployment:
- Update treeland systemd unit to use seatd-dde.service instead of the generic seatd.service