### PR TITLE
fix: prevent title bar and window buttons from stealing focus

### DIFF
--- a/src/core/qml/TitleBar.qml
+++ b/src/core/qml/TitleBar.qml
@@ -22,6 +22,9 @@ Control {
     height: TreelandConfig.windowTitlebarHeight
     width: surfaceItem.width
 
+    // Ensure title bar does not accept keyboard focus
+    focusPolicy: Qt.NoFocus
+
     HoverHandler {
         // block hover events to resizing mouse area, avoid cursor change
         cursorShape: Qt.ArrowCursor
@@ -86,6 +89,7 @@ Control {
                     icon.name: "window_minimize"
                     textColor: control.textColor
                     height: root.height
+                    focusPolicy: Qt.NoFocus
 
                     onClicked: {
                         surface.requestMinimize()
@@ -100,6 +104,7 @@ Control {
                     icon.name: "window_quit_full"
                     textColor: control.textColor
                     height: root.height
+                    focusPolicy: Qt.NoFocus
 
                     onClicked: {
                     }
@@ -114,6 +119,7 @@ Control {
                     icon.name: surface.isMaximized ? "window_restore" : "window_maximize"
                     textColor: control.textColor
                     height: root.height
+                    focusPolicy: Qt.NoFocus
 
                     onClicked: {
                         surface.requestToggleMaximize()
@@ -135,6 +141,7 @@ Control {
                         icon.name: "window_close"
                         textColor: control.textColor
                         height: parent.height
+                        focusPolicy: Qt.NoFocus
 
                         onClicked: {
                             surface.requestClose()


### PR DESCRIPTION
1. Added Qt.NoFocus policy to title bar component to prevent keyboard focus
2. Added focusPolicy to all window control buttons (minimize, close, maximize)
3. Ensures focus remains with active window content during window operations
4. Improves accessibility and prevents focus-related UI glitches

fix: 防止标题栏和窗口按钮获取焦点

1. 为标题栏组件添加 Qt.NoFocus 策略以阻止键盘焦点
2. 为所有窗口控制按钮（最小化、关闭、最大化）添加 focusPolicy
3. 确保窗口操作期间焦点保留在活动窗口内容上
4. 提升可访问性并防止焦点相关的界面故障