### PR TITLE
fix: improve D-Bus connection handling and QML hover visibility

### DIFF
--- a/src/core/lockscreen.cpp
+++ b/src/core/lockscreen.cpp
@@ -30,7 +30,7 @@ void LockScreen::lock()
 
     for (const auto &[k, v] : m_components) {
         v->setProperty("currentMode", static_cast<int>(LockScreen::CurrentMode::Lock));
-        QMetaObject::invokeMethod(v.get(), "start");
+        QMetaObject::invokeMethod(v.get(), "start", QVariant::fromValue(true));
     }
 }
 
@@ -44,7 +44,7 @@ void LockScreen::shutdown()
 
     for (const auto &[k, v] : m_components) {
         v->setProperty("currentMode", static_cast<int>(LockScreen::CurrentMode::Shutdown));
-        QMetaObject::invokeMethod(v.get(), "start");
+        QMetaObject::invokeMethod(v.get(), "start", QVariant::fromValue(true));
     }
 }
 
@@ -58,7 +58,7 @@ void LockScreen::switchUser()
 
     for (const auto &[k, v] : m_components) {
         v->setProperty("currentMode", static_cast<int>(LockScreen::CurrentMode::SwitchUser));
-        QMetaObject::invokeMethod(v.get(), "start");
+        QMetaObject::invokeMethod(v.get(), "start", QVariant::fromValue(true));
     }
 }
 

--- a/src/plugins/lockscreen/qml/UserInput.qml
+++ b/src/plugins/lockscreen/qml/UserInput.qml
@@ -294,7 +294,7 @@ Item {
             Layout.preferredHeight: 16
             background: Rectangle {
                 id: hintBtnBackground
-                visible: hovered
+                visible: hintBtn.hovered
                 anchors.fill: parent
                 color: Qt.rgba(1.0, 1.0, 1.0, 0.1)
                 radius: 4

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1967,7 +1967,10 @@ void Helper::setLockScreenImpl(ILockScreen *impl)
         }
     });
 
-    QDBusConnection::systemBus().connect("org.freedesktop.login1", "/org/freedesktop/login1", "org.freedesktop.login1.Manager", "SessionNew", this, SLOT(onSessionNew(const QString &,const QDBusObjectPath &)));
+    bool dbusConnected = QDBusConnection::systemBus().connect("org.freedesktop.login1", "/org/freedesktop/login1", "org.freedesktop.login1.Manager", "SessionNew", this, SLOT(onSessionNew(const QString &,const QDBusObjectPath &)));
+    if (!dbusConnected) {
+        qCWarning(qLcHelper) << "Could not connect to org.freedesktop.login1.Manager SessionNew signal";
+    }
 
     if (CmdLine::ref().useLockScreen()) {
         showLockScreen();


### PR DESCRIPTION
1. Add proper boolean parameter passing in LockScreen component method
calls
2. Fix QML hover state reference to use correct item ID
3. Add error handling for D-Bus connection failure in Helper class
4. Improve logging for D-Bus connection issues

The changes address three different issues:
- LockScreen component methods now properly pass boolean parameters
- QML hover state visualization was incorrectly referencing the parent
container
- D-Bus connection failure handling was missing proper error reporting

fix: 改进 D-Bus 连接处理和 QML 悬停可见性

1. 在 LockScreen 组件方法调用中添加正确的布尔参数传递
2. 修复 QML 悬停状态引用以使用正确组件ID
3. 在 Helper 类中添加 D-Bus 连接失败的错误处理
4. 增强 D-Bus 连接问题的日志记录

这些修改解决了三个不同问题：
- LockScreen 组件方法现在能正确传递布尔参数
- QML 悬停状态显示错误引用了父容器的问题已修复
- D-Bus 连接失败处理缺少错误报告的问题得到解决

## Summary by Sourcery

Improve LockScreen and Helper robustness by fixing parameter passing, correcting QML hover visibility, and adding error handling and logging for D-Bus connection failures.

Bug Fixes:
- Properly pass boolean parameter to LockScreen component start method calls
- Fix QML hover state reference to use hintBtn.hovered for visibility
- Add error handling for D-Bus signal connection failure in Helper class

Enhancements:
- Improve logging for D-Bus connection issues