### PR TITLE
chore: update nix dependencies and clean up configurations

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,26 +38,6 @@
               {
                 imports = [ "${nixpkgs}/nixos/modules/virtualisation/qemu-vm.nix" ];
 
-                # TODO:  allow set Environment in services.seatd
-                users.groups.seat = { };
-                systemd.services.seatd = {
-                  description = "Seat management daemon";
-                  documentation = [ "man:seatd(1)" ];
-
-                  wantedBy = [ "multi-user.target" ];
-                  restartIfChanged = false;
-
-                  serviceConfig = {
-                    Type = "notify";
-                    NotifyAccess = "all";
-                    SyslogIdentifier = "seatd";
-                    ExecStart = "${pkgs.sdnotify-wrapper}/bin/sdnotify-wrapper ${pkgs.seatd.bin}/bin/seatd -n 1 -u dde -g dde -l debug";
-                    RestartSec = 1;
-                    Restart = "always";
-                    Environment = "SEATD_VTBOUND=0";
-                  };
-                };
-
                 environment.systemPackages = with pkgs; [
                   foot
                   gdb
@@ -194,22 +174,6 @@
           };
 
           devShells.default = pkgs.mkShell {
-            packages = with pkgs; [
-              # For submodule build
-              wayland
-              wayland-protocols
-              wlr-protocols
-              pixman
-              mesa
-              libdrm
-              vulkan-loader
-              libinput
-              xorg.libXdmcp
-              xorg.xcbutilerrors
-              seatd
-              wlroots
-            ];
-
             inputsFrom = [
               self.packages.${system}.default
             ];
@@ -222,8 +186,8 @@
               ''
                 #export QT_LOGGING_RULES="*.debug=true;qt.*.debug=false"
                 #export WAYLAND_DEBUG=1
-                export QT_PLUGIN_PATH=${makeQtpluginPath (with pkgs.qt6; [ qtbase qtdeclarative qtquick3d qtimageformats qtwayland qt5compat qtsvg ])}
-                export QML2_IMPORT_PATH=${makeQmlpluginPath (with pkgs; with qt6; [ qtdeclarative qtquick3d qt5compat deepin.dtk6declarative ] )}
+                export QT_PLUGIN_PATH=${makeQtpluginPath (with pkgs.qt6; [ qtbase qtdeclarative qtimageformats qtwayland qtsvg ])}
+                export QML2_IMPORT_PATH=${makeQmlpluginPath (with pkgs; with qt6; [ qtdeclarative deepin.dtk6declarative ] )}
                 export QML_IMPORT_PATH=$QML2_IMPORT_PATH
               '';
           };

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -19,7 +19,7 @@
   wayland,
   wayland-protocols,
   wlr-protocols,
-  wlroots,
+  wlroots_0_19,
   treeland-protocols,
   pixman,
   pam,
@@ -34,7 +34,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "treeland";
-  version = "0.2.2";
+  version = "0.5-unstable";
 
   src = nix-filter.filter {
     root = ./..;
@@ -58,6 +58,8 @@ stdenv.mkDerivation (finalAttrs: {
     done
   '';
 
+  depsBuildBuild = [ pkg-config ];
+
   nativeBuildInputs = [
     cmake
     ninja
@@ -80,8 +82,8 @@ stdenv.mkDerivation (finalAttrs: {
     wayland
     wayland-protocols
     wlr-protocols
-    wlroots
     treeland-protocols
+    wlroots_0_19
     pixman
     pam
     libxcrypt


### PR DESCRIPTION
1. Remove redundant seatd service configuration in flake.nix that was previously used for testing
2. Clean up development shell packages by removing unnecessary Wayland- related dependencies
3. Update wlroots dependency to wlroots_0_19 in both flake.nix and default.nix
4. Update project version from 0.2.2 to 0.5-unstable to reflect recent development progress
5. Add depsBuildBuild input for pkg-config to ensure proper build environment setup
6. Remove outdated wlroots reference from nativeBuildInputs

chore: 更新 nix 依赖并清理配置

1. 移除 flake.nix 中冗余的 seatd 服务配置（之前用于测试）
2. 清理开发环境中的 shell 包，移除不必要的 Wayland 相关依赖
3. 在 flake.nix 和 default.nix 中将 wlroots 依赖更新为 wlroots_0_19
4. 将项目版本从 0.2.2 更新为 0.5-unstable 以反映最新开发进展
5. 添加 pkg-config 的 depsBuildBuild 输入以确保正确的构建环境

## Summary by Sourcery

Clean up and update Nix configurations: remove obsolete service and dev dependencies, bump wlroots, add pkg-config build input, and bump project version.

Enhancements:
- Remove redundant seatd systemd service configuration from flake.nix
- Prune unnecessary Wayland and related packages from the development shell
- Simplify Qt plugin and QML import paths in the dev shell
- Update wlroots dependency to wlroots_0_19 in both flake.nix and default.nix
- Add pkg-config to depsBuildBuild for a correct build environment
- Bump project version from 0.2.2 to 0.5-unstable