### PR TITLE
refactor: use unified CI build preset with Werror

### DIFF
--- a/.github/workflows/qwlroots-archlinux-build.yml
+++ b/.github/workflows/qwlroots-archlinux-build.yml
@@ -32,15 +32,12 @@ jobs:
           pacman -Syu --noconfirm qt6-base cmake pkgconfig wlroots0.19 pixman wayland-protocols wlr-protocols
           pacman -Syu --noconfirm clang ninja base-devel git
 
-      - name: Configure CMake for qwlroots
+      - name: Configure and build qwlroots
         working-directory: qwlroots
         run: |
           echo "Working directory:" $PWD
-          cmake -B build -G Ninja
-
-      - name: Build qwlroots
-        working-directory: qwlroots
-        run: cmake --build build
+          cmake --preset ci
+          cmake --build --preset ci
 
       - name: Install qwlroots to staging directory
         working-directory: qwlroots

--- a/.github/workflows/treeland-archlinux-build.yml
+++ b/.github/workflows/treeland-archlinux-build.yml
@@ -57,43 +57,28 @@ jobs:
           # Try to install DDM from available packages
           pacman -Syu --noconfirm --noprogressbar ddm
 
-      - name: Install treeland-protocols from AUR
+      - name: Build and Install treeland-protocols
         run: |
-          # Install treeland-protocols-git from AUR using makepkg
-          echo "Installing treeland-protocols-git from AUR..."
-
-          # Create a temporary user for makepkg (can't run as root)
-          useradd -m -s /bin/bash aur_builder
-          echo "aur_builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
-
-          # Switch to aur_builder and install treeland-protocols-git
-          sudo -u aur_builder bash -c "
-            cd /home/aur_builder
-            git clone https://aur.archlinux.org/treeland-protocols-git.git
-            cd treeland-protocols-git
-            makepkg -si --noconfirm
-          "
-
-          echo "✅ treeland-protocols-git installed from AUR"
+          echo "Building treeland-protocols from source..."
+          git clone https://github.com/linuxdeepin/treeland-protocols.git --depth 1
+          cd treeland-protocols
+          cmake -B build \
+            -DCMAKE_INSTALL_PREFIX=/usr \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build build
+          cmake --install build
+          echo "✅ treeland-protocols built and installed from source"
 
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Configure CMake for treeland
+      - name: Configure and Build treeland with ci preset
         run: |
           echo "Working directory:" $PWD
           echo "Configuring treeland with merged waylib and qwlroots code..."
-          # Configuration matches ArchLinux PKGBUILD
-          cmake -B build -G Ninja \
-            -DCMAKE_INSTALL_LIBDIR=lib \
-            -DCMAKE_INSTALL_LIBEXECDIR=lib \
-            -DCMAKE_INSTALL_SYSCONFDIR=/etc \
-            -DCMAKE_INSTALL_PREFIX=/usr
-
-      - name: Build treeland
-        run: |
-          cmake --build build
+          cmake --preset ci
+          cmake --build --preset ci
           echo "✅ treeland built successfully with merged waylib and qwlroots code!"
 
       - name: Install treeland to staging directory

--- a/.github/workflows/waylib-archlinux-build.yml
+++ b/.github/workflows/waylib-archlinux-build.yml
@@ -44,15 +44,12 @@ jobs:
           echo "✅ Created symlink: waylib/qwlroots -> ../qwlroots"
           ls -la qwlroots
 
-      - name: Configure CMake for waylib
+      - name: Configure and Build waylib with ci preset
         working-directory: waylib
         run: |
           echo "Working directory:" $PWD
-          cmake -B build -G Ninja -DWITH_SUBMODULE_QWLROOTS=ON
-
-      - name: Build waylib
-        working-directory: waylib
-        run: cmake --build build
+          cmake --preset ci -DWITH_SUBMODULE_QWLROOTS=ON
+          cmake --build --preset ci
 
       - name: Install waylib to staging directory
         working-directory: waylib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,10 +35,6 @@ if (ADDRESS_SANITIZER)
     add_compile_options(-fsanitize=address -fno-optimize-sibling-calls -fno-omit-frame-pointer)
     add_link_options(-fsanitize=address)
 endif()
-add_compile_options(-Wall -Wextra)
-add_compile_options(-Werror)
-# Temporarily disable array-bounds warning due to false positive with Qt DBus and GCC 14.3
-add_compile_options(-Wno-error=array-bounds)
 # NOTE: Qt keywords conflict with wlroots. but dtksystemsettings still uses it.
 # add_definitions("-DQT_NO_KEYWORDS")
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -24,6 +24,48 @@
                 "CMAKE_C_COMPILER": "clang",
                 "CMAKE_CXX_COMPILER": "clang++"
             }
+        },
+        {
+            "name": "ci",
+            "displayName": "CI Build Config",
+            "description": "Build configuration with warnings as errors",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror -Wno-stringop-overflow",
+                "CMAKE_C_FLAGS": "-Wall -Wextra -Werror -Wno-stringop-overflow"
+            }
+        },
+        {
+            "name": "deb",
+            "displayName": "Debian Package Build Config",
+            "description": "Build configuration for Debian packaging with examples enabled",
+            "generator": "Ninja",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "gcc",
+                "CMAKE_CXX_COMPILER": "g++",
+                "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror -Wno-stringop-overflow",
+                "CMAKE_C_FLAGS": "-Wall -Wextra -Werror -Wno-stringop-overflow",
+                "BUILD_TREELAND_EXAMPLES": "ON"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "default",
+            "configurePreset": "default"
+        },
+        {
+            "name": "clang",
+            "configurePreset": "clang"
+        },
+        {
+            "name": "ci",
+            "configurePreset": "ci"
+        },
+        {
+            "name": "deb",
+            "configurePreset": "deb"
         }
     ]
 }

--- a/debian/rules
+++ b/debian/rules
@@ -8,14 +8,12 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 # see ENVIRONMENT in dpkg-buildflags(1)
 # package maintainers to append CFLAGS
-export DEB_CFLAGS_MAINT_APPEND  = -Wall -pedantic
+# export DEB_CFLAGS_MAINT_APPEND  = -Wall -pedantic
 # package maintainers to append LDFLAGS
 export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
-
-TREELAND_CMAKE_ARGS = -DBUILD_TREELAND_EXAMPLES=ON
 
 %:
 	dh $@
 
 override_dh_auto_configure:
-	dh_auto_configure -- -GNinja ${TREELAND_CMAKE_ARGS}
+	dh_auto_configure -- --preset deb

--- a/examples/test_capture/main.cpp
+++ b/examples/test_capture/main.cpp
@@ -89,7 +89,7 @@ int main(int argc, char *argv[])
     QObject::connect(&engine,
                      &QQmlApplicationEngine::objectCreated,
                      manager,
-                     [&app, manager, captureWithMask](QObject *object, const QUrl &url) {
+                     [&app, manager, captureWithMask](QObject *object, const QUrl &) {
                          if (auto canvasWindow = qobject_cast<QQuickWindow *>(object)) {
                              auto waylandWindow = static_cast<QtWaylandClient::QWaylandWindow *>(
                                  canvasWindow->handle());

--- a/examples/test_capture/player.cpp
+++ b/examples/test_capture/player.cpp
@@ -60,7 +60,7 @@ void Player::setCaptureContext(TreelandCaptureContext *context)
     Q_EMIT captureContextChanged();
 }
 
-QSGNode *Player::updatePaintNode(QSGNode *old, UpdatePaintNodeData *data)
+QSGNode *Player::updatePaintNode(QSGNode *old, [[maybe_unused]] UpdatePaintNodeData *data)
 {
     ensureDebugLogger();
     if (!m_captureContext || !m_captureContext->session()
@@ -119,7 +119,7 @@ static const char *eglGetErrorString(EGLint error)
     }
 }
 
-static const char *drmFormatString(int fourcc)
+[[maybe_unused]] static const char *drmFormatString(int fourcc)
 {
     switch (fourcc) {
         CASE_STR(DRM_FORMAT_R8)

--- a/examples/test_monitor_active_event/main.cpp
+++ b/examples/test_monitor_active_event/main.cpp
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
             if (!seat)
                 qFatal("Failed to get wl_seat from QtWayland QPA!");
 
-            TreelandDDEActiveV1 *active =
+            [[maybe_unused]] TreelandDDEActiveV1 *active =
                 new TreelandDDEActiveV1(manager->get_treeland_dde_active(seat));
         }
     });

--- a/examples/test_pinch_handler/main.cpp
+++ b/examples/test_pinch_handler/main.cpp
@@ -12,7 +12,8 @@ int main(int argc, char *argv[])
 
     QQmlApplicationEngine engine;
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
-    const QUrl url(u"qrc:/qt/qml/pinchhandler/Main.qml"_qs);
+    using namespace Qt::StringLiterals;
+    const QUrl url(u"qrc:/qt/qml/pinchhandler/Main.qml"_s);
 #else
     const QUrl url(u"qrc:/pinchhandler/Main.qml"_qs);
 #endif

--- a/examples/test_super_overlay_surface/ddeshelsurfacewindow.cpp
+++ b/examples/test_super_overlay_surface/ddeshelsurfacewindow.cpp
@@ -11,10 +11,10 @@ DDEShelSurfaceWindow::DDEShelSurfaceWindow(TestMode mode, QWidget *parent)
     : QWidget{ parent }
     , m_mode(mode)
 {
-    QLineEdit *l = new QLineEdit(this);
+    [[maybe_unused]] QLineEdit *l = new QLineEdit(this);
 }
 
-void DDEShelSurfaceWindow::showEvent(QShowEvent *event)
+void DDEShelSurfaceWindow::showEvent([[maybe_unused]] QShowEvent *event)
 {
     if (isVisible()) {
         apply();

--- a/examples/test_virtual_output/main.cpp
+++ b/examples/test_virtual_output/main.cpp
@@ -20,7 +20,7 @@ class VirtualOutputManager
 public:
     explicit VirtualOutputManager();
 
-    void virtual_output_manager_v1_virtual_output_list(wl_array *names) { }
+    void virtual_output_manager_v1_virtual_output_list([[maybe_unused]] wl_array *names) { }
 };
 
 VirtualOutputManager::VirtualOutputManager()
@@ -36,7 +36,7 @@ class VirtualOutput
 public:
     explicit VirtualOutput(struct ::treeland_virtual_output_v1 *object);
 
-    void virtual_output_v1_outputs(const QString &name, wl_array *outputs)
+    void virtual_output_v1_outputs(const QString &name, [[maybe_unused]] wl_array *outputs)
     {
         qInfo() << "Screen group name: " << name;
     }

--- a/qwlroots/CMakePresets.json
+++ b/qwlroots/CMakePresets.json
@@ -1,0 +1,24 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "ci",
+      "displayName": "CI Build Config",
+      "description": "Build configuration with warnings as errors",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror",
+        "CMAKE_C_FLAGS": "-Wall -Wextra -Werror"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "ci",
+      "configurePreset": "ci",
+      "jobs": 0
+    }
+  ]
+}

--- a/waylib/CMakePresets.json
+++ b/waylib/CMakePresets.json
@@ -1,0 +1,24 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "ci",
+      "displayName": "CI Build Config",
+      "description": "Build configuration with warnings as errors",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror -Wno-stringop-overflow",
+        "CMAKE_C_FLAGS": "-Wall -Wextra -Werror -Wno-stringop-overflow"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "ci",
+      "configurePreset": "ci",
+      "jobs": 0
+    }
+  ]
+}

--- a/waylib/examples/tinywl/helper.cpp
+++ b/waylib/examples/tinywl/helper.cpp
@@ -165,7 +165,7 @@ void Helper::init()
     auto wOutputManager = m_server->attach<WOutputManagerV1>();
     connect(m_backend, &WBackend::outputAdded, this, [this, wOutputManager] (WOutput *output) {
         allowNonDrmOutputAutoChangeMode(output);
-        Output *o;
+        Output *o = nullptr;
         if (m_mode == OutputMode::Extension || !m_surfaceContainer->primaryOutput()) {
             o = Output::createPrimary(output, qmlEngine(), this);
             o->outputItem()->stackBefore(m_surfaceContainer);
@@ -173,6 +173,7 @@ void Helper::init()
         } else if (m_mode == OutputMode::Copy) {
             o = Output::createCopy(output, m_surfaceContainer->primaryOutput(), qmlEngine(), this);
         }
+        Q_ASSERT(o);
 
         m_outputList.append(o);
         enableOutput(output);
@@ -747,7 +748,7 @@ void Helper::setOutputMode(OutputMode mode)
         if (m_outputList.at(i) == m_surfaceContainer->primaryOutput())
             continue;
 
-        Output *o;
+        Output *o = nullptr;
         if (mode == OutputMode::Copy) {
             o = Output::createCopy(m_outputList.at(i)->output(), m_surfaceContainer->primaryOutput(), qmlEngine(), this);
             m_surfaceContainer->removeOutput(m_outputList.at(i));
@@ -757,6 +758,7 @@ void Helper::setOutputMode(OutputMode mode)
             m_surfaceContainer->addOutput(o);
             enableOutput(o->output());
         }
+        Q_ASSERT(o);
 
         m_outputList.at(i)->deleteLater();
         m_outputList.replace(i,o);

--- a/waylib/src/server/kernel/woutput.cpp
+++ b/waylib/src/server/kernel/woutput.cpp
@@ -232,8 +232,7 @@ static bool output_pick_format(struct wlr_output *output,
                                const struct wlr_drm_format_set *display_formats,
                                struct wlr_drm_format *format, uint32_t fmt) {
     struct wlr_renderer *renderer = output->renderer;
-    struct wlr_allocator *allocator = output->allocator;
-    assert(renderer != NULL && allocator != NULL);
+    assert(renderer != NULL && output->allocator != NULL);
 
     const struct wlr_drm_format_set *render_formats =
         wlr_renderer_get_render_formats(renderer);

--- a/waylib/src/server/protocols/ext_foreign_toplevel_image_capture_source.c
+++ b/waylib/src/server/protocols/ext_foreign_toplevel_image_capture_source.c
@@ -58,7 +58,7 @@ static void foreign_toplevel_manager_handle_create_source(struct wl_client *clie
 	wl_signal_emit_mutable(&manager->events.new_request, request);
 }
 
-static void foreign_toplevel_manager_handle_destroy([[maybe_unused]] struct wl_client *client,
+static void foreign_toplevel_manager_handle_destroy(struct wl_client *,
 		struct wl_resource *manager_resource) {
 	wl_resource_destroy(manager_resource);
 }
@@ -81,7 +81,7 @@ static void foreign_toplevel_manager_bind(struct wl_client *client, void *data,
 	wl_resource_set_implementation(resource, &foreign_toplevel_manager_impl, manager, NULL);
 }
 
-static void foreign_toplevel_manager_handle_display_destroy(struct wl_listener *listener, [[maybe_unused]] void *data) {
+static void foreign_toplevel_manager_handle_display_destroy(struct wl_listener *listener, void *) {
 	struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1 *manager =
 		wl_container_of(listener, manager, display_destroy);
 	wl_signal_emit_mutable(&manager->events.destroy, NULL);

--- a/waylib/src/server/qtquick/private/wbufferrenderer.cpp
+++ b/waylib/src/server/qtquick/private/wbufferrenderer.cpp
@@ -243,8 +243,13 @@ qw_buffer *WBufferRenderer::lastBuffer() const
 
 QRhiTexture *WBufferRenderer::currentRenderTarget() const
 {
+    if (!state.sgRenderTarget.rt)
+        return nullptr;
     auto textureRT = static_cast<QRhiTextureRenderTarget*>(state.sgRenderTarget.rt);
-    return textureRT->description().colorAttachmentAt(0)->texture();
+    auto colorAttachment = textureRT->description().colorAttachmentAt(0);
+    if (!colorAttachment)
+        return nullptr;
+    return colorAttachment->texture();
 }
 
 const qw_damage_ring *WBufferRenderer::damageRing() const


### PR DESCRIPTION
1. Replace manual CMake configuration with --preset ci in all ArchLinux workflows
2. Add new CI build preset in CMakePresets.json with -Werror enabled
3. Remove redundant per-project CMake configuration steps
4. Simplify workflow steps by combining configure and build phases
5. Maintain compatibility with existing build requirements while standardizing

The changes standardize build configuration across projects using a centralized CMake preset. This ensures consistent build behavior while maintaining the strict -Werror flag for CI builds. The update simplifies workflow maintenance and improves build reliability by using CMake's modern preset system.

## Summary by Sourcery

Unify CI builds using a new CMake preset with strict -Werror enforcement, streamline workflow definitions, and update code to remain warning-free under the stricter build settings

New Features:
- Introduce a centralized CI CMake build preset with -Werror enabled

Bug Fixes:
- Address new Werror-triggered warnings by adding null checks, initializing variables, and marking unused parameters

Enhancements:
- Simplify and standardize GitHub Actions workflows for treeland, qwlroots, and waylib to use the CI preset
- Add CMakePresets.json to qwlroots and waylib and remove redundant manual CMake configurations
- Remove global -Wall, -Wextra, and -Werror options from the top-level CMakeLists and migrate them into the CI preset

CI:
- Replace manual configure and build steps with cmake --preset ci in ArchLinux workflows