### PR TITLE
Multi seat

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2822,11 +2822,14 @@ void Helper::setActivatedSurfaceForSeat(WSeat *seat, SurfaceWrapper *surface)
     if (currentSurface == surface)
         return;
 
-    if (currentSurface) {
-        currentSurface->setActivate(false);
+    if (currentSurface && currentSurface->shellSurface()) {
+        if (!(surface && surface->type() == SurfaceWrapper::Type::XWayland &&
+              surface->shellSurface() && !surface->shellSurface()->hasCapability(WToplevelSurface::Capability::Focus))) {
+            currentSurface->setActivate(false);
+        }
     }
 
-    if (surface && surface->shellSurface()) {
+    if (surface) {
         surface->setActivate(true);
         surface->stackToLast();
         if (auto sh = surface->shellSurface(); sh && surface->surface() && surface->surface()->mapped()) {

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -132,6 +132,10 @@ public:
 
     static Helper *instance();
 
+    static bool getSeatMoveResizeInfo(SurfaceWrapper *surface, Qt::Edges &edges, QRectF &startGeometry);
+    static bool isSettingSeatPosition();
+    static void setSeatPositionFlag(bool setting);
+
     QmlEngine *qmlEngine() const;
     WOutputRenderWindow *window() const;
     ShellHandler *shellHandler() const;
@@ -387,8 +391,13 @@ private:
     QString m_seatConfigPath;
 
     QMap<WSeat*, SurfaceWrapper*> m_seatActivatedSurfaces;
-    QMap<WSeat*, SurfaceWrapper*> m_seatMoveResizeSurfaces;
-    QMap<WSeat*, Qt::Edges> m_seatMoveResizeEdges;
+    struct SeatMoveResizeState {
+        SurfaceWrapper *surface = nullptr;
+        Qt::Edges edges;
+        QRectF startGeometry;
+        QPointF initialPosition;
+    };
+    QMap<WSeat*, SeatMoveResizeState> m_seatMoveResizeStates;
     QMap<WSeat*, QPointF> m_seatLastPressedPositions;
     QMap<WSeat*, bool> m_seatMetaKeyStates;
     QMap<WSeat*, SurfaceWrapper*> m_seatKeyboardFocusSurfaces;


### PR DESCRIPTION
修复多座位窗口resize冲突和XWayland对话框焦点丢失问题

## Summary by Sourcery

Refactor per-seat move/resize handling into a unified state and static API, enhance geometry filtering, and fix multi-seat resize conflicts and XWayland dialog focus loss

New Features:
- Add static methods getSeatMoveResizeInfo, isSettingSeatPosition, and setSeatPositionFlag for querying and controlling seat move/resize state

Bug Fixes:
- Resolve conflicting window resize operations in multi-seat setups
- Prevent deactivating XWayland dialogs without focus capability to avoid focus loss

Enhancements:
- Consolidate move/resize tracking into a SeatMoveResizeState struct with surface, edges, start geometry, and initial position
- Streamline move/resize workflow to use initial geometry and incremental delta, simplifying begin, do, and end operations
- Enhance RootSurfaceContainer::filterSurfaceGeometryChanged to respect seat-based resize edges and avoid recursive geometry updates