### PR TITLE
fix: remove unused quit full button and add helper activation

### DIFF
--- a/src/core/qml/TitleBar.qml
+++ b/src/core/qml/TitleBar.qml
@@ -98,20 +98,6 @@ Control {
             }
 
             Loader {
-                objectName: "quitFullBtn"
-                visible: false
-                sourceComponent: D.WindowButton {
-                    icon.name: "window_quit_full"
-                    textColor: control.textColor
-                    height: root.height
-                    focusPolicy: Qt.NoFocus
-
-                    onClicked: {
-                    }
-                }
-            }
-
-            Loader {
                 id: maxOrWindedBtn
 
                 objectName: "maxOrWindedBtn"
@@ -122,6 +108,7 @@ Control {
                     focusPolicy: Qt.NoFocus
 
                     onClicked: {
+                        Helper.activateSurface(surface)
                         surface.requestToggleMaximize()
                     }
                 }


### PR DESCRIPTION
1. Remove the unused "quitFullBtn" Loader component that was not visible
2. Add Helper.activateSurface call before maximizing window
3. This ensures proper window activation before state change

fix: 删除未使用的退出全屏按钮并添加窗口激活

1. 移除了未使用的 "quitFullBtn" Loader 组件
2. 在窗口最大化前添加了 Helper.activateSurface 调用
3. 这确保了在状态改变前正确激活窗口

## Summary by Sourcery

Remove the unused quitFullBtn loader and activate the window surface before maximizing to ensure proper window state change

Bug Fixes:
- Call Helper.activateSurface before toggling window maximize to ensure proper activation

Enhancements:
- Remove unused quitFullBtn Loader component in TitleBar.qml