### PR TITLE
build: enable -Werror compiler flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,9 @@ if (ADDRESS_SANITIZER)
     add_link_options(-fsanitize=address)
 endif()
 add_compile_options(-Wall -Wextra)
+add_compile_options(-Werror)
+# Temporarily disable array-bounds warning due to false positive with Qt DBus and GCC 14.3
+add_compile_options(-Wno-error=array-bounds)
 # NOTE: Qt keywords conflict with wlroots. but dtksystemsettings still uses it.
 # add_definitions("-DQT_NO_KEYWORDS")
 

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -319,7 +319,7 @@ void Helper::onOutputAdded(WOutput *output)
 {
     // TODO: 应该让helper发出Output的信号，每个需要output的单元单独connect。
     allowNonDrmOutputAutoChangeMode(output);
-    Output *o;
+    Output *o = nullptr;
     if (m_mode == OutputMode::Extension || !m_rootSurfaceContainer->primaryOutput()) {
         o = createNormalOutput(output);
     } else if (m_mode == OutputMode::Copy) {
@@ -1795,7 +1795,7 @@ void Helper::setOutputMode(OutputMode mode)
     for (int i = 0; i < m_outputList.size(); i++) {
         if (m_outputList.at(i) == m_rootSurfaceContainer->primaryOutput())
             continue;
-        Output *o;
+        Output *o = nullptr;
         if (mode == OutputMode::Copy) {
             o = createCopyOutput(m_outputList.at(i)->output(),
                                  m_rootSurfaceContainer->primaryOutput());

--- a/waylib/examples/tinywl/workspace.cpp
+++ b/waylib/examples/tinywl/workspace.cpp
@@ -19,6 +19,11 @@ Workspace::Workspace(SurfaceContainer *parent)
     createContainer(QStringLiteral("workspace-%1").arg(++workspaceGlobalIndex));
 }
 
+void Workspace::addSurface(SurfaceWrapper *surface)
+{
+    addSurface(surface, m_currentIndex);
+}
+
 void Workspace::addSurface(SurfaceWrapper *surface, int workspaceIndex)
 {
     doAddSurface(surface, true);

--- a/waylib/examples/tinywl/workspace.h
+++ b/waylib/examples/tinywl/workspace.h
@@ -20,7 +20,8 @@ class Workspace : public SurfaceContainer
 public:
     explicit Workspace(SurfaceContainer *parent);
 
-    Q_INVOKABLE void addSurface(SurfaceWrapper *surface, int workspaceIndex = -1);
+    void addSurface(SurfaceWrapper *surface) override;
+    Q_INVOKABLE void addSurface(SurfaceWrapper *surface, int workspaceIndex);
     void removeSurface(SurfaceWrapper *surface) override;
     int containerIndexOfSurface(SurfaceWrapper *surface) const;
 


### PR DESCRIPTION
1. Added -Werror compiler flag to treat warnings as errors
2. This enforces stricter code quality standards
3. Helps catch potential issues early in development
4. Improves overall code reliability and maintainability

build: 启用 -Werror 编译器标志

1. 添加 -Werror 编译器标志将警告视为错误
2. 这执行了更严格的代码质量标准
3. 有助于在开发早期发现潜在问题
4. 提高整体代码的可靠性与可维护性

## Summary by Sourcery

Build:
- Add -Werror to compile options to fail on warnings