### PR TITLE
fix: remove redundant submodule options and configs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,7 @@ include(FeatureSummary)
 
 include(cmake/DefineTarget.cmake)
 
-option(WITH_SUBMODULE_WAYLIB "Use the waylib from git submodule" ON)
-add_feature_info(submodule_waylib WITH_SUBMODULE_WAYLIB "Use waylib from submodule")
+set(WITH_SUBMODULE_WAYLIB ON)
 
 option(ADDRESS_SANITIZER "Enable address sanitize" OFF)
 add_feature_info(ASanSupport ADDRESS_SANITIZER "https://github.com/google/sanitizers/wiki/AddressSanitizer")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,13 +12,7 @@
             "displayName": "Default Config",
             "description": "Default build using Ninja generator",
             "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build",
-            "cacheVariables": {
-                "WITH_SUBMODULE_WAYLIB": {
-                    "type": "BOOL",
-                    "value": "OFF"
-                }
-            }
+            "binaryDir": "${sourceDir}/build"
         },
         {
             "name": "clang",
@@ -27,38 +21,6 @@
             "generator": "Ninja",
             "binaryDir": "${sourceDir}/build",
             "cacheVariables": {
-                "WITH_SUBMODULE_WAYLIB": {
-                    "type": "BOOL",
-                    "value": "OFF"
-                },
-                "CMAKE_C_COMPILER": "clang",
-                "CMAKE_CXX_COMPILER": "clang++"
-            }
-        },
-        {
-            "name": "submodule",
-            "displayName": "use submodule",
-            "description": "Default build using Ninja generator with git submodule",
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build",
-            "cacheVariables": {
-                "WITH_SUBMODULE_WAYLIB": {
-                    "type": "BOOL",
-                    "value": "ON"
-                }
-            }
-        },
-        {
-            "name": "submodule-with-clang",
-            "displayName": "use submodule with clang",
-            "description": "Default build using Ninja generator with git submodule",
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build",
-            "cacheVariables": {
-                "WITH_SUBMODULE_WAYLIB":{
-                    "type": "BOOL",
-                    "value": "ON"
-                },
                 "CMAKE_C_COMPILER": "clang",
                 "CMAKE_CXX_COMPILER": "clang++"
             }


### PR DESCRIPTION
1. Remove duplicate CMake option for WITH_SUBMODULE_WAYLIB that was both defined and set to ON
2. Eliminate redundant build presets (submodule & submodule-with-clang) that only differed by compiler settings
3. Simplify CMakePresets.json by keeping only essential configurations
4. Maintain single source of truth for binary directory configuration

fix: 删除冗余的子模块选项和配置

1. 移除重复定义的 WITH_SUBMODULE_WAYLIB 选项，该选项已被设置为 ON
2. 删除冗余的构建预设（submodule 和 submodule-with-clang），这些配置仅编 译器设置不同
3. 简化 CMakePresets.json 文件，保留必要配置
4. 维护单一可信的二进制目录配置来源

## Summary by Sourcery

Simplify CMake configuration and build presets by removing redundant submodule options, consolidating presets, and centralizing binary directory settings.

Build:
- Remove duplicate WITH_SUBMODULE_WAYLIB option and its redundant feature info
- Delete redundant submodule and submodule-with-clang build presets
- Streamline CMakePresets.json to retain only essential configurations
- Consolidate binary directory configuration into a single source of truth