### PR TITLE
fix: prevent crash during preview item handling

### DIFF
--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -329,8 +329,8 @@ void Workspace::doSetCurrentIndex(int newCurrentIndex)
 
 void Workspace::startPreviewing(SurfaceWrapper *previewingItem)
 {
-    if (m_previewingItem) {
-        // TODO: don't use QPointer, should watch SurfaceWrapper::aboutToBeInvalidated
+    if (m_previewingItem && m_previewingItem->shellSurface() ) {
+        // Check shellSurface() since SurfaceWrapper::aboutToBeInvalidated can't make QPointer null in time
         auto modle = modelFromId(m_previewingItem->workspaceId());
         m_previewingItem->setOpacity(modle->opaque() ? 1.0 : 0.0);
         m_previewingItem->setHideByWorkspace(!modle->visible());

--- a/src/workspace/workspace.h
+++ b/src/workspace/workspace.h
@@ -6,7 +6,7 @@
 #include "surface/surfacefilterproxymodel.h"
 #include "workspace/workspacemodel.h"
 
-#include <wwrappointer.h>
+#include <QPointer>
 
 class SurfaceWrapper;
 class Workspace;
@@ -106,5 +106,5 @@ private:
     SurfaceFilterProxyModel *m_currentFilter;
     WorkspaceAnimationController *m_animationController;
     bool m_switcherEnabled = true;
-    WWrapPointer<SurfaceWrapper> m_previewingItem;
+    QPointer<SurfaceWrapper> m_previewingItem;
 };


### PR DESCRIPTION
1. Replace WWrapPointer with QPointer for SurfaceWrapper
2. Add shellSurface() check before accessing preview item properties
3. Fix race condition where SurfaceWrapper might be invalid

The changes prevent a crash that occurred when accessing a SurfaceWrapper object after it had been invalidated. Using QPointer with an explicit shellSurface() validity check ensures we don't access dangling pointers, as the SurfaceWrapper::aboutToBeInvalidated signal doesn't nullify WWrapPointer in time.

fix: 修复预览项处理时的崩溃问题

1. 将 SurfaceWrapper 的指针类型从 WWrapPointer 改为 QPointer
2. 在访问预览项属性前增加 shellSurface() 有效性检查
3. 解决 SurfaceWrapper 被标记为无效后仍被访问的竞态条件

这些修改解决了在 SurfaceWrapper 对象被销毁后仍然尝试访问其属性导致的崩溃
问题。使用 QPointer 并配合显式的 shellSurface() 有效性检查，可以确保不会
访问到悬空指针，因为 SurfaceWrapper::aboutToBeInvalidated 信号无法及时将 WWrapPointer 置空。

## Summary by Sourcery

Prevent crashes during workspace preview by replacing WWrapPointer with QPointer and adding explicit shellSurface() validity checks

Bug Fixes:
- Track SurfaceWrapper validity with QPointer instead of WWrapPointer to avoid dangling pointers
- Add shellSurface() check before accessing preview item properties to prevent race condition crashes