### PR TITLE
fix : build error

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -256,9 +256,9 @@ Helper::Helper(QObject *parent)
     );
 
     if (!connected) {
-        qCWarning(treelandCore) << "Failed to connect to systemd-logind PrepareForSleep signal";
+        qCWarning(qLcHelper) << "Failed to connect to systemd-logind PrepareForSleep signal";
     } else {
-        qCInfo(treelandCore) << "Successfully connected to systemd-logind PrepareForSleep signal";
+        qCInfo(qLcHelper) << "Successfully connected to systemd-logind PrepareForSleep signal";
     }
 
     // Also connect to SessionNew signal for logging purposes
@@ -3048,11 +3048,19 @@ void Helper::toggleFpsDisplay()
 void Helper::onPrepareForSleep(bool sleep)
 {
     if (sleep) {
-        qCInfo(treelandCore) << "Rendering black frames to all outputs before hibernate";
+        qCInfo(qLcHelper) << "Rendering black frames to all outputs before hibernate";
         disableRender();
         // TODO：should we disable output？
     } else {
-        qCInfo(treelandCore) << "Re-enabled rendering after hibernate";
+        qCInfo(qLcHelper) << "Re-enabled rendering after hibernate";
         enableRender();
     }
+}
+
+void Helper::enableRender() {
+    m_renderWindow->setRenderEnabled(true);
+}
+
+void Helper::disableRender() {
+    m_renderWindow->setRenderEnabled(false);
 }

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -219,6 +219,8 @@ public:
     void setActivatedSurfaceForSeat(WSeat *seat, SurfaceWrapper *surface);
     SurfaceWrapper *getActivatedSurfaceForSeat(WSeat *seat) const;
     void toggleFpsDisplay();
+    void enableRender();
+    void disableRender();
 
 public Q_SLOTS:
     void activateSurface(SurfaceWrapper *wrapper, Qt::FocusReason reason = Qt::OtherFocusReason);


### PR DESCRIPTION
add render enable interface.

cherry-pick form #516

## Summary by Sourcery

Add a render enable interface to the Helper class, update onPrepareForSleep logic to use it, and correct the logging category.

New Features:
- Introduce enableRender() and disableRender() methods to control rendering in Helper.

Bug Fixes:
- Resolve build errors by implementing the missing render control methods.

Enhancements:
- Switch logging from treelandCore to qLcHelper in Helper.
- Invoke render enable/disable before and after hibernation in onPrepareForSleep.