### PR TITLE
fix(waylib): Specify required rendering flags in WSGRenderFootprintNode

### DIFF
--- a/waylib/src/server/qtquick/wsurfaceitem.cpp
+++ b/waylib/src/server/qtquick/wsurfaceitem.cpp
@@ -511,6 +511,11 @@ public:
             m_owner->d_func()->rendered = true;
     }
 
+    RenderingFlags flags() const override
+    {
+        return QSGRenderNode::NoExternalRendering | QSGRenderNode::BoundedRectRendering;
+    }
+
     QPointer<WSurfaceItemContent> m_owner;
 };
 


### PR DESCRIPTION
The render() implementation uses QRhi, which requires explicit rendering flags.

Log:

## Summary by Sourcery

Bug Fixes:
- Specify NoExternalRendering and BoundedRectRendering flags in WSGRenderFootprintNode