### PR TITLE
feat: CLI option: switch from --disable-debug-view to --enable-debug-…

### DIFF
--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -83,7 +83,7 @@ Output *Output::create(WOutput *output, QQmlEngine *engine, QObject *parent)
     // o->m_taskBar = Helper::instance()->qmlEngine()->createTaskBar(o,
     // contentItem); o->m_taskBar->setZ(RootSurfaceContainer::TaskBarZOrder);
 
-    if (!CmdLine::ref().disableDebugView()) {
+    if (CmdLine::ref().enableDebugView()) {
         o->m_debugMenuBar = Helper::instance()->qmlEngine()->createMenuBar(outputItem, contentItem);
         o->m_debugMenuBar->setZ(RootSurfaceContainer::MenuBarZOrder);
 #ifndef QT_DEBUG

--- a/src/utils/cmdline.cpp
+++ b/src/utils/cmdline.cpp
@@ -20,10 +20,10 @@ CmdLine::CmdLine()
     , m_lockScreen(std::make_unique<QCommandLineOption>("lockscreen",
                                                         "use lockscreen, need DDM auth socket"))
     , m_tryExec("try-exec", "Only try exec, don't show on screen")
-    , m_disableDebugView("disable-debug-view", "Disable debug view")
+    , m_enableDebugView("enable-debug-view", "Enable debug view")
 {
     m_parser->addHelpOption();
-    m_parser->addOptions({ *m_run.get(), *m_lockScreen.get(), m_tryExec, m_disableDebugView});
+    m_parser->addOptions({ *m_run.get(), *m_lockScreen.get(), m_tryExec, m_enableDebugView});
     m_parser->process(*QCoreApplication::instance());
 }
 
@@ -127,9 +127,9 @@ bool CmdLine::tryExec() const
     return m_parser->isSet(m_tryExec);
 }
 
-bool CmdLine::disableDebugView() const
+bool CmdLine::enableDebugView() const
 {
-    return m_parser->isSet(m_disableDebugView);
+    return m_parser->isSet(m_enableDebugView);
 }
 
 std::optional<QString> CmdLine::run() const

--- a/src/utils/cmdline.h
+++ b/src/utils/cmdline.h
@@ -26,7 +26,7 @@ public:
     bool useLockScreen() const;
     std::optional<QStringList> unescapeExecArgs(const QString &str) noexcept;
     bool tryExec() const;
-    bool disableDebugView() const;
+    bool enableDebugView() const;
 
 private:
     CmdLine();
@@ -38,5 +38,5 @@ private:
     std::unique_ptr<QCommandLineOption> m_run;
     std::unique_ptr<QCommandLineOption> m_lockScreen;
     QCommandLineOption m_tryExec;
-    QCommandLineOption m_disableDebugView;
+    QCommandLineOption m_enableDebugView;
 };


### PR DESCRIPTION
…view

- Replace `disableDebugView` logic with `enableDebugView` for improved clarity.
- Avoid displaying debug view during Debug compilation

Log:

## Summary by Sourcery

Switch the debug view CLI option from a disable flag to an enable flag and invert its default behavior

Enhancements:
- Replace the `--disable-debug-view` flag with `--enable-debug-view` for clearer semantics
- Rename CmdLine API and option names to use enable semantics
- Invert the output module logic to show the debug view only when the enable flag is set