### PR TITLE
feat: Add multi-seat support

### DIFF
--- a/src/input/inputdevice.cpp
+++ b/src/input/inputdevice.cpp
@@ -354,6 +354,16 @@ InputDevice *InputDevice::instance()
 
 bool InputDevice::initTouchPad(WInputDevice *device)
 {
+    if (!device) {
+        qWarning() << "Cannot initialize touchpad for null device";
+        return false;
+    }
+
+    if (!device->qtDevice()) {
+        qWarning() << "Cannot initialize touchpad: device has no qtDevice";
+        return false;
+    }
+
     if (device->handle()->is_libinput()
         && device->qtDevice()->type() == QInputDevice::DeviceType::TouchPad) {
         configTapEnabled(libinput_device_handle(device->handle()), LIBINPUT_CONFIG_TAP_ENABLED);

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -890,6 +890,10 @@ void SurfaceWrapper::doSetSurfaceState(State newSurfaceState)
     m_surfaceState.notify();
     updateTitleBar();
     updateVisible();
+
+    if (surfaceItem() && surfaceItem()->eventItem()) {
+        surfaceItem()->eventItem()->forceActiveFocus();
+    }
 }
 
 void SurfaceWrapper::onAnimationReady()


### PR DESCRIPTION
Add comprehensive multi-seat functionality to improve multi-user experience:
- Implement seat management and device assignment system
- Add seat-specific window activation and focus handling
- Support per-seat window movement and resizing
- Handle seat-specific surface interactions and events

This enables multiple users to independently interact with the system using different input devices simultaneously.

## Summary by Sourcery

Add multi-seat support to allow multiple users to interact independently using different input devices.

New Features:
- Initialize multi-seat support with WSeatManager including seat config loading, validation, and default seat creation.
- Automatically assign and maintain input device-to-seat mappings with periodic fix-up of unassigned devices.
- Route input events per seat and manage seat-specific keyboard focus, window activation, and workspace switching.
- Support per-seat window move and resize operations with dedicated tracking and event handling.
- Track and update seat-specific surface interactions to maintain correct focus and activation context.

Enhancements:
- Refactor destruction logic to disconnect multi-seat resources and clear relevant state maps.
- Add defensive null checks and warnings in device initialization and focus operations.
- Extend SurfaceWrapper to force active focus on its event item after state changes.