### PR TITLE
feat: add transient_seat_v1 implementation

### DIFF
--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -63,6 +63,7 @@ class qw_idle_inhibit_manager_v1;
 class qw_output_configuration_v1;
 class qw_output_power_manager_v1;
 class qw_idle_inhibitor_v1;
+class qw_transient_seat_manager_v1;
 QW_END_NAMESPACE
 
 WAYLIB_SERVER_USE_NAMESPACE
@@ -318,6 +319,7 @@ private:
     WBackend *m_backend = nullptr;
     qw_renderer *m_renderer = nullptr;
     qw_allocator *m_allocator = nullptr;
+    qw_transient_seat_manager_v1 *m_transientSeatManager = nullptr;
 
     // protocols
     qw_compositor *m_compositor = nullptr;
@@ -366,4 +368,5 @@ private:
     UserModel *m_userModel{ nullptr };
 
     quint32 m_atomDeepinNoTitlebar;
+    uint64_t m_transientSeatCounter = 0;
 };


### PR DESCRIPTION
Create separate seats for virtual-pointer and virtual-keyboard

Log:

## Summary by Sourcery

Add transient seat v1 support by including its manager, connecting creation signals, and spawning WSeat instances with proper lifecycle handling.

New Features:
- Integrate the transient_seat_v1 protocol into the seat helper
- Handle notify_create_seat events to dynamically allocate and manage new virtual seats