### PR TITLE
fix: prevent workspace moveSurfaceTo crash on null wrapper

### DIFF
--- a/src/plugins/multitaskview/qml/WindowSelectionGrid.qml
+++ b/src/plugins/multitaskview/qml/WindowSelectionGrid.qml
@@ -344,7 +344,7 @@ Item {
                                 let index = workspaceNumKeys.includes(event.key) ?
                                         workspaceNumKeys.indexOf(event.key) : workspaceNumComposedKeys.indexOf(event.key)
                                 const ws = Helper.workspace.modelAt(index)
-                                if (ws)
+                                if (ws && wrapper)
                                     Helper.workspace.moveSurfaceTo(wrapper, ws.id)
                             }
                         } else if (event.modifiers === Qt.AltModifier

--- a/src/plugins/multitaskview/qml/WorkspaceSelectionList.qml
+++ b/src/plugins/multitaskview/qml/WorkspaceSelectionList.qml
@@ -60,7 +60,9 @@ Item {
                 // Substitute switch workspace
                 dragManager.accept = () => {
                     switchTimer.stop()
-                    Helper.workspace.moveSurfaceTo(dragManager.item.wrapper, switchTimer.switchToModel.id)
+                    if (dragManager.item?.wrapper && switchTimer.switchToModel) {
+                        Helper.workspace.moveSurfaceTo(dragManager.item.wrapper, switchTimer.switchToModel.id)
+                    }
                 }
             } else {
                 dragManager.doNotRestoreAccept = true
@@ -217,7 +219,9 @@ Item {
                                         if (workspace.id !== dragManager.item.wrapper.workspaceId && !dragManager.doNotRestoreAccept) {
                                             dragManager.accept = () => {
                                                 switchTimer.stop()
-                                                Helper.workspace.moveSurfaceTo(dragManager.item.wrapper, workspace.id)
+                                                if (dragManager.item?.wrapper) {
+                                                    Helper.workspace.moveSurfaceTo(dragManager.item.wrapper, workspace.id)
+                                                }
                                             }
                                         }
                                     }


### PR DESCRIPTION
1. Add null check for wrapper in WindowSelectionGrid.qml before calling moveSurfaceTo
2. Add conditional checks in WorkspaceSelectionList.qml to verify both wrapper and model exist before workspace move
3. Use optional chaining operator (dragManager.item?.wrapper) for safer null handling
4. Prevent potential crashes when moving surfaces between workspaces during drag operations

fix: 防止工作区 moveSurfaceTo 在空包装器时崩溃

1. 在 WindowSelectionGrid.qml 中调用 moveSurfaceTo 前添加对 wrapper 的空 值检查
2. 在 WorkspaceSelectionList.qml 中添加条件检查以验证包装器和模型存在后 再进行工作区移动
3. 使用可选链操作符 (dragManager.item?.wrapper) 以更安全地处理空值
4. 防止在拖放操作期间跨工作区移动时出现潜在崩溃

## Summary by Sourcery

Add null-checks around wrapper and model references before invoking moveSurfaceTo to prevent crashes when moving surfaces between workspaces during drag and keyboard operations.

Bug Fixes:
- Guard against null dragManager.item.wrapper and switchTimer.switchToModel in WorkspaceSelectionList.qml before calling moveSurfaceTo
- Verify wrapper and workspace model exist in WindowSelectionGrid.qml before invoking moveSurfaceTo using optional chaining