### PR TITLE
ci: Trigger waylib builds when qwlroots changes

### DIFF
--- a/.github/workflows/waylib-archlinux-build.yml
+++ b/.github/workflows/waylib-archlinux-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - 'waylib/**'
+      - 'qwlroots/**'
       - '.github/workflows/waylib-archlinux-build.yml'
     branches:
       - master
@@ -11,6 +12,7 @@ on:
   pull_request:
     paths:
       - 'waylib/**'
+      - 'qwlroots/**'
       - '.github/workflows/waylib-archlinux-build.yml'
     branches:
       - master

--- a/.github/workflows/waylib-debian-build.yml
+++ b/.github/workflows/waylib-debian-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - 'waylib/**'
+      - 'qwlroots/**'
       - '.github/workflows/waylib-debian-build.yml'
     branches:
       - master
@@ -11,6 +12,7 @@ on:
   pull_request:
     paths:
       - 'waylib/**'
+      - 'qwlroots/**'
       - '.github/workflows/waylib-debian-build.yml'
     branches:
       - master

--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ $ sudo apt build-dep . # install build dependencies
 $ dpkg-buildpackage -uc -us -nc -b # build binary package(s)
 ```
 
+## GitHub Actions / CI
+
+This project uses GitHub Actions for continuous integration. The following workflows are configured:
+
+- **qwlroots builds**: Triggered when `qwlroots/**` files are modified
+- **waylib builds**: Triggered when `waylib/**` or `qwlroots/**` files are modified (since waylib depends on qwlroots)
+- **treeland builds**: Main project builds
+
+The waylib workflows are configured to also trigger when qwlroots code changes, ensuring that waylib builds remain compatible with qwlroots modifications.
+
 ## Getting Involved
 
 - [Code contribution via GitHub](https://github.com/linuxdeepin/treeland/)

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -47,6 +47,16 @@ $ sudo apt build-dep . # 安装构建依赖
 $ dpkg-buildpackage -uc -us -nc -b # 构建二进制软件包
 ```
 
+## GitHub Actions / 持续集成
+
+本项目使用 GitHub Actions 进行持续集成。配置了以下工作流：
+
+- **qwlroots 构建**：当 `qwlroots/**` 文件被修改时触发
+- **waylib 构建**：当 `waylib/**` 或 `qwlroots/**` 文件被修改时触发（因为 waylib 依赖于 qwlroots）
+- **treeland 构建**：主项目构建
+
+waylib 工作流配置为在 qwlroots 代码变化时也会触发，确保 waylib 构建与 qwlroots 修改保持兼容。
+
 ## 参与贡献
 
 - [通过 GitHub 发起代码贡献](https://github.com/linuxdeepin/treeland/)


### PR DESCRIPTION
This commit modifies the GitHub Actions workflows for waylib builds to ensure they are triggered when qwlroots code changes occur, since waylib depends on qwlroots.

Changes:
1. Added 'qwlroots/**' to the paths trigger for waylib-archlinux-build.yml
2. Added 'qwlroots/**' to the paths trigger for waylib-debian-build.yml
3. Updated README.md to document the CI workflow dependencies
4. Updated README.zh_CN.md to maintain consistency across all language versions

This ensures proper dependency management and prevents build failures when qwlroots modifications affect waylib compilation.

ci: 当qwlroots代码修改时触发waylib构建

此提交修改了waylib构建的GitHub Actions工作流，确保在qwlroots
代码发生变化时触发waylib构建，因为waylib依赖于qwlroots。

变更内容：
1. 在waylib-archlinux-build.yml的路径触发器中添加'qwlroots/**'
2. 在waylib-debian-build.yml的路径触发器中添加'qwlroots/**'
3. 更新README.md文档记录CI工作流的依赖关系
4. 更新README.zh_CN.md保持所有语言版本文档的一致性

这确保了正确的依赖管理，防止qwlroots修改影响waylib编译时
出现构建失败的情况。

## Summary by Sourcery

Trigger waylib builds when qwlroots code changes by extending CI workflow path filters and update documentation accordingly

CI:
- Extend waylib-archlinux-build and waylib-debian-build workflows to trigger on qwlroots/** path changes

Documentation:
- Update README.md and README.zh_CN.md to document waylib CI triggers and its dependency on qwlroots