### PR TITLE
fix: resolve library versioning and installation path issues

### DIFF
--- a/debian/treeland.install
+++ b/debian/treeland.install
@@ -7,4 +7,4 @@ usr/share/*/translations/*
 usr/share/dbus-1/system.d/*
 usr/lib/*/lib*.so.*
 usr/lib/*/treeland/plugins/lib*.so
-usr/share/treeland/qml
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,6 +68,8 @@ qt_add_library(libtreeland SHARED)
 
 set_target_properties(libtreeland PROPERTIES
     OUTPUT_NAME "treeland"
+    VERSION ${CMAKE_PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
 )
 
 qt_add_qml_module(libtreeland
@@ -271,6 +273,7 @@ target_link_libraries(libtreeland
         PkgConfig::PIXMAN
         PkgConfig::WAYLAND
         PkgConfig::LIBINPUT
+        PkgConfig::XCB
         $<$<NOT:$<BOOL:${DISABLE_DDM}>>:DDM::Auth>
         $<$<NOT:$<BOOL:${DISABLE_DDM}>>:DDM::Common>
         $<$<NOT:$<BOOL:${DISABLE_DDM}>>:PkgConfig::PAM>
@@ -298,8 +301,6 @@ target_link_libraries(${BIN_NAME} PRIVATE
 install(TARGETS ${BIN_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 install(PROGRAMS treeland.sh DESTINATION "${CMAKE_INSTALL_BINDIR}")
 install(TARGETS libtreeland LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
-# TODO: The qml plugin installation directory still needs to be adjusted
-install(DIRECTORY ${PROJECT_BINARY_DIR}/qt/qml/Treeland DESTINATION "${TREELAND_DATA_DIR}/qml/Treeland")
 
 ## systemd socket
 

--- a/src/modules/capture/CMakeLists.txt
+++ b/src/modules/capture/CMakeLists.txt
@@ -15,6 +15,8 @@ qt_add_library(${MODULE_NAME} SHARED)
 
 set_target_properties(${MODULE_NAME} PROPERTIES
     OUTPUT_NAME "treeland-protocol-capture-v1"
+    VERSION ${CMAKE_PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
 )
 
 qt_add_qml_module(${MODULE_NAME}
@@ -41,7 +43,6 @@ target_compile_definitions(${MODULE_NAME}
 target_include_directories(${MODULE_NAME}
 PRIVATE
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src>
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
 
@@ -63,4 +64,3 @@ impl_treeland(
 )
 
 install(TARGETS ${MODULE_NAME} DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(DIRECTORY ${PROJECT_BINARY_DIR}/qt/qml/Treeland/Capture/ DESTINATION ${TREELAND_DATA_DIR}/qml/Treeland/Capture)


### PR DESCRIPTION
1. Add proper versioning to libtreeland and capture module with VERSION and SOVERSION properties
2. Remove duplicate and unnecessary qml directory installation commands that were causing conflicts
3. Add XCB dependency to libtreeland target_link_libraries for improved X11 compatibility
4. Clean up commented-out installation code that was no longer needed

fix: 解决库版本和安装路径问题

1. 为 libtreeland 和 capture 模块添加正确的版本信息，使用 VERSION 和 SOVERSION 属性
2. 移除导致冲突的重复 qml 目录安装命令
3. 在 libtreeland 的 target_link_libraries 中添加 XCB 依赖以提升 X11 兼 容性
4. 清理不再需要的注释掉的安装代码

## Summary by Sourcery

Fix library versioning and installation path issues by adding proper version properties to CMake targets, removing conflicting QML install steps, and updating link dependencies

Bug Fixes:
- Add VERSION and SOVERSION properties to libtreeland and capture modules to enforce proper library versioning
- Remove duplicate QML directory installation commands to eliminate installation conflicts

Enhancements:
- Link XCB in libtreeland target_link_libraries to improve X11 compatibility

Chores:
- Remove commented-out and outdated installation code