### PR TITLE
fix: resolve brief black screen during standby

### DIFF
--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -243,6 +243,8 @@ Q_SIGNALS:
 private Q_SLOTS:
     void onShowDesktop();
     void deleteTaskSwitch();
+    void onPrepareForSleep(bool sleep);
+    void onSessionNew(const QString &sessionId, const QDBusObjectPath &objectPath);
 
 private:
     void onOutputAdded(WOutput *output);
@@ -266,7 +268,6 @@ private:
     void onSurfaceWrapperAboutToRemove(SurfaceWrapper *wrapper);
     void handleRequestDrag([[maybe_unused]] WSurface *surface);
     void handleLockScreen(LockScreenInterface *lockScreen);
-    void onSessionNew(const QString &sessionId, const QDBusObjectPath &sessionPath);
     void onSessionLock();
     void onSessionUnlock();
 


### PR DESCRIPTION
1. Move D-Bus includes to fix potential header conflicts
2. Add new D-Bus signal handler for systemd-logind's PrepareForSleep
3. Implement onPrepareForSleep slot to manage rendering during hibernate
4. Improve session management with proper signal connections
5. Add logging for better debugging of power management events

The changes address the brief black screen issue that occurs during system standby/hibernate transitions by properly managing the rendering state through systemd-logind's PrepareForSleep signal. When entering hibernate, we now explicitly disable rendering to prevent visual artifacts, and re-enable it after waking up. The D-Bus signal handlers have been reorganized for better maintainability and proper header inclusion order.

fix: 解决待机时短暂黑屏问题

1. 移动 D-Bus 头文件包含位置以修复潜在的头文件冲突
2. 添加对 systemd-logind PrepareForSleep 信号的新 D-Bus 处理器
3. 实现 onPrepareForSleep 槽函数来管理休眠期间的渲染状态
4. 通过改进的信号连接提升会话管理功能
5. 添加日志记录以便更好地调试电源管理事件

cherry-pick from #524

## Summary by Sourcery

Manage rendering during system standby transitions by listening to systemd-logind PrepareForSleep signals and reorganize D-Bus setup to prevent header conflicts.

Bug Fixes:
- Disable rendering before hibernate and re-enable it after resume to prevent a brief black screen during standby

Enhancements:
- Relocate D-Bus includes to resolve potential header conflicts
- Connect to systemd-logind PrepareForSleep and SessionNew signals for improved session and power management
- Implement onPrepareForSleep slot to handle rendering state on sleep and wake events
- Add logging for power management signals for better debugging