### PR TITLE
feat: create ext-data-control manager

### DIFF
--- a/qwlroots/src/CMakeLists.txt
+++ b/qwlroots/src/CMakeLists.txt
@@ -91,6 +91,7 @@ set(HEADERS
     types/qwsubcompositor.h
     types/qwdatadevice.h
     types/qwdatacontrolv1.h
+    types/qwextdatacontrolv1.h
     types/qwdamagering.h
     types/qwdrm.h
     types/qwdrmleasev1.h

--- a/qwlroots/src/types/qwextdatacontrolv1.h
+++ b/qwlroots/src/types/qwextdatacontrolv1.h
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 <UnionTech Software Technology Co., Ltd.>.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <qwobject.h>
+
+extern "C" {
+#include <wlr/types/wlr_ext_data_control_v1.h>
+}
+
+QW_BEGIN_NAMESPACE
+
+class QW_CLASS_OBJECT(ext_data_control_manager_v1)
+{
+    QW_OBJECT
+    Q_OBJECT
+
+    QW_SIGNAL(new_device, wlr_ext_data_control_device_v1*)
+
+public:
+    QW_FUNC_STATIC(ext_data_control_manager_v1, create, qw_ext_data_control_manager_v1 *, wl_display *display, uint32_t version);
+};
+
+QW_END_NAMESPACE
+

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -68,6 +68,7 @@
 #include <qwdatacontrolv1.h>
 #include <qwdatadevice.h>
 #include <qwdisplay.h>
+#include <qwextdatacontrolv1.h>
 #include <qwfractionalscalemanagerv1.h>
 #include <qwgammacontorlv1.h>
 #include <qwlayershellv1.h>
@@ -95,6 +96,7 @@
 #include <utility>
 
 #define WLR_FRACTIONAL_SCALE_V1_VERSION 1
+#define EXT_DATA_CONTROL_MANAGER_V1_VERSION 1
 #define _DEEPIN_NO_TITLEBAR "_DEEPIN_NO_TITLEBAR"
 
 static xcb_atom_t internAtom(xcb_connection_t *connection, const char *name, bool onlyIfExists)
@@ -1050,6 +1052,7 @@ void Helper::init()
     m_server->attach<WCursorShapeManagerV1>();
     qw_fractional_scale_manager_v1::create(*m_server->handle(), WLR_FRACTIONAL_SCALE_V1_VERSION);
     qw_data_control_manager_v1::create(*m_server->handle());
+    qw_ext_data_control_manager_v1::create(*m_server->handle(), EXT_DATA_CONTROL_MANAGER_V1_VERSION);
     qw_alpha_modifier_v1::create(*m_server->handle());
 
     m_dockPreview = engine->createDockPreview(m_renderWindow->contentItem());

--- a/waylib/examples/tinywl/helper.cpp
+++ b/waylib/examples/tinywl/helper.cpp
@@ -57,6 +57,7 @@
 #include <qwgammacontorlv1.h>
 #include <qwbuffer.h>
 #include <qwdatacontrolv1.h>
+#include <qwextdatacontrolv1.h>
 #include <qwviewporter.h>
 #include <qwalphamodifierv1.h>
 
@@ -74,6 +75,7 @@
 #include <QVariant>
 
 #define WLR_FRACTIONAL_SCALE_V1_VERSION 1
+#define EXT_DATA_CONTROL_MANAGER_V1_VERSION 1
 
 Helper *Helper::m_instance = nullptr;
 Helper::Helper(QObject *parent)
@@ -458,6 +460,7 @@ void Helper::init()
     m_server->attach<WCursorShapeManagerV1>();
     qw_fractional_scale_manager_v1::create(*m_server->handle(), WLR_FRACTIONAL_SCALE_V1_VERSION);
     qw_data_control_manager_v1::create(*m_server->handle());
+    qw_ext_data_control_manager_v1::create(*m_server->handle(), EXT_DATA_CONTROL_MANAGER_V1_VERSION);
     qw_alpha_modifier_v1::create(*m_server->handle());
 
     m_backend->handle()->start();

--- a/waylib/src/server/pch/pch.hxx
+++ b/waylib/src/server/pch/pch.hxx
@@ -18,6 +18,7 @@
 #include<qwdrmleasev1.h>
 #include<qwegl.h>
 #include<qwexportdmabufv1.h>
+#include<qwextdatacontrolv1.h>
 #include<qwforeigntoplevelhandlev1.h>
 #include<qwfractionalscalemanagerv1.h>
 #include<qwfullscreenshellv1.h>


### PR DESCRIPTION
support ext-data-control-v1 protocol(#444 )

## Summary by Sourcery

Enable ext-data-control-v1 protocol support by defining the manager and device bindings and integrating their creation into the helper initialization routines.

New Features:
- Add support for the ext-data-control-v1 protocol with ext_data_control_manager_v1 and ext_data_control_device_v1 classes

Enhancements:
- Initialize the ext_data_control_manager_v1 in Helper::init for both the main server and tinywl example

Build:
- Include the new qwextdatacontrolv1.h header in CMakeLists and the server precompiled header