### PR TITLE
fix: Handle VT switching keys

### DIFF
--- a/waylib/src/server/kernel/wseat.cpp
+++ b/waylib/src/server/kernel/wseat.cpp
@@ -527,6 +527,14 @@ void WSeatPrivate::on_keyboard_key(wlr_keyboard_key_event *event, WInputDevice *
 
     // Qt doesn't support XF86Switch_VT_1 to XF86Switch_VT_12, so convert them to
     // Ctrl+Alt+F1 to Ctrl+Alt+F12
+    //
+    // Assumption: XKB_KEY_XF86Switch_VT_1 and XKB_KEY_F1 are contiguous and ordered such that
+    // (XKB_KEY_F1 + (sym - XKB_KEY_XF86Switch_VT_1)) yields the correct F-key.
+    // If this is not true, the calculation below may be unsafe.
+    static_assert(
+        (XKB_KEY_XF86Switch_VT_12 - XKB_KEY_XF86Switch_VT_1) == (XKB_KEY_F12 - XKB_KEY_F1),
+        "XKB_KEY_XF86Switch_VT_1..12 and XKB_KEY_F1..F12 must be contiguous and ordered for keysym calculation"
+    );
     if (sym >= XKB_KEY_XF86Switch_VT_1 && sym <= XKB_KEY_XF86Switch_VT_12) {
         if (keyModifiers == (Qt::ControlModifier | Qt::AltModifier)) {
             sym = XKB_KEY_F1 + (sym - XKB_KEY_XF86Switch_VT_1);

--- a/waylib/src/server/kernel/wseat.cpp
+++ b/waylib/src/server/kernel/wseat.cpp
@@ -524,6 +524,15 @@ void WSeatPrivate::on_keyboard_key(wlr_keyboard_key_event *event, WInputDevice *
     auto code = event->keycode + 8; // map to wl_keyboard::keymap_format::keymap_format_xkb_v1
     auto et = event->state == WL_KEYBOARD_KEY_STATE_PRESSED ? QEvent::KeyPress : QEvent::KeyRelease;
     xkb_keysym_t sym = xkb_state_key_get_one_sym(keyboard->handle()->xkb_state, code);
+
+    // Qt doesn't support XF86Switch_VT_1 to XF86Switch_VT_12, so convert them to
+    // Ctrl+Alt+F1 to Ctrl+Alt+F12
+    if (sym >= XKB_KEY_XF86Switch_VT_1 && sym <= XKB_KEY_XF86Switch_VT_12) {
+        if (keyModifiers == (Qt::ControlModifier | Qt::AltModifier)) {
+            sym = XKB_KEY_F1 + (sym - XKB_KEY_XF86Switch_VT_1);
+        }
+    }
+
     int qtkey = QXkbCommon::keysymToQtKey(sym, keyModifiers, keyboard->handle()->xkb_state, code);
     const QString &text = QXkbCommon::lookupString(keyboard->handle()->xkb_state, code);
 


### PR DESCRIPTION
This commit addresses an issue where the XF86Switch_VT_1 to XF86Switch_VT_12 keys were not properly handled by Qt. Qt does not directly support these keys. The fix involves converting these keys to Ctrl+Alt+F1 through Ctrl+Alt+F12 when the Ctrl and Alt modifiers are already pressed. This enables users to switch virtual terminals within the Wayland environment using these key combinations, matching the expected behavior on traditional Linux systems. This conversion only happens when Ctrl+Alt are already pressed, preventing accidental mapping of other keys.

fix: 处理 VT 切换键

此提交解决了一个 Qt 无法正确处理 XF86Switch_VT_1 到 XF86Switch_VT_12 键的问题。Qt 不直接支持这些键。此修复包括将这些键转换为 Ctrl+Alt+F1
到 Ctrl+Alt+F12（如果 Ctrl 和 Alt 修改键已被按下）。这使得用户能够在
Wayland 环境中使用这些组合键切换虚拟终端，从而匹配传统 Linux 系统上的预
期行为。此转换仅在 Ctrl+Alt 已被按下时发生，防止意外映射其他键。

## Summary by Sourcery

Bug Fixes:
- Convert XF86Switch_VT_1–XF86Switch_VT_12 keysyms to corresponding F1–F12 keys when Ctrl and Alt are already held down