### PR TITLE
feat: add Nix flake support for project configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,10 @@ include(FeatureSummary)
 
 include(cmake/DefineTarget.cmake)
 
-set(WITH_SUBMODULE_WAYLIB ON)
+option(WITH_SUBMODULE_WAYLIB "Use the waylib from git submodule" ON)
+add_feature_info(submodule_waylib WITH_SUBMODULE_WAYLIB "Use waylib from submodule")
 
-option(ADDRESS_SANITIZER "Enable address sanitize" OFF)
+option(ADDRESS_SANITIZER "Enable address sanitizer" OFF)
 add_feature_info(ASanSupport ADDRESS_SANITIZER "https://github.com/google/sanitizers/wiki/AddressSanitizer")
 
 option(BUILD_TREELAND_EXAMPLES "Build clients demo to test treeland" OFF)

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,27 @@
+{
+  pkgs ? import <nixpkgs> { },
+  nix-filter,
+  ddm,
+  treeland-protocols,
+}:
+rec {
+  qwlroots = pkgs.qt6Packages.callPackage ./qwlroots/nix {
+    inherit nix-filter;
+    wlroots = pkgs.wlroots_0_19;
+  };
+
+  waylib = pkgs.qt6Packages.callPackage ./waylib/nix {
+    inherit nix-filter qwlroots;
+    makeTest = import (pkgs.path + "/nixos/tests/make-test-python.nix");
+  };
+
+  treeland = pkgs.qt6Packages.callPackage ./nix {
+    inherit
+      nix-filter
+      ddm
+      treeland-protocols
+      qwlroots
+      waylib
+      ;
+  };
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -25,18 +25,16 @@
   pam,
   libxcrypt,
   libinput,
-  mesa,
-  libdrm,
-  vulkan-loader,
-  seatd,
   nixos-artwork,
+  qwlroots,
+  waylib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "treeland";
   version = "0.5-unstable";
 
-  src = nix-filter.filter {
+  src = nix-filter.lib.filter {
     root = ./..;
 
     exclude = [
@@ -45,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
       "LICENSES"
       "README.md"
       "README.zh_CN.md"
-      (nix-filter.matchExt "nix")
+      (nix-filter.lib.matchExt "nix")
     ];
   };
 
@@ -88,19 +86,18 @@ stdenv.mkDerivation (finalAttrs: {
     pam
     libxcrypt
     libinput
-    mesa
-    libdrm
-    vulkan-loader
-    seatd
+    qwlroots
+    waylib
   ];
 
   cmakeFlags = [
-    "-DQT_IMPORTS_DIR=${placeholder "out"}/${qtbase.qtQmlPrefix}"
-    "-DCMAKE_INSTALL_SYSCONFDIR=${placeholder "out"}/etc"
-    "-DSYSTEMD_SYSTEM_UNIT_DIR=${placeholder "out"}/lib/systemd/system"
-    "-DSYSTEMD_SYSUSERS_DIR=${placeholder "out"}/lib/sysusers.d"
-    "-DSYSTEMD_TMPFILES_DIR=${placeholder "out"}/lib/tmpfiles.d"
-    "-DDBUS_CONFIG_DIR=${placeholder "out"}/share/dbus-1/system.d"
+    (lib.cmakeFeature "QT_IMPORTS_DIR" "${placeholder "out"}/${qtbase.qtQmlPrefix}")
+    (lib.cmakeFeature "CMAKE_INSTALL_SYSCONFDIR" "${placeholder "out"}/etc")
+    (lib.cmakeFeature "SYSTEMD_SYSTEM_UNIT_DIR" "${placeholder "out"}/lib/systemd/system")
+    (lib.cmakeFeature "SYSTEMD_SYSUSERS_DIR" "${placeholder "out"}/lib/sysusers.d")
+    (lib.cmakeFeature "SYSTEMD_TMPFILES_DIR" "${placeholder "out"}/lib/tmpfiles.d")
+    (lib.cmakeFeature "DBUS_CONFIG_DIR" "${placeholder "out"}/share/dbus-1/system.d")
+    (lib.cmakeBool "WITH_SUBMODULE_WAYLIB" false)
   ];
 
   env.PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "${placeholder "out"}/lib/systemd/user";

--- a/waylib/flake.nix
+++ b/waylib/flake.nix
@@ -20,11 +20,10 @@
           pkgs = nixpkgs.legacyPackages.${system};
 
           waylib = pkgs.qt6Packages.callPackage ./nix {
-            nix-filter = nix-filter.lib;
             qwlroots = qwlroots.packages.${system}.qwlroots-qt6;
 
             # for test
-            inherit pkgs waylib;
+            inherit pkgs waylib nix-filter;
             makeTest = import (pkgs.path + "/nixos/tests/make-test-python.nix");
           };
         in

--- a/waylib/nix/default.nix
+++ b/waylib/nix/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "waylib";
   version = "0.1.1";
 
-  src = nix-filter.filter {
+  src = nix-filter.lib.filter {
     root = ./..;
 
     exclude = [
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
       "LICENSES"
       "README.md"
       "README.zh_CN.md"
-      (nix-filter.matchExt "nix")
+      (nix-filter.lib.matchExt "nix")
     ];
   };
 
@@ -64,8 +64,9 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeBuildType = if debug then "Debug" else "Release";
 
   cmakeFlags = [
-    (lib.cmakeBool "INSTALL_TINYWL" true)
+    (lib.cmakeBool "BUILD_EXAMPLES" false)
     (lib.cmakeBool "ADDRESS_SANITIZER" debug)
+    (lib.cmakeBool "WITH_SUBMODULE_QWLROOTS" false)
   ];
 
   strictDeps = true;


### PR DESCRIPTION
1. Introduce `default.nix` at the root to define Nix packages and dependencies
2. Migrate CMakeLists.txt to use `option()` and `add_feature_info()` for better feature management
3. Update `flake.nix` to import and organize Nix modules and packages
4. Modify `nix/default.nix` to use `nix-filter.lib` and add new dependencies like `qwlroots` and `waylib`
5. Update `waylib/flake.nix` and `waylib/nix/default.nix` to improve test support and source filtering

feat: 添加 Nix flake 支持以优化项目配置

1. 在项目根目录引入 `default.nix` 来定义 Nix 包及其依赖
2. 将 CMakeLists.txt 中的配置改为使用 `option()` 和 `add_feature_info()` 以更好地管理功能选项
3. 更新 `flake.nix` 以导入并组织 Nix 模块和包
4. 修改 `nix/default.nix` 使用 `nix-filter.lib` 并添加 `qwlroots` 和 `waylib` 等包

## Summary by Sourcery

Add comprehensive Nix flake support across the project by centralizing package definitions in default.nix, updating flake.nix for unified package and devShell configurations, and refactoring build scripts and CMake feature management for consistency

New Features:
- Add a root-level default.nix and enhanced flake.nix to unifiedly define treeland, waylib, and qwlroots packages
- Introduce a Nix development shell with all necessary dependencies for building and testing

Enhancements:
- Refactor CMakeLists.txt to use option() and add_feature_info for consistent feature toggles
- Migrate Nix derivations to use nix-filter.lib for source filtering and parameterized dependencies
- Replace raw cmakeFlags strings with lib.cmakeFeature and lib.cmakeBool for standardized flag definitions
- Extend waylib flake to include nix-filter and Python-based test support via nixos/tests/make-test-python.nix