### PR TITLE
fix: resolve multiple compiler warnings

### DIFF
--- a/qwlroots/src/qwobject.h
+++ b/qwlroots/src/qwobject.h
@@ -161,10 +161,10 @@ public:
 
     template <typename S, typename SS>
     void bind_signal(S s, SS qt_signal) {
-        typedef typename QtPrivate::FunctionPointer<SS>::Object DeriveType;
-        static_assert(std::is_base_of<qw_object, DeriveType>::value,
+        typedef typename QtPrivate::FunctionPointer<SS>::Object SignalObjectType;
+        static_assert(std::is_base_of<qw_object, SignalObjectType>::value,
                       "The signal is not defined in the derive class of qw_object");
-        auto obj = static_cast<DeriveType*>(this);
+        auto obj = static_cast<SignalObjectType*>(this);
         sc.connect(&(obj->handle()->events.*s), obj, qt_signal);
     }
 

--- a/qwlroots/src/qwsession.h
+++ b/qwlroots/src/qwsession.h
@@ -33,7 +33,7 @@ public:
 
     QW_FUNC_MEMBER(session, open_file, wlr_device *, const char *path)
     QW_FUNC_MEMBER(session, close_file, void, wlr_device *device)
-    QW_FUNC_MEMBER(session, change_vt, bool, unsigned vt);
+    QW_FUNC_MEMBER(session, change_vt, bool, unsigned vt)
     QW_FUNC_MEMBER(session, find_gpus, ssize_t, size_t ret_len, wlr_device **ret)
 
 protected:

--- a/qwlroots/src/types/qwdatacontrolv1.h
+++ b/qwlroots/src/types/qwdatacontrolv1.h
@@ -25,7 +25,7 @@ class QW_CLASS_OBJECT(data_control_manager_v1)
     QW_SIGNAL(new_device, wlr_data_control_device_v1*)
 
 public:
-    QW_FUNC_STATIC(data_control_manager_v1, create, qw_data_control_manager_v1 *, wl_display *display);
+    QW_FUNC_STATIC(data_control_manager_v1, create, qw_data_control_manager_v1 *, wl_display *display)
 };
 
 QW_END_NAMESPACE

--- a/qwlroots/src/types/qwdatadevice.h
+++ b/qwlroots/src/types/qwdatadevice.h
@@ -49,9 +49,9 @@ class QW_CLASS_OBJECT(drag)
     QW_SIGNAL(drop, wlr_drag_drop_event*)
 
 public:
-    QW_FUNC_STATIC(drag, create, qw_drag *, wlr_seat_client *seat_client, wlr_data_source *source, wlr_surface *icon_surface);
+    QW_FUNC_STATIC(drag, create, qw_drag *, wlr_seat_client *seat_client, wlr_data_source *source, wlr_surface *icon_surface)
     QW_FUNC_STATIC(seat, request_start_drag, void, wlr_seat *seat, wlr_drag *drag, wlr_surface *origin, uint32_t serial)
-    QW_FUNC_STATIC(seat, start_drag, void, wlr_seat *seat, wlr_drag *drag, uint32_t serial);
+    QW_FUNC_STATIC(seat, start_drag, void, wlr_seat *seat, wlr_drag *drag, uint32_t serial)
 };
 
 QW_END_NAMESPACE

--- a/qwlroots/src/types/qwdrmleasev1.h
+++ b/qwlroots/src/types/qwdrmleasev1.h
@@ -15,14 +15,14 @@ QW_BEGIN_NAMESPACE
 class QW_CLASS_REINTERPRET_CAST(drm_lease_v1)
 {
 public:
-    QW_FUNC_MEMBER(drm_lease_v1, revoke, void);
+    QW_FUNC_MEMBER(drm_lease_v1, revoke, void)
 };
 
 class QW_CLASS_REINTERPRET_CAST(drm_lease_request_v1)
 {
 public:
-    QW_FUNC_MEMBER(drm_lease_request_v1, grant, wlr_drm_lease_v1 *);
-    QW_FUNC_MEMBER(drm_lease_request_v1, reject, void);
+    QW_FUNC_MEMBER(drm_lease_request_v1, grant, wlr_drm_lease_v1 *)
+    QW_FUNC_MEMBER(drm_lease_request_v1, reject, void)
 };
 
 class QW_CLASS_OBJECT(drm_lease_v1_manager)
@@ -33,10 +33,10 @@ class QW_CLASS_OBJECT(drm_lease_v1_manager)
     QW_SIGNAL(request, wlr_drm_lease_request_v1*)
 
 public:
-    QW_FUNC_STATIC(drm_lease_v1_manager, create, qw_drm_lease_v1_manager *, wl_display *display, wlr_backend *backend);
+    QW_FUNC_STATIC(drm_lease_v1_manager, create, qw_drm_lease_v1_manager *, wl_display *display, wlr_backend *backend)
 
-    QW_FUNC_MEMBER(drm_lease_v1_manager, offer_output, bool, wlr_output *output);
-    QW_FUNC_MEMBER(drm_lease_v1_manager, withdraw_output, void, wlr_output *output);
+    QW_FUNC_MEMBER(drm_lease_v1_manager, offer_output, bool, wlr_output *output)
+    QW_FUNC_MEMBER(drm_lease_v1_manager, withdraw_output, void, wlr_output *output)
 };
 
 QW_END_NAMESPACE

--- a/qwlroots/src/types/qwextdatacontrolv1.h
+++ b/qwlroots/src/types/qwextdatacontrolv1.h
@@ -19,7 +19,7 @@ class QW_CLASS_OBJECT(ext_data_control_manager_v1)
     QW_SIGNAL(new_device, wlr_ext_data_control_device_v1*)
 
 public:
-    QW_FUNC_STATIC(ext_data_control_manager_v1, create, qw_ext_data_control_manager_v1 *, wl_display *display, uint32_t version);
+    QW_FUNC_STATIC(ext_data_control_manager_v1, create, qw_ext_data_control_manager_v1 *, wl_display *display, uint32_t version)
 };
 
 QW_END_NAMESPACE

--- a/qwlroots/src/types/qwlayershellv1.h
+++ b/qwlroots/src/types/qwlayershellv1.h
@@ -31,7 +31,7 @@ public:
     QW_FUNC_MEMBER(layer_surface_v1, for_each_popup_surface, void, wlr_surface_iterator_func_t iterator, void *user_data)
     QW_FUNC_MEMBER(layer_surface_v1, surface_at, wlr_surface *, double sx, double sy, double *sub_x, double *sub_y)
     QW_FUNC_MEMBER(layer_surface_v1, popup_surface_at, wlr_surface *, double sx, double sy, double *sub_x, double *sub_y)
-    QW_FUNC_MEMBER(layer_surface_v1, configure, uint32_t, uint32_t width, uint32_t height);
+    QW_FUNC_MEMBER(layer_surface_v1, configure, uint32_t, uint32_t width, uint32_t height)
     QW_FUNC_MEMBER(layer_surface_v1, destroy, void)
 };
 

--- a/qwlroots/src/types/qwlinuxdrmsyncobjv1.h
+++ b/qwlroots/src/types/qwlinuxdrmsyncobjv1.h
@@ -25,7 +25,7 @@ class QW_CLASS_REINTERPRET_CAST(linux_drm_syncobj_surface_v1_state)
 {
 public:
 #if WLR_VERSION_MINOR >= 19
-    QW_FUNC_MEMBER(linux_drm_syncobj_surface_v1_state, signal_release_with_buffer, bool, wlr_buffer *buffer);
+    QW_FUNC_MEMBER(linux_drm_syncobj_surface_v1_state, signal_release_with_buffer, bool, wlr_buffer *buffer)
 #endif
 };
 

--- a/qwlroots/src/types/qwscene.h
+++ b/qwlroots/src/types/qwscene.h
@@ -71,7 +71,7 @@ protected:
 class QW_CLASS_REINTERPRET_CAST(scene_output_layout)
 {
 public:
-    QW_FUNC_MEMBER(scene_output_layout, add_output, void, wlr_output_layout_output *lo, wlr_scene_output *so);
+    QW_FUNC_MEMBER(scene_output_layout, add_output, void, wlr_output_layout_output *lo, wlr_scene_output *so)
 };
 
 #define QW_SCENE_NODE(name) \

--- a/src/modules/tools/qtwaylandscanner.cpp
+++ b/src/modules/tools/qtwaylandscanner.cpp
@@ -506,6 +506,8 @@ bool Scanner::process()
         printf("QT_WARNING_PUSH\n");
         printf("QT_WARNING_DISABLE_GCC(\"-Wmissing-field-initializers\")\n");
         printf("QT_WARNING_DISABLE_CLANG(\"-Wmissing-field-initializers\")\n");
+        printf("QT_WARNING_DISABLE_GCC(\"-Wreorder\")\n");
+        printf("QT_WARNING_DISABLE_CLANG(\"-Wreorder\")\n");
         QByteArray serverExport;
         if (m_headerPath.size()) {
             serverExport = QByteArray("Q_WAYLAND_SERVER_") + preProcessorProtocolName + "_EXPORT";
@@ -694,6 +696,8 @@ bool Scanner::process()
         printf("QT_BEGIN_NAMESPACE\n");
         printf("QT_WARNING_PUSH\n");
         printf("QT_WARNING_DISABLE_GCC(\"-Wmissing-field-initializers\")\n");
+        printf("QT_WARNING_DISABLE_GCC(\"-Wreorder\")\n");
+        printf("QT_WARNING_DISABLE_CLANG(\"-Wreorder\")\n");
         printf("\n");
         printf("namespace QtWaylandServer {\n");
 
@@ -1145,6 +1149,8 @@ bool Scanner::process()
         printf("QT_BEGIN_NAMESPACE\n");
         printf("QT_WARNING_PUSH\n");
         printf("QT_WARNING_DISABLE_GCC(\"-Wmissing-field-initializers\")\n");
+        printf("QT_WARNING_DISABLE_GCC(\"-Wreorder\")\n");
+        printf("QT_WARNING_DISABLE_CLANG(\"-Wreorder\")\n");
 
         QByteArray clientExport;
 
@@ -1271,6 +1277,8 @@ bool Scanner::process()
         printf("QT_BEGIN_NAMESPACE\n");
         printf("QT_WARNING_PUSH\n");
         printf("QT_WARNING_DISABLE_GCC(\"-Wmissing-field-initializers\")\n");
+        printf("QT_WARNING_DISABLE_GCC(\"-Wreorder\")\n");
+        printf("QT_WARNING_DISABLE_CLANG(\"-Wreorder\")\n");
         printf("\n");
         printf("namespace QtWayland {\n");
         printf("\n");

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -99,7 +99,7 @@ public:
         Full = Mapped | UnMinimized | HasInitializeContainer,
     };
     Q_ENUM(ActiveControlState);
-    Q_DECLARE_FLAGS(ActiveControlStates, ActiveControlState);
+    Q_DECLARE_FLAGS(ActiveControlStates, ActiveControlState)
 
     enum class SurfaceRole
     {

--- a/waylib/src/server/kernel/winputdevice.cpp
+++ b/waylib/src/server/kernel/winputdevice.cpp
@@ -34,7 +34,7 @@ public:
 
     WWRAP_HANDLE_FUNCTIONS(qw_input_device, wlr_input_device)
 
-    W_DECLARE_PUBLIC(WInputDevice);
+    W_DECLARE_PUBLIC(WInputDevice)
 
     QPointer<QInputDevice> qtDevice;
     QPointer<QObject> hoverTarget;


### PR DESCRIPTION
1. Fix multiple compiler warning issues across various header files
2. Corrected template typedef naming in qobject.h for better clarity
3. Removed semicolons after QW_FUNC_MEMBER macros in several header files
4. Added missing compiler warning disables for -Wreorder in qtwaylandscanner.cpp
5. Fixed Q_DECLARE_FLAGS macro usage in surfacewrapper.h
6. Fixed W_DECLARE_PUBLIC macro usage in winputdevice.cpp

These changes eliminate compiler warnings during the build process while maintaining full functionality and improving code consistency across the codebase.

修复: 解决多个编译器警告

1. 修复多个头文件中的编译器警告问题
2. 在 qobject.h 中修正了模板类型定义名称以提高清晰度
3. 在多个头文件中移除了 QW_FUNC_MEMBER 宏后的分号
4. 在 qtwaylandscanner.cpp 中添加了缺失的 -Wreorder 警告禁用指令
5. 修正了 surfacewrapper.h 中的 Q_DECLARE_FLAGS 宏使用
6. 修正了 winputdevice.cpp 中的 W_DECLARE_PUBLIC 宏使用

这些修改在保持完整功能的同时消除了构建过程中的编译器警告

## Summary by Sourcery

Eliminate multiple compiler warnings across the codebase by adjusting macro usages, adding missing warning suppressions, and clarifying a template typedef name

Bug Fixes:
- Remove extraneous semicolons after QW_FUNC_MEMBER and QW_FUNC_STATIC macros to silence compiler warnings
- Fix Q_DECLARE_FLAGS and W_DECLARE_PUBLIC macro formatting to resolve warnings
- Suppress -Wreorder warnings in qtwaylandscanner.cpp

Enhancements:
- Rename template typedef in qwobject.h from DeriveType to SignalObjectType for improved clarity