### PR TITLE
fix: Scaling animation not shown while return from shutdown page

### DIFF
--- a/src/plugins/lockscreen/qml/Greeter.qml
+++ b/src/plugins/lockscreen/qml/Greeter.qml
@@ -93,6 +93,7 @@ FocusScope {
         anchors.fill: parent
 
         onClicked: function () {
+            wallpaperController.type = WallpaperController.Normal
             root.animationPlayed()
             root.animationPlayFinished()
         }


### PR DESCRIPTION
按下Ctrl+Alt+Del后会出现关机与锁定选项界面，同时播放桌面图片放大的动画；点击空白区域退出该界面时却没有出现桌面图片缩小恢复的动画。加入这行可以解决。

## Summary by Sourcery

Bug Fixes:
- Restore wallpaper scaling-down animation upon returning from the shutdown screen by setting wallpaperController.type to Normal on click.