### PR TITLE
fix: fix wrong display render issue when switching VT too quickly

### DIFF
--- a/src/modules/ddm/ddminterfacev1.cpp
+++ b/src/modules/ddm/ddminterfacev1.cpp
@@ -36,11 +36,21 @@ static void deactivateSession([[maybe_unused]] struct wl_client *client, [[maybe
     Helper::instance()->deactivateSession();
 }
 
+static void enableRender([[maybe_unused]] struct wl_client *client, [[maybe_unused]] struct wl_resource *resource) {
+    Helper::instance()->enableRender();
+}
+
+static void disableRender([[maybe_unused]] struct wl_client *client, [[maybe_unused]] struct wl_resource *resource) {
+    Helper::instance()->disableRender();
+}
+
 static const struct treeland_ddm_interface treeland_ddm_impl {
     .switch_to_greeter = switchToGreeter,
     .switch_to_user = switchToUser,
     .activate_session = activateSession,
     .deactivate_session = deactivateSession,
+    .enable_render = enableRender,
+    .disable_render = disableRender,
 };
 
 // wayland object binding

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2160,3 +2160,11 @@ void Helper::deactivateSession() {
     if (m_backend->isSessionActive())
         m_backend->deactivateSession();
 }
+
+void Helper::enableRender() {
+    m_renderWindow->setRenderEnabled(true);
+}
+
+void Helper::disableRender() {
+    m_renderWindow->setRenderEnabled(false);
+}

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -210,6 +210,8 @@ public:
 
     void activateSession();
     void deactivateSession();
+    void enableRender();
+    void disableRender();
 public Q_SLOTS:
     void activateSurface(SurfaceWrapper *wrapper, Qt::FocusReason reason = Qt::OtherFocusReason);
     void forceActivateSurface(SurfaceWrapper *wrapper,

--- a/waylib/src/server/qtquick/woutputrenderwindow.cpp
+++ b/waylib/src/server/qtquick/woutputrenderwindow.cpp
@@ -451,6 +451,7 @@ public:
 
     bool componentCompleted = true;
     bool inRendering = false;
+    bool renderEnabled = true;
 
     QPointer<qw_renderer> m_renderer;
     QPointer<qw_allocator> m_allocator;
@@ -1475,6 +1476,9 @@ void WOutputRenderWindowPrivate::doRender(const QList<OutputHelper *> &outputs,
 {
     Q_ASSERT(rendererList.isEmpty());
     Q_ASSERT(!inRendering);
+    if (!renderEnabled)
+        return;
+
     inRendering = true;
 
     W_Q(WOutputRenderWindow);
@@ -1814,6 +1818,11 @@ bool WOutputRenderWindow::inRendering() const
 {
     Q_D(const WOutputRenderWindow);
     return d->inRendering;
+}
+
+void WOutputRenderWindow::setRenderEnabled(bool enabled) {
+    Q_D(WOutputRenderWindow);
+    d->renderEnabled = enabled;
 }
 
 QList<QPointer<QQuickItem>> WOutputRenderWindow::paintOrderItemList(QQuickItem *root, std::function<bool(QQuickItem*)> filter)

--- a/waylib/src/server/qtquick/woutputrenderwindow.h
+++ b/waylib/src/server/qtquick/woutputrenderwindow.h
@@ -55,6 +55,8 @@ public:
     WBufferRenderer *currentRenderer() const;
     bool inRendering() const;
 
+    void setRenderEnabled(bool enabled);
+
     static QList<QPointer<QQuickItem>> paintOrderItemList(QQuickItem *root, std::function<bool(QQuickItem*)> filter);
 
     bool disableLayers() const;


### PR DESCRIPTION
When cooperating with DDM, switching VT will not drop DRM FD. This makes treeland still able to draw to the DRM after VT switch, which will cause wrong display rendering when switching VT too quickly. This commit cooperate new treeland-ddm-v1 protocol and expose interface to enable / disable global rendering, which is used in DDM to control render before / after TTY switching, to solve the render issue.

## Summary by Sourcery

Add global rendering control to fix display glitches during rapid VT switches by pausing and resuming output rendering via the treeland-ddm-v1 protocol.

New Features:
- Expose enable_render and disable_render methods in the treeland_ddm v1 interface for DDM to control global rendering.
- Implement enableRender and disableRender in Helper to toggle rendering on the output window.
- Add setRenderEnabled API and renderEnabled guard in WOutputRenderWindow to pause and resume rendering.

Bug Fixes:
- Prevent wrong display rendering when switching virtual terminals too quickly by disabling rendering during the switch.

Enhancements:
- Update the treeland-ddm interface and cooperate with the new treeland-ddm-v1 protocol.