### PR TITLE
chore(debian): update version to 0.6.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+treeland (0.6.1) unstable; urgency=medium
+
+  * fix: improve D-Bus connection handling and QML hover visibility
+  * feat: CLI option: switch from --disable-debug-view to --enable-debug-
+    view
+  * fix(waylib): Specify required rendering flags in
+    WSGRenderFootprintNode
+
+ -- rewine <luhongxu@uniontech.com>  Fri, 01 Aug 2025 13:33:07 +0800
+
 treeland (0.6.0) unstable; urgency=medium
 
   * fix: improve image capture error handling and code structure


### PR DESCRIPTION
log: 0.6.1

## Summary by Sourcery

Chores:
- Update debian/changelog to reflect version 0.6.1