### PR TITLE
feat: add foreign toplevel image capture suppor

### DIFF
--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,23 @@
+MIT License
+
+Copyright (c) 2017, 2018 Drew DeVault
+Copyright (c) 2014 Jari Vetoniemi
+Copyright (c) 2023 The wlroots contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/qwlroots/src/CMakeLists.txt
+++ b/qwlroots/src/CMakeLists.txt
@@ -163,10 +163,12 @@ set(HEADERS
 )
 
 if (USE_WLROOTS_19)  # 0.19
-    list(APPEND HEADERS 
+    list(APPEND HEADERS
         types/qwcolormanagerv1.h
         types/qwextimagecopycapturev1.h
+        types/qwextimagecapturesourcev1.h
         types/qwextforeigntoplevellistv1.h
+        interfaces/qwextimagecapturesourcev1interface.h
     )
 else()
     list(APPEND HEADERS

--- a/qwlroots/src/cmake/CMakeConfig.cmake.in
+++ b/qwlroots/src/cmake/CMakeConfig.cmake.in
@@ -18,6 +18,7 @@ ws_generate(server wayland-protocols unstable/pointer-constraints/pointer-constr
 ws_generate(server wayland-protocols staging/content-type/content-type-v1.xml content-type-v1-protocol)
 ws_generate(server wayland-protocols staging/cursor-shape/cursor-shape-v1.xml cursor-shape-v1-protocol)
 ws_generate(server wayland-protocols staging/tearing-control/tearing-control-v1.xml tearing-control-v1-protocol)
+ws_generate(server wayland-protocols staging/ext-image-copy-capture/ext-image-copy-capture-v1.xml ext-image-copy-capture-v1-protocol)
 
 @WLR_PROTOCOLS_CMAKE_CONFIG_INIT@
 

--- a/qwlroots/src/interfaces/qwextimagecapturesourcev1interface.h
+++ b/qwlroots/src/interfaces/qwextimagecapturesourcev1interface.h
@@ -1,0 +1,18 @@
+// Copyright (C) 2025 rewine <luhongxu@deepin.org>.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <qwinterface.h>
+
+extern "C" {
+#include <wlr/interfaces/wlr_ext_image_capture_source_v1.h>
+}
+
+QW_BEGIN_NAMESPACE
+
+using wlr_ext_image_capture_source_v1_impl = wlr_ext_image_capture_source_v1_interface;
+
+QW_CLASS_INTERFACE(ext_image_capture_source_v1)
+
+QW_END_NAMESPACE

--- a/qwlroots/src/interfaces/qwextimagecapturesourcev1interface.h
+++ b/qwlroots/src/interfaces/qwextimagecapturesourcev1interface.h
@@ -16,3 +16,4 @@ using wlr_ext_image_capture_source_v1_impl = wlr_ext_image_capture_source_v1_int
 QW_CLASS_INTERFACE(ext_image_capture_source_v1)
 
 QW_END_NAMESPACE
+

--- a/qwlroots/src/types/qwextimagecapturesourcev1.h
+++ b/qwlroots/src/types/qwextimagecapturesourcev1.h
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
 #pragma once
 
 #include <qwobject.h>

--- a/qwlroots/src/types/qwextimagecapturesourcev1.h
+++ b/qwlroots/src/types/qwextimagecapturesourcev1.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <qwobject.h>
+
+extern "C" {
+#include <wlr/types/wlr_ext_image_capture_source_v1.h>
+#include <wlr/interfaces/wlr_ext_image_capture_source_v1.h>
+}
+
+QW_BEGIN_NAMESPACE
+
+class QW_CLASS_OBJECT(ext_image_capture_source_v1)
+{
+    QW_OBJECT
+    Q_OBJECT
+
+    QW_SIGNAL(constraints_update)
+    QW_SIGNAL(frame, wlr_ext_image_capture_source_v1_frame_event*)
+
+public:
+    QW_FUNC_STATIC(ext_image_capture_source_v1, from_resource, qw_ext_image_capture_source_v1 *, wl_resource *resource)
+
+    QW_FUNC_MEMBER(ext_image_capture_source_v1, create_resource, bool, wl_client *client, uint32_t new_id)
+    QW_FUNC_MEMBER(ext_image_capture_source_v1, set_constraints_from_swapchain, bool, wlr_swapchain *swapchain, wlr_renderer *renderer)
+    QW_FUNC_MEMBER(ext_image_capture_source_v1, init, void, const wlr_ext_image_capture_source_v1_interface *impl)
+
+protected:
+    QW_FUNC_MEMBER(ext_image_capture_source_v1, finish, void)
+};
+
+class QW_CLASS_OBJECT(ext_image_capture_source_v1_cursor)
+{
+    QW_OBJECT
+    Q_OBJECT
+
+    QW_SIGNAL(update)
+
+public:
+    QW_FUNC_MEMBER(ext_image_capture_source_v1_cursor, init, void, const wlr_ext_image_capture_source_v1_interface *impl)
+
+protected:
+    QW_FUNC_MEMBER(ext_image_capture_source_v1_cursor, finish, void)
+};
+
+class QW_CLASS_REINTERPRET_CAST(ext_output_image_capture_source_manager_v1)
+{
+public:
+    QW_FUNC_STATIC(ext_output_image_capture_source_manager_v1, create, qw_ext_output_image_capture_source_manager_v1 *, wl_display *display, uint32_t version)
+};
+
+QW_END_NAMESPACE

--- a/qwlroots/src/types/qwextimagecopycapturev1.h
+++ b/qwlroots/src/types/qwextimagecopycapturev1.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <qwglobal.h>
+#include <qwobject.h>
 
 extern "C" {
 #include <wlr/types/wlr_ext_image_copy_capture_v1.h>
@@ -14,16 +14,20 @@ QW_BEGIN_NAMESPACE
 class QW_CLASS_REINTERPRET_CAST(ext_image_copy_capture_manager_v1)
 {
 public:
-    QW_FUNC_STATIC(ext_image_copy_capture_manager_v1, create, qw_ext_image_copy_capture_manager_v1 *, wl_display *display,
-        uint32_t version)
+    QW_FUNC_STATIC(ext_image_copy_capture_manager_v1, create, qw_ext_image_copy_capture_manager_v1 *, wl_display *display, uint32_t version)
 };
 
-class QW_CLASS_REINTERPRET_CAST(ext_image_copy_capture_frame_v1)
+class QW_CLASS_OBJECT(ext_image_copy_capture_frame_v1)
 {
+    QW_OBJECT
+    Q_OBJECT
+
 public:
-    QW_FUNC_MEMBER(ext_image_copy_capture_frame_v1, ready, enum wl_output_transform transform, const timespec *presentation_time)
-    QW_FUNC_MEMBER(ext_image_copy_capture_frame_v1, fail, enum ext_image_copy_capture_frame_v1_failure_reason reason)
-    QW_FUNC_MEMBER(ext_image_copy_capture_frame_v1, copy_buffer, wlr_buffer *src, wlr_renderer *renderer)
+    QW_FUNC_STATIC(ext_image_copy_capture_frame_v1, copy_buffer, bool, wlr_ext_image_copy_capture_frame_v1 *frame, wlr_buffer *src, wlr_renderer *renderer)
+
+    QW_FUNC_MEMBER(ext_image_copy_capture_frame_v1, ready, void, enum wl_output_transform transform, const timespec *presentation_time)
+    QW_FUNC_MEMBER(ext_image_copy_capture_frame_v1, fail, void, enum ext_image_copy_capture_frame_v1_failure_reason reason)
+    QW_FUNC_MEMBER(ext_image_copy_capture_frame_v1, copy_buffer, bool, wlr_buffer *src, wlr_renderer *renderer)
 };
 
 QW_END_NAMESPACE

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2066,16 +2066,34 @@ Output *Helper::getOutputAtCursor() const
 void Helper::handleNewForeignToplevelCaptureRequest(wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request *request)
 {
     if (!request || !request->toplevel_handle) {
-        qCDebug(qLcImageCapture) << "Invalid capture request or toplevel handle";
+        qCWarning(qLcImageCapture) << "Invalid capture request or toplevel handle";
         return;
     }
 
     auto *qw_handle = qw_ext_foreign_toplevel_handle_v1::from(request->toplevel_handle);
     WToplevelSurface *toplevelSurface = m_extForeignToplevelListV1->findSurfaceByHandle(qw_handle);
+    if (!toplevelSurface) {
+        qCWarning(qLcImageCapture) << "Could not find toplevel surface for handle";
+        return;
+    }
+    
     SurfaceWrapper *surfaceWrapper = m_rootSurfaceContainer->getSurface(toplevelSurface);
+    if (!surfaceWrapper) {
+        qCWarning(qLcImageCapture) << "Could not find SurfaceWrapper for toplevel surface";
+        return;
+    }
+    
     WSurfaceItem *surfaceItem = surfaceWrapper->surfaceItem();
+    if (!surfaceItem) {
+        qCWarning(qLcImageCapture) << "Could not get WSurfaceItem from SurfaceWrapper";
+        return;
+    }
+    
     WSurfaceItemContent *surfaceContent = surfaceItem->findItemContent();
-    Q_ASSERT(surfaceContent);
+    if (!surfaceContent) {
+        qCWarning(qLcImageCapture) << "Could not find WSurfaceItemContent";
+        return;
+    }
 
     qCDebug(qLcImageCapture) << "Found WSurfaceItemContent for capture:"
              << "size=" << surfaceContent->size()
@@ -2084,7 +2102,7 @@ void Helper::handleNewForeignToplevelCaptureRequest(wlr_ext_foreign_toplevel_ima
 
     auto *output = surfaceWrapper->ownsOutput()->output();
     if (!output) {
-        qCDebug(qLcImageCapture) << "Could not get WOutput from SurfaceWrapper";
+        qCWarning(qLcImageCapture) << "Could not get WOutput from SurfaceWrapper";
         return;
     }
 
@@ -2094,7 +2112,7 @@ void Helper::handleNewForeignToplevelCaptureRequest(wlr_ext_foreign_toplevel_ima
         request, *imageCaptureSource);
 
     if (!success) {
-        qCDebug(qLcImageCapture) << "Failed to accept foreign toplevel image capture request";
+        qCWarning(qLcImageCapture) << "Failed to accept foreign toplevel image capture request";
         delete imageCaptureSource;
     }
 }

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -92,6 +92,11 @@ class ILockScreen;
 class UserModel;
 struct wlr_idle_inhibitor_v1;
 struct wlr_output_power_v1_set_mode_event;
+struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request;
+
+QW_BEGIN_NAMESPACE
+class qw_ext_foreign_toplevel_image_capture_source_manager_v1;
+QW_END_NAMESPACE
 
 class Helper : public WSeatEventFilter
 {
@@ -247,6 +252,7 @@ private:
     void onSessionNew(const QString &sessionId, const QDBusObjectPath &sessionPath);
     void onSessionLock();
     void onSessionUnlock();
+    void handleNewForeignToplevelCaptureRequest(wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request *request);
 
 private:
     void allowNonDrmOutputAutoChangeMode(WOutput *output);
@@ -309,6 +315,7 @@ private:
     qw_idle_notifier_v1 *m_idleNotifier = nullptr;
     qw_idle_inhibit_manager_v1 *m_idleInhibitManager = nullptr;
     qw_output_power_manager_v1 *m_outputPowerManager = nullptr;
+    qw_ext_foreign_toplevel_image_capture_source_manager_v1 *m_foreignToplevelImageCaptureManager = nullptr;
     ShellHandler *m_shellHandler = nullptr;
     WXWayland *m_defaultXWayland = nullptr;
     WXdgDecorationManager *m_xdgDecorationManager = nullptr;

--- a/waylib/src/server/CMakeLists.txt
+++ b/waylib/src/server/CMakeLists.txt
@@ -60,7 +60,7 @@ ws_generate(
     color-management-v1-protocol
 )
 
-# Remove after wlroots 0.20
+#TODO: Remove after wlroots 0.20
 ws_generate(
     server
     wayland-protocols
@@ -68,7 +68,7 @@ ws_generate(
     ext-image-capture-source-v1-protocol
 )
 
-# Remove after wlroots 0.20
+#TODO: Remove after wlroots 0.20
 ws_generate(
     server
     wayland-protocols
@@ -127,8 +127,8 @@ set(SOURCES
     ${WAYLAND_PROTOCOLS_OUTPUTDIR}/text-input-unstable-v1-protocol.c
     ${WAYLAND_PROTOCOLS_OUTPUTDIR}/text-input-unstable-v2-protocol.c
     ${WAYLAND_PROTOCOLS_OUTPUTDIR}/xdg-output-unstable-v1-protocol.c
-    ${WAYLAND_PROTOCOLS_OUTPUTDIR}/ext-image-capture-source-v1-protocol.c # Remove after wlroots 0.20
-    ${WAYLAND_PROTOCOLS_OUTPUTDIR}/ext-foreign-toplevel-list-v1-protocol.c # Remove after wlroots 0.20
+    ${WAYLAND_PROTOCOLS_OUTPUTDIR}/ext-image-capture-source-v1-protocol.c #TODO: Remove after wlroots 0.20
+    ${WAYLAND_PROTOCOLS_OUTPUTDIR}/ext-foreign-toplevel-list-v1-protocol.c #TODO Remove after wlroots 0.20
 
     utils/wtools.cpp
     utils/wthreadutils.cpp
@@ -161,7 +161,7 @@ set(SOURCES
     protocols/private/wtextinputv2.cpp
     protocols/private/wtextinputv3.cpp
     protocols/private/wvirtualkeyboardv1.cpp
-    protocols/ext_foreign_toplevel_image_capture_source.c # Remove after wlroots 0.20
+    protocols/ext_foreign_toplevel_image_capture_source.c #TODO: Remove after wlroots 0.20
     protocols/wcursorshapemanagerv1.cpp
     protocols/woutputmanagerv1.cpp
     protocols/wextforeigntoplevellistv1.cpp
@@ -257,8 +257,8 @@ set(HEADERS
     protocols/wxwaylandsurface.h
     protocols/WXWaylandSurface
     protocols/wextforeigntoplevellistv1.h
-    protocols/ext_foreign_toplevel_image_capture_source_manager_v1.h # Remove after wlroots 0.20
-    protocols/qwextforeigntoplevelimagecapturesourcemanagerv1.h # Move to qwlroots after wlroots 0.20
+    protocols/ext_foreign_toplevel_image_capture_source_manager_v1.h #TODO: Remove after wlroots 0.20
+    protocols/qwextforeigntoplevelimagecapturesourcemanagerv1.h #TODO: Move to qwlroots after wlroots 0.20
 )
 
 set(PRIVATE_HEADERS
@@ -283,8 +283,8 @@ set(PRIVATE_HEADERS
     ${WAYLAND_PROTOCOLS_OUTPUTDIR}/text-input-unstable-v1-protocol.h
     ${WAYLAND_PROTOCOLS_OUTPUTDIR}/text-input-unstable-v2-protocol.h
     ${WAYLAND_PROTOCOLS_OUTPUTDIR}/xdg-output-unstable-v1-protocol.h
-    ${WAYLAND_PROTOCOLS_OUTPUTDIR}/ext-image-capture-source-v1-protocol.h # Remove after wlroots 0.20
-    ${WAYLAND_PROTOCOLS_OUTPUTDIR}/ext-foreign-toplevel-list-v1-protocol.h # Remove after wlroots 0.20
+    ${WAYLAND_PROTOCOLS_OUTPUTDIR}/ext-image-capture-source-v1-protocol.h #TODO: Remove after wlroots 0.20
+    ${WAYLAND_PROTOCOLS_OUTPUTDIR}/ext-foreign-toplevel-list-v1-protocol.h #TODO: Remove after wlroots 0.20
 
     protocols/private/winputmethodv2_p.h
     protocols/private/wtextinput_p.h

--- a/waylib/src/server/CMakeLists.txt
+++ b/waylib/src/server/CMakeLists.txt
@@ -60,6 +60,22 @@ ws_generate(
     color-management-v1-protocol
 )
 
+# Remove after wlroots 0.20
+ws_generate(
+    server
+    wayland-protocols
+    staging/ext-image-capture-source/ext-image-capture-source-v1.xml
+    ext-image-capture-source-v1-protocol
+)
+
+# Remove after wlroots 0.20
+ws_generate(
+    server
+    wayland-protocols
+    staging/ext-foreign-toplevel-list/ext-foreign-toplevel-list-v1.xml
+    ext-foreign-toplevel-list-v1-protocol
+)
+
 set(SOURCES
     kernel/wbackend.cpp
     kernel/wcursor.cpp
@@ -111,11 +127,14 @@ set(SOURCES
     ${WAYLAND_PROTOCOLS_OUTPUTDIR}/text-input-unstable-v1-protocol.c
     ${WAYLAND_PROTOCOLS_OUTPUTDIR}/text-input-unstable-v2-protocol.c
     ${WAYLAND_PROTOCOLS_OUTPUTDIR}/xdg-output-unstable-v1-protocol.c
+    ${WAYLAND_PROTOCOLS_OUTPUTDIR}/ext-image-capture-source-v1-protocol.c # Remove after wlroots 0.20
+    ${WAYLAND_PROTOCOLS_OUTPUTDIR}/ext-foreign-toplevel-list-v1-protocol.c # Remove after wlroots 0.20
 
     utils/wtools.cpp
     utils/wthreadutils.cpp
     utils/wimagebuffer.cpp
     utils/wcursorimage.cpp
+    utils/wextimagecapturesourcev1impl.cpp
 
     platformplugin/qwlrootsintegration.cpp
     platformplugin/qwlrootscreen.cpp
@@ -142,11 +161,10 @@ set(SOURCES
     protocols/private/wtextinputv2.cpp
     protocols/private/wtextinputv3.cpp
     protocols/private/wvirtualkeyboardv1.cpp
+    protocols/ext_foreign_toplevel_image_capture_source.c # Remove after wlroots 0.20
     protocols/wcursorshapemanagerv1.cpp
     protocols/woutputmanagerv1.cpp
     protocols/wextforeigntoplevellistv1.cpp
-
-    ${WAYLAND_PROTOCOLS_OUTPUTDIR}/text-input-unstable-v1-protocol.c
 )
 
 set(HEADERS
@@ -208,6 +226,7 @@ set(HEADERS
     utils/WCursorImage
     utils/wwrappointer.h
     utils/WWrapPointer
+    utils/wextimagecapturesourcev1impl.h
 
     protocols/wxdgshell.h
     protocols/WXdgShell
@@ -238,6 +257,8 @@ set(HEADERS
     protocols/wxwaylandsurface.h
     protocols/WXWaylandSurface
     protocols/wextforeigntoplevellistv1.h
+    protocols/ext_foreign_toplevel_image_capture_source_manager_v1.h # Remove after wlroots 0.20
+    protocols/qwextforeigntoplevelimagecapturesourcemanagerv1.h # Move to qwlroots after wlroots 0.20
 )
 
 set(PRIVATE_HEADERS
@@ -262,6 +283,8 @@ set(PRIVATE_HEADERS
     ${WAYLAND_PROTOCOLS_OUTPUTDIR}/text-input-unstable-v1-protocol.h
     ${WAYLAND_PROTOCOLS_OUTPUTDIR}/text-input-unstable-v2-protocol.h
     ${WAYLAND_PROTOCOLS_OUTPUTDIR}/xdg-output-unstable-v1-protocol.h
+    ${WAYLAND_PROTOCOLS_OUTPUTDIR}/ext-image-capture-source-v1-protocol.h # Remove after wlroots 0.20
+    ${WAYLAND_PROTOCOLS_OUTPUTDIR}/ext-foreign-toplevel-list-v1-protocol.h # Remove after wlroots 0.20
 
     protocols/private/winputmethodv2_p.h
     protocols/private/wtextinput_p.h
@@ -308,8 +331,8 @@ set_target_properties(${TARGET}
         SOVERSION ${PROJECT_VERSION_MAJOR}
         EXPORT_NAME WaylibServer
         PUBLIC_HEADER "${HEADERS}"
-	# PRIVATE_HEADER "${PRIVATE_HEADERS}"
-	# CMake Warning has PRIVATE_HEADER files but no PRIVATE_HEADER DESTINATION
+        # PRIVATE_HEADER "${PRIVATE_HEADERS}"
+        # CMake Warning has PRIVATE_HEADER files but no PRIVATE_HEADER DESTINATION
         POSITION_INDEPENDENT_CODE ON
 )
 

--- a/waylib/src/server/protocols/ext_foreign_toplevel_image_capture_source.c
+++ b/waylib/src/server/protocols/ext_foreign_toplevel_image_capture_source.c
@@ -1,0 +1,121 @@
+// Copyright (c) 2017, 2018 Drew DeVault
+// Copyright (c) 2014 Jari Vetoniemi
+// Copyright (c) 2023 The wlroots contributors
+// SPDX-License-Identifier: MIT
+
+#include <assert.h>
+#include <stdlib.h>
+#include <wlr/interfaces/wlr_ext_image_capture_source_v1.h>
+#include <wlr/types/wlr_ext_foreign_toplevel_list_v1.h>
+#include "ext_foreign_toplevel_image_capture_source_manager_v1.h"
+#include "ext-image-capture-source-v1-protocol.h"
+
+#define FOREIGN_TOPLEVEL_IMAGE_SOURCE_MANAGER_V1_VERSION 1
+
+struct wlr_ext_foreign_toplevel_image_capture_source_v1 {
+	struct wlr_ext_image_capture_source_v1 base;
+};
+
+static const struct ext_foreign_toplevel_image_capture_source_manager_v1_interface foreign_toplevel_manager_impl;
+
+static struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1 *
+foreign_toplevel_manager_from_resource(struct wl_resource *resource) {
+	assert(wl_resource_instance_of(resource,
+		&ext_foreign_toplevel_image_capture_source_manager_v1_interface,
+		&foreign_toplevel_manager_impl));
+	return wl_resource_get_user_data(resource);
+}
+
+bool wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request_accept(
+		struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request *request,
+		struct wlr_ext_image_capture_source_v1 *source) {
+	return wlr_ext_image_capture_source_v1_create_resource(source, request->client, request->new_id);
+}
+
+static void foreign_toplevel_manager_handle_create_source(struct wl_client *client,
+		struct wl_resource *manager_resource, uint32_t new_id,
+		struct wl_resource *foreign_toplevel_resource) {
+	struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1 *manager =
+		foreign_toplevel_manager_from_resource(manager_resource);
+	struct wlr_ext_foreign_toplevel_handle_v1 *toplevel_handle =
+		wlr_ext_foreign_toplevel_handle_v1_from_resource(foreign_toplevel_resource);
+	if (toplevel_handle == NULL) {
+		wlr_ext_image_capture_source_v1_create_resource(NULL, client, new_id);
+		return;
+	}
+
+	struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request *request =
+		calloc(1, sizeof(*request));
+	if (request == NULL) {
+		wl_resource_post_no_memory(manager_resource);
+		return;
+	}
+
+	request->toplevel_handle = toplevel_handle;
+	request->client = client;
+	request->new_id = new_id;
+
+	wl_signal_emit_mutable(&manager->events.new_request, request);
+}
+
+static void foreign_toplevel_manager_handle_destroy(struct wl_client *client,
+		struct wl_resource *manager_resource) {
+	wl_resource_destroy(manager_resource);
+}
+
+static const struct ext_foreign_toplevel_image_capture_source_manager_v1_interface foreign_toplevel_manager_impl = {
+	.create_source = foreign_toplevel_manager_handle_create_source,
+	.destroy = foreign_toplevel_manager_handle_destroy,
+};
+
+static void foreign_toplevel_manager_bind(struct wl_client *client, void *data,
+		uint32_t version, uint32_t id) {
+	struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1 *manager = data;
+
+	struct wl_resource *resource = wl_resource_create(client,
+		&ext_foreign_toplevel_image_capture_source_manager_v1_interface, version, id);
+	if (!resource) {
+		wl_client_post_no_memory(client);
+		return;
+	}
+	wl_resource_set_implementation(resource, &foreign_toplevel_manager_impl, manager, NULL);
+}
+
+static void foreign_toplevel_manager_handle_display_destroy(struct wl_listener *listener, void *data) {
+	struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1 *manager =
+		wl_container_of(listener, manager, display_destroy);
+	wl_signal_emit_mutable(&manager->events.destroy, NULL);
+	assert(wl_list_empty(&manager->events.destroy.listener_list));
+	assert(wl_list_empty(&manager->events.new_request.listener_list));
+	wl_list_remove(&manager->display_destroy.link);
+	wl_global_destroy(manager->global);
+	free(manager);
+}
+
+struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1 *
+wlr_ext_foreign_toplevel_image_capture_source_manager_v1_create(struct wl_display *display,
+		uint32_t version) {
+	assert(version <= FOREIGN_TOPLEVEL_IMAGE_SOURCE_MANAGER_V1_VERSION);
+
+	struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1 *manager =
+		calloc(1, sizeof(*manager));
+	if (manager == NULL) {
+		return NULL;
+	}
+
+	manager->global = wl_global_create(display,
+		&ext_foreign_toplevel_image_capture_source_manager_v1_interface,
+		version, manager, foreign_toplevel_manager_bind);
+	if (manager->global == NULL) {
+		free(manager);
+		return NULL;
+	}
+
+	wl_signal_init(&manager->events.destroy);
+	wl_signal_init(&manager->events.new_request);
+
+	manager->display_destroy.notify = foreign_toplevel_manager_handle_display_destroy;
+	wl_display_add_destroy_listener(display, &manager->display_destroy);
+
+	return manager;
+}

--- a/waylib/src/server/protocols/ext_foreign_toplevel_image_capture_source_manager_v1.h
+++ b/waylib/src/server/protocols/ext_foreign_toplevel_image_capture_source_manager_v1.h
@@ -1,0 +1,80 @@
+// Copyright (c) 2017, 2018 Drew DeVault
+// Copyright (c) 2014 Jari Vetoniemi
+// Copyright (c) 2023 The wlroots contributors
+// SPDX-License-Identifier: MIT
+
+/*
+ * This an unstable interface of wlroots. No guarantees are made regarding the
+ * future consistency of this API.
+ */
+#ifndef WLR_USE_UNSTABLE
+#error "Add -DWLR_USE_UNSTABLE to enable unstable wlroots features"
+#endif
+
+#ifndef WLR_TYPES_WLR_EXT_FOREIGN_TOPLEVEL_IMAGE_CAPTURE_SOURCE_MANAGER_V1_H
+#define WLR_TYPES_WLR_EXT_FOREIGN_TOPLEVEL_IMAGE_CAPTURE_SOURCE_MANAGER_V1_H
+
+#include <wayland-server-core.h>
+
+struct wlr_ext_foreign_toplevel_handle_v1;
+struct wlr_ext_image_capture_source_v1;
+struct wlr_scene_node;
+struct wlr_allocator;
+struct wlr_renderer;
+
+/**
+ * Interface exposing one screen capture source per foreign toplevel.
+ */
+struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1 {
+	struct wl_global *global;
+
+	struct {
+		struct wl_signal destroy;
+		struct wl_signal new_request; // struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request
+	} events;
+
+	struct {
+		struct wl_listener display_destroy;
+	} WLR_PRIVATE;
+};
+
+struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request {
+	struct wlr_ext_foreign_toplevel_handle_v1 *toplevel_handle;
+	struct wl_client *client;
+
+	struct {
+		uint32_t new_id;
+	} WLR_PRIVATE;
+};
+
+/**
+ * Create a new ext_foreign_toplevel_image_capture_source_manager_v1 global.
+ */
+struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1 *
+wlr_ext_foreign_toplevel_image_capture_source_manager_v1_create(struct wl_display *display, uint32_t version);
+
+/**
+ * Accept a request to create a new image capture source for a foreign toplevel.
+ * 
+ * @param request The request from the client
+ * @param source The image capture source to associate with the request
+ * @return true if the request was accepted successfully, false otherwise
+ */
+bool wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request_accept(
+	struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request *request,
+	struct wlr_ext_image_capture_source_v1 *source);
+
+/**
+ * Create a new image capture source backed by a scene node.
+ * 
+ * @param node The scene node to capture
+ * @param event_loop The event loop for scheduling frames
+ * @param allocator The allocator for creating buffers
+ * @param renderer The renderer for processing frames
+ * @return A new image capture source, or NULL on failure
+ */
+struct wlr_ext_image_capture_source_v1 *wlr_ext_image_capture_source_v1_create_with_scene_node(
+	struct wlr_scene_node *node, struct wl_event_loop *event_loop,
+	struct wlr_allocator *allocator, struct wlr_renderer *renderer);
+
+#endif

--- a/waylib/src/server/protocols/qwextforeigntoplevelimagecapturesourcemanagerv1.h
+++ b/waylib/src/server/protocols/qwextforeigntoplevelimagecapturesourcemanagerv1.h
@@ -1,0 +1,24 @@
+// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <qwobject.h>
+
+extern "C" {
+#include "ext_foreign_toplevel_image_capture_source_manager_v1.h"
+}
+
+QW_BEGIN_NAMESPACE
+
+class QW_CLASS_OBJECT(ext_foreign_toplevel_image_capture_source_manager_v1)
+{
+    QW_OBJECT
+    Q_OBJECT
+    QW_SIGNAL(new_request, wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request*)
+public:
+    QW_FUNC_STATIC(ext_foreign_toplevel_image_capture_source_manager_v1, create, qw_ext_foreign_toplevel_image_capture_source_manager_v1 *, wl_display *display, uint32_t version)
+    QW_FUNC_STATIC(ext_foreign_toplevel_image_capture_source_manager_v1, request_accept, bool, wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request *request, wlr_ext_image_capture_source_v1 *source)
+};
+
+QW_END_NAMESPACE

--- a/waylib/src/server/protocols/wextforeigntoplevellistv1.cpp
+++ b/waylib/src/server/protocols/wextforeigntoplevellistv1.cpp
@@ -61,6 +61,16 @@ public:
         surfaces.erase(surface);
     }
 
+    WToplevelSurface *findSurfaceByHandle(qw_ext_foreign_toplevel_handle_v1 *handle) const
+    {
+        for (const auto &pair : surfaces) {
+            if (pair.second.get() == handle) {
+                return pair.first;
+            }
+        }
+        return nullptr;
+    }
+
 private:
     void updateState(WToplevelSurface *surface, qw_ext_foreign_toplevel_handle_v1 *handle)
     {
@@ -95,6 +105,13 @@ void WExtForeignToplevelListV1::removeSurface(WToplevelSurface *surface)
     W_D(WExtForeignToplevelListV1);
 
     d->remove(surface);
+}
+
+WToplevelSurface *WExtForeignToplevelListV1::findSurfaceByHandle(qw_ext_foreign_toplevel_handle_v1 *handle) const
+{
+    W_D(const WExtForeignToplevelListV1);
+
+    return d->findSurfaceByHandle(handle);
 }
 
 QByteArrayView WExtForeignToplevelListV1::interfaceName() const

--- a/waylib/src/server/protocols/wextforeigntoplevellistv1.h
+++ b/waylib/src/server/protocols/wextforeigntoplevellistv1.h
@@ -12,6 +12,10 @@
 
 Q_MOC_INCLUDE("wsurface.h")
 
+QW_BEGIN_NAMESPACE
+class qw_ext_foreign_toplevel_handle_v1;
+QW_END_NAMESPACE
+
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
 class WToplevelSurface;
@@ -26,6 +30,9 @@ public:
 
     void addSurface(WToplevelSurface *surface);
     void removeSurface(WToplevelSurface *surface); // Must `removeSurface` manually before surface destroy
+
+    // Reverse lookup: find WToplevelSurface from protocol handle
+    WToplevelSurface *findSurfaceByHandle(qw_ext_foreign_toplevel_handle_v1 *handle) const;
 
     QByteArrayView interfaceName() const override;
 

--- a/waylib/src/server/qtquick/private/wbufferrenderer.cpp
+++ b/waylib/src/server/qtquick/private/wbufferrenderer.cpp
@@ -43,26 +43,6 @@
 QW_USE_NAMESPACE
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
-struct Q_DECL_HIDDEN PixmanRegion
-{
-    PixmanRegion() {
-        pixman_region32_init(&data);
-    }
-    ~PixmanRegion() {
-        pixman_region32_fini(&data);
-    }
-
-    inline operator pixman_region32_t*() {
-        return &data;
-    }
-
-    inline bool isEmpty() const {
-        return !pixman_region32_not_empty(&data);
-    }
-
-    pixman_region32_t data;
-};
-
 inline static WImageRenderTarget *getImageFrom(const QQuickRenderTarget &rt)
 {
     auto d = QQuickRenderTargetPrivate::get(&rt);
@@ -386,7 +366,7 @@ qw_buffer *WBufferRenderer::beginRender(const QSize &pixelSize, qreal devicePixe
     }
 
     // For software renderer, update the dirty parts relative to the last paint device.
-    PixmanRegion damage;
+    WPixmanRegion damage;
     m_damageRing.rotate_buffer(wbuffer, damage);
     state.dirty = WTools::fromPixmanRegion(damage);
 
@@ -597,7 +577,7 @@ void WBufferRenderer::render(int sourceIndex, const QMatrix4x4 &renderMatrix,
             currentImage->setDevicePixelRatio(1.0);
             const auto scaleTF = QTransform::fromScale(devicePixelRatio, devicePixelRatio);
             const auto scaledFlushRegion = scaleTF.map(softwareRenderer->flushRegion());
-            PixmanRegion scaledFlushDamage;
+            WPixmanRegion scaledFlushDamage;
             bool ok = WTools::toPixmanRegion(scaledFlushRegion, scaledFlushDamage);
             Q_ASSERT(ok);
 

--- a/waylib/src/server/qtquick/wsurfaceitem.cpp
+++ b/waylib/src/server/qtquick/wsurfaceitem.cpp
@@ -22,6 +22,7 @@
 #include <QQuickWindow>
 #include <QSGImageNode>
 #include <QSGRenderNode>
+#include <QQueue>
 #include <private/qquickitem_p.h>
 
 QW_USE_NAMESPACE
@@ -1502,6 +1503,21 @@ void WSurfaceItem::setSubsurfacesVisible(bool newSubsurfacesVisible)
     if (d->aboveSubsurfaceContainer)
         d->aboveSubsurfaceContainer->setVisible(d->subsurfacesVisible);
     Q_EMIT subsurfacesVisibleChanged();
+}
+
+WSurfaceItemContent *WSurfaceItem::findItemContent() const
+{
+    QQueue<QQuickItem *> q;
+    q.enqueue(const_cast<WSurfaceItem*>(this));
+    while (!q.empty()) {
+        auto node = q.dequeue();
+        if (auto content = qobject_cast<WSurfaceItemContent *>(node))
+            return content;
+        for (auto child : node->childItems()) {
+            q.enqueue(child);
+        }
+    }
+    return nullptr;
 }
 
 WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/qtquick/wsurfaceitem.h
+++ b/waylib/src/server/qtquick/wsurfaceitem.h
@@ -193,6 +193,9 @@ public:
     bool subsurfacesVisible() const;
     void setSubsurfacesVisible(bool newSubsurfacesVisible);
 
+    // Find WSurfaceItemContent in child items
+    WSurfaceItemContent *findItemContent() const;
+
 Q_SIGNALS:
     void surfaceChanged();
     void subsurfaceAdded(WAYLIB_SERVER_NAMESPACE::WSurfaceItem *item);

--- a/waylib/src/server/utils/wextimagecapturesourcev1impl.cpp
+++ b/waylib/src/server/utils/wextimagecapturesourcev1impl.cpp
@@ -1,0 +1,361 @@
+// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "wextimagecapturesourcev1impl.h"
+#include "wsurfaceitem.h"
+#include "wsgtextureprovider.h"
+#include "woutputrenderwindow.h"
+#include "woutput.h"
+
+#include <qwextimagecopycapturev1.h>
+#include <qwrenderer.h>
+#include <qwbuffer.h>
+#include <qwswapchain.h>
+#include <qwallocator.h>
+#include <qwcompositor.h>
+
+#include <QLoggingCategory>
+#include <private/qquickwindow_p.h>
+
+Q_LOGGING_CATEGORY(qLcImageCapture, "waylib.server.imagecapture")
+
+extern "C" {
+#include <wlr/interfaces/wlr_output.h>
+#include <pixman.h>
+#include <drm_fourcc.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <stdlib.h>
+}
+
+QW_USE_NAMESPACE
+
+WAYLIB_SERVER_BEGIN_NAMESPACE
+
+WExtImageCaptureSourceV1Impl::WExtImageCaptureSourceV1Impl(WSurfaceItemContent *surfaceContent, WOutput *output)
+    : QObject(nullptr)
+    , m_surfaceContent(surfaceContent)
+    , m_output(output)
+    , m_capturing(false)
+    , m_renderEndConnection()
+{    
+    Q_ASSERT(m_surfaceContent);
+    
+    // Get texture provider and render window for thread setup
+    auto textureProvider = m_surfaceContent->wTextureProvider();
+    if (textureProvider) {
+        auto renderWindow = textureProvider->window();
+        if (renderWindow) {
+            // Move to render thread
+            moveToThread(QQuickWindowPrivate::get(renderWindow)->context->thread());
+        }
+    }
+    
+    // Initialize wlr_ext_image_capture_source_v1
+    wlr_ext_image_capture_source_v1_init(handle(), impl());
+    
+    // Get actual surface size and set constraints
+    auto surface = m_surfaceContent->surface();
+    if (surface && surface->handle()) {
+        auto wlr_surface = surface->handle()->handle();
+        int width = wlr_surface->current.width;
+        int height = wlr_surface->current.height;
+        setConstraintsManually(width, height);
+    }
+}
+
+WExtImageCaptureSourceV1Impl::~WExtImageCaptureSourceV1Impl()
+{
+    if (m_capturing) {
+        qCDebug(qLcImageCapture) << "WExtImageCaptureSourceV1Impl destroyed while capturing";
+    }
+}
+
+void WExtImageCaptureSourceV1Impl::start(bool with_cursors)
+{
+    Q_UNUSED(with_cursors) // TODO: Implement cursor capture if needed
+    m_capturing = true;
+    qCDebug(qLcImageCapture) << "WExtImageCaptureSourceV1Impl::start() with_cursors:" << with_cursors;
+    
+    if (!m_surfaceContent) {
+        qCWarning(qLcImageCapture) << "No surface content available for capture";
+        return;
+    }
+    
+    // Get render window
+    auto textureProvider = m_surfaceContent->wTextureProvider();
+    if (!textureProvider) {
+        qCWarning(qLcImageCapture) << "No texture provider available for start";
+        return;
+    }
+    
+    auto renderWindow = textureProvider->window();
+    if (!renderWindow) {
+        qCWarning(qLcImageCapture) << "No render window available for start";
+        return;
+    }
+    
+    // Connect to renderEnd signal
+    m_renderEndConnection = connect(renderWindow,
+                                   &WOutputRenderWindow::renderEnd,
+                                   this,
+                                   &WExtImageCaptureSourceV1Impl::handleRenderEnd,
+                                   Qt::AutoConnection);
+    
+    if (!m_renderEndConnection) {
+        qCWarning(qLcImageCapture) << "Cannot connect to render end of output render window";
+    }
+    
+    // If not currently rendering, trigger immediately
+    if (!renderWindow->inRendering()) {
+        QMetaObject::invokeMethod(this, &WExtImageCaptureSourceV1Impl::handleRenderEnd, Qt::AutoConnection);
+    }
+}
+
+void WExtImageCaptureSourceV1Impl::stop()
+{
+    m_capturing = false;
+    qCDebug(qLcImageCapture) << "WExtImageCaptureSourceV1Impl::stop()";
+    
+    // Disconnect render end connection
+    if (m_renderEndConnection) {
+        disconnect(m_renderEndConnection);
+        m_renderEndConnection = QMetaObject::Connection();
+    }
+}
+
+void WExtImageCaptureSourceV1Impl::schedule_frame()
+{
+    qCDebug(qLcImageCapture) << "WExtImageCaptureSourceV1Impl::schedule_frame()";
+    
+    if (!m_capturing) {
+        qCWarning(qLcImageCapture) << "schedule_frame called but not capturing";
+        return;
+    }
+    
+    if (!m_surfaceContent) {
+        qCWarning(qLcImageCapture) << "No surface content available for frame scheduling";
+        return;
+    }
+    
+    // Request output update to ensure next frame will be rendered
+    wlr_output_update_needs_frame(m_output->nativeHandle());
+    
+    // Get render window to check if currently rendering
+    auto textureProvider = m_surfaceContent->wTextureProvider();
+    if (textureProvider) {
+        auto renderWindow = textureProvider->window();
+        if (renderWindow && !renderWindow->inRendering()) {
+            QMetaObject::invokeMethod(this, &WExtImageCaptureSourceV1Impl::handleRenderEnd, Qt::AutoConnection);
+        }
+    }
+    
+    qCDebug(qLcImageCapture) << "Scheduled frame capture";
+}
+
+void WExtImageCaptureSourceV1Impl::handleRenderEnd()
+{
+    qCDebug(qLcImageCapture) << "WExtImageCaptureSourceV1Impl::handleRenderEnd() - triggering frame event";
+    
+    if (!m_capturing) {
+        qCWarning(qLcImageCapture) << "handleRenderEnd called but not capturing";
+        return;
+    }
+    
+    // Create damage region (entire surface)
+    pixman_region32_t full_damage;
+    
+    // Get surface size to set correct damage region
+    QSize surfaceSize= m_surfaceContent->size().toSize();
+    pixman_region32_init_rect(&full_damage, 0, 0, surfaceSize.width(), surfaceSize.height());
+    // Create frame event and emit
+    wlr_ext_image_capture_source_v1_frame_event event {
+        .damage = &full_damage,
+    };
+    wl_signal_emit_mutable(&handle()->events.frame, &event);
+    
+    // Cleanup damage region
+    pixman_region32_fini(&full_damage);
+    qCDebug(qLcImageCapture) << "Frame event emitted with damage region:" << surfaceSize;
+}
+
+void WExtImageCaptureSourceV1Impl::copy_frame(wlr_ext_image_copy_capture_frame_v1 *dst_frame, 
+                                              wlr_ext_image_capture_source_v1_frame_event *frame_event)
+{
+    qCDebug(qLcImageCapture) << "WExtImageCaptureSourceV1Impl::copy_frame()";
+    
+    if (!m_capturing) {
+        qCWarning(qLcImageCapture) << "copy_frame called but not capturing";
+        qw_ext_image_copy_capture_frame_v1::from(dst_frame)->fail(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_STOPPED);
+        return;
+    }
+    
+    if (!m_surfaceContent) {
+        qCWarning(qLcImageCapture) << "No surface content available for frame copy";
+        qw_ext_image_copy_capture_frame_v1::from(dst_frame)->fail(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
+        return;
+    }
+    
+    // Get texture provider
+    auto textureProvider = m_surfaceContent->wTextureProvider();
+    if (!textureProvider) {
+        qCWarning(qLcImageCapture) << "No texture provider available";
+        qw_ext_image_copy_capture_frame_v1::from(dst_frame)->fail(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
+        return;
+    }
+    
+    // Get internal buffer
+    auto buffer = m_surfaceContent->surface()->buffer();
+    if (!buffer) {
+        qCWarning(qLcImageCapture) << "No internal buffer available";
+        qw_ext_image_copy_capture_frame_v1::from(dst_frame)->fail(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
+        return;
+    }
+    
+    // Get renderer
+    auto renderWindow = textureProvider->window();
+    if (!renderWindow) {
+        qCWarning(qLcImageCapture) << "No render window available";
+        qw_ext_image_copy_capture_frame_v1::from(dst_frame)->fail(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
+        return;
+    }
+    
+    auto renderer = m_output->renderer();
+    if (!renderer) {
+        qCWarning(qLcImageCapture) << "No renderer available";
+        qw_ext_image_copy_capture_frame_v1::from(dst_frame)->fail(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
+        return;
+    }
+    
+    // Use wlroots image copy function
+    bool success = qw_ext_image_copy_capture_frame_v1::copy_buffer(dst_frame, buffer->handle(), renderer->handle());
+    qCDebug(qLcImageCapture) << "Copy result:" << success;
+    
+    if (success) {
+        // Successfully copied, mark frame as ready
+        struct timespec now;
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        
+        qw_ext_image_copy_capture_frame_v1::from(dst_frame)->ready(WL_OUTPUT_TRANSFORM_NORMAL, &now);
+        qCDebug(qLcImageCapture) << "Frame copy successful";
+    } else {
+        qCWarning(qLcImageCapture) << "Failed to copy frame buffer";
+        qCWarning(qLcImageCapture) << "Possible reasons:";
+        qCWarning(qLcImageCapture) << "  - Buffer size mismatch";
+        qCWarning(qLcImageCapture) << "  - Unsupported buffer format";
+        qCWarning(qLcImageCapture) << "  - Renderer issues";
+        qCWarning(qLcImageCapture) << "  - Memory access problems";
+        
+        // Check if it's a buffer constraints issue
+        if (dst_frame->buffer && buffer->handle()) {
+            if (dst_frame->buffer->width != buffer->handle()->width ||
+                dst_frame->buffer->height != buffer->handle()->height) {
+                qCWarning(qLcImageCapture) << "Buffer size mismatch detected, using BUFFER_CONSTRAINTS failure reason";
+                qw_ext_image_copy_capture_frame_v1::from(dst_frame)->fail(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_BUFFER_CONSTRAINTS);
+                return;
+            }
+        }
+        
+        // For other failures, use UNKNOWN reason
+        qw_ext_image_copy_capture_frame_v1::from(dst_frame)->fail(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
+    }
+}
+
+wlr_ext_image_capture_source_v1_cursor *WExtImageCaptureSourceV1Impl::get_pointer_cursor(wlr_seat *seat)
+{
+    Q_UNUSED(seat)
+    qCDebug(qLcImageCapture) << "WExtImageCaptureSourceV1Impl::get_pointer_cursor()";
+    // TODO: Implement cursor retrieval logic
+    // This needs to get cursor information from seat and create corresponding cursor structure
+    // Currently return nullptr to indicate no cursor information
+    return nullptr;
+}
+
+void WExtImageCaptureSourceV1Impl::setConstraintsManually(int width, int height)
+{    
+    // Directly access wlr_ext_image_capture_source_v1 structure and set constraints
+    auto source = handle();
+    if (!source) {
+        qCWarning(qLcImageCapture) << "No source handle available for setting constraints";
+        return;
+    }
+    
+    // Set size constraints (directly set fields)
+    source->width = width;
+    source->height = height;
+    
+    // Set format constraints based on wlroots implementation
+    auto renderer = m_output->renderer();
+    auto swapchain = m_output->swapchain();
+    
+    if (renderer && swapchain) {
+        // Set SHM format (based on get_swapchain_shm_format logic)
+        struct wlr_buffer *buffer = wlr_swapchain_acquire(swapchain->handle());
+        if (buffer) {
+            struct wlr_texture *texture = wlr_texture_from_buffer(renderer->handle(), buffer);
+            wlr_buffer_unlock(buffer);
+            
+            if (texture) {
+                uint32_t shm_format = wlr_texture_preferred_read_format(texture);
+                wlr_texture_destroy(texture);
+                
+                if (shm_format != DRM_FORMAT_INVALID) {
+                    uint32_t *shm_formats = (uint32_t*)calloc(1, sizeof(uint32_t));
+                    if (shm_formats) {
+                        shm_formats[0] = shm_format;
+                        
+                        free(source->shm_formats);
+                        source->shm_formats = shm_formats;
+                        source->shm_formats_len = 1;
+                        
+                        qCDebug(qLcImageCapture) << "Set SHM format:" << shm_format;
+                    }
+                }
+            }
+        }
+        
+        // Set DMA-BUF constraints
+        int drm_fd = wlr_renderer_get_drm_fd(renderer->handle());
+        if (swapchain->handle()->allocator && 
+            (swapchain->handle()->allocator->buffer_caps & WLR_BUFFER_CAP_DMABUF) && 
+            drm_fd >= 0) {
+            
+            struct stat dev_stat;
+            if (fstat(drm_fd, &dev_stat) == 0) {
+                source->dmabuf_device = dev_stat.st_rdev;
+                
+                // Clean up old DMA-BUF formats
+                wlr_drm_format_set_finish(&source->dmabuf_formats);
+                source->dmabuf_formats = (struct wlr_drm_format_set){0};
+                
+                // Copy DMA-BUF formats from swapchain
+                for (size_t i = 0; i < swapchain->handle()->format.len; i++) {
+                    wlr_drm_format_set_add(&source->dmabuf_formats,
+                        swapchain->handle()->format.format, swapchain->handle()->format.modifiers[i]);
+                }
+                qCDebug(qLcImageCapture) << "Set DMA-BUF constraints";
+            }
+        }
+    }
+    
+    // If no format was set, use default format
+    if (source->shm_formats_len == 0) {
+        uint32_t *default_formats = (uint32_t*)calloc(1, sizeof(uint32_t));
+        if (default_formats) {
+            default_formats[0] = DRM_FORMAT_ARGB8888;
+            source->shm_formats = default_formats;
+            source->shm_formats_len = 1;
+            qCDebug(qLcImageCapture) << "Set default SHM format: ARGB8888";
+        }
+    }
+    
+    // Trigger constraints update event
+    wl_signal_emit_mutable(&source->events.constraints_update, nullptr);
+    
+    qCDebug(qLcImageCapture) << "Manual constraints set successfully:";
+    qCDebug(qLcImageCapture) << "  - Width:" << source->width;
+    qCDebug(qLcImageCapture) << "  - Height:" << source->height;
+    qCDebug(qLcImageCapture) << "  - SHM formats count:" << source->shm_formats_len;
+}
+
+WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/utils/wextimagecapturesourcev1impl.h
+++ b/waylib/src/server/utils/wextimagecapturesourcev1impl.h
@@ -1,0 +1,48 @@
+// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <wglobal.h>
+#include <qwextimagecapturesourcev1interface.h>
+
+#include <QObject>
+
+Q_DECLARE_LOGGING_CATEGORY(qLcImageCapture)
+
+QW_BEGIN_NAMESPACE
+class qw_buffer;
+QW_END_NAMESPACE
+
+WAYLIB_SERVER_BEGIN_NAMESPACE
+
+class WSurfaceItemContent;
+class WOutput;
+
+class WAYLIB_SERVER_EXPORT WExtImageCaptureSourceV1Impl : public QObject, public QW_NAMESPACE::qw_ext_image_capture_source_v1_interface
+{
+    Q_OBJECT
+public:
+    explicit WExtImageCaptureSourceV1Impl(WSurfaceItemContent *surfaceContent, WOutput *output);
+    ~WExtImageCaptureSourceV1Impl();
+
+    QW_INTERFACE(start, void, bool with_cursors);
+    QW_INTERFACE(stop, void);
+    QW_INTERFACE(schedule_frame, void);
+    QW_INTERFACE(copy_frame, void, wlr_ext_image_copy_capture_frame_v1 *dst_frame,
+                 wlr_ext_image_capture_source_v1_frame_event *frame_event);
+    QW_INTERFACE(get_pointer_cursor, wlr_ext_image_capture_source_v1_cursor *, wlr_seat *seat);
+
+private Q_SLOTS:
+    void handleRenderEnd();
+
+private:
+    void setConstraintsManually(int width, int height);
+
+    WSurfaceItemContent *m_surfaceContent;
+    WOutput *m_output;
+    bool m_capturing;
+    QMetaObject::Connection m_renderEndConnection;
+};
+
+WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/utils/wextimagecapturesourcev1impl.h
+++ b/waylib/src/server/utils/wextimagecapturesourcev1impl.h
@@ -37,8 +37,6 @@ private Q_SLOTS:
     void handleRenderEnd();
 
 private:
-    void setConstraintsManually(int width, int height);
-
     WSurfaceItemContent *m_surfaceContent;
     WOutput *m_output;
     bool m_capturing;

--- a/waylib/src/server/utils/wtools.cpp
+++ b/waylib/src/server/utils/wtools.cpp
@@ -309,4 +309,17 @@ Qt::Edges WTools::toQtEdge(uint32_t edges)
     return qedges;
 }
 
+// WPixmanRegion implementation
+WPixmanRegion::WPixmanRegion() {
+    pixman_region32_init(&r);
+}
+
+WPixmanRegion::WPixmanRegion(int x, int y, int w, int h) {
+    pixman_region32_init_rect(&r, x, y, w, h);
+}
+
+WPixmanRegion::~WPixmanRegion() {
+    pixman_region32_fini(&r);
+}
+
 WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/utils/wtools.h
+++ b/waylib/src/server/utils/wtools.h
@@ -12,6 +12,10 @@
 struct pixman_region32;
 typedef int wl_shm_format_t;
 
+extern "C" {
+#include <pixman.h>
+}
+
 QT_BEGIN_NAMESPACE
 class QQuickItem;
 QT_END_NAMESPACE
@@ -32,6 +36,27 @@ public:
     static QRect fromWLRBox(void *box);
     static void toWLRBox(const QRect &rect, void *box);
     static Qt::Edges toQtEdge(uint32_t edges);
+};
+
+// RAII wrapper for pixman region
+struct WAYLIB_SERVER_EXPORT WPixmanRegion {
+    pixman_region32_t r;
+    
+    // Default constructor - initializes empty region
+    WPixmanRegion();
+    // Constructor with rectangle - initializes with specific rect
+    WPixmanRegion(int x, int y, int w, int h);
+    ~WPixmanRegion();
+    
+    pixman_region32_t* get() { return &r; }
+    
+    // Conversion operator for compatibility
+    inline operator pixman_region32_t*() { return &r; }
+    
+    // Utility method to check if region is empty
+    inline bool isEmpty() const {
+        return !pixman_region32_not_empty(&r);
+    }
 };
 
 WAYLIB_SERVER_END_NAMESPACE


### PR DESCRIPTION
1. Added support for Wayland foreign toplevel image capture protocol
2. Implemented capture source creation and handling in Helper class
3. Added new protocol files for ext-image-capture-source and ext-
foreign-toplevel-list
4. Created WExtImageCaptureSourceV1Impl for handling actual image
capture logic
5. Added findSurfaceByHandle method to support reverse lookup from
protocol handles
6. Implemented frame scheduling and buffer copying with format
constraints handling

## Summary by Sourcery

Enable external toplevel image capture by integrating new wlroots protocols and implementing back-end support while also hardening workspace move operations against null wrappers

New Features:
- Integrate ext-image-capture-source-v1 and ext-foreign-toplevel-image-capture-source-manager-v1 protocols with generated protocol files and Wayland globals
- Implement WExtImageCaptureSourceV1Impl for external toplevel surface image capture, including frame scheduling and buffer copying
- Add request handling in Helper and reverse-to-surface lookup in WExtForeignToplevelListV1 for new capture requests

Bug Fixes:
- Prevent moveSurfaceTo crashes by adding null checks in WindowSelectionGrid.qml and WorkspaceSelectionList.qml

Enhancements:
- Add WSurfaceItem::findItemContent and WToplevelSurface lookup by handle to support capture source implementation
- Use optional chaining in QML for safer null handling

Build:
- Update CMakeLists in waylib and qwlroots to include new protocol XML definitions, sources, and headers for image capture features

## Summary by Sourcery

Enable foreign toplevel image capture by integrating new Wayland protocols and implementing back-end support in Helper and WExtImageCaptureSourceV1Impl

New Features:
- Add support for ext-image-capture-source-v1 and ext-foreign-toplevel-image-capture-source-manager-v1 protocols with generated globals
- Implement Helper::handleNewForeignToplevelCaptureRequest to create and accept image capture sources for foreign toplevels
- Introduce WExtImageCaptureSourceV1Impl to schedule frames, emit damage events, and copy buffers for external toplevel surfaces

Enhancements:
- Add WExtForeignToplevelListV1::findSurfaceByHandle and WSurfaceItem::findItemContent for reverse lookup of surfaces by protocol handles
- Manually set and update capture constraints including SHM and DMA-BUF formats in the capture source

Build:
- Update CMakeLists in waylib and qwlroots to include new protocol XML definitions, sources, and headers for the image capture extensions