### PR TITLE
fix: Resolve placeSmartCascaded crash in multi-seat scenarios

### DIFF
--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -376,7 +376,10 @@ void Workspace::removeActivedSurface(SurfaceWrapper *surface)
             wpModle->removeActivedSurface(surface);
         m_showOnAllWorkspaceModel->removeActivedSurface(surface);
     } else {
-        auto wpModle = modelFromId(surface->workspaceId());
+        int workspaceId = surface->workspaceId();
+        if (workspaceId == -1)
+            return;
+        auto wpModle = modelFromId(workspaceId);
         Q_ASSERT(wpModle);
         wpModle->removeActivedSurface(surface);
     }


### PR DESCRIPTION
Multi-seat functionality increased the frequency of pushActivedSurface calls, causing unstable/unmapped surfaces to enter the active window history. When placeSmartCascaded accessed these half-invalidated surfaces for cascade positioning, it crashed on null shellSurface dereferences.

Bug: PMS-327661

## Summary by Sourcery

Prevent placeSmartCascaded crashes by removing half-invalid surfaces from active history upon invalidation and adding safety checks before activating or pushing surfaces.

Bug Fixes:
- Remove surfaces from workspace active history early when they begin invalidation or removal to avoid stale entries.

Enhancements:
- Add null, mapping, and capability checks around shellSurface before setting activation or pushing surfaces to active history in Helper::activateSurface, afterHandleEvent, setActivatedSurface, and setActivatedSurfaceForSeat.