### PR TITLE
fix(treeland.sh): use exec to replace process and avoid duplicate logs

### DIFF
--- a/misc/systemd/treeland.service.in
+++ b/misc/systemd/treeland.service.in
@@ -14,3 +14,7 @@ Environment=DSG_APP_ID=org.deepin.dde.treeland
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/treeland.sh --lockscreen
 Restart=on-failure
 RestartSec=1s
+# Disable logs from treeland.sh to avoid duplicate entries in journalctl
+# since exec replaces the process, logs would appear from both treeland.sh and treeland
+StandardOutput=null
+StandardError=null

--- a/src/treeland.sh
+++ b/src/treeland.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env sh
 
 script_path=$(realpath $(dirname "$0"))
-cmd="$script_path/treeland $@"
-output=$($cmd --try-exec 2>&1)
+cmd="$script_path/treeland"
+# Include all user arguments in test to ensure consistent environment
+output=$($cmd --try-exec "$@" 2>&1)
 exit_code=$?
 
 if [ $exit_code -ne 0 ] && echo "$output" | grep -q "failed to create dri2 screen"; then
@@ -13,4 +14,6 @@ if [ $exit_code -ne 0 ] && echo "$output" | grep -q "failed to create dri2 scree
     echo "Treeland crash, try fallback to software renderer."
 fi
 
-$cmd
+# Use exec to replace current process instead of creating a subprocess
+# This ensures treeland directly replaces treeland.sh process, avoiding dual processes
+exec $cmd "$@"


### PR DESCRIPTION
- Use exec to replace treeland.sh process with treeland, avoiding dual processes
- Include all user arguments in --try-exec test for environment consistency
- Disable systemd logs from treeland.sh to prevent duplicate journal entries
- Add English comments explaining the process replacement logic

This resolves the issue where treeland.sh and treeland would run as separate processes, and eliminates duplicate log entries in journalctl.

## Summary by Sourcery

Streamline treeland startup by replacing the wrapper script process with exec, ensure consistent argument handling in the startup test, disable redundant journald logging, and clarify logic with comments

Bug Fixes:
- Prevent treeland.sh from spawning a separate treeland process and creating duplicate processes

Enhancements:
- Include all user arguments in the --try-exec check for environment consistency
- Use exec to replace the wrapper script with the treeland binary directly
- Add English comments to explain the process replacement logic

Deployment:
- Disable systemd logs in the service configuration to prevent duplicate journal entries