### PR TITLE
fix: resolve compilation warnings and improve code structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ if (ADDRESS_SANITIZER)
     add_compile_options(-fsanitize=address -fno-optimize-sibling-calls -fno-omit-frame-pointer)
     add_link_options(-fsanitize=address)
 endif()
+add_compile_options(-Wall -Wextra)
 
 set(LOCAL_QML_IMPORT_PATH "${PROJECT_BINARY_DIR}/qt/qml")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ if (ADDRESS_SANITIZER)
     add_link_options(-fsanitize=address)
 endif()
 add_compile_options(-Wall -Wextra)
+# NOTE: Qt keywords conflict with wlroots. but dtksystemsettings still uses it.
+# add_definitions("-DQT_NO_KEYWORDS")
 
 set(LOCAL_QML_IMPORT_PATH "${PROJECT_BINARY_DIR}/qt/qml")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ add_compile_options(-Wall -Wextra)
 # NOTE: Qt keywords conflict with wlroots. but dtksystemsettings still uses it.
 # add_definitions("-DQT_NO_KEYWORDS")
 
+# NOTE: Enable Qt logging with context.
+add_definitions("-DQT_MESSAGELOGCONTEXT")
+
 set(LOCAL_QML_IMPORT_PATH "${PROJECT_BINARY_DIR}/qt/qml")
 
 if(WITH_SUBMODULE_WAYLIB)

--- a/examples/test_capture/capture.cpp
+++ b/examples/test_capture/capture.cpp
@@ -274,7 +274,7 @@ void TreelandCaptureManager::setRecord(bool newRecord)
     if (m_record == newRecord)
         return;
     m_record = newRecord;
-    emit recordChanged();
+    Q_EMIT recordChanged();
 }
 
 bool TreelandCaptureManager::recordStarted() const

--- a/examples/test_capture/subwindow.h
+++ b/examples/test_capture/subwindow.h
@@ -11,7 +11,7 @@ class SubWindow : public QQuickWindow
     Q_OBJECT
     QML_ELEMENT
     Q_PROPERTY(QQuickWindow *parent READ parent WRITE setParent NOTIFY parentChanged FINAL)
-signals:
+Q_SIGNALS:
     void parentChanged();
 
 public:

--- a/qwlroots/doc/ai/qwlroots-wrapping-patterns-best-practices-en.md
+++ b/qwlroots/doc/ai/qwlroots-wrapping-patterns-best-practices-en.md
@@ -522,7 +522,7 @@ class TestQwExample : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testCreate();
     void testSignals();
     void testMethods();

--- a/qwlroots/doc/ai/qwlroots-wrapping-patterns-best-practices.md
+++ b/qwlroots/doc/ai/qwlroots-wrapping-patterns-best-practices.md
@@ -522,7 +522,7 @@ class TestQwExample : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testCreate();
     void testSignals();
     void testMethods();

--- a/qwlroots/src/interfaces/qwinterface.h
+++ b/qwlroots/src/interfaces/qwinterface.h
@@ -77,8 +77,8 @@ protected:
     }
 
     qw_interface()
-        : m_handleImpl(new Impl { nullptr })
-        , m_handle(reinterpret_cast<_handle*>(calloc(1, sizeof(_handle))))
+        : m_handle(reinterpret_cast<_handle*>(calloc(1, sizeof(_handle))))
+        , m_handleImpl(new Impl {})
     {
         static_cast<_handle*>(m_handle)->interface = this;
         constexpr bool has_destroy = requires(const Impl &i) {

--- a/src/config/treelandconfig.cpp
+++ b/src/config/treelandconfig.cpp
@@ -73,7 +73,7 @@ void TreelandConfig::setWorkspaceThumbCornerRadius(uint newWorkspaceThumbCornerR
     if (m_workspaceThumbCornerRadius == newWorkspaceThumbCornerRadius)
         return;
     m_workspaceThumbCornerRadius = newWorkspaceThumbCornerRadius;
-    emit workspaceThumbCornerRadiusChanged();
+    Q_EMIT workspaceThumbCornerRadiusChanged();
 }
 
 uint TreelandConfig::highlightBorderWidth() const
@@ -86,7 +86,7 @@ void TreelandConfig::setHighlightBorderWidth(uint newHighlightBorderWidth)
     if (m_highlightBorderWidth == newHighlightBorderWidth)
         return;
     m_highlightBorderWidth = newHighlightBorderWidth;
-    emit highlightBorderWidthChanged();
+    Q_EMIT highlightBorderWidthChanged();
 }
 
 uint TreelandConfig::maxWorkspace() const
@@ -112,7 +112,7 @@ void TreelandConfig::setMinMultitaskviewSurfaceHeight(uint newMinMultitaskviewSu
     if (m_minMultitaskviewSurfaceHeight == newMinMultitaskviewSurfaceHeight)
         return;
     m_minMultitaskviewSurfaceHeight = newMinMultitaskviewSurfaceHeight;
-    emit minMultitaskviewSurfaceHeightChanged();
+    Q_EMIT minMultitaskviewSurfaceHeightChanged();
 }
 
 uint TreelandConfig::titleBoxCornerRadius() const
@@ -125,7 +125,7 @@ void TreelandConfig::setTitleBoxCornerRadius(uint newTitleBoxCornerRadius)
     if (m_titleBoxCornerRadius == newTitleBoxCornerRadius)
         return;
     m_titleBoxCornerRadius = newTitleBoxCornerRadius;
-    emit titleBoxCornerRadiusChanged();
+    Q_EMIT titleBoxCornerRadiusChanged();
 }
 
 void TreelandConfig::onDConfigChanged(const QString &key)
@@ -149,7 +149,7 @@ void TreelandConfig::setNormalWindowHeight(uint newNormalWindowHeight)
     if (m_normalWindowHeight == newNormalWindowHeight)
         return;
     m_normalWindowHeight = newNormalWindowHeight;
-    emit normalWindowHeightChanged();
+    Q_EMIT normalWindowHeightChanged();
 }
 
 uint TreelandConfig::windowHeightStep() const
@@ -162,7 +162,7 @@ void TreelandConfig::setWindowHeightStep(uint newWindowHeightStep)
     if (m_windowHeightStep == newWindowHeightStep)
         return;
     m_windowHeightStep = newWindowHeightStep;
-    emit windowHeightStepChanged();
+    Q_EMIT windowHeightStepChanged();
 }
 
 uint TreelandConfig::numWorkspace() const
@@ -208,7 +208,7 @@ void TreelandConfig::setForceSoftwareCursor(bool enable)
         return;
     m_forceSoftwareCursor = enable;
     m_dconfig->setValue("forceSoftwareCursor", QVariant::fromValue(m_forceSoftwareCursor));
-    emit forceSoftwareCursorChanged();
+    Q_EMIT forceSoftwareCursorChanged();
 }
 
 qreal TreelandConfig::multitaskviewPaddingOpacity() const
@@ -221,7 +221,7 @@ void TreelandConfig::setMultitaskviewPaddingOpacity(qreal newMultitaskviewPaddin
     if (qFuzzyCompare(m_multitaskviewPaddingOpacity, newMultitaskviewPaddingOpacity))
         return;
     m_multitaskviewPaddingOpacity = newMultitaskviewPaddingOpacity;
-    emit multitaskviewPaddingOpacityChanged();
+    Q_EMIT multitaskviewPaddingOpacityChanged();
 }
 
 uint TreelandConfig::multitaskviewAnimationDuration() const
@@ -234,7 +234,7 @@ void TreelandConfig::setMultitaskviewAnimationDuration(uint newMultitaskviewAnim
     if (m_multitaskviewAnimationDuration == newMultitaskviewAnimationDuration)
         return;
     m_multitaskviewAnimationDuration = newMultitaskviewAnimationDuration;
-    emit multitaskviewAnimationDurationChanged();
+    Q_EMIT multitaskviewAnimationDurationChanged();
 }
 
 QEasingCurve::Type TreelandConfig::multitaskviewEasingCurveType() const
@@ -248,7 +248,7 @@ void TreelandConfig::setMultitaskviewEasingCurveType(
     if (m_multitaskviewEasingCurveType == newMultitaskviewEasingCurveType)
         return;
     m_multitaskviewEasingCurveType = newMultitaskviewEasingCurveType;
-    emit multitaskviewEasingCurveTypeChanged();
+    Q_EMIT multitaskviewEasingCurveTypeChanged();
 }
 
 void TreelandConfig::setCursorThemeName(const QString &theme)
@@ -260,7 +260,7 @@ void TreelandConfig::setCursorThemeName(const QString &theme)
     m_cursorThemeName = theme;
     m_dconfig->setValue("cursorThemeName", theme);
 
-    emit cursorThemeNameChanged();
+    Q_EMIT cursorThemeNameChanged();
 }
 
 QString TreelandConfig::cursorThemeName()
@@ -284,7 +284,7 @@ void TreelandConfig::setCursorSize(QSize size)
     m_cursorSize = size;
     m_dconfig->setValue("cursorSize", size.width());
 
-    emit cursorSizeChanged();
+    Q_EMIT cursorSizeChanged();
 }
 
 QSize TreelandConfig::cursorSize()
@@ -324,7 +324,7 @@ void TreelandConfig::setActiveColor(const QString &color)
     }
     m_dconfig->setValue("activeColor", color);
     m_activeColor = color;
-    emit activeColorChanged();
+    Q_EMIT activeColorChanged();
 }
 
 QString TreelandConfig::activeColor()
@@ -344,7 +344,7 @@ void TreelandConfig::setWindowOpacity(uint32_t opacity)
 
     m_windowOpacity = opacity;
 
-    emit windowOpacityChanged();
+    Q_EMIT windowOpacityChanged();
 }
 
 uint32_t TreelandConfig::windowOpacity()
@@ -364,7 +364,7 @@ void TreelandConfig::setWindowThemeType(uint32_t type)
 
     m_windowThemeType = type;
 
-    emit windowThemeTypeChanged();
+    Q_EMIT windowThemeTypeChanged();
 }
 
 uint32_t TreelandConfig::windowThemeType()
@@ -384,7 +384,7 @@ void TreelandConfig::setWindowTitlebarHeight(uint32_t height)
 
     m_windowTitlebarHeight = height;
 
-    emit windowTitlebarHeightChanged();
+    Q_EMIT windowTitlebarHeightChanged();
 }
 
 uint32_t TreelandConfig::windowTitlebarHeight()

--- a/src/config/treelandconfig.h
+++ b/src/config/treelandconfig.h
@@ -200,12 +200,12 @@ private:
     uint m_currentWorkspace;
     bool m_forceSoftwareCursor;
     QString m_activeColor;
+    qreal m_windowRadius;
+    QString m_cursorThemeName;
+    QSize m_cursorSize;
     uint32_t m_windowOpacity;
     uint32_t m_windowThemeType;
     uint32_t m_windowTitlebarHeight;
-    QString m_cursorThemeName;
-    QSize m_cursorSize;
-    qreal m_windowRadius;
     QString m_fontName;
     QString m_monoFontName;
     uint32_t m_fontSize;

--- a/src/core/lockscreen.cpp
+++ b/src/core/lockscreen.cpp
@@ -66,7 +66,6 @@ void LockScreen::addOutput(Output *output)
 {
     SurfaceContainer::addOutput(output);
 
-    auto engine = Helper::instance()->qmlEngine();
     auto *item = m_impl->createLockScreen(output, this);
 
     if (isVisible()) {

--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -97,6 +97,7 @@ WXWayland *ShellHandler::createXWayland(WServer *server,
                                         qw_compositor *compositor,
                                         bool lazy)
 {
+    Q_UNUSED(lazy)
     auto *xwayland = server->attach<WXWayland>(compositor, false);
     m_xwaylands.append(xwayland);
     xwayland->setSeat(seat);

--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -95,9 +95,8 @@ void ShellHandler::initLayerShell(WServer *server)
 WXWayland *ShellHandler::createXWayland(WServer *server,
                                         WSeat *seat,
                                         qw_compositor *compositor,
-                                        bool lazy)
+                                        [[maybe_unused]] bool lazy)
 {
-    Q_UNUSED(lazy)
     auto *xwayland = server->attach<WXWayland>(compositor, false);
     m_xwaylands.append(xwayland);
     xwayland->setSeat(seat);

--- a/src/core/windowpicker.cpp
+++ b/src/core/windowpicker.cpp
@@ -49,6 +49,7 @@ QRectF WindowPicker::selectionRegion() const
 
 void WindowPicker::mousePressEvent(QMouseEvent *event)
 {
+    Q_UNUSED(event)
     auto window = qobject_cast<WSurfaceItem *>(m_itemSelector->hoveredItem());
     Q_EMIT windowPicked(window);
 }

--- a/src/core/windowpicker.cpp
+++ b/src/core/windowpicker.cpp
@@ -47,9 +47,8 @@ QRectF WindowPicker::selectionRegion() const
     return m_itemSelector->selectionRegion();
 }
 
-void WindowPicker::mousePressEvent(QMouseEvent *event)
+void WindowPicker::mousePressEvent([[maybe_unused]] QMouseEvent *event)
 {
-    Q_UNUSED(event)
     auto window = qobject_cast<WSurfaceItem *>(m_itemSelector->hoveredItem());
     Q_EMIT windowPicked(window);
 }

--- a/src/effects/tquickradiuseffect.cpp
+++ b/src/effects/tquickradiuseffect.cpp
@@ -56,22 +56,22 @@ void TQuickRadiusEffect::setRadius(qreal radius)
     d->maybeSetImplicitAntialiasing();
 
     update();
-    emit radiusChanged();
+    Q_EMIT radiusChanged();
 
     if (d->extraRadius.isAllocated()) {
         if (d->extraRadius->topLeftRadius < 0.)
-            emit topLeftRadiusChanged();
+            Q_EMIT topLeftRadiusChanged();
         if (d->extraRadius->topRightRadius < 0.)
-            emit topRightRadiusChanged();
+            Q_EMIT topRightRadiusChanged();
         if (d->extraRadius->bottomLeftRadius < 0.)
-            emit bottomLeftRadiusChanged();
+            Q_EMIT bottomLeftRadiusChanged();
         if (d->extraRadius->bottomRightRadius < 0.)
-            emit bottomRightRadiusChanged();
+            Q_EMIT bottomRightRadiusChanged();
     } else {
-        emit topLeftRadiusChanged();
-        emit topRightRadiusChanged();
-        emit bottomLeftRadiusChanged();
-        emit bottomRightRadiusChanged();
+        Q_EMIT topLeftRadiusChanged();
+        Q_EMIT topRightRadiusChanged();
+        Q_EMIT bottomLeftRadiusChanged();
+        Q_EMIT bottomRightRadiusChanged();
     }
 }
 
@@ -100,7 +100,7 @@ void TQuickRadiusEffect::setTopLeftRadius(qreal radius)
     d->maybeSetImplicitAntialiasing();
 
     update();
-    emit topLeftRadiusChanged();
+    Q_EMIT topLeftRadiusChanged();
 }
 
 void TQuickRadiusEffect::resetTopLeftRadius()
@@ -116,7 +116,7 @@ void TQuickRadiusEffect::resetTopLeftRadius()
     d->maybeSetImplicitAntialiasing();
 
     update();
-    emit topLeftRadiusChanged();
+    Q_EMIT topLeftRadiusChanged();
 }
 
 qreal TQuickRadiusEffect::topRightRadius() const
@@ -144,7 +144,7 @@ void TQuickRadiusEffect::setTopRightRadius(qreal radius)
     d->maybeSetImplicitAntialiasing();
 
     update();
-    emit topRightRadiusChanged();
+    Q_EMIT topRightRadiusChanged();
 }
 
 void TQuickRadiusEffect::resetTopRightRadius()
@@ -160,7 +160,7 @@ void TQuickRadiusEffect::resetTopRightRadius()
     d->maybeSetImplicitAntialiasing();
 
     update();
-    emit topRightRadiusChanged();
+    Q_EMIT topRightRadiusChanged();
 }
 
 qreal TQuickRadiusEffect::bottomLeftRadius() const
@@ -188,7 +188,7 @@ void TQuickRadiusEffect::setBottomLeftRadius(qreal radius)
     d->maybeSetImplicitAntialiasing();
 
     update();
-    emit bottomLeftRadiusChanged();
+    Q_EMIT bottomLeftRadiusChanged();
 }
 
 void TQuickRadiusEffect::resetBottomLeftRadius()
@@ -204,7 +204,7 @@ void TQuickRadiusEffect::resetBottomLeftRadius()
     d->maybeSetImplicitAntialiasing();
 
     update();
-    emit bottomLeftRadiusChanged();
+    Q_EMIT bottomLeftRadiusChanged();
 }
 
 qreal TQuickRadiusEffect::bottomRightRadius() const
@@ -232,7 +232,7 @@ void TQuickRadiusEffect::setBottomRightRadius(qreal radius)
     d->maybeSetImplicitAntialiasing();
 
     update();
-    emit bottomRightRadiusChanged();
+    Q_EMIT bottomRightRadiusChanged();
 }
 
 void TQuickRadiusEffect::resetBottomRightRadius()
@@ -248,7 +248,7 @@ void TQuickRadiusEffect::resetBottomRightRadius()
     d->maybeSetImplicitAntialiasing();
 
     update();
-    emit bottomRightRadiusChanged();
+    Q_EMIT bottomRightRadiusChanged();
 }
 
 QQuickItem *TQuickRadiusEffect::sourceItem() const
@@ -300,18 +300,17 @@ void TQuickRadiusEffect::setSourceItem(QQuickItem *item)
         }
     }
     update();
-    emit sourceItemChanged();
+    Q_EMIT sourceItemChanged();
 }
 
-void TQuickRadiusEffect::sourceItemDestroyed(QObject *item)
+void TQuickRadiusEffect::sourceItemDestroyed([[maybe_unused]] QObject *item)
 {
     Q_D(TQuickRadiusEffect);
 
     Q_ASSERT(item == d->sourceItem);
-    Q_UNUSED(item);
     d->sourceItem = nullptr;
     update();
-    emit sourceItemChanged();
+    Q_EMIT sourceItemChanged();
 }
 
 bool TQuickRadiusEffect::hideSource() const
@@ -333,7 +332,7 @@ void TQuickRadiusEffect::setHideSource(bool hide)
         QQuickItemPrivate::get(d->sourceItem)->derefFromEffectItem(d->hideSource);
     }
     d->hideSource = hide;
-    emit hideSourceChanged();
+    Q_EMIT hideSourceChanged();
 }
 
 QSGNode *TQuickRadiusEffect::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData *)

--- a/src/effects/tsgradiusimagenode.cpp
+++ b/src/effects/tsgradiusimagenode.cpp
@@ -141,9 +141,8 @@ QSGMaterialType *TSGRadiusSmoothTextureMaterial::type() const
 }
 
 QSGMaterialShader *TSGRadiusSmoothTextureMaterial::createShader(
-    QSGRendererInterface::RenderMode renderMode) const
+    [[maybe_unused]] QSGRendererInterface::RenderMode renderMode) const
 {
-    Q_UNUSED(renderMode);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
     Q_ASSERT_X(viewCount() == 1, __func__, "Multiview not supported now.");
 #endif
@@ -411,9 +410,8 @@ void TSGRadiusImageNode::updateGeometry()
     m_node.markDirty(QSGNode::DirtyGeometry);
 }
 
-void TSGRadiusImageNode::updateTexturedRadiusGeometry(const QRectF &rect, const QRectF &textureRect)
+void TSGRadiusImageNode::updateTexturedRadiusGeometry(const QRectF &rect, [[maybe_unused]] const QRectF &textureRect)
 {
-    Q_UNUSED(textureRect)
     float width = float(rect.width());
     float height = float(rect.height());
 

--- a/src/effects/tsgradiusimagenode.cpp
+++ b/src/effects/tsgradiusimagenode.cpp
@@ -58,7 +58,7 @@ struct SmoothImageVertex
     float dx, dy, du, dv;
 };
 
-const QSGGeometry::AttributeSet &smoothImageAttributeSet()
+[[maybe_unused]] const QSGGeometry::AttributeSet &smoothImageAttributeSet()
 {
     static QSGGeometry::Attribute data[] = {
         QSGGeometry::Attribute::createWithAttributeType(0,
@@ -413,6 +413,7 @@ void TSGRadiusImageNode::updateGeometry()
 
 void TSGRadiusImageNode::updateTexturedRadiusGeometry(const QRectF &rect, const QRectF &textureRect)
 {
+    Q_UNUSED(textureRect)
     float width = float(rect.width());
     float height = float(rect.height());
 

--- a/src/effects/tsgradiusimagenode.h
+++ b/src/effects/tsgradiusimagenode.h
@@ -45,7 +45,7 @@ public:
     void setAntialiasing(bool antialiasing);
     void setTextureProvider(QSGTextureProvider *p);
 
-public slots:
+public Q_SLOTS:
     void handleTextureChange();
 
 protected:

--- a/src/greeter/greeterproxy.cpp
+++ b/src/greeter/greeterproxy.cpp
@@ -370,6 +370,7 @@ void GreeterProxy::onSessionAdded(const QDBusObjectPath &session)
 
 void GreeterProxy::onSessionRemoved(const QDBusObjectPath &session)
 {
+    Q_UNUSED(session)
     // FIXME: Reset all user state, because we can't know which user was logout.
     userModel()->clearUserLoginState();
     updateLocketState();
@@ -480,6 +481,8 @@ bool GreeterProxy::localValidation(const QString &user, const QString &password)
            const struct pam_message **msg,
            struct pam_response **resp,
            void *appdata_ptr) {
+            Q_UNUSED(num_msg)
+            Q_UNUSED(msg)
             auto *reply = new pam_response;
             reply->resp = strdup(static_cast<const char *>(appdata_ptr)); // 将密码传递给PAM
             reply->resp_retcode = 0;

--- a/src/greeter/greeterproxy.cpp
+++ b/src/greeter/greeterproxy.cpp
@@ -368,9 +368,8 @@ void GreeterProxy::onSessionAdded(const QDBusObjectPath &session)
     updateLocketState();   
 }
 
-void GreeterProxy::onSessionRemoved(const QDBusObjectPath &session)
+void GreeterProxy::onSessionRemoved([[maybe_unused]] const QDBusObjectPath &session)
 {
-    Q_UNUSED(session)
     // FIXME: Reset all user state, because we can't know which user was logout.
     userModel()->clearUserLoginState();
     updateLocketState();
@@ -407,7 +406,7 @@ void GreeterProxy::readyRead()
             d->canHibernate = capabilities & Capability::Hibernate;
             d->canHybridSleep = capabilities & Capability::HybridSleep;
 
-            // emit signals
+            // Q_EMIT signals
             Q_EMIT canPowerOffChanged(d->canPowerOff);
             Q_EMIT canRebootChanged(d->canReboot);
             Q_EMIT canSuspendChanged(d->canSuspend);
@@ -420,7 +419,7 @@ void GreeterProxy::readyRead()
             // read host name
             input >> d->hostName;
 
-            // emit signal
+            // Q_EMIT signal
             Q_EMIT hostNameChanged(d->hostName);
         } break;
         case DaemonMessages::LoginSucceeded: {
@@ -477,12 +476,10 @@ void GreeterProxy::readyRead()
 bool GreeterProxy::localValidation(const QString &user, const QString &password) const
 {
     struct pam_conv conv = {
-        [](int num_msg,
-           const struct pam_message **msg,
+        []([[maybe_unused]] int num_msg,
+           [[maybe_unused]] const struct pam_message **msg,
            struct pam_response **resp,
            void *appdata_ptr) {
-            Q_UNUSED(num_msg)
-            Q_UNUSED(msg)
             auto *reply = new pam_response;
             reply->resp = strdup(static_cast<const char *>(appdata_ptr)); // 将密码传递给PAM
             reply->resp_retcode = 0;

--- a/src/input/inputdevice.cpp
+++ b/src/input/inputdevice.cpp
@@ -29,7 +29,7 @@ static bool ensureStatus(libinput_config_status status)
     return true;
 }
 
-static bool configSendEventsMode(libinput_device *device, uint32_t mode)
+[[maybe_unused]] static bool configSendEventsMode(libinput_device *device, uint32_t mode)
 {
     if (libinput_device_config_send_events_get_mode(device) == mode) {
         qCCritical(qLcInputdevice) << "libinput_device_config_send_events_set_mode repeat set mode"
@@ -58,7 +58,7 @@ static bool configTapEnabled(libinput_device *device, libinput_config_tap_state 
     return ensureStatus(status);
 }
 
-static bool configTapButtonMap(libinput_device *device, libinput_config_tap_button_map map)
+[[maybe_unused]] static bool configTapButtonMap(libinput_device *device, libinput_config_tap_button_map map)
 {
     if (libinput_device_config_tap_get_finger_count(device) <= 0
         || libinput_device_config_tap_get_button_map(device) == map) {
@@ -73,7 +73,7 @@ static bool configTapButtonMap(libinput_device *device, libinput_config_tap_butt
     return ensureStatus(status);
 }
 
-static bool configTapDragEnabled(libinput_device *device, libinput_config_drag_state drag)
+[[maybe_unused]] static bool configTapDragEnabled(libinput_device *device, libinput_config_drag_state drag)
 {
     if (libinput_device_config_tap_get_finger_count(device) <= 0
         || libinput_device_config_tap_get_drag_enabled(device) == drag) {
@@ -88,7 +88,7 @@ static bool configTapDragEnabled(libinput_device *device, libinput_config_drag_s
     return ensureStatus(status);
 }
 
-static bool configTapDragLockEnabled(libinput_device *device, libinput_config_drag_lock_state lock)
+[[maybe_unused]] static bool configTapDragLockEnabled(libinput_device *device, libinput_config_drag_lock_state lock)
 {
     if (libinput_device_config_tap_get_finger_count(device) <= 0
         || libinput_device_config_tap_get_drag_lock_enabled(device) == lock) {
@@ -104,7 +104,7 @@ static bool configTapDragLockEnabled(libinput_device *device, libinput_config_dr
     return ensureStatus(status);
 }
 
-static bool configAccelSpeed(libinput_device *device, double speed)
+[[maybe_unused]] static bool configAccelSpeed(libinput_device *device, double speed)
 {
     if (!libinput_device_config_accel_is_available(device)
         || libinput_device_config_accel_get_speed(device) == speed) {
@@ -119,7 +119,7 @@ static bool configAccelSpeed(libinput_device *device, double speed)
     return ensureStatus(status);
 }
 
-static bool configRotationAngle(libinput_device *device, double angle)
+[[maybe_unused]] static bool configRotationAngle(libinput_device *device, double angle)
 {
     if (!libinput_device_config_rotation_is_available(device)
         || libinput_device_config_rotation_get_angle(device) == angle) {
@@ -134,7 +134,7 @@ static bool configRotationAngle(libinput_device *device, double angle)
     return ensureStatus(status);
 }
 
-static bool configAccelProfile(libinput_device *device, libinput_config_accel_profile profile)
+[[maybe_unused]] static bool configAccelProfile(libinput_device *device, libinput_config_accel_profile profile)
 {
     if (!libinput_device_config_accel_is_available(device)
         || libinput_device_config_accel_get_profile(device) == profile) {
@@ -149,7 +149,7 @@ static bool configAccelProfile(libinput_device *device, libinput_config_accel_pr
     return ensureStatus(status);
 }
 
-static bool configNaturalScroll(libinput_device *device, bool natural)
+[[maybe_unused]] static bool configNaturalScroll(libinput_device *device, bool natural)
 {
     if (!libinput_device_config_scroll_has_natural_scroll(device)
         || libinput_device_config_scroll_get_natural_scroll_enabled(device) == natural) {
@@ -165,7 +165,7 @@ static bool configNaturalScroll(libinput_device *device, bool natural)
     return ensureStatus(status);
 }
 
-static bool configLeftHanded(libinput_device *device, bool left)
+[[maybe_unused]] static bool configLeftHanded(libinput_device *device, bool left)
 {
     if (!libinput_device_config_left_handed_is_available(device)
         || libinput_device_config_left_handed_get(device) == left) {
@@ -180,7 +180,7 @@ static bool configLeftHanded(libinput_device *device, bool left)
     return ensureStatus(status);
 }
 
-static bool configClickMethod(libinput_device *device, libinput_config_click_method method)
+[[maybe_unused]] static bool configClickMethod(libinput_device *device, libinput_config_click_method method)
 {
     uint32_t click = libinput_device_config_click_get_methods(device);
     if ((click & ~LIBINPUT_CONFIG_CLICK_METHOD_NONE) == 0
@@ -196,7 +196,7 @@ static bool configClickMethod(libinput_device *device, libinput_config_click_met
     return ensureStatus(status);
 }
 
-static bool configMiddleEmulation(libinput_device *device,
+[[maybe_unused]] static bool configMiddleEmulation(libinput_device *device,
                                   libinput_config_middle_emulation_state mid)
 {
     if (!libinput_device_config_middle_emulation_is_available(device)
@@ -213,7 +213,7 @@ static bool configMiddleEmulation(libinput_device *device,
     return ensureStatus(status);
 }
 
-static bool configScrollMethod(libinput_device *device, libinput_config_scroll_method method)
+[[maybe_unused]] static bool configScrollMethod(libinput_device *device, libinput_config_scroll_method method)
 {
     uint32_t scroll = libinput_device_config_scroll_get_methods(device);
     if ((scroll & ~LIBINPUT_CONFIG_SCROLL_NO_SCROLL) == 0
@@ -229,7 +229,7 @@ static bool configScrollMethod(libinput_device *device, libinput_config_scroll_m
     return ensureStatus(status);
 }
 
-static bool configScrollButton(libinput_device *device, uint32_t button)
+[[maybe_unused]] static bool configScrollButton(libinput_device *device, uint32_t button)
 {
     uint32_t scroll = libinput_device_config_scroll_get_methods(device);
     if ((scroll & ~LIBINPUT_CONFIG_SCROLL_NO_SCROLL) == 0
@@ -245,7 +245,7 @@ static bool configScrollButton(libinput_device *device, uint32_t button)
     return ensureStatus(status);
 }
 
-static bool configScrollButtonLock(libinput_device *device,
+[[maybe_unused]] static bool configScrollButtonLock(libinput_device *device,
                                    libinput_config_scroll_button_lock_state lock)
 {
     uint32_t scroll = libinput_device_config_scroll_get_methods(device);
@@ -263,7 +263,7 @@ static bool configScrollButtonLock(libinput_device *device,
     return ensureStatus(status);
 }
 
-static bool configDwtEnabled(libinput_device *device, enum libinput_config_dwt_state enable)
+[[maybe_unused]] static bool configDwtEnabled(libinput_device *device, enum libinput_config_dwt_state enable)
 {
     if (!libinput_device_config_dwt_is_available(device)
         || libinput_device_config_dwt_get_enabled(device) == enable) {
@@ -278,7 +278,7 @@ static bool configDwtEnabled(libinput_device *device, enum libinput_config_dwt_s
     return ensureStatus(status);
 }
 
-static bool configDwtpEnabled(libinput_device *device, enum libinput_config_dwtp_state enable)
+[[maybe_unused]] static bool configDwtpEnabled(libinput_device *device, enum libinput_config_dwtp_state enable)
 {
     if (!libinput_device_config_dwtp_is_available(device)
         || libinput_device_config_dwtp_get_enabled(device) == enable) {
@@ -293,7 +293,7 @@ static bool configDwtpEnabled(libinput_device *device, enum libinput_config_dwtp
     return ensureStatus(status);
 }
 
-static bool configCalibrationMatrix(libinput_device *device, float mat[])
+[[maybe_unused]] static bool configCalibrationMatrix(libinput_device *device, float mat[])
 {
     if (!libinput_device_config_calibration_has_matrix(device)) {
         qCCritical(qLcInputdevice) << "setCalibrationMatrix mat is invalid";

--- a/src/modules/capture/capture.cpp
+++ b/src/modules/capture/capture.cpp
@@ -1082,7 +1082,7 @@ void CaptureSourceSelector::doSetSelectionMode(const SelectionMode &newSelection
     updateCursorShape();
     setItemSelectionMode(true);
     updateItemSelectorItemTypes();
-    emit selectionModeChanged();
+    Q_EMIT selectionModeChanged();
 }
 
 CaptureSource::CaptureSourceHint CaptureSourceSelector::selectionModeHint(

--- a/src/modules/capture/capture.cpp
+++ b/src/modules/capture/capture.cpp
@@ -405,7 +405,7 @@ void CaptureManagerV1::create(WServer *server)
             });
 }
 
-void CaptureManagerV1::destroy(WServer *server)
+void CaptureManagerV1::destroy([[maybe_unused]] WServer *server)
 {
     this->disconnect();
 }
@@ -493,7 +493,7 @@ CaptureContextModel::CaptureContextModel(QObject *parent)
 {
 }
 
-int CaptureContextModel::rowCount(const QModelIndex &parent) const
+int CaptureContextModel::rowCount([[maybe_unused]] const QModelIndex &parent) const
 {
     return m_captureContexts.size();
 }
@@ -554,7 +554,7 @@ CaptureSourceSelector::CaptureSourceSelector(QQuickItem *parent)
             &CaptureSourceSelector::handleItemSelectorSelectionRegionChanged,
             Qt::UniqueConnection);
     m_itemSelector->addCustomFilter([this](QQuickItem *item,
-                                           ItemSelector::ItemTypes selectionHint) -> bool {
+                                           [[maybe_unused]] ItemSelector::ItemTypes selectionHint) -> bool {
         if (auto surfaceItemContent = qobject_cast<WSurfaceItemContent *>(item)) {
             return surfaceItemContent->surface() != captureManager()->contextInSelection()->mask();
         } else if (auto surfaceItem = qobject_cast<WSurfaceItem *>(item)) {
@@ -831,7 +831,7 @@ void CaptureSourceSelector::mousePressEvent(QMouseEvent *event)
     }
 }
 
-void CaptureSourceSelector::mouseReleaseEvent(QMouseEvent *event)
+void CaptureSourceSelector::mouseReleaseEvent([[maybe_unused]] QMouseEvent *event)
 {
     switch (selectionMode()) {
     case SelectionMode::SelectRegion: {

--- a/src/modules/capture/impl/capturev1impl.cpp
+++ b/src/modules/capture/impl/capturev1impl.cpp
@@ -154,7 +154,7 @@ void treeland_capture_manager_v1::destroyClientResource(WClient *client, wl_reso
     }
 }
 
-void handle_treeland_capture_session_v1_destroy(wl_client *client, wl_resource *resource)
+void handle_treeland_capture_session_v1_destroy([[maybe_unused]] wl_client *client, wl_resource *resource)
 {
     wl_resource_destroy(resource);
 }
@@ -221,7 +221,7 @@ void handle_treeland_capture_context_v1_create_session(wl_client *client,
     Q_EMIT context->newSession(capture_session);
 }
 
-void handle_treeland_capture_context_v1_select_source(wl_client *client,
+void handle_treeland_capture_context_v1_select_source([[maybe_unused]] wl_client *client,
                                                       wl_resource *resource,
                                                       uint32_t source_hint,
                                                       uint32_t freeze,

--- a/src/modules/personalization/impl/appearance_impl.cpp
+++ b/src/modules/personalization/impl/appearance_impl.cpp
@@ -16,6 +16,7 @@ static const struct treeland_personalization_appearance_context_v1_interface
             &personalization_appearance_context_v1::setRoundCornerRadius>(),
         .get_round_corner_radius =
             [](struct wl_client *client, struct wl_resource *resource) {
+                Q_UNUSED(client)
                 Q_EMIT personalization_appearance_context_v1::fromResource(resource)
                     ->requestRoundCornerRadius();
             },
@@ -23,18 +24,21 @@ static const struct treeland_personalization_appearance_context_v1_interface
             dispatch_member_function<&personalization_appearance_context_v1::setIconTheme>(),
         .get_icon_theme =
             [](struct wl_client *client, struct wl_resource *resource) {
+                Q_UNUSED(client)
                 Q_EMIT personalization_appearance_context_v1::fromResource(resource)->requestIconTheme();
             },
         .set_active_color =
             dispatch_member_function<&personalization_appearance_context_v1::setActiveColor>(),
         .get_active_color =
             [](struct wl_client *client, struct wl_resource *resource) {
+                Q_UNUSED(client)
                 Q_EMIT personalization_appearance_context_v1::fromResource(resource)->requestActiveColor();
             },
         .set_window_opacity =
             dispatch_member_function<&personalization_appearance_context_v1::setWindowOpacity>(),
         .get_window_opacity =
             [](struct wl_client *client, struct wl_resource *resource) {
+                Q_UNUSED(client)
                 Q_EMIT personalization_appearance_context_v1::fromResource(resource)
                     ->requestWindowOpacity();
             },
@@ -42,6 +46,7 @@ static const struct treeland_personalization_appearance_context_v1_interface
             dispatch_member_function<&personalization_appearance_context_v1::setWindowThemeType>(),
         .get_window_theme_type =
             [](struct wl_client *client, struct wl_resource *resource) {
+                Q_UNUSED(client)
                 Q_EMIT personalization_appearance_context_v1::fromResource(resource)
                     ->requestWindowThemeType();
             },
@@ -49,6 +54,7 @@ static const struct treeland_personalization_appearance_context_v1_interface
             &personalization_appearance_context_v1::setWindowTitlebarHeight>(),
         .get_window_titlebar_height =
             [](struct wl_client *client, struct wl_resource *resource) {
+                Q_UNUSED(client)
                 Q_EMIT personalization_appearance_context_v1::fromResource(resource)
                     ->requestWindowTitlebarHeight();
             },

--- a/src/modules/personalization/impl/appearance_impl.cpp
+++ b/src/modules/personalization/impl/appearance_impl.cpp
@@ -15,46 +15,40 @@ static const struct treeland_personalization_appearance_context_v1_interface
         .set_round_corner_radius = dispatch_member_function<
             &personalization_appearance_context_v1::setRoundCornerRadius>(),
         .get_round_corner_radius =
-            [](struct wl_client *client, struct wl_resource *resource) {
-                Q_UNUSED(client)
+            []([[maybe_unused]] struct wl_client *client, struct wl_resource *resource) {
                 Q_EMIT personalization_appearance_context_v1::fromResource(resource)
                     ->requestRoundCornerRadius();
             },
         .set_icon_theme =
             dispatch_member_function<&personalization_appearance_context_v1::setIconTheme>(),
         .get_icon_theme =
-            [](struct wl_client *client, struct wl_resource *resource) {
-                Q_UNUSED(client)
+            []([[maybe_unused]] struct wl_client *client, struct wl_resource *resource) {
                 Q_EMIT personalization_appearance_context_v1::fromResource(resource)->requestIconTheme();
             },
         .set_active_color =
             dispatch_member_function<&personalization_appearance_context_v1::setActiveColor>(),
         .get_active_color =
-            [](struct wl_client *client, struct wl_resource *resource) {
-                Q_UNUSED(client)
+            []([[maybe_unused]] struct wl_client *client, struct wl_resource *resource) {
                 Q_EMIT personalization_appearance_context_v1::fromResource(resource)->requestActiveColor();
             },
         .set_window_opacity =
             dispatch_member_function<&personalization_appearance_context_v1::setWindowOpacity>(),
         .get_window_opacity =
-            [](struct wl_client *client, struct wl_resource *resource) {
-                Q_UNUSED(client)
+            []([[maybe_unused]] struct wl_client *client, struct wl_resource *resource) {
                 Q_EMIT personalization_appearance_context_v1::fromResource(resource)
                     ->requestWindowOpacity();
             },
         .set_window_theme_type =
             dispatch_member_function<&personalization_appearance_context_v1::setWindowThemeType>(),
         .get_window_theme_type =
-            [](struct wl_client *client, struct wl_resource *resource) {
-                Q_UNUSED(client)
+            []([[maybe_unused]] struct wl_client *client, struct wl_resource *resource) {
                 Q_EMIT personalization_appearance_context_v1::fromResource(resource)
                     ->requestWindowThemeType();
             },
         .set_window_titlebar_height = dispatch_member_function<
             &personalization_appearance_context_v1::setWindowTitlebarHeight>(),
         .get_window_titlebar_height =
-            [](struct wl_client *client, struct wl_resource *resource) {
-                Q_UNUSED(client)
+            []([[maybe_unused]] struct wl_client *client, struct wl_resource *resource) {
                 Q_EMIT personalization_appearance_context_v1::fromResource(resource)
                     ->requestWindowTitlebarHeight();
             },

--- a/src/modules/personalization/impl/util.h
+++ b/src/modules/personalization/impl/util.h
@@ -28,8 +28,7 @@ template<std::size_t N, auto mFunc, typename typeList, typename class_type, type
 constexpr auto make_lambda()
 {
     if constexpr (N == 0) {
-        auto tmp = [](struct wl_client *client, struct wl_resource *resource, Args... args) {
-            Q_UNUSED(client)
+        auto tmp = []([[maybe_unused]] struct wl_client *client, struct wl_resource *resource, Args... args) {
             auto obj = reinterpret_cast<class_type *>(class_type::fromResource(resource));
             (obj->*mFunc)(args...);
         };

--- a/src/modules/personalization/impl/util.h
+++ b/src/modules/personalization/impl/util.h
@@ -29,6 +29,7 @@ constexpr auto make_lambda()
 {
     if constexpr (N == 0) {
         auto tmp = [](struct wl_client *client, struct wl_resource *resource, Args... args) {
+            Q_UNUSED(client)
             auto obj = reinterpret_cast<class_type *>(class_type::fromResource(resource));
             (obj->*mFunc)(args...);
         };

--- a/src/modules/personalization/personalizationmanager.cpp
+++ b/src/modules/personalization/personalizationmanager.cpp
@@ -550,7 +550,9 @@ void PersonalizationV1::create(WServer *server)
             &PersonalizationV1::onFontContextCreated);
 }
 
-void PersonalizationV1::destroy(WServer *server) { }
+void PersonalizationV1::destroy(WServer *server) { 
+    Q_UNUSED(server)
+}
 
 wl_global *PersonalizationV1::global() const
 {

--- a/src/modules/personalization/personalizationmanager.cpp
+++ b/src/modules/personalization/personalizationmanager.cpp
@@ -550,8 +550,7 @@ void PersonalizationV1::create(WServer *server)
             &PersonalizationV1::onFontContextCreated);
 }
 
-void PersonalizationV1::destroy(WServer *server) { 
-    Q_UNUSED(server)
+void PersonalizationV1::destroy([[maybe_unused]] WServer *server) { 
 }
 
 wl_global *PersonalizationV1::global() const

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -349,7 +349,7 @@ void Output::enable()
     // Don't care for WOutput::isEnabled, must do WOutput::commit here,
     // In order to ensure trigger QWOutput::frame signal, WOutputRenderWindow
     // needs this signal to render next frame. Because QWOutput::frame signal
-    // maybe emit before WOutputRenderWindow::attach, if no commit here,
+    // maybe Q_EMIT before WOutputRenderWindow::attach, if no commit here,
     // WOutputRenderWindow will ignore this output on render.
     if (!qwoutput->property("_Enabled").toBool()) {
         qwoutput->setProperty("_Enabled", true);

--- a/src/plugins/multitaskview/multitaskview.cpp
+++ b/src/plugins/multitaskview/multitaskview.cpp
@@ -13,6 +13,9 @@
 #include <woutputrenderwindow.h>
 
 #include <QtConcurrentMap>
+#include <QLoggingCategory>
+
+Q_LOGGING_CATEGORY(qLcMultitaskview, "treeland.plugins.multitaskview")
 
 WAYLIB_SERVER_USE_NAMESPACE
 
@@ -184,6 +187,7 @@ QHash<int, QByteArray> MultitaskviewSurfaceModel::roleNames() const
 
 QModelIndex MultitaskviewSurfaceModel::index(int row, int column, const QModelIndex &parent) const
 {
+    Q_UNUSED(parent)
     if (row < 0 || row >= m_data.size())
         return QModelIndex();
     return QAbstractItemModel::createIndex(row, column, &m_data[row]);
@@ -218,11 +222,13 @@ void MultitaskviewSurfaceModel::updateZOrder()
     Q_EMIT dataChanged(index(0), index(rowCount() - 1), { ZOrderRole });
 }
 
-int MultitaskviewSurfaceModel::prevSameAppIndex(int index)
+uint MultitaskviewSurfaceModel::prevSameAppIndex(uint index)
 {
-    if (index < 0 || index >= count())
-        return -1;
-    auto circularPrev = [this](int i) {
+    if (index >= count()) {
+        qCWarning(qLcMultitaskview) << "prevSameAppIndex: invalid index" << index << "count:" << count();
+        return index;
+    }
+    auto circularPrev = [this](uint i) {
         return (i + count() - 1) % count();
     };
     auto i = circularPrev(index);
@@ -235,11 +241,13 @@ int MultitaskviewSurfaceModel::prevSameAppIndex(int index)
     return i;
 }
 
-int MultitaskviewSurfaceModel::nextSameAppIndex(int index)
+uint MultitaskviewSurfaceModel::nextSameAppIndex(uint index)
 {
-    if (index < 0 || index >= count())
-        return -1;
-    auto circularNext = [this](int i) {
+    if (index >= count()) {
+        qCWarning(qLcMultitaskview) << "nextSameAppIndex: invalid index" << index << "count:" << count();
+        return index;
+    }
+    auto circularNext = [this](uint i) {
         return (i + 1) % count();
     };
     auto i = circularNext(index);
@@ -411,6 +419,7 @@ void MultitaskviewSurfaceModel::doUpdateZOrder(const QList<ModelDataPtr> &rawDat
 std::pair<int, int> MultitaskviewSurfaceModel::commitAndGetUpdateRange(
     const QList<ModelDataPtr> &rawData)
 {
+    Q_UNUSED(rawData)
     // TODO: better algorithm
     int beginIndex = 0, endIndex = -1;
     bool unchanged = true;

--- a/src/plugins/multitaskview/multitaskview.cpp
+++ b/src/plugins/multitaskview/multitaskview.cpp
@@ -185,9 +185,8 @@ QHash<int, QByteArray> MultitaskviewSurfaceModel::roleNames() const
     };
 }
 
-QModelIndex MultitaskviewSurfaceModel::index(int row, int column, const QModelIndex &parent) const
+QModelIndex MultitaskviewSurfaceModel::index(int row, int column, [[maybe_unused]] const QModelIndex &parent) const
 {
-    Q_UNUSED(parent)
     if (row < 0 || row >= m_data.size())
         return QModelIndex();
     return QAbstractItemModel::createIndex(row, column, &m_data[row]);
@@ -271,7 +270,7 @@ void MultitaskviewSurfaceModel::setLayoutArea(const QRectF &newLayoutArea)
         return;
     m_layoutArea = newLayoutArea;
     initializeModel();
-    emit layoutAreaChanged();
+    Q_EMIT layoutAreaChanged();
 }
 
 bool MultitaskviewSurfaceModel::tryLayout(const QList<ModelDataPtr> &rawData,
@@ -417,9 +416,8 @@ void MultitaskviewSurfaceModel::doUpdateZOrder(const QList<ModelDataPtr> &rawDat
 }
 
 std::pair<int, int> MultitaskviewSurfaceModel::commitAndGetUpdateRange(
-    const QList<ModelDataPtr> &rawData)
+    [[maybe_unused]] const QList<ModelDataPtr> &rawData)
 {
-    Q_UNUSED(rawData)
     // TODO: better algorithm
     int beginIndex = 0, endIndex = -1;
     bool unchanged = true;
@@ -701,7 +699,7 @@ void MultitaskviewSurfaceModel::setWorkspace(WorkspaceModel *newWorkspace)
     if (m_workspace)
         connectWorkspace(m_workspace);
     initializeModel();
-    emit workspaceChanged();
+    Q_EMIT workspaceChanged();
 }
 
 qreal MultitaskviewSurfaceModel::contentHeight() const
@@ -720,7 +718,7 @@ void MultitaskviewSurfaceModel::setOutput(Output *newOutput)
         return;
     m_output = newOutput;
     initializeModel();
-    emit outputChanged();
+    Q_EMIT outputChanged();
 }
 
 uint MultitaskviewSurfaceModel::count() const

--- a/src/plugins/multitaskview/multitaskview.h
+++ b/src/plugins/multitaskview/multitaskview.h
@@ -139,8 +139,8 @@ public:
 
     Q_INVOKABLE void calcLayout();
     Q_INVOKABLE void updateZOrder();
-    Q_INVOKABLE int prevSameAppIndex(int index);
-    Q_INVOKABLE int nextSameAppIndex(int index);
+    Q_INVOKABLE uint prevSameAppIndex(uint index);
+    Q_INVOKABLE uint nextSameAppIndex(uint index);
 
     QRectF layoutArea() const;
     void setLayoutArea(const QRectF &newLayoutArea);

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1810,9 +1810,6 @@ void Helper::setOutputMode(OutputMode mode)
     }
 }
 
-void Helper::setOutputProxy([[maybe_unused]] Output *output) { 
-}
-
 float Helper::animationSpeed() const
 {
     return m_animationSpeed;

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -164,8 +164,8 @@ Helper::Helper(QObject *parent)
     , m_renderWindow(new WOutputRenderWindow(this))
     , m_server(new WServer(this))
     , m_rootSurfaceContainer(new RootSurfaceContainer(m_renderWindow->contentItem()))
-    , m_windowGesture(new TogglableGesture(this))
     , m_multiTaskViewGesture(new TogglableGesture(this))
+    , m_windowGesture(new TogglableGesture(this))
 {
     Q_ASSERT(!m_instance);
     m_instance = this;
@@ -752,6 +752,7 @@ void Helper::onSurfaceWrapperAdded(SurfaceWrapper *wrapper)
 
     if (!isLayer) {
         auto windowOverlapChecker = new WindowOverlapChecker(wrapper, wrapper);
+        Q_UNUSED(windowOverlapChecker)
     }
 
 #ifndef DISABLE_DDM
@@ -792,7 +793,7 @@ void Helper::onSurfaceWrapperAboutToRemove(SurfaceWrapper *wrapper)
 
 bool Helper::surfaceBelongsToCurrentUser(SurfaceWrapper *wrapper)
 {
-    static const int puid = getuid();
+    static const uid_t puid = getuid();
     auto credentials = WClient::getCredentials(wrapper->surface()->waylandClient()->handle());
     auto user = m_userModel->currentUser();
     if (user) {
@@ -1810,7 +1811,9 @@ void Helper::setOutputMode(OutputMode mode)
     }
 }
 
-void Helper::setOutputProxy(Output *output) { }
+void Helper::setOutputProxy(Output *output) { 
+    Q_UNUSED(output)
+}
 
 float Helper::animationSpeed() const
 {

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -751,8 +751,7 @@ void Helper::onSurfaceWrapperAdded(SurfaceWrapper *wrapper)
     }
 
     if (!isLayer) {
-        auto windowOverlapChecker = new WindowOverlapChecker(wrapper, wrapper);
-        Q_UNUSED(windowOverlapChecker)
+        [[maybe_unused]] auto windowOverlapChecker = new WindowOverlapChecker(wrapper, wrapper);
     }
 
 #ifndef DISABLE_DDM
@@ -1811,8 +1810,7 @@ void Helper::setOutputMode(OutputMode mode)
     }
 }
 
-void Helper::setOutputProxy(Output *output) { 
-    Q_UNUSED(output)
+void Helper::setOutputProxy([[maybe_unused]] Output *output) { 
 }
 
 float Helper::animationSpeed() const

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -259,8 +259,6 @@ private:
 
     int indexOfOutput(WOutput *output) const;
 
-    void setOutputProxy(Output *output);
-
     SurfaceWrapper *keyboardFocusSurface() const;
     void requestKeyboardFocusForSurface(SurfaceWrapper *newActivateSurface, Qt::FocusReason reason);
     SurfaceWrapper *activatedSurface() const;

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -299,11 +299,12 @@ private:
     QQuickItem *m_dockPreview = nullptr;
 
     // gesture
+    WServer *m_server = nullptr;
+    RootSurfaceContainer *m_rootSurfaceContainer = nullptr;
     TogglableGesture *m_multiTaskViewGesture = nullptr;
     TogglableGesture *m_windowGesture = nullptr;
 
     // wayland helper
-    WServer *m_server = nullptr;
     WSocket *m_socket = nullptr;
     WSeat *m_seat = nullptr;
     WBackend *m_backend = nullptr;
@@ -338,7 +339,6 @@ private:
     QList<qw_idle_inhibitor_v1 *> m_idleInhibitors;
 
     SurfaceWrapper *m_activatedSurface = nullptr;
-    RootSurfaceContainer *m_rootSurfaceContainer = nullptr;
     LockScreen *m_lockScreen = nullptr;
     float m_animationSpeed = 1.0;
     quint64 m_taskAltTimestamp = 0;

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -1660,11 +1660,11 @@ void SurfaceWrapper::setSurfaceRole(SurfaceRole role)
     if (role != SurfaceRole::Normal) {
         setZ(ALWAYSONTOPLAYER + static_cast<int>(role));
         for (const auto &sub : std::as_const(m_subSurfaces))
-            setZ(ALWAYSONTOPLAYER + static_cast<int>(role));
+            sub->setZ(ALWAYSONTOPLAYER + static_cast<int>(role));
     } else {
         setZ(0);
         for (const auto &sub : std::as_const(m_subSurfaces))
-            setZ(0);
+            sub->setZ(0);
     }
 
     Q_EMIT surfaceRoleChanged();

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -394,12 +394,12 @@ private:
     uint m_titleBarState : 2;
     uint m_noCornerRadius : 1;
     uint m_alwaysOnTop : 1;
-    uint m_wrapperAboutToRemove : 1;
     uint m_skipSwitcher : 1;
     uint m_skipDockPreView : 1;
     uint m_skipMutiTaskView : 1;
     uint m_isDdeShellSurface : 1;
     uint m_xwaylandPositionFromSurface : 1;
+    uint m_wrapperAboutToRemove : 1;
     uint m_isProxy : 1;
     uint m_hideByWorkspace : 1;
     uint m_hideByshowDesk : 1;

--- a/src/utils/propertymonitor.cpp
+++ b/src/utils/propertymonitor.cpp
@@ -26,7 +26,7 @@ void PropertyMonitor::setTarget(QObject *newTarget)
         disconnect(m_target, nullptr, this, SLOT(handlePropertyChanged()));
     m_target = newTarget;
     connectToTarget();
-    emit targetChanged();
+    Q_EMIT targetChanged();
 }
 
 QString PropertyMonitor::properties() const
@@ -40,7 +40,7 @@ void PropertyMonitor::setProperties(const QString &newProperties)
         return;
     m_properties = newProperties;
     connectToTarget();
-    emit propertiesChanged();
+    Q_EMIT propertiesChanged();
 }
 
 void PropertyMonitor::handlePropertyChanged()

--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -23,7 +23,7 @@ Workspace::Workspace(SurfaceContainer *parent)
     m_showOnAllWorkspaceModel = new WorkspaceModel(this, ShowOnAllWorkspaceId, {});
     m_showOnAllWorkspaceModel->setName("show-on-all-workspace");
     m_showOnAllWorkspaceModel->setVisible(true);
-    for (auto index = 0; index < TreelandConfig::ref().numWorkspace(); index++) {
+    for (uint index = 0; index < TreelandConfig::ref().numWorkspace(); index++) {
         doCreateModel(QStringLiteral("workspace-%1").arg(index),
                       index == TreelandConfig::ref().currentWorkspace());
     }

--- a/src/workspace/workspaceanimationcontroller.cpp
+++ b/src/workspace/workspaceanimationcontroller.cpp
@@ -52,7 +52,7 @@ void WorkspaceAnimationController::setRefWidth(qreal newRefWidth)
     if (qFuzzyCompare(m_refWidth, newRefWidth))
         return;
     m_refWidth = newRefWidth;
-    emit refWidthChanged();
+    Q_EMIT refWidthChanged();
     Q_EMIT refWrapChanged();
 }
 
@@ -66,7 +66,7 @@ void WorkspaceAnimationController::setRefGap(qreal newRefGap)
     if (qFuzzyCompare(m_refGap, newRefGap))
         return;
     m_refGap = newRefGap;
-    emit refGapChanged();
+    Q_EMIT refGapChanged();
     Q_EMIT refWrapChanged();
 }
 
@@ -80,7 +80,7 @@ void WorkspaceAnimationController::setRefBounce(qreal newRefBounce)
     if (qFuzzyCompare(m_refBounce, newRefBounce))
         return;
     m_refBounce = newRefBounce;
-    emit refBounceChanged();
+    Q_EMIT refBounceChanged();
 }
 
 qreal WorkspaceAnimationController::bounceFactor() const
@@ -93,7 +93,7 @@ void WorkspaceAnimationController::setBounceFactor(qreal newBounceFactor)
     if (qFuzzyCompare(m_bounceFactor, newBounceFactor))
         return;
     m_bounceFactor = newBounceFactor;
-    emit bounceFactorChanged();
+    Q_EMIT bounceFactorChanged();
 }
 
 qreal WorkspaceAnimationController::refWrap() const
@@ -216,5 +216,5 @@ void WorkspaceAnimationController::setViewportPos(qreal newViewportPos)
     if (qFuzzyCompare(m_viewportPos, newViewportPos))
         return;
     m_viewportPos = newViewportPos;
-    emit viewportPosChanged();
+    Q_EMIT viewportPosChanged();
 }

--- a/waylib/examples/blur/main.cpp
+++ b/waylib/examples/blur/main.cpp
@@ -95,7 +95,7 @@ void Helper::initProtocols(WOutputRenderWindow *window, QQmlEngine *qmlEngine)
             // Don't care for WOutput::isEnabled, must do WOutput::commit here,
             // In order to ensure trigger QWOutput::frame signal, WOutputRenderWindow
             // needs this signal to render next frmae. Because QWOutput::frame signal
-            // maybe emit before WOutputRenderWindow::attach, if no commit here,
+            // maybe Q_EMIT before WOutputRenderWindow::attach, if no commit here,
             // WOutputRenderWindow will ignore this ouptut on render.
             if (!qwoutput->property("_Enabled").toBool()) {
                 qwoutput->setProperty("_Enabled", true);

--- a/waylib/examples/outputcopy/main.cpp
+++ b/waylib/examples/outputcopy/main.cpp
@@ -159,7 +159,7 @@ void Helper::initProtocols(QQmlEngine *qmlEngine)
             // Don't care for WOutput::isEnabled, must do WOutput::commit here,
             // In order to ensure trigger qw_output::frame signal, WOutputRenderWindow
             // needs this signal to render next frmae. Because qw_output::frame signal
-            // maybe emit before WOutputRenderWindow::attach, if no commit here,
+            // maybe Q_EMIT before WOutputRenderWindow::attach, if no commit here,
             // WOutputRenderWindow will ignore this ouptut on render.
             if (!qwoutput->property("_Enabled").toBool()) {
                 qwoutput->setProperty("_Enabled", true);

--- a/waylib/examples/outputviewport/main.cpp
+++ b/waylib/examples/outputviewport/main.cpp
@@ -96,7 +96,7 @@ void Helper::initProtocols(WOutputRenderWindow *window, QQmlEngine *qmlEngine)
             // Don't care for WOutput::isEnabled, must do WOutput::commit here,
             // In order to ensure trigger QWOutput::frame signal, WOutputRenderWindow
             // needs this signal to render next frmae. Because QWOutput::frame signal
-            // maybe emit before WOutputRenderWindow::attach, if no commit here,
+            // maybe Q_EMIT before WOutputRenderWindow::attach, if no commit here,
             // WOutputRenderWindow will ignore this ouptut on render.
             if (!qwoutput->property("_Enabled").toBool()) {
                 qwoutput->setProperty("_Enabled", true);

--- a/waylib/examples/tinywl/helper.cpp
+++ b/waylib/examples/tinywl/helper.cpp
@@ -765,7 +765,7 @@ void Helper::setOutputMode(OutputMode mode)
     }
 }
 
-void Helper::setOutputProxy(Output *output)
+void Helper::setOutputProxy([[maybe_unused]] Output *output)
 {
 
 }

--- a/waylib/examples/tinywl/helper.cpp
+++ b/waylib/examples/tinywl/helper.cpp
@@ -763,11 +763,6 @@ void Helper::setOutputMode(OutputMode mode)
     }
 }
 
-void Helper::setOutputProxy([[maybe_unused]] Output *output)
-{
-
-}
-
 void Helper::updateLayerSurfaceContainer(SurfaceWrapper *surface)
 {
     auto layer = qobject_cast<WLayerSurface*>(surface->shellSurface());

--- a/waylib/examples/tinywl/helper.cpp
+++ b/waylib/examples/tinywl/helper.cpp
@@ -576,10 +576,8 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *, QInputEvent *event)
     return false;
 }
 
-bool Helper::afterHandleEvent(WSeat *seat, WSurface *watched, QObject *surfaceItem, QObject *, QInputEvent *event)
+bool Helper::afterHandleEvent([[maybe_unused]] WSeat *seat, WSurface *watched, QObject *surfaceItem, QObject *, QInputEvent *event)
 {
-    Q_UNUSED(seat)
-
     if (event->isSinglePointEvent() && static_cast<QSinglePointEvent*>(event)->isBeginEvent()) {
         // surfaceItem is qml type: XdgSurfaceItem or LayerSurfaceItem
         auto toplevelSurface = qobject_cast<WSurfaceItem*>(surfaceItem)->shellSurface();
@@ -692,7 +690,7 @@ void Helper::enableOutput(WOutput *output)
     // Don't care for WOutput::isEnabled, must do WOutput::commit here,
     // In order to ensure trigger QWOutput::frame signal, WOutputRenderWindow
     // needs this signal to render next frmae. Because QWOutput::frame signal
-    // maybe emit before WOutputRenderWindow::attach, if no commit here,
+    // maybe Q_EMIT before WOutputRenderWindow::attach, if no commit here,
     // WOutputRenderWindow will ignore this ouptut on render.
     if (!qwoutput->property("_Enabled").toBool()) {
         qwoutput->setProperty("_Enabled", true);
@@ -819,7 +817,7 @@ void Helper::setAnimationSpeed(float newAnimationSpeed)
     if (qFuzzyCompare(m_animationSpeed, newAnimationSpeed))
         return;
     m_animationSpeed = newAnimationSpeed;
-    emit animationSpeedChanged();
+    Q_EMIT animationSpeedChanged();
 }
 
 Helper::OutputMode Helper::outputMode() const

--- a/waylib/examples/tinywl/helper.h
+++ b/waylib/examples/tinywl/helper.h
@@ -110,7 +110,7 @@ public Q_SLOTS:
     void activeSurface(SurfaceWrapper *wrapper);
     void fakePressSurfaceBottomRightToReszie(SurfaceWrapper *surface);
 
-signals:
+Q_SIGNALS:
     void socketEnabledChanged();
     void keyboardFocusSurfaceChanged();
     void activatedSurfaceChanged();

--- a/waylib/examples/tinywl/helper.h
+++ b/waylib/examples/tinywl/helper.h
@@ -126,8 +126,6 @@ private:
 
     int indexOfOutput(WOutput *output) const;
 
-    void setOutputProxy(Output *output);
-
     void updateLayerSurfaceContainer(SurfaceWrapper *surface);
 
     SurfaceWrapper *keyboardFocusSurface() const;

--- a/waylib/examples/tinywl/output.cpp
+++ b/waylib/examples/tinywl/output.cpp
@@ -328,7 +328,7 @@ void Output::layoutLayerSurfaces()
 
     if (oldExclusiveZone != m_exclusiveZone) {
         layoutNonLayerSurfaces();
-        emit exclusiveZoneChanged();
+        Q_EMIT exclusiveZoneChanged();
     }
 }
 

--- a/waylib/examples/tinywl/output.h
+++ b/waylib/examples/tinywl/output.h
@@ -65,7 +65,7 @@ public:
     WOutputViewport *screenViewport() const;
     void updatePositionFromLayout();
 
-signals:
+Q_SIGNALS:
     void exclusiveZoneChanged();
     void moveResizeFinised();
 

--- a/waylib/examples/tinywl/rootsurfacecontainer.cpp
+++ b/waylib/examples/tinywl/rootsurfacecontainer.cpp
@@ -328,10 +328,8 @@ bool RootSurfaceContainer::filterSurfaceGeometryChanged(SurfaceWrapper *surface,
     return false;
 }
 
-bool RootSurfaceContainer::filterSurfaceStateChange(SurfaceWrapper *surface, SurfaceWrapper::State newState, SurfaceWrapper::State oldState)
+bool RootSurfaceContainer::filterSurfaceStateChange(SurfaceWrapper *surface, [[maybe_unused]] SurfaceWrapper::State newState, [[maybe_unused]] SurfaceWrapper::State oldState)
 {
-    Q_UNUSED(oldState);
-    Q_UNUSED(newState);
     return surface == moveResizeState.surface;
 }
 
@@ -366,7 +364,7 @@ void RootSurfaceContainer::setPrimaryOutput(Output *newPrimaryOutput)
     if (m_primaryOutput == newPrimaryOutput)
         return;
     m_primaryOutput = newPrimaryOutput;
-    emit primaryOutputChanged();
+    Q_EMIT primaryOutputChanged();
 }
 
 const QList<Output*> &RootSurfaceContainer::outputs() const

--- a/waylib/examples/tinywl/rootsurfacecontainer.h
+++ b/waylib/examples/tinywl/rootsurfacecontainer.h
@@ -71,12 +71,12 @@ public:
 
     OutputListModel *outputModel() const;
 
-public slots:
+public Q_SLOTS:
     void startMove(SurfaceWrapper *surface);
     void startResize(SurfaceWrapper *surface, Qt::Edges edges);
     void cancelMoveResize(SurfaceWrapper *surface);
 
-signals:
+Q_SIGNALS:
     void primaryOutputChanged();
     void moveResizeFinised();
 

--- a/waylib/examples/tinywl/surfacecontainer.cpp
+++ b/waylib/examples/tinywl/surfacecontainer.cpp
@@ -218,7 +218,7 @@ bool SurfaceContainer::doAddSurface(SurfaceWrapper *surface, bool setContainer)
     }
 
     m_model->addSurface(surface);
-    emit surfaceAdded(surface);
+    Q_EMIT surfaceAdded(surface);
 
     if (auto p = parentContainer())
         p->addBySubContainer(this, surface);
@@ -237,7 +237,7 @@ bool SurfaceContainer::doRemoveSurface(SurfaceWrapper *surface, bool setContaine
     }
 
     m_model->removeSurface(surface);
-    emit surfaceRemoved(surface);
+    Q_EMIT surfaceRemoved(surface);
 
     if (auto p = parentContainer())
         p->removeBySubContainer(this, surface);
@@ -245,15 +245,13 @@ bool SurfaceContainer::doRemoveSurface(SurfaceWrapper *surface, bool setContaine
     return true;
 }
 
-void SurfaceContainer::addBySubContainer(SurfaceContainer *sub, SurfaceWrapper *surface)
+void SurfaceContainer::addBySubContainer([[maybe_unused]] SurfaceContainer *sub, SurfaceWrapper *surface)
 {
-    Q_UNUSED(sub);
     doAddSurface(surface, false);
 }
 
-void SurfaceContainer::removeBySubContainer(SurfaceContainer *sub, SurfaceWrapper *surface)
+void SurfaceContainer::removeBySubContainer([[maybe_unused]] SurfaceContainer *sub, SurfaceWrapper *surface)
 {
-    Q_UNUSED(sub);
     doRemoveSurface(surface, false);
 }
 

--- a/waylib/examples/tinywl/surfacecontainer.h
+++ b/waylib/examples/tinywl/surfacecontainer.h
@@ -48,8 +48,7 @@ public:
         data.insert(Qt::DisplayRole, QVariant::fromValue(m_objects.at(index.row())));
         return data;
     }
-    Qt::ItemFlags flags(const QModelIndex &index) const override {
-        Q_UNUSED(index);
+    Qt::ItemFlags flags([[maybe_unused]] const QModelIndex &index) const override {
         return Qt::ItemIsSelectable|Qt::ItemIsEnabled;
     }
     QHash<int, QByteArray> roleNames() const override {
@@ -96,11 +95,11 @@ public:
 
     virtual void addSurface(SurfaceWrapper *surface) {
         if (addObject(surface))
-            emit surfaceAdded(surface);
+            Q_EMIT surfaceAdded(surface);
     }
     virtual void removeSurface(SurfaceWrapper *surface) {
         if (removeObject(surface))
-            emit surfaceRemoved(surface);
+            Q_EMIT surfaceRemoved(surface);
     }
 
     QHash<int, QByteArray> roleNames() const override;
@@ -115,7 +114,7 @@ public:
         return hasObject(surface);
     }
 
-signals:
+Q_SIGNALS:
     void surfaceAdded(SurfaceWrapper *surface);
     void surfaceRemoved(SurfaceWrapper *surface);
 
@@ -204,7 +203,7 @@ public:
         return m_model;
     }
 
-signals:
+Q_SIGNALS:
     void surfaceAdded(SurfaceWrapper *surface);
     void surfaceRemoved(SurfaceWrapper *surface);
 

--- a/waylib/examples/tinywl/surfaceproxy.cpp
+++ b/waylib/examples/tinywl/surfaceproxy.cpp
@@ -76,7 +76,7 @@ void SurfaceProxy::setSurface(SurfaceWrapper *newSurface)
         m_shadow = nullptr;
     }
 
-    emit surfaceChanged();
+    Q_EMIT surfaceChanged();
 }
 
 void SurfaceProxy::geometryChange(const QRectF &newGeo, const QRectF &oldGeo)
@@ -142,7 +142,7 @@ void SurfaceProxy::onSourceRadiusChanged()
     if (m_shadow)
         m_shadow->setProperty("radius", radius());
     if (m_radius < 0)
-        emit radiusChanged();
+        Q_EMIT radiusChanged();
 }
 
 qreal SurfaceProxy::radius() const
@@ -163,7 +163,7 @@ void SurfaceProxy::setRadius(qreal newRadius)
             m_shadow->setProperty("radius", radius());
     }
 
-    emit radiusChanged();
+    Q_EMIT radiusChanged();
 }
 
 void SurfaceProxy::resetRadius()
@@ -190,7 +190,7 @@ void SurfaceProxy::setLive(bool newLive)
         }
     }
 
-    emit liveChanged();
+    Q_EMIT liveChanged();
 }
 
 QSizeF SurfaceProxy::maxSize() const
@@ -205,7 +205,7 @@ void SurfaceProxy::setMaxSize(const QSizeF &newMaxSize)
     m_maxSize = newMaxSize;
     updateImplicitSize();
 
-    emit maxSizeChanged();
+    Q_EMIT maxSizeChanged();
 }
 
 bool SurfaceProxy::fullProxy() const
@@ -233,5 +233,5 @@ void SurfaceProxy::setFullProxy(bool newFullProxy)
         updateProxySurfaceTitleBarAndDecoration();
     }
 
-    emit fullProxyChanged();
+    Q_EMIT fullProxyChanged();
 }

--- a/waylib/examples/tinywl/surfaceproxy.h
+++ b/waylib/examples/tinywl/surfaceproxy.h
@@ -35,7 +35,7 @@ public:
     bool fullProxy() const;
     void setFullProxy(bool newFullProxy);
 
-signals:
+Q_SIGNALS:
     void surfaceChanged();
     void radiusChanged();
     void liveChanged();

--- a/waylib/examples/tinywl/surfacewrapper.cpp
+++ b/waylib/examples/tinywl/surfacewrapper.cpp
@@ -219,7 +219,7 @@ void SurfaceWrapper::setNormalGeometry(const QRectF &newNormalGeometry)
     if (m_normalGeometry == newNormalGeometry)
         return;
     m_normalGeometry = newNormalGeometry;
-    emit normalGeometryChanged();
+    Q_EMIT normalGeometryChanged();
 }
 
 QRectF SurfaceWrapper::maximizedGeometry() const
@@ -244,7 +244,7 @@ void SurfaceWrapper::setMaximizedGeometry(const QRectF &newMaximizedGeometry)
         m_geometryAnimation->setProperty("targetGeometry", newMaximizedGeometry);
     }
 
-    emit maximizedGeometryChanged();
+    Q_EMIT maximizedGeometryChanged();
 }
 
 QRectF SurfaceWrapper::fullscreenGeometry() const
@@ -269,7 +269,7 @@ void SurfaceWrapper::setFullscreenGeometry(const QRectF &newFullscreenGeometry)
         m_geometryAnimation->setProperty("targetGeometry", newFullscreenGeometry);
     }
 
-    emit fullscreenGeometryChanged();
+    Q_EMIT fullscreenGeometryChanged();
 
     updateClipRect();
 }
@@ -294,7 +294,7 @@ void SurfaceWrapper::setTilingGeometry(const QRectF &newTilingGeometry)
         resize(newTilingGeometry.size());
     }
 
-    emit tilingGeometryChanged();
+    Q_EMIT tilingGeometryChanged();
 }
 
 bool SurfaceWrapper::positionAutomatic() const
@@ -307,7 +307,7 @@ void SurfaceWrapper::setPositionAutomatic(bool newPositionAutomatic)
     if (m_positionAutomatic == newPositionAutomatic)
         return;
     m_positionAutomatic = newPositionAutomatic;
-    emit positionAutomaticChanged();
+    Q_EMIT positionAutomaticChanged();
 }
 
 void SurfaceWrapper::resetWidth()
@@ -352,7 +352,7 @@ void SurfaceWrapper::setOwnsOutput(Output *newOwnsOutput)
         m_ownsOutput->addSurface(this);
     }
 
-    emit ownsOutputChanged();
+    Q_EMIT ownsOutputChanged();
 }
 
 void SurfaceWrapper::setOutputs(const QList<WOutput*> &outputs)
@@ -476,7 +476,7 @@ void SurfaceWrapper::setNoDecoration(bool newNoDecoration)
     }
 
     updateBoundingRect();
-    emit noDecorationChanged();
+    Q_EMIT noDecorationChanged();
 }
 
 void SurfaceWrapper::updateTitleBar()
@@ -501,7 +501,7 @@ void SurfaceWrapper::updateTitleBar()
         });
     }
 
-    emit noTitleBarChanged();
+    Q_EMIT noTitleBarChanged();
 }
 
 void SurfaceWrapper::setBoundedRect(const QRectF &newBoundedRect)
@@ -509,7 +509,7 @@ void SurfaceWrapper::setBoundedRect(const QRectF &newBoundedRect)
     if (m_boundedRect == newBoundedRect)
         return;
     m_boundedRect = newBoundedRect;
-    emit boundingRectChanged();
+    Q_EMIT boundingRectChanged();
 }
 
 void SurfaceWrapper::updateBoundingRect()
@@ -681,7 +681,7 @@ void SurfaceWrapper::setRadius(qreal newRadius)
     if (qFuzzyCompare(m_radius, newRadius))
         return;
     m_radius = newRadius;
-    emit radiusChanged();
+    Q_EMIT radiusChanged();
 }
 
 void SurfaceWrapper::requestMinimize()
@@ -895,7 +895,7 @@ void SurfaceWrapper::setContainer(SurfaceContainer *newContainer)
     if (m_container == newContainer)
         return;
     m_container = newContainer;
-    emit containerChanged();
+    Q_EMIT containerChanged();
 }
 
 QQuickItem *SurfaceWrapper::titleBar() const
@@ -924,7 +924,7 @@ void SurfaceWrapper::setVisibleDecoration(bool newVisibleDecoration)
         return;
     m_visibleDecoration = newVisibleDecoration;
     updateBoundingRect();
-    emit visibleDecorationChanged();
+    Q_EMIT visibleDecorationChanged();
 }
 
 bool SurfaceWrapper::clipInOutput() const
@@ -938,7 +938,7 @@ void SurfaceWrapper::setClipInOutput(bool newClipInOutput)
         return;
     m_clipInOutput = newClipInOutput;
     updateClipRect();
-    emit clipInOutputChanged();
+    Q_EMIT clipInOutputChanged();
 }
 
 QRectF SurfaceWrapper::clipRect() const
@@ -986,7 +986,7 @@ void SurfaceWrapper::setNoCornerRadius(bool newNoCornerRadius)
     if (m_noCornerRadius == newNoCornerRadius)
         return;
     m_noCornerRadius = newNoCornerRadius;
-    emit noCornerRadiusChanged();
+    Q_EMIT noCornerRadiusChanged();
 }
 
 int SurfaceWrapper::workspaceId() const

--- a/waylib/examples/tinywl/wallpaperprovider.h
+++ b/waylib/examples/tinywl/wallpaperprovider.h
@@ -21,10 +21,10 @@ public:
 private:
     QImage im;
     QSize size;
+    WallpaperImageProvider *m_wallpaperProvider = nullptr;
     QString m_wallpaperId;
     bool m_textureExist = false;
     mutable QSGTexture *m_texture = nullptr;
-    WallpaperImageProvider *m_wallpaperProvider = nullptr;
 };
 
 class WallpaperImageProvider : public QQuickImageProvider

--- a/waylib/examples/tinywl/workspace.cpp
+++ b/waylib/examples/tinywl/workspace.cpp
@@ -106,7 +106,7 @@ void Workspace::removeContainer(int index)
     container->deleteLater();
 
     if (oldCurrent != current)
-        emit currentChanged();
+        Q_EMIT currentChanged();
 }
 
 WorkspaceModel *Workspace::container(int index) const
@@ -148,7 +148,7 @@ void Workspace::setCurrentIndex(int newCurrentIndex)
         m_models.at(i)->setVisible(i == m_currentIndex);
     }
 
-    emit currentChanged();
+    Q_EMIT currentChanged();
 }
 
 void Workspace::switchToNext()

--- a/waylib/examples/tinywl/workspace.h
+++ b/waylib/examples/tinywl/workspace.h
@@ -39,7 +39,7 @@ public:
     WorkspaceModel *current() const;
     void setCurrent(WorkspaceModel *container);
 
-signals:
+Q_SIGNALS:
     void currentChanged();
     void countChanged();
 

--- a/waylib/src/server/kernel/wbackend.cpp
+++ b/waylib/src/server/kernel/wbackend.cpp
@@ -212,9 +212,8 @@ void WBackend::create(WServer *server)
     d->connect();
 }
 
-void WBackend::destroy(WServer *server)
+void WBackend::destroy([[maybe_unused]] WServer *server)
 {
-    Q_UNUSED(server)
     W_D(WBackend);
 
     qDeleteAll(d->inputList);

--- a/waylib/src/server/kernel/wglobal.cpp
+++ b/waylib/src/server/kernel/wglobal.cpp
@@ -80,8 +80,8 @@ WWrapObject::WWrapObject(QObject *parent)
 }
 
 WWrapObject::WWrapObject(WWrapObjectPrivate &d, QObject *parent)
-    : WObject(d, nullptr)
-    , QObject(parent)
+    : QObject(parent)
+    , WObject(d, nullptr)
 {
 
 }

--- a/waylib/src/server/kernel/wglobal.h
+++ b/waylib/src/server/kernel/wglobal.h
@@ -237,7 +237,9 @@ public:
         ColResize,
         RowResize,
         ZoomIn,
-        ZoomOut
+        ZoomOut,
+        DndAsk,
+        AllResize
     };
     Q_ENUM(CursorShape)
     static_assert(CursorShape::BottomLeftCorner > CursorShape::Default, "");

--- a/waylib/src/server/kernel/woutput.cpp
+++ b/waylib/src/server/kernel/woutput.cpp
@@ -282,7 +282,7 @@ static struct wlr_swapchain *create_swapchain(struct wlr_output *output,
 
     const struct wlr_drm_format_set *display_formats =
         wlr_output_get_primary_formats(output, allocator->buffer_caps);
-    struct wlr_drm_format format = {0};
+    struct wlr_drm_format format{};
     if (!output_pick_format(output, display_formats, &format, render_format)) {
         qDebug("Failed to pick primary buffer format for output '%s'",
                output->name);
@@ -414,7 +414,7 @@ bool WOutput::configureCursorSwapchain(const QSize &size, uint32_t drmFormat, qw
     Q_ASSERT(!size.isEmpty());
     auto sc = *swapchain;
     if (!sc || sc->handle()->width != size.width() || sc->handle()->height != size.height()) {
-        wlr_drm_format format = {0};
+        wlr_drm_format format = {};
         if (!output_pick_cursor_format(nativeHandle(), &format, drmFormat)) {
             qCDebug(qLcOutput, "Failed to pick cursor format");
             return false;

--- a/waylib/src/server/kernel/wseat.cpp
+++ b/waylib/src/server/kernel/wseat.cpp
@@ -1204,6 +1204,7 @@ void WSeat::notifyFrame(WCursor *cursor)
 
 void WSeat::notifyGestureBegin(WCursor *cursor, WInputDevice *device, uint32_t time_msec, uint32_t fingers, WGestureEvent::WLibInputGestureType libInputGestureType)
 {
+    Q_UNUSED(time_msec)
     W_D(WSeat);
     if (d->gestureActive) {
         qCWarning(qLcWlrGestureEvents) << "Unexpected GestureBegin while already active";
@@ -1223,6 +1224,7 @@ void WSeat::notifyGestureBegin(WCursor *cursor, WInputDevice *device, uint32_t t
 
 void WSeat::notifyGestureUpdate(WCursor *cursor, WInputDevice *device, uint32_t time_msec, const QPointF &delta, double scale, double rotation, WGestureEvent::WLibInputGestureType libInputGestureType)
 {
+    Q_UNUSED(time_msec)
     W_D(WSeat);
     if (!d->gestureActive) {
         qCWarning(qLcWlrGestureEvents) << "Unexpected GestureUpdate while not begin";
@@ -1255,6 +1257,8 @@ void WSeat::notifyGestureUpdate(WCursor *cursor, WInputDevice *device, uint32_t 
 
 void WSeat::notifyGestureEnd(WCursor *cursor, WInputDevice *device, uint32_t time_msec, bool cancelled, WGestureEvent::WLibInputGestureType libInputGestureType)
 {
+    Q_UNUSED(time_msec)
+    Q_UNUSED(cancelled)
     W_D(WSeat);
     if (!d->gestureActive) {
         qCWarning(qLcWlrGestureEvents) << "Unexpected GestureEnd while not begin";
@@ -1316,6 +1320,7 @@ void WSeat::notifyHoldEnd(WCursor *cursor, WInputDevice *device, uint32_t time_m
 
 void WSeat::notifyTouchDown(WCursor *cursor, WInputDevice *device, int32_t touch_id, uint32_t time_msec)
 {
+    Q_UNUSED(time_msec)
     W_D(WSeat);
     auto qwDevice = qobject_cast<QPointingDevice*>(device->qtDevice());
     Q_ASSERT(qwDevice);
@@ -1352,7 +1357,7 @@ void WSeat::notifyTouchDown(WCursor *cursor, WInputDevice *device, int32_t touch
                                << ", at position" << globalPos;
 }
 
-void WSeat::notifyTouchMotion(WCursor *cursor, WInputDevice *device, int32_t touch_id, uint32_t time_msec)
+void WSeat::notifyTouchMotion(WCursor *cursor, WInputDevice *device, int32_t touch_id, [[maybe_unused]] uint32_t time_msec)
 {
 
     W_DC(WSeat);
@@ -1382,7 +1387,7 @@ void WSeat::notifyTouchMotion(WCursor *cursor, WInputDevice *device, int32_t tou
     }
 }
 
-void WSeat::notifyTouchUp(WCursor *cursor, WInputDevice *device, int32_t touch_id, uint32_t time_msec)
+void WSeat::notifyTouchUp(WCursor *cursor, WInputDevice *device, int32_t touch_id, [[maybe_unused]] uint32_t time_msec)
 {
     W_DC(WSeat);
     auto qwDevice = qobject_cast<QPointingDevice*>(device->qtDevice());

--- a/waylib/src/server/kernel/wseat.cpp
+++ b/waylib/src/server/kernel/wseat.cpp
@@ -1195,16 +1195,14 @@ void WSeat::notifyAxis(WCursor *cursor, WInputDevice *device, wl_pointer_axis_so
     }
 }
 
-void WSeat::notifyFrame(WCursor *cursor)
+void WSeat::notifyFrame([[maybe_unused]] WCursor *cursor)
 {
-    Q_UNUSED(cursor);
     W_D(WSeat);
     d->doNotifyFrame();
 }
 
-void WSeat::notifyGestureBegin(WCursor *cursor, WInputDevice *device, uint32_t time_msec, uint32_t fingers, WGestureEvent::WLibInputGestureType libInputGestureType)
+void WSeat::notifyGestureBegin(WCursor *cursor, WInputDevice *device, [[maybe_unused]] uint32_t time_msec, uint32_t fingers, WGestureEvent::WLibInputGestureType libInputGestureType)
 {
-    Q_UNUSED(time_msec)
     W_D(WSeat);
     if (d->gestureActive) {
         qCWarning(qLcWlrGestureEvents) << "Unexpected GestureBegin while already active";
@@ -1222,9 +1220,8 @@ void WSeat::notifyGestureBegin(WCursor *cursor, WInputDevice *device, uint32_t t
         QCoreApplication::sendEvent(w, &e);
 }
 
-void WSeat::notifyGestureUpdate(WCursor *cursor, WInputDevice *device, uint32_t time_msec, const QPointF &delta, double scale, double rotation, WGestureEvent::WLibInputGestureType libInputGestureType)
+void WSeat::notifyGestureUpdate(WCursor *cursor, WInputDevice *device, [[maybe_unused]] uint32_t time_msec, const QPointF &delta, double scale, double rotation, WGestureEvent::WLibInputGestureType libInputGestureType)
 {
-    Q_UNUSED(time_msec)
     W_D(WSeat);
     if (!d->gestureActive) {
         qCWarning(qLcWlrGestureEvents) << "Unexpected GestureUpdate while not begin";
@@ -1255,10 +1252,8 @@ void WSeat::notifyGestureUpdate(WCursor *cursor, WInputDevice *device, uint32_t 
     }
 }
 
-void WSeat::notifyGestureEnd(WCursor *cursor, WInputDevice *device, uint32_t time_msec, bool cancelled, WGestureEvent::WLibInputGestureType libInputGestureType)
+void WSeat::notifyGestureEnd(WCursor *cursor, WInputDevice *device, [[maybe_unused]] uint32_t time_msec, [[maybe_unused]] bool cancelled, WGestureEvent::WLibInputGestureType libInputGestureType)
 {
-    Q_UNUSED(time_msec)
-    Q_UNUSED(cancelled)
     W_D(WSeat);
     if (!d->gestureActive) {
         qCWarning(qLcWlrGestureEvents) << "Unexpected GestureEnd while not begin";
@@ -1318,9 +1313,8 @@ void WSeat::notifyHoldEnd(WCursor *cursor, WInputDevice *device, uint32_t time_m
 
 // deal with touch event form wlr_cursor
 
-void WSeat::notifyTouchDown(WCursor *cursor, WInputDevice *device, int32_t touch_id, uint32_t time_msec)
+void WSeat::notifyTouchDown(WCursor *cursor, WInputDevice *device, int32_t touch_id, [[maybe_unused]] uint32_t time_msec)
 {
-    Q_UNUSED(time_msec)
     W_D(WSeat);
     auto qwDevice = qobject_cast<QPointingDevice*>(device->qtDevice());
     Q_ASSERT(qwDevice);
@@ -1440,10 +1434,9 @@ void WSeat::notifyTouchCancel(WCursor *cursor, WInputDevice *device, int32_t tou
     }
 }
 
-void WSeat::notifyTouchFrame(WCursor *cursor)
+void WSeat::notifyTouchFrame([[maybe_unused]] WCursor *cursor)
 {
     W_D(WSeat);
-    Q_UNUSED(cursor);
     for (auto *device: std::as_const(d->touchDeviceList)) {
         d->doNotifyTouchFrame(device);
     }

--- a/waylib/src/server/kernel/wserver.cpp
+++ b/waylib/src/server/kernel/wserver.cpp
@@ -90,8 +90,8 @@ void WServerPrivate::init()
     Q_ASSERT(display);
 
     // free follow display
-    Q_UNUSED(qw_data_device_manager::create(*display));
-    Q_UNUSED(qw_primary_selection_v1_device_manager::create(*display));
+    [[maybe_unused]] auto ddm = qw_data_device_manager::create(*display);
+    [[maybe_unused]] auto psm = qw_primary_selection_v1_device_manager::create(*display);
 
     W_Q(WServer);
 

--- a/waylib/src/server/kernel/wserver.h
+++ b/waylib/src/server/kernel/wserver.h
@@ -64,11 +64,9 @@ protected:
     WServer *m_server = nullptr;
     std::function<bool(WClient*)> m_filter;
 
-    virtual void create(WServer *server) {
-        Q_UNUSED(server);
+    virtual void create([[maybe_unused]] WServer *server) {
     }
-    virtual void destroy(WServer *server) {
-        Q_UNUSED(server);
+    virtual void destroy([[maybe_unused]] WServer *server) {
     }
     virtual wl_global *global() const = 0;
 

--- a/waylib/src/server/kernel/wsocket.cpp
+++ b/waylib/src/server/kernel/wsocket.cpp
@@ -493,7 +493,7 @@ bool WSocket::create(const QString &filePath)
 
 static QString getSocketFile(int fd, bool doCheck) {
     if (doCheck) {   // check socket file
-        struct ::stat stat_buf = {0};
+        struct ::stat stat_buf{};
         if (fstat(fd, &stat_buf) != 0) {
             qDebug("fstat failed on create by FD");
             return {};

--- a/waylib/src/server/kernel/wtoplevelsurface.h
+++ b/waylib/src/server/kernel/wtoplevelsurface.h
@@ -82,26 +82,20 @@ public:
     }
 
 public Q_SLOTS:
-    virtual void setMaximize(bool on) {
-        Q_UNUSED(on);
+    virtual void setMaximize([[maybe_unused]] bool on) {
     }
-    virtual void setMinimize(bool on) {
-        Q_UNUSED(on);
+    virtual void setMinimize([[maybe_unused]] bool on) {
     }
-    virtual void setActivate(bool on) {
-        Q_UNUSED(on);
+    virtual void setActivate([[maybe_unused]] bool on) {
     }
-    virtual void setResizeing(bool on) {
-        Q_UNUSED(on);
+    virtual void setResizeing([[maybe_unused]] bool on) {
     }
-    virtual void setFullScreen(bool on) {
-        Q_UNUSED(on);
+    virtual void setFullScreen([[maybe_unused]] bool on) {
     }
 
     // when `checkNewSize` return false, will set `clipedSize` to fit max/min size
     virtual bool checkNewSize(const QSize &size, QSize *clipedSize = nullptr) = 0;
-    virtual void resize(const QSize &size) {
-        Q_UNUSED(size)
+    virtual void resize([[maybe_unused]] const QSize &size) {
     }
     virtual void close() {
     }

--- a/waylib/src/server/kernel/wxcursorimage.cpp
+++ b/waylib/src/server/kernel/wxcursorimage.cpp
@@ -78,7 +78,7 @@ bool WXCursorImage::jumpToImage(int imageNumber)
     if (!d->cursor)
         return false;
 
-    if (imageNumber >= d->cursor->image_count)
+    if (imageNumber >= static_cast<int>(d->cursor->image_count))
         return false;
     d->currentImageNumber = imageNumber;
 

--- a/waylib/src/server/platformplugin/qwlrootscursor.cpp
+++ b/waylib/src/server/platformplugin/qwlrootscursor.cpp
@@ -27,9 +27,8 @@ void QWlrootsCursor::changeCursor(QCursor *windowCursor, QWindow *window)
     cursor->setCursor(windowCursor ? *windowCursor : WCursor::defaultCursor());
 }
 
-void QWlrootsCursor::setOverrideCursor(const QCursor &cursor)
+void QWlrootsCursor::setOverrideCursor([[maybe_unused]] const QCursor &cursor)
 {
-    Q_UNUSED(cursor);
     return;
 }
 

--- a/waylib/src/server/platformplugin/qwlrootscursor.cpp
+++ b/waylib/src/server/platformplugin/qwlrootscursor.cpp
@@ -44,7 +44,7 @@ QPoint QWlrootsCursor::pos() const
     return cursors.isEmpty() ? QPoint() : cursors.first()->position().toPoint();
 }
 
-void QWlrootsCursor::setPos(const QPoint &pos)
+void QWlrootsCursor::setPos([[maybe_unused]] const QPoint &pos)
 {
 
 }

--- a/waylib/src/server/platformplugin/qwlrootsintegration.cpp
+++ b/waylib/src/server/platformplugin/qwlrootsintegration.cpp
@@ -76,11 +76,10 @@ public:
 };
 
 QWlrootsIntegration *QWlrootsIntegration::m_instance = nullptr;
-QWlrootsIntegration::QWlrootsIntegration(bool master, const QStringList &parameters, std::function<void ()> onInitialized)
+QWlrootsIntegration::QWlrootsIntegration(bool master, [[maybe_unused]] const QStringList &parameters, std::function<void ()> onInitialized)
     : m_master(master)
     , m_onInitialized(onInitialized)
 {
-    Q_UNUSED(parameters);
     Q_ASSERT(!m_instance);
     m_instance = this;
 }
@@ -118,7 +117,7 @@ QWlrootsScreen *QWlrootsIntegration::addScreen(WOutput *output)
             QWindowSystemInterface::handleScreenRemoved(m_placeholderScreen.release());
         }
     } else {
-        Q_UNUSED(new QScreen(m_screens.last()))
+        [[maybe_unused]] auto screen = new QScreen(m_screens.last());
     }
 
     m_screens.last()->initialize();
@@ -360,17 +359,14 @@ public:
         return m_format;
     }
 
-    void swapBuffers(QPlatformSurface *surface) override {
-        Q_UNUSED(surface);
+    void swapBuffers([[maybe_unused]] QPlatformSurface *surface) override {
         Q_UNREACHABLE();
     }
-    GLuint defaultFramebufferObject(QPlatformSurface *surface) const override {
-        Q_UNUSED(surface);
+    GLuint defaultFramebufferObject([[maybe_unused]] QPlatformSurface *surface) const override {
         return 0;
     }
 
-    bool makeCurrent(QPlatformSurface *surface) override {
-        Q_UNUSED(surface);
+    bool makeCurrent([[maybe_unused]] QPlatformSurface *surface) override {
         if (auto c = qobject_cast<QW::OpenGLContext*>(m_context)) {
             return eglMakeCurrent(c->eglDisplay(), EGL_NO_SURFACE, EGL_NO_SURFACE, c->eglContext());
         }

--- a/waylib/src/server/protocols/ext_foreign_toplevel_image_capture_source.c
+++ b/waylib/src/server/protocols/ext_foreign_toplevel_image_capture_source.c
@@ -58,7 +58,7 @@ static void foreign_toplevel_manager_handle_create_source(struct wl_client *clie
 	wl_signal_emit_mutable(&manager->events.new_request, request);
 }
 
-static void foreign_toplevel_manager_handle_destroy(struct wl_client *client,
+static void foreign_toplevel_manager_handle_destroy([[maybe_unused]] struct wl_client *client,
 		struct wl_resource *manager_resource) {
 	wl_resource_destroy(manager_resource);
 }
@@ -81,7 +81,7 @@ static void foreign_toplevel_manager_bind(struct wl_client *client, void *data,
 	wl_resource_set_implementation(resource, &foreign_toplevel_manager_impl, manager, NULL);
 }
 
-static void foreign_toplevel_manager_handle_display_destroy(struct wl_listener *listener, void *data) {
+static void foreign_toplevel_manager_handle_display_destroy(struct wl_listener *listener, [[maybe_unused]] void *data) {
 	struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1 *manager =
 		wl_container_of(listener, manager, display_destroy);
 	wl_signal_emit_mutable(&manager->events.destroy, NULL);

--- a/waylib/src/server/protocols/private/winputmethodv2.cpp
+++ b/waylib/src/server/protocols/private/winputmethodv2.cpp
@@ -35,7 +35,9 @@ public:
 
 WInputMethodManagerV2::WInputMethodManagerV2(QObject *parent)
     : WObject(*new WInputMethodManagerV2Private(this), nullptr)
-{ }
+{ 
+    Q_UNUSED(parent)
+}
 
 QByteArrayView WInputMethodManagerV2::interfaceName() const
 {

--- a/waylib/src/server/protocols/private/winputmethodv2.cpp
+++ b/waylib/src/server/protocols/private/winputmethodv2.cpp
@@ -33,10 +33,9 @@ public:
     QList<WInputMethodV2 *> inputMethods;
 };
 
-WInputMethodManagerV2::WInputMethodManagerV2(QObject *parent)
+WInputMethodManagerV2::WInputMethodManagerV2([[maybe_unused]] QObject *parent)
     : WObject(*new WInputMethodManagerV2Private(this), nullptr)
 { 
-    Q_UNUSED(parent)
 }
 
 QByteArrayView WInputMethodManagerV2::interfaceName() const

--- a/waylib/src/server/protocols/private/wtextinputv1.cpp
+++ b/waylib/src/server/protocols/private/wtextinputv1.cpp
@@ -227,7 +227,7 @@ WTextInputV1::WTextInputV1(QObject *parent)
 }
 
 static WTextInputV1 *text_input_from_resource(wl_resource *resource);
-void text_input_handle_activate(wl_client *client,
+void text_input_handle_activate([[maybe_unused]] wl_client *client,
                                 wl_resource *resource,
                                 wl_resource *seat,
                                 wl_resource *surface)
@@ -255,7 +255,7 @@ void text_input_handle_activate(wl_client *client,
     Q_EMIT text_input->activate();
 }
 
-void text_input_handle_deactivate(wl_client *client,
+void text_input_handle_deactivate([[maybe_unused]] wl_client *client,
                                   wl_resource *resource,
                                   wl_resource *seat)
 {
@@ -271,21 +271,21 @@ void text_input_handle_deactivate(wl_client *client,
     Q_EMIT text_input->deactivate();
 }
 
-void text_input_handle_show_input_panel(wl_client *client,
+void text_input_handle_show_input_panel([[maybe_unused]] wl_client *client,
                                         wl_resource *resource)
 {
     Q_UNUSED(client);
     Q_UNUSED(resource);
 }
 
-void text_input_handle_hide_input_panel(wl_client *client,
+void text_input_handle_hide_input_panel([[maybe_unused]] wl_client *client,
                                         wl_resource *resource)
 {
     Q_UNUSED(client);
     Q_UNUSED(resource);
 }
 
-void text_input_handle_reset(wl_client *client,
+void text_input_handle_reset([[maybe_unused]] wl_client *client,
                              wl_resource *resource)
 {
     WTextInputV1 *text_input = text_input_from_resource(resource);
@@ -298,7 +298,7 @@ void text_input_handle_reset(wl_client *client,
     d->contentPurpose = 0;
 }
 
-void text_input_handle_set_surrounding_text(wl_client *client,
+void text_input_handle_set_surrounding_text([[maybe_unused]] wl_client *client,
                                             wl_resource *resource,
                                             const char *text,
                                             uint32_t cursor,
@@ -311,7 +311,7 @@ void text_input_handle_set_surrounding_text(wl_client *client,
     d->surroundingAnchor = anchor;
 }
 
-void text_input_handle_set_content_type(wl_client *client,
+void text_input_handle_set_content_type([[maybe_unused]] wl_client *client,
                                         wl_resource *resource,
                                         uint32_t hint,
                                         uint32_t purpose)
@@ -322,7 +322,7 @@ void text_input_handle_set_content_type(wl_client *client,
     d->contentPurpose = purpose;
 }
 
-void text_input_handle_set_cursor_rectangle(wl_client *client,
+void text_input_handle_set_cursor_rectangle([[maybe_unused]] wl_client *client,
                                             wl_resource *resource,
                                             int32_t x,
                                             int32_t y,
@@ -343,7 +343,7 @@ void text_input_handle_set_preferred_language(wl_client *client,
     Q_UNUSED(language);
 }
 
-void text_input_handle_commit_state(wl_client *client,
+void text_input_handle_commit_state([[maybe_unused]] wl_client *client,
                                     wl_resource *resource,
                                     uint32_t serial)
 {
@@ -353,7 +353,7 @@ void text_input_handle_commit_state(wl_client *client,
     Q_EMIT text_input->committed();
 }
 
-void text_input_handle_invoke_action(wl_client *client,
+void text_input_handle_invoke_action([[maybe_unused]] wl_client *client,
                                      wl_resource *resource,
                                      uint32_t button,
                                      uint32_t index)

--- a/waylib/src/server/protocols/private/wtextinputv1.cpp
+++ b/waylib/src/server/protocols/private/wtextinputv1.cpp
@@ -272,17 +272,13 @@ void text_input_handle_deactivate([[maybe_unused]] wl_client *client,
 }
 
 void text_input_handle_show_input_panel([[maybe_unused]] wl_client *client,
-                                        wl_resource *resource)
+                                        [[maybe_unused]] wl_resource *resource)
 {
-    Q_UNUSED(client);
-    Q_UNUSED(resource);
 }
 
 void text_input_handle_hide_input_panel([[maybe_unused]] wl_client *client,
-                                        wl_resource *resource)
+                                        [[maybe_unused]] wl_resource *resource)
 {
-    Q_UNUSED(client);
-    Q_UNUSED(resource);
 }
 
 void text_input_handle_reset([[maybe_unused]] wl_client *client,
@@ -334,13 +330,10 @@ void text_input_handle_set_cursor_rectangle([[maybe_unused]] wl_client *client,
     d->cursorRectangle = QRect(x, y, width, height);
 }
 
-void text_input_handle_set_preferred_language(wl_client *client,
-                                              wl_resource *resource,
-                                              const char *language)
+void text_input_handle_set_preferred_language([[maybe_unused]] wl_client *client,
+                                              [[maybe_unused]] wl_resource *resource,
+                                              [[maybe_unused]] const char *language)
 {
-    Q_UNUSED(client);
-    Q_UNUSED(resource);
-    Q_UNUSED(language);
 }
 
 void text_input_handle_commit_state([[maybe_unused]] wl_client *client,
@@ -354,14 +347,10 @@ void text_input_handle_commit_state([[maybe_unused]] wl_client *client,
 }
 
 void text_input_handle_invoke_action([[maybe_unused]] wl_client *client,
-                                     wl_resource *resource,
-                                     uint32_t button,
-                                     uint32_t index)
+                                     [[maybe_unused]] wl_resource *resource,
+                                     [[maybe_unused]] uint32_t button,
+                                     [[maybe_unused]] uint32_t index)
 {
-    Q_UNUSED(client);
-    Q_UNUSED(resource);
-    Q_UNUSED(button);
-    Q_UNUSED(index);
 }
 
 static const struct zwp_text_input_v1_interface text_input_v1_impl = {
@@ -460,9 +449,8 @@ void WTextInputManagerV1::create(WServer *server)
     m_handle = this;
 }
 
-void WTextInputManagerV1::destroy(WServer *server)
+void WTextInputManagerV1::destroy([[maybe_unused]] WServer *server)
 {
-    Q_UNUSED(server);
     W_D(WTextInputManagerV1);
     wl_global_destroy(m_global);
     for (auto textInput : std::as_const(d->textInputs)) {

--- a/waylib/src/server/protocols/private/wtextinputv2.cpp
+++ b/waylib/src/server/protocols/private/wtextinputv2.cpp
@@ -134,9 +134,8 @@ void text_input_manager_bind(wl_client *client,
     wl_resource_set_implementation(resource, &manager_impl, manager, nullptr);
 }
 
-void handle_manager_destroy(wl_client *client, wl_resource *resource)
+void handle_manager_destroy([[maybe_unused]] wl_client *client, wl_resource *resource)
 {
-    Q_UNUSED(client);
     wl_resource_destroy(resource);
 }
 
@@ -194,27 +193,25 @@ void handle_manager_get_text_input(wl_client *client,
     Q_EMIT manager->newTextInput(text_input);
 }
 
-void handle_text_input_destroy(wl_client *client, wl_resource *resource)
+void handle_text_input_destroy([[maybe_unused]] wl_client *client, wl_resource *resource)
 {
-    Q_UNUSED(client)
     wl_resource_destroy(resource);
 }
 
-void handle_text_input_enable(wl_client *client, wl_resource *resource, wl_resource *surface)
+void handle_text_input_enable([[maybe_unused]] wl_client *client, wl_resource *resource, wl_resource *surface)
 {
-    Q_UNUSED(client)
     auto text_input = text_input_from_resource(resource);
     Q_ASSERT(text_input);
     auto wSurface = WSurface::fromHandle(wlr_surface_from_resource(surface));
     // Surface must be existent already, this means wSurface should always be non-null.
     if (!wSurface) {
-        wl_client_post_implementation_error(client, "Enabled surface not found.");
+        wl_client_post_implementation_error(wl_resource_get_client(resource), "Enabled surface not found.");
         return;
     }
     auto d = text_input->d_func();
     if (d->enabledSurface) {
         // FIXME: Is this necessary? As protocol does not guarantee disable is ought to happen after enable, we may still need this.
-        qCWarning(qLcTextInputV2) << "Client" << client << "does emit disable on surface"
+        qCWarning(qLcTextInputV2) << "Client" << client << "does Q_EMIT disable on surface"
                                  << d->enabledSurface << "before enable on surface" << wSurface;
         text_input->clearEnabledSurface();
     }
@@ -223,19 +220,18 @@ void handle_text_input_enable(wl_client *client, wl_resource *resource, wl_resou
     Q_EMIT text_input->enableOnSurface(wSurface);
 }
 
-void handle_text_input_disable(wl_client *client, wl_resource *resource, wl_resource *surface)
+void handle_text_input_disable([[maybe_unused]] wl_client *client, wl_resource *resource, wl_resource *surface)
 {
-    Q_UNUSED(client)
     auto text_input = text_input_from_resource(resource);
     Q_ASSERT(text_input);
     auto wSurface = WSurface::fromHandle(wlr_surface_from_resource(surface));
     if (!wSurface) {
-        wl_client_post_implementation_error(client, "Disabled surface not found, may be already destroyed.");
+        wl_client_post_implementation_error(wl_resource_get_client(resource), "Disabled surface not found, may be already destroyed.");
         return;
     }
     auto d = text_input->d_func();
     if (!d->enabledSurface) {
-        qCWarning(qLcTextInputV2) << "Client" << client
+        qCWarning(qLcTextInputV2) << "Client" << wl_resource_get_client(resource)
                                     << "try to disable surface" << wSurface
                                     << "on a text input" << text_input
                                     << "that is not enabled on this surface. Do nothing!";
@@ -251,22 +247,17 @@ void handle_text_input_disable(wl_client *client, wl_resource *resource, wl_reso
     text_input->clearEnabledSurface();
 }
 
-void handle_text_input_show_input_panel(wl_client *client, wl_resource *resource)
+void handle_text_input_show_input_panel([[maybe_unused]] wl_client *client, [[maybe_unused]] wl_resource *resource)
 {
-    Q_UNUSED(client)
-    Q_UNUSED(resource)
 }
 
-void handle_text_input_hide_input_panel(wl_client *client, wl_resource *resource)
+void handle_text_input_hide_input_panel([[maybe_unused]] wl_client *client, [[maybe_unused]] wl_resource *resource)
 {
-    Q_UNUSED(client)
-    Q_UNUSED(resource)
 }
 
 void handle_text_input_set_surrounding_text(
-    wl_client *client, wl_resource *resource, const char *text, int32_t cursor, int32_t anchor)
+    [[maybe_unused]] wl_client *client, wl_resource *resource, const char *text, int32_t cursor, int32_t anchor)
 {
-    Q_UNUSED(client)
     auto text_input = text_input_from_resource(resource);
     Q_ASSERT(text_input);
     auto d = text_input->d_func();
@@ -275,12 +266,11 @@ void handle_text_input_set_surrounding_text(
     d->surroundingAnchor = anchor;
 }
 
-void handle_text_input_set_content_type(wl_client *client,
+void handle_text_input_set_content_type([[maybe_unused]] wl_client *client,
                                         wl_resource *resource,
                                         uint32_t hint,
                                         uint32_t purpose)
 {
-    Q_UNUSED(client)
     auto text_input = text_input_from_resource(resource);
     Q_ASSERT(text_input);
     auto d = text_input->d_func();
@@ -289,30 +279,25 @@ void handle_text_input_set_content_type(wl_client *client,
 }
 
 void handle_text_input_set_cursor_rectangle(
-    wl_client *client, wl_resource *resource, int32_t x, int32_t y, int32_t width, int32_t height)
+    [[maybe_unused]] wl_client *client, wl_resource *resource, int32_t x, int32_t y, int32_t width, int32_t height)
 {
-    Q_UNUSED(client)
     auto text_input = text_input_from_resource(resource);
     Q_ASSERT(text_input);
     auto d = text_input->d_func();
     d->cursorRectangle = QRect(x, y, width, height);
 }
 
-void handle_text_input_set_preferred_language(wl_client *client,
-                                              wl_resource *resource,
-                                              const char *language)
+void handle_text_input_set_preferred_language([[maybe_unused]] wl_client *client,
+                                              [[maybe_unused]] wl_resource *resource,
+                                              [[maybe_unused]] const char *language)
 {
-    Q_UNUSED(client)
-    Q_UNUSED(resource)
-    Q_UNUSED(language)
 }
 
-void handle_text_input_update_state(wl_client *client,
-                                    wl_resource *resource,
+void handle_text_input_update_state([[maybe_unused]] wl_client *client,
+                                    [[maybe_unused]] wl_resource *resource,
                                     [[maybe_unused]] uint32_t serial,
                                     uint32_t reason)
 {
-    Q_UNUSED(client)
     auto text_input = text_input_from_resource(resource);
     Q_ASSERT(text_input);
     Q_EMIT text_input->stateUpdated(WTextInputV2::UpdateReason(reason));
@@ -339,7 +324,7 @@ void WTextInputManagerV2::create(WServer *server)
 
 void WTextInputManagerV2::destroy(WServer *server)
 {
-    Q_UNUSED(server);
+    [[maybe_unused]] auto server_unused = server;
     W_D(WTextInputManagerV2);
     wl_global_destroy(m_global);
     for (auto textInput : std::as_const(d->textInputs)) {

--- a/waylib/src/server/protocols/private/wtextinputv2.cpp
+++ b/waylib/src/server/protocols/private/wtextinputv2.cpp
@@ -114,7 +114,7 @@ WTextInputV2 *text_input_from_resource(wl_resource *resource)
 
 void text_input_manager_bind(wl_client *client,
                              void *data,
-                             uint32_t version,
+                             [[maybe_unused]] uint32_t version,
                              uint32_t id)
 {
     WTextInputManagerV2 *manager = static_cast<WTextInputManagerV2 *>(data);
@@ -309,7 +309,7 @@ void handle_text_input_set_preferred_language(wl_client *client,
 
 void handle_text_input_update_state(wl_client *client,
                                     wl_resource *resource,
-                                    uint32_t serial,
+                                    [[maybe_unused]] uint32_t serial,
                                     uint32_t reason)
 {
     Q_UNUSED(client)

--- a/waylib/src/server/protocols/private/wtextinputv3.cpp
+++ b/waylib/src/server/protocols/private/wtextinputv3.cpp
@@ -60,7 +60,7 @@ void WTextInputManagerV3::create(WServer *server)
     });
 }
 
-void WTextInputManagerV3::destroy(WServer *server)
+void WTextInputManagerV3::destroy([[maybe_unused]] WServer *server)
 {
     for (auto ti : std::as_const(d_func()->textInputs)) {
         Q_EMIT ti->entityAboutToDestroy();

--- a/waylib/src/server/protocols/private/wvirtualkeyboardv1.cpp
+++ b/waylib/src/server/protocols/private/wvirtualkeyboardv1.cpp
@@ -22,7 +22,7 @@ public:
     { }
 };
 
-WVirtualKeyboardManagerV1::WVirtualKeyboardManagerV1(QObject *parent)
+WVirtualKeyboardManagerV1::WVirtualKeyboardManagerV1([[maybe_unused]] QObject *parent)
     : WObject(*new WVirtualKeyboardManagerV1Private(this))
 {}
 

--- a/waylib/src/server/protocols/wcursorshapemanagerv1.cpp
+++ b/waylib/src/server/protocols/wcursorshapemanagerv1.cpp
@@ -10,7 +10,7 @@
 #include <qwseat.h>
 #include <qwdisplay.h>
 
-#define CURSOR_SHAPE_MANAGER_V1_VERSION 1
+#define CURSOR_SHAPE_MANAGER_V1_VERSION 2
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 

--- a/waylib/src/server/protocols/wcursorshapemanagerv1.cpp
+++ b/waylib/src/server/protocols/wcursorshapemanagerv1.cpp
@@ -10,7 +10,8 @@
 #include <qwseat.h>
 #include <qwdisplay.h>
 
-#define CURSOR_SHAPE_MANAGER_V1_VERSION 2
+// TODO: set to 2 after wlroots 0.20
+#define CURSOR_SHAPE_MANAGER_V1_VERSION 1
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 

--- a/waylib/src/server/protocols/wcursorshapemanagerv1.cpp
+++ b/waylib/src/server/protocols/wcursorshapemanagerv1.cpp
@@ -107,6 +107,10 @@ static inline auto wpToWCursorShape(wp_cursor_shape_device_v1_shape shape) {
         return WGlobal::CursorShape::ZoomIn;
     case WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_ZOOM_OUT:
         return WGlobal::CursorShape::ZoomOut;
+    case WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_DND_ASK:
+        return WGlobal::CursorShape::DndAsk;
+    case WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_ALL_RESIZE:
+        return WGlobal::CursorShape::AllResize;
     }
     return WGlobal::CursorShape::Invalid;
 }

--- a/waylib/src/server/protocols/wextforeigntoplevellistv1.cpp
+++ b/waylib/src/server/protocols/wextforeigntoplevellistv1.cpp
@@ -88,7 +88,7 @@ private:
     std::map<WToplevelSurface *, std::unique_ptr<qw_ext_foreign_toplevel_handle_v1>> surfaces;
 };
 
-WExtForeignToplevelListV1::WExtForeignToplevelListV1(QObject *parent)
+WExtForeignToplevelListV1::WExtForeignToplevelListV1([[maybe_unused]] QObject *parent)
     : WObject(*new WExtForeignToplevelListV1Private(this), nullptr)
 {
 }

--- a/waylib/src/server/protocols/wextforeigntoplevellistv1.cpp
+++ b/waylib/src/server/protocols/wextforeigntoplevellistv1.cpp
@@ -126,9 +126,8 @@ void WExtForeignToplevelListV1::create(WServer *server)
     m_handle = qw_ext_foreign_toplevel_list_v1::create(*server->handle(), EXT_FOREIGN_TOPLEVEL_LIST_V1_VERSION);
 }
 
-void WExtForeignToplevelListV1::destroy(WServer *server)
+void WExtForeignToplevelListV1::destroy([[maybe_unused]] WServer *server)
 {
-    Q_UNUSED(server);
 }
 
 wl_global *WExtForeignToplevelListV1::global() const

--- a/waylib/src/server/protocols/wforeigntoplevelv1.cpp
+++ b/waylib/src/server/protocols/wforeigntoplevelv1.cpp
@@ -115,7 +115,7 @@ public:
         QObject::connect(handle,
                          &qw_foreign_toplevel_handle_v1::notify_request_activate,
                          surface,
-                         [surface, q](wlr_foreign_toplevel_handle_v1_activated_event *event) {
+                         [surface, q]([[maybe_unused]] wlr_foreign_toplevel_handle_v1_activated_event *event) {
                              Q_EMIT q->requestActivate(surface);
                          });
 
@@ -192,7 +192,7 @@ public:
     std::map<WToplevelSurface *, std::unique_ptr<qw_foreign_toplevel_handle_v1>> surfaces;
 };
 
-WForeignToplevel::WForeignToplevel(QObject *parent)
+WForeignToplevel::WForeignToplevel([[maybe_unused]] QObject *parent)
     : WObject(*new WForeignToplevelPrivate(this), nullptr)
 {
 }
@@ -223,7 +223,7 @@ void WForeignToplevel::create(WServer *server)
     m_handle = qw_foreign_toplevel_manager_v1::create(*server->handle());
 }
 
-void WForeignToplevel::destroy(WServer *server)
+void WForeignToplevel::destroy([[maybe_unused]] WServer *server)
 {
 }
 

--- a/waylib/src/server/protocols/winputmethodhelper.cpp
+++ b/waylib/src/server/protocols/winputmethodhelper.cpp
@@ -73,9 +73,9 @@ public:
         , enabledTextInput(nullptr)
         , activeInputMethod(nullptr)
         , activeKeyboardGrab(nullptr)
-        , keyboardGrab()
-        , grabInterface()
-        , handlerArg({.helper = qq})
+        , keyboardGrab{}
+        , grabInterface{}
+        , handlerArg({.helper = qq, .grab = nullptr})
     {
         Q_ASSERT(server);
         Q_ASSERT(seat);

--- a/waylib/src/server/protocols/wlayershell.cpp
+++ b/waylib/src/server/protocols/wlayershell.cpp
@@ -71,7 +71,7 @@ void WLayerShellPrivate::onSurfaceDestroy(qw_layer_surface_v1 *layerSurface)
     surface->safeDeleteLater();
 }
 
-WLayerShell::WLayerShell(WXdgShell *xdgshell, QObject *parent):
+WLayerShell::WLayerShell(WXdgShell *xdgshell, [[maybe_unused]] QObject *parent):
     WWrapObject(*new WLayerShellPrivate(this), nullptr)
 {
     W_D(WLayerShell);

--- a/waylib/src/server/protocols/wlayershell.cpp
+++ b/waylib/src/server/protocols/wlayershell.cpp
@@ -100,9 +100,8 @@ void WLayerShell::create(WServer *server)
     m_handle = layer_shell;
 }
 
-void WLayerShell::destroy(WServer *server)
+void WLayerShell::destroy([[maybe_unused]] WServer *server)
 {
-    Q_UNUSED(server);
     W_D(WLayerShell);
 
     auto list = d->surfaceList;

--- a/waylib/src/server/protocols/wxdgdecorationmanager.cpp
+++ b/waylib/src/server/protocols/wxdgdecorationmanager.cpp
@@ -56,7 +56,7 @@ void WXdgDecorationManagerPrivate::onNewToplevelDecoration(qw_xdg_toplevel_decor
                 [decorat, this]() {
                     this->updateDecorationMode(decorat);
                 });
-    /* For some reason, a lot of clients don't emit the request_mode signal. */
+    /* For some reason, a lot of clients don't Q_EMIT the request_mode signal. */
     updateDecorationMode(decorat);
 }
 
@@ -123,9 +123,8 @@ void WXdgDecorationManager::create(WServer *server)
     });
 }
 
-void WXdgDecorationManager::destroy(WServer *server)
+void WXdgDecorationManager::destroy([[maybe_unused]] WServer *server)
 {
-    Q_UNUSED(server);
 }
 
 wl_global *WXdgDecorationManager::global() const

--- a/waylib/src/server/protocols/wxdgoutput.cpp
+++ b/waylib/src/server/protocols/wxdgoutput.cpp
@@ -419,9 +419,8 @@ WOutputLayout *WXdgOutputManager::layout() const
     return d->layout;
 }
 
-void WXdgOutputManager::destroy(WServer *server)
+void WXdgOutputManager::destroy([[maybe_unused]] WServer *server)
 {
-    Q_UNUSED(server);
     W_D(WXdgOutputManager);
     d->manager = nullptr;
     m_handle = nullptr;
@@ -433,9 +432,8 @@ wl_global *WXdgOutputManager::global() const
     return handle->global;
 }
 
-void WXdgOutputManager::create(WServer *wserver)
+void WXdgOutputManager::create([[maybe_unused]] WServer *wserver)
 {
-    Q_UNUSED(wserver)
     W_D(WXdgOutputManager);
     if (d->layout) {
         d->manager = way_xdg_output_manager_v1_create(*server()->handle(),

--- a/waylib/src/server/protocols/wxdgpopupsurface.cpp
+++ b/waylib/src/server/protocols/wxdgpopupsurface.cpp
@@ -133,7 +133,7 @@ WXdgPopupSurface *WXdgPopupSurface::fromSurface(WSurface *surface)
     return surface->getAttachedData<WXdgPopupSurface>();
 }
 
-void WXdgPopupSurface::resize(const QSize &size)
+void WXdgPopupSurface::resize([[maybe_unused]] const QSize &size)
 {
 
 }

--- a/waylib/src/server/protocols/wxdgpopupsurface.cpp
+++ b/waylib/src/server/protocols/wxdgpopupsurface.cpp
@@ -153,9 +153,8 @@ QRect WXdgPopupSurface::getContentGeometry() const
     return tmp.toQRect();
 }
 
-bool WXdgPopupSurface::checkNewSize(const QSize &size, QSize *clipedSize)
+bool WXdgPopupSurface::checkNewSize(const QSize &size, [[maybe_unused]] QSize *clipedSize)
 {
-    Q_UNUSED(clipedSize);
     return size.isValid();
 }
 

--- a/waylib/src/server/protocols/wxdgshell.cpp
+++ b/waylib/src/server/protocols/wxdgshell.cpp
@@ -133,9 +133,8 @@ void WXdgShell::create(WServer *server)
     m_handle = xdg_shell;
 }
 
-void WXdgShell::destroy(WServer *server)
+void WXdgShell::destroy([[maybe_unused]] WServer *server)
 {
-    Q_UNUSED(server);
     W_D(WXdgShell);
 
     QVector<WXdgToplevelSurface*> toplevelList;

--- a/waylib/src/server/protocols/wxwayland.cpp
+++ b/waylib/src/server/protocols/wxwayland.cpp
@@ -343,9 +343,8 @@ void WXWayland::create(WServer *server)
     });
 }
 
-void WXWayland::destroy(WServer *server)
+void WXWayland::destroy([[maybe_unused]] WServer *server)
 {
-    Q_UNUSED(server);
     W_D(WXWayland);
 
     auto list = d->surfaceList;

--- a/waylib/src/server/protocols/wxwaylandsurface.cpp
+++ b/waylib/src/server/protocols/wxwaylandsurface.cpp
@@ -202,8 +202,10 @@ void WXWaylandSurfacePrivate::updateWindowTypes()
 {
     WXWaylandSurface::WindowTypes types = {0};
 
-    for (int i = 0; i < nativeHandle()->window_type_len; ++i) {
-        switch (xwayland->atomType(nativeHandle()->window_type[i])) {
+    for (size_t i = 0; i < nativeHandle()->window_type_len; ++i) {
+        auto atomType = xwayland->atomType(nativeHandle()->window_type[i]);
+        
+        switch (atomType) {
         case WXWayland::_NET_WM_WINDOW_TYPE_NORMAL:
             types |= WXWaylandSurface::NET_WM_WINDOW_TYPE_NORMAL;
             break;

--- a/waylib/src/server/qtquick/private/wbufferrenderer.cpp
+++ b/waylib/src/server/qtquick/private/wbufferrenderer.cpp
@@ -392,7 +392,6 @@ qw_buffer *WBufferRenderer::beginRender(const QSize &pixelSize, qreal devicePixe
 #ifndef QT_NO_OPENGL
         if (wd->rhi->backend() == QRhi::OpenGLES2) {
             auto glRT = QRHI_RES(QGles2TextureRenderTarget, rtd->u.rhiRt);
-            Q_ASSERT(glRT->framebuffer >= 0);
             auto glContext = QOpenGLContext::currentContext();
             Q_ASSERT(glContext);
             QOpenGLContextPrivate::get(glContext)->defaultFboRedirect = glRT->framebuffer;

--- a/waylib/src/server/qtquick/private/wrenderbuffernode.cpp
+++ b/waylib/src/server/qtquick/private/wrenderbuffernode.cpp
@@ -161,8 +161,7 @@ public:
             DataManager *manager;
         };
 
-        TryClean cleanJob(this);
-        Q_UNUSED(cleanJob)
+        [[maybe_unused]] TryClean cleanJob(this);
 
         {
             auto d = data.lock();
@@ -701,8 +700,7 @@ public:
         }
     }
 
-    void render(const RenderState *state) override {
-        Q_UNUSED(state)
+    void render([[maybe_unused]] const RenderState *state) override {
 
         auto texture = this->texture.lock();
         if (Q_UNLIKELY(!texture))
@@ -983,8 +981,7 @@ public:
         return image.expired() ? QImage() : *image.lock()->data;
     }
 
-    void render(const RenderState *state) override {
-        Q_UNUSED(state)
+    void render([[maybe_unused]] const RenderState *state) override {
         auto window = renderWindow();
         if (!window)
             return;

--- a/waylib/src/server/qtquick/private/wrenderbuffernode.cpp
+++ b/waylib/src/server/qtquick/private/wrenderbuffernode.cpp
@@ -136,6 +136,7 @@ public:
     }
 
     static DataManagerPointer<Derive> resolve(const DataManagerPointer<Derive> &other, QQuickWindow *owner) {
+        static_assert(requires { &Derive::metaObject; });
         Q_ASSERT(owner);
         if (other && other->owner() == owner)
             return other;

--- a/waylib/src/server/qtquick/private/wrenderbuffernode.cpp
+++ b/waylib/src/server/qtquick/private/wrenderbuffernode.cpp
@@ -136,7 +136,6 @@ public:
     }
 
     static DataManagerPointer<Derive> resolve(const DataManagerPointer<Derive> &other, QQuickWindow *owner) {
-        static_assert(&Derive::metaObject);
         Q_ASSERT(owner);
         if (other && other->owner() == owner)
             return other;

--- a/waylib/src/server/qtquick/private/wrenderbuffernode.cpp
+++ b/waylib/src/server/qtquick/private/wrenderbuffernode.cpp
@@ -25,6 +25,7 @@
 #include <private/qsgdefaultrendercontext_p.h>
 #include <private/qsgrhisupport_p.h>
 #include <private/qquickrendercontrol_p.h>
+#include <qobjectdefs.h>
 
 #include <algorithm>
 
@@ -136,7 +137,7 @@ public:
     }
 
     static DataManagerPointer<Derive> resolve(const DataManagerPointer<Derive> &other, QQuickWindow *owner) {
-        static_assert(requires { &Derive::metaObject; });
+        static_assert(QtPrivate::HasQ_OBJECT_Macro<Derive>::Value, "Derive must have Q_OBJECT macro");
         Q_ASSERT(owner);
         if (other && other->owner() == owner)
             return other;

--- a/waylib/src/server/qtquick/woutputrenderwindow.cpp
+++ b/waylib/src/server/qtquick/woutputrenderwindow.cpp
@@ -813,13 +813,15 @@ WBufferRenderer *OutputHelper::afterRender()
         layers.append({
             .layer = i->wlrLayer->handle(),
             .buffer = buffer->handle(),
+            .src_box = {},
             .dst_box = {
                 .x = i->mapToOutput.x(),
                 .y = i->mapToOutput.y(),
                 .width = i->mapToOutput.width(),
                 .height = i->mapToOutput.height(),
             },
-            .damage = &i->renderer->damageRing()->handle()->current
+            .damage = &i->renderer->damageRing()->handle()->current,
+            .accepted = false
         });
 
         if (needsEndBuffer) {
@@ -1185,7 +1187,7 @@ bool OutputHelper::tryToHardwareCursor(const LayerData *layer)
         }
 
         const auto pos = layer->mapToOutput.topLeft() + hotSpot;
-        wlr_box cleanTransform {.x = pos.x(), .y = pos.y()};
+        wlr_box cleanTransform {.x = pos.x(), .y = pos.y(), .width = 0, .height = 0};
         const auto outputSize = output()->output()->size();
         // the layer->mapRect has been transform in renderLayer, but
         // wlroot's move_cursor also will transform the cursor's position.

--- a/waylib/src/server/qtquick/wrenderbufferblitter.cpp
+++ b/waylib/src/server/qtquick/wrenderbufferblitter.cpp
@@ -222,9 +222,8 @@ static void onTextureChanged(WRenderBufferNode *node, void *data) {
     Q_EMIT d->tp->textureChanged();
 }
 
-QSGNode *WRenderBufferBlitter::updatePaintNode(QSGNode *oldNode, QQuickItem::UpdatePaintNodeData *oldData)
+QSGNode *WRenderBufferBlitter::updatePaintNode(QSGNode *oldNode, [[maybe_unused]] QQuickItem::UpdatePaintNodeData *oldData)
 {
-    Q_UNUSED(oldData)
 
     auto node = static_cast<WRenderBufferNode*>(oldNode);
     if (Q_LIKELY(node)) {

--- a/waylib/src/server/qtquick/wrenderhelper.cpp
+++ b/waylib/src/server/qtquick/wrenderhelper.cpp
@@ -703,7 +703,7 @@ QSGRendererInterface::GraphicsApi WRenderHelper::probe(qw_backend *testBackend, 
             std::unique_ptr<qw_allocator> alloc(qw_allocator::autocreate(*testBackend, *renderer.get()));
 
             bool hasSupportedFormat = false;
-            for (int formatId = 0; formatId < formats->len; formatId++) {
+            for (size_t formatId = 0; formatId < formats->len; formatId++) {
                 auto *format = &formats->formats[formatId];
 
                 std::unique_ptr<qw_swapchain> swapchain(qw_swapchain::create(*alloc.get(), 1000, 800, format));

--- a/waylib/src/server/qtquick/wrenderhelper.cpp
+++ b/waylib/src/server/qtquick/wrenderhelper.cpp
@@ -392,9 +392,8 @@ VkTextureBuffer::VkTextureBuffer(VkInstance instance, VkDevice device, QSGTextur
 
 }
 
-bool VkTextureBuffer::get_dmabuf(wlr_dmabuf_attributes *attribs)
+bool VkTextureBuffer::get_dmabuf([[maybe_unused]] wlr_dmabuf_attributes *attribs)
 {
-    Q_UNUSED(attribs);
 //    static auto vkGetInstanceProcAddr =
 //        reinterpret_cast<PFN_vkGetInstanceProcAddr>(::dlsym(RTLD_DEFAULT, "vkGetInstanceProcAddr"));
 //    static auto vkGetMemoryFdKHR =
@@ -440,9 +439,8 @@ bool QImageBuffer::get_shm(wlr_shm_attributes *attribs)
     return true;
 }
 
-bool QImageBuffer::begin_data_ptr_access(uint32_t flags, void **data, uint32_t *format, size_t *stride)
+bool QImageBuffer::begin_data_ptr_access([[maybe_unused]] uint32_t flags, void **data, uint32_t *format, size_t *stride)
 {
-    Q_UNUSED(flags);
     *data = m_image.bits();
     *format = WTools::toDrmFormat(m_image.format());
     *stride = m_image.bytesPerLine();

--- a/waylib/src/server/qtquick/wsurfaceitem.cpp
+++ b/waylib/src/server/qtquick/wsurfaceitem.cpp
@@ -156,7 +156,7 @@ private:
 class Q_DECL_HIDDEN WSurfaceItemContentPrivate: public QQuickItemPrivate
 {
 public:
-    WSurfaceItemContentPrivate(WSurfaceItemContent *qq){}
+    WSurfaceItemContentPrivate([[maybe_unused]] WSurfaceItemContent *qq){}
 
     ~WSurfaceItemContentPrivate() {
     }

--- a/waylib/src/server/utils/wcursorimage.cpp
+++ b/waylib/src/server/utils/wcursorimage.cpp
@@ -471,6 +471,10 @@ static inline const char *qcursorShapeToType(std::underlying_type_t<WGlobal::Cur
         return "zoom-in";
     case static_cast<int>(WGlobal::CursorShape::ZoomOut):
         return "zoom-out";
+    case static_cast<int>(WGlobal::CursorShape::DndAsk):
+        return "dnd-ask";
+    case static_cast<int>(WGlobal::CursorShape::AllResize):
+        return "all-resize";
     default:
         break;
     }
@@ -575,7 +579,7 @@ void WCursorImagePrivate::updateCursorImage()
 void WCursorImagePrivate::playXCursor()
 {
     Q_ASSERT(xcursor);
-    Q_ASSERT(currentXCursorImageIndex < xcursor->image_count);
+    Q_ASSERT(static_cast<unsigned int>(currentXCursorImageIndex) < xcursor->image_count);
     Q_ASSERT(xcursorPlayTimer);
     Q_ASSERT(!xcursorPlayTimer->isActive());
 

--- a/waylib/src/server/utils/wextimagecapturesourcev1impl.cpp
+++ b/waylib/src/server/utils/wextimagecapturesourcev1impl.cpp
@@ -169,9 +169,9 @@ WExtImageCaptureSourceV1Impl::~WExtImageCaptureSourceV1Impl()
     }
 }
 
-void WExtImageCaptureSourceV1Impl::start(bool with_cursors)
+void WExtImageCaptureSourceV1Impl::start([[maybe_unused]] bool with_cursors)
 {
-    Q_UNUSED(with_cursors) // TODO: Implement cursor capture if needed
+    // TODO: Implement cursor capture if needed
     m_capturing = true;
     qCDebug(qLcImageCapture) << "WExtImageCaptureSourceV1Impl::start() with_cursors:" << with_cursors;
 
@@ -275,7 +275,7 @@ void WExtImageCaptureSourceV1Impl::handleRenderEnd()
     // Create damage region with RAII
     WPixmanRegion fullDamage(0, 0, surfaceSize.width(), surfaceSize.height());
     
-    // Create frame event and emit
+    // Create frame event and Q_EMIT
     wlr_ext_image_capture_source_v1_frame_event event {
         .damage = fullDamage.get(),
     };
@@ -366,9 +366,8 @@ void WExtImageCaptureSourceV1Impl::copy_frame(wlr_ext_image_copy_capture_frame_v
     }
 }
 
-wlr_ext_image_capture_source_v1_cursor *WExtImageCaptureSourceV1Impl::get_pointer_cursor(wlr_seat *seat)
+wlr_ext_image_capture_source_v1_cursor *WExtImageCaptureSourceV1Impl::get_pointer_cursor([[maybe_unused]] wlr_seat *seat)
 {
-    Q_UNUSED(seat)
     qCDebug(qLcImageCapture) << "WExtImageCaptureSourceV1Impl::get_pointer_cursor()";
     // TODO: Implement cursor retrieval logic
     // This needs to get cursor information from seat and create corresponding cursor structure

--- a/waylib/src/server/utils/wextimagecapturesourcev1impl.cpp
+++ b/waylib/src/server/utils/wextimagecapturesourcev1impl.cpp
@@ -96,7 +96,7 @@ struct ConstraintBuilder {
                 
                 // Clean up old DMA-BUF formats
                 wlr_drm_format_set_finish(&source->dmabuf_formats);
-                source->dmabuf_formats = (struct wlr_drm_format_set){0};
+                source->dmabuf_formats = (struct wlr_drm_format_set){};
                 
                 // Copy DMA-BUF formats from swapchain
                 for (size_t i = 0; i < swapchain->handle()->format.len; i++) {
@@ -285,7 +285,7 @@ void WExtImageCaptureSourceV1Impl::handleRenderEnd()
 }
 
 void WExtImageCaptureSourceV1Impl::copy_frame(wlr_ext_image_copy_capture_frame_v1 *dst_frame, 
-                                              wlr_ext_image_capture_source_v1_frame_event *frame_event)
+                                              [[maybe_unused]] wlr_ext_image_capture_source_v1_frame_event *frame_event)
 {
     qCDebug(qLcImageCapture) << "WExtImageCaptureSourceV1Impl::copy_frame()";
     

--- a/waylib/tests/manual/live/main.cpp
+++ b/waylib/tests/manual/live/main.cpp
@@ -110,7 +110,7 @@ void Helper::initProtocols(WOutputRenderWindow *window, QQmlEngine *qmlEngine)
             // Don't care for WOutput::isEnabled, must do WOutput::commit here,
             // In order to ensure trigger QWOutput::frame signal, WOutputRenderWindow
             // needs this signal to render next frmae. Because QWOutput::frame signal
-            // maybe emit before WOutputRenderWindow::attach, if no commit here,
+            // maybe Q_EMIT before WOutputRenderWindow::attach, if no commit here,
             // WOutputRenderWindow will ignore this ouptut on render.
             if (!qwoutput->property("_Enabled").toBool()) {
                 qwoutput->setProperty("_Enabled", true);

--- a/waylib/tests/manual/subsurface/main.cpp
+++ b/waylib/tests/manual/subsurface/main.cpp
@@ -19,7 +19,7 @@ void CustomWindow::setParent(QWindow *newParent)
     QQuickWindow::setParent(newParent);
     show();
 
-    emit parentChanged();
+    Q_EMIT parentChanged();
 }
 
 int main(int argc, char *argv[])

--- a/waylib/tests/manual/subsurface/window.h
+++ b/waylib/tests/manual/subsurface/window.h
@@ -24,7 +24,7 @@ public:
         return true;
     }
 
-signals:
+Q_SIGNALS:
     void parentChanged();
 
 private:


### PR DESCRIPTION
1. Fix order of member variable initialization in qw_interface
constructor
2. Move add_compile_options after ASAN flags to ensure proper priority
3. Fix member variable order in TreelandConfig to match declaration
4. Add [[maybe_unused]] attribute to unused function parameters
5. Fix surface wrapper bitfield member ordering
6. Fix cursor image index comparison type mismatch
7. Fix various minor code style and structure issues

fix: 解决编译警告并改进代码结构

1. 修复 qw_interface 构造函数中成员变量的初始化顺序
2. 将 add_compile_options 移至 ASAN 标志之后以确保优先级
3. 修复 TreelandConfig 中成员变量顺序以匹配声明
4. 为未使用的函数参数添加 [[maybe_unused]] 属性
5. 修复 surface wrapper 位域成员顺序
6. 修复光标图像索引比较的类型不匹配问题
7. 解决其他次要的代码风格和结构问题

## Summary by Sourcery

Resolve compilation warnings and improve code structure across the codebase

Bug Fixes:
- Fix constructor member initialization order in qw_interface and TreelandConfig
- Correct cursor image index comparison type mismatch

Enhancements:
- Annotate unused parameters and variables with [[maybe_unused]] and remove Q_UNUSED calls
- Standardize signal emission using Q_EMIT instead of emit
- Reorder bitfield and member variable declarations to match definition and avoid warnings
- Replace implicit zero-initializers with {} and align loop index types with container sizes

Build:
- Move add_compile_options after ASAN flags to ensure proper priority
- Add -Wall and -Wextra compiler flags