### PR TITLE
feat: Support TTY switching

### DIFF
--- a/qwlroots/src/CMakeLists.txt
+++ b/qwlroots/src/CMakeLists.txt
@@ -75,6 +75,7 @@ set(HEADERS
     qwobject.h
     qwbackend.h
     qwdisplay.h
+    qwsession.h
     render/qwrenderer.h
     render/qwtexture.h
     render/qwallocator.h

--- a/qwlroots/src/qwsession.h
+++ b/qwlroots/src/qwsession.h
@@ -1,0 +1,42 @@
+// Copyright (C) 2025 April Lu <apr3vau@outlook.com>.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <qwglobal.h>
+#include <qwobject.h>
+
+extern "C" {
+#include <wlr/backend/session.h>
+}
+
+QW_BEGIN_NAMESPACE
+class QW_CLASS_OBJECT(device)
+{
+    QW_OBJECT
+    Q_OBJECT
+
+    QW_SIGNAL(change)
+    QW_SIGNAL(remove)
+};
+
+class QW_CLASS_OBJECT(session)
+{
+    QW_OBJECT
+    Q_OBJECT
+
+    QW_SIGNAL(active)
+    QW_SIGNAL(add_drm_card)
+
+public:
+    QW_FUNC_STATIC(session, create, qw_session *, struct wl_event_loop *loop)
+
+    QW_FUNC_MEMBER(session, open_file, wlr_device *, const char *path)
+    QW_FUNC_MEMBER(session, close_file, void, wlr_device *device)
+    QW_FUNC_MEMBER(session, change_vt, bool, unsigned vt);
+    QW_FUNC_MEMBER(session, find_gpus, ssize_t, size_t ret_len, wlr_device **ret)
+
+protected:
+    QW_FUNC_MEMBER(session, destroy, void)
+};
+QW_END_NAMESPACE

--- a/src/core/lockscreen.cpp
+++ b/src/core/lockscreen.cpp
@@ -70,6 +70,7 @@ void LockScreen::addOutput(Output *output)
     auto *item = m_impl->createLockScreen(output, this);
 
     if (isVisible()) {
+        item->setProperty("showAnimation", false);
         QMetaObject::invokeMethod(item, "start");
     }
 

--- a/src/core/lockscreen.cpp
+++ b/src/core/lockscreen.cpp
@@ -70,8 +70,7 @@ void LockScreen::addOutput(Output *output)
     auto *item = m_impl->createLockScreen(output, this);
 
     if (isVisible()) {
-        item->setProperty("showAnimation", false);
-        QMetaObject::invokeMethod(item, "start");
+        QMetaObject::invokeMethod(item, "start", QVariant::fromValue(false));
     }
 
     connect(item, SIGNAL(animationPlayed()), this, SLOT(onAnimationPlayed()));

--- a/src/plugins/lockscreen/qml/Greeter.qml
+++ b/src/plugins/lockscreen/qml/Greeter.qml
@@ -22,6 +22,7 @@ FocusScope {
     required property QtObject outputItem
     property int currentMode: Greeter.CurrentMode.Lock
     property string primaryOutputName
+    property bool showAnimation: true
     visible: primaryOutputName === "" || primaryOutputName === output.name
 
     function start()
@@ -73,6 +74,7 @@ FocusScope {
 
     LockView {
         id: lockView
+        showAnimation: root.showAnimation
         visible: root.currentMode === Greeter.CurrentMode.Lock ||
                  root.currentMode === Greeter.CurrentMode.SwitchUser
         anchors.fill: parent

--- a/src/plugins/lockscreen/qml/Greeter.qml
+++ b/src/plugins/lockscreen/qml/Greeter.qml
@@ -22,11 +22,14 @@ FocusScope {
     required property QtObject outputItem
     property int currentMode: Greeter.CurrentMode.Lock
     property string primaryOutputName
-    property bool showAnimation: true
     visible: primaryOutputName === "" || primaryOutputName === output.name
 
-    function start()
+    function start(showAnimation)
     {
+        if (showAnimation === undefined) {
+            showAnimation = true
+        }
+        lockView.showAnimation = showAnimation
         lockView.forceActiveFocus()
         wallpaperController.type = WallpaperController.Scale
         switch (root.currentMode) {
@@ -74,7 +77,6 @@ FocusScope {
 
     LockView {
         id: lockView
-        showAnimation: root.showAnimation
         visible: root.currentMode === Greeter.CurrentMode.Lock ||
                  root.currentMode === Greeter.CurrentMode.SwitchUser
         anchors.fill: parent

--- a/src/plugins/lockscreen/qml/LockView.qml
+++ b/src/plugins/lockscreen/qml/LockView.qml
@@ -8,6 +8,7 @@ import Treeland
 
 FocusScope {
     id: root
+    property bool showAnimation: true
     property int state: LoginAnimation.Show
     readonly property bool powerVisible: controlAction.powerVisible
     signal quit()
@@ -15,10 +16,17 @@ FocusScope {
 
     function start() {
         root.state = LoginAnimation.Show
-        leftAnimation.item.start({x: root.x - quickAction.width, y: quickAction.y}, {x: quickAction.x, y: quickAction.y})
-        logoAnimation.item.start({x: root.x - logo.width, y: logo.y}, {x: logo.x, y: logo.y})
-        rightAnimation.item.start({x: root.width + userInput.width, y: userInput.y}, {x: userInput.x, y: userInput.y})
-        bottomAnimation.item.start({x: controlAction.x, y: controlAction.y + controlAction.height}, {x: controlAction.x, y: controlAction.y})
+        if (showAnimation) {
+            leftAnimation.item.start({x: root.x - quickAction.width, y: quickAction.y}, {x: quickAction.x, y: quickAction.y})
+            logoAnimation.item.start({x: root.x - logo.width, y: logo.y}, {x: logo.x, y: logo.y})
+            rightAnimation.item.start({x: root.width + userInput.width, y: userInput.y}, {x: userInput.x, y: userInput.y})
+            bottomAnimation.item.start({x: controlAction.x, y: controlAction.y + controlAction.height}, {x: controlAction.x, y: controlAction.y})
+        } else {
+            leftAnimation.item.skip({x: quickAction.x, y: quickAction.y})
+            logoAnimation.item.skip({x: logo.x, y: logo.y})
+            rightAnimation.item.skip({x: userInput.x, y: userInput.y})
+            bottomAnimation.item.skip({x: controlAction.x, y: controlAction.y})
+        }
     }
 
     function showUserView()
@@ -178,10 +186,17 @@ FocusScope {
                 break
                 case GreeterModel.Quit: {
                     root.state = LoginAnimation.Hide
-                    leftAnimation.item.start({x: quickAction.x, y: quickAction.y}, {x: root.x - quickAction.width, y: quickAction.y})
-                    logoAnimation.item.start({x: logo.x, y: logo.y}, {x: root.x - logo.width, y: logo.y})
-                    rightAnimation.item.start({x: userInput.x, y: userInput.y}, {x: root.width + userInput.width, y: userInput.y})
-                    bottomAnimation.item.start({x: controlAction.x, y: controlAction.y}, {x: controlAction.x, y: controlAction.y + controlAction.height})
+                    if (showAnimation) {
+                        leftAnimation.item.start({x: quickAction.x, y: quickAction.y}, {x: root.x - quickAction.width, y: quickAction.y})
+                        logoAnimation.item.start({x: logo.x, y: logo.y}, {x: root.x - logo.width, y: logo.y})
+                        rightAnimation.item.start({x: userInput.x, y: userInput.y}, {x: root.width + userInput.width, y: userInput.y})
+                        bottomAnimation.item.start({x: controlAction.x, y: controlAction.y}, {x: controlAction.x, y: controlAction.y + controlAction.height})
+                    } else {
+                        leftAnimation.item.skip({x: root.x - quickAction.width, y: quickAction.y})
+                        logoAnimation.item.skip({x: root.x - logo.width, y: logo.y})
+                        rightAnimation.item.skip({x: root.width + userInput.width, y: userInput.y})
+                        bottomAnimation.item.skip({x: controlAction.x, y: controlAction.y + controlAction.height})
+                    }
 
                     root.quit()
                 }

--- a/src/plugins/lockscreen/qml/LoginAnimation.qml
+++ b/src/plugins/lockscreen/qml/LoginAnimation.qml
@@ -32,6 +32,12 @@ Item {
         animation.start()
     }
 
+    function skip(to) {
+        target.x = to.x
+        target.y = to.y
+        stop()
+    }
+
     function stop() {
         visible = false
         effect.sourceItem = null

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -195,7 +195,7 @@ public:
 
     void setCurrentMode(CurrentMode mode);
 
-    void showLockScreen();
+    void showLockScreen(bool async = true);
 
     Output* getOutputAtCursor() const;
 public Q_SLOTS:

--- a/waylib/src/server/kernel/wbackend.cpp
+++ b/waylib/src/server/kernel/wbackend.cpp
@@ -13,6 +13,7 @@
 #include <qwdisplay.h>
 #include <qwoutput.h>
 #include <qwinputdevice.h>
+#include <qwsession.h>
 
 #include <QDebug>
 
@@ -61,6 +62,9 @@ public:
         wl_listener modifiers;
         wl_listener key;
     };
+
+private:
+    qw_session *session = nullptr;
 };
 
 void WBackendPrivate::on_new_output(wlr_output *output)
@@ -142,6 +146,12 @@ qw_backend *WBackend::handle() const
     return nativeInterface<qw_backend>();
 }
 
+qw_session *WBackend::session() const
+{
+    W_DC(WBackend);
+    return d->session;
+}
+
 QVector<WOutput*> WBackend::outputList() const
 {
     W_DC(WBackend);
@@ -193,8 +203,10 @@ void WBackend::create(WServer *server)
     W_D(WBackend);
 
     if (!m_handle) {
-        m_handle = qw_backend::autocreate(server->handle()->get_event_loop(), nullptr);
+        wlr_session *session = nullptr;
+        m_handle = qw_backend::autocreate(server->handle()->get_event_loop(), &session);
         Q_ASSERT(m_handle);
+        d->session = qw_session::from(session);
     }
 
     d->connect();

--- a/waylib/src/server/kernel/wbackend.h
+++ b/waylib/src/server/kernel/wbackend.h
@@ -9,6 +9,10 @@
 
 #include <QObject>
 
+QW_BEGIN_NAMESPACE
+class qw_session;
+QW_END_NAMESPACE
+
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
 class WOutput;
@@ -24,6 +28,7 @@ public:
     explicit WBackend();
 
     QW_NAMESPACE::qw_backend *handle() const;
+    QW_NAMESPACE::qw_session *session() const;
 
     QVector<WOutput*> outputList() const;
     QVector<WInputDevice*> inputDeviceList() const;

--- a/waylib/src/server/kernel/wseat.cpp
+++ b/waylib/src/server/kernel/wseat.cpp
@@ -680,6 +680,25 @@ WSeat *WSeat::fromHandle(const qw_seat *handle)
     return handle->get_data<WSeat>();
 }
 
+// Some event filter related functions needs to get WSeat from QInputEvent,
+// but the input event may come with a virtual device (e.g. created after a TTY
+// switch by an intenal mechanism, like QHoverEvent). Thus we needs a special
+// guarded getter.
+
+// @return A pointer to WSeat if the event is valid, nullptr if not.
+WSeat *WSeat::fromInputEvent(QInputEvent *event) {
+    auto qtDevice = event->device();
+    if (qtDevice->seatName().isEmpty()) {
+        return nullptr;
+    } else {
+        auto device = WInputDevice::from(qtDevice);
+        Q_ASSERT(device);
+        auto seat = device->seat();
+        Q_ASSERT(seat);
+        return seat;
+    }
+}
+
 qw_seat *WSeat::handle() const
 {
     return d_func()->handle();

--- a/waylib/src/server/kernel/wseat.h
+++ b/waylib/src/server/kernel/wseat.h
@@ -65,6 +65,7 @@ public:
     WSeat(const QString &name = QStringLiteral("seat0"));
 
     static WSeat *fromHandle(const QW_NAMESPACE::qw_seat *handle);
+    static WSeat *fromInputEvent(QInputEvent *event);
     QW_NAMESPACE::qw_seat *handle() const;
     wlr_seat *nativeHandle() const;
 

--- a/waylib/src/server/platformplugin/qwlrootswindow.cpp
+++ b/waylib/src/server/platformplugin/qwlrootswindow.cpp
@@ -132,11 +132,10 @@ bool QWlrootsRenderWindow::beforeDisposeEventFilter(QEvent *event)
 {
     if (event->isInputEvent()) {
         auto ie = static_cast<QInputEvent*>(event);
-        auto device = WInputDevice::from(ie->device());
-        Q_ASSERT(device);
-        Q_ASSERT(device->seat());
-        lastActiveCursor = device->seat()->cursor();
-        return device->seat()->filterEventBeforeDisposeStage(window(), ie);
+        auto seat = WSeat::fromInputEvent(ie);
+        if (!seat) return true;
+        lastActiveCursor = seat->cursor();
+        return seat->filterEventBeforeDisposeStage(window(), ie);
     }
 
     return false;
@@ -146,10 +145,10 @@ bool QWlrootsRenderWindow::afterDisposeEventFilter(QEvent *event)
 {
     if (event->isInputEvent()) {
         auto ie = static_cast<QInputEvent*>(event);
-        auto device = WInputDevice::from(ie->device());
-        Q_ASSERT(device);
-        lastActiveCursor = device->seat()->cursor();
-        return device->seat()->filterEventAfterDisposeStage(window(), ie);
+        auto seat = WSeat::fromInputEvent(ie);
+        if (!seat) return true;
+        lastActiveCursor = seat->cursor();
+        return seat->filterEventAfterDisposeStage(window(), ie);
     }
 
     return false;

--- a/waylib/src/server/qtquick/woutputrenderwindow.cpp
+++ b/waylib/src/server/qtquick/woutputrenderwindow.cpp
@@ -1971,10 +1971,9 @@ bool WOutputRenderWindow::eventFilter(QObject *watched, QEvent *event)
 {
     if (event->isInputEvent() && watched->isQuickItemType()) {
         auto ie = static_cast<QInputEvent*>(event);
-        auto device = WInputDevice::from(ie->device());
-        Q_ASSERT(device);
-        Q_ASSERT(device->seat());
-        if (device->seat()->filterEventBeforeDisposeStage(qobject_cast<QQuickItem*>(watched), ie))
+        auto seat = WSeat::fromInputEvent(ie);
+        if (!seat) return true;
+        if (seat->filterEventBeforeDisposeStage(qobject_cast<QQuickItem*>(watched), ie))
             return true;
     }
 


### PR DESCRIPTION
helper.cpp: 使用`wlr_session_change_vt`实现TTY切换
wbackend.cpp, wserver.h: 暴露`wlr_session`对象，供`wlr_session_change_vt`使用
qwlrootswindow.cpp: 解决切换TTY后崩溃退出的问题

## Summary by Sourcery

Enable TTY switching support by exposing and using wlr_session_change_vt on Ctrl+Alt+F-keys, lock the screen during switch, and add safety checks to avoid crashes after switching.

New Features:
- Support switching virtual terminals with Ctrl+Alt+F1–F6 using wlr_session_change_vt and auto-lock the screen

Bug Fixes:
- Prevent crashes after TTY switching by adding null checks for input devices and seats in QWlrootsRenderWindow event filters

Enhancements:
- Expose the underlying wlr_session object in WServerInterface and capture it in WBackend to enable session operations