### PR TITLE
fix: correct log category and add null check for surface activation

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1150,7 +1150,11 @@ void Helper::activateSurface(SurfaceWrapper *wrapper, Qt::FocusReason reason)
 void Helper::forceActivateSurface(SurfaceWrapper *wrapper, Qt::FocusReason reason)
 {
     if (!wrapper) {
-        qCCritical(treelandCore) << "Don't force activate to empty surface! do you want `Helper::activeSurface(nullptr)`?";
+        qCCritical(treelandShell) << "Don't force activate to empty surface! do you want `Helper::activeSurface(nullptr)`?";
+        return;
+    }
+    if (!wrapper->shellSurface()) {
+        qCWarning(treelandShell) << "Try to force activate a destroyed surface!";
         return;
     }
 
@@ -1162,7 +1166,7 @@ void Helper::forceActivateSurface(SurfaceWrapper *wrapper, Qt::FocusReason reaso
     }
 
     if (!wrapper->surface()->mapped()) {
-        qCWarning(treelandCore) << "Can't activate unmapped surface: " << wrapper;
+        qCWarning(treelandShell) << "Can't activate unmapped surface: " << wrapper;
         return;
     }
 


### PR DESCRIPTION
1. Change log category from treelandCore to treelandShell for consistency
2. Add explicit null check for wrapper parameter
3. Add validation for shellSurface() before accessing it
4. Update log category in unmapped surface check

修复表面激活的日志分类并添加空值检查

1. 将日志分类从 treelandCore 改为保持一致性的 treelandShell
2. 为 wrapper 参数添加显式空值检查
3. 在访问 shellSurface() 前添加有效性验证
4. 更新未映射表面检查中的日志分类

## Summary by Sourcery

Fix log categories and add null checks in forceActivateSurface to improve stability and consistency

Bug Fixes:
- Add early return when wrapper is null to prevent null dereference
- Add validation for shellSurface() before accessing it to avoid crashes

Enhancements:
- Standardize log category from treelandCore to treelandShell for consistency

fix: https://github.com/linuxdeepin/treeland/issues/519