### PR TITLE
fix: occasional crash during stop preview item handling

### DIFF
--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -344,7 +344,7 @@ void Workspace::startPreviewing(SurfaceWrapper *previewingItem)
 void Workspace::stopPreviewing()
 {
     current()->setOpaque(true);
-    if (m_previewingItem) {
+    if (m_previewingItem && m_previewingItem->shellSurface()) {
         auto modle = modelFromId(m_previewingItem->workspaceId());
         m_previewingItem->setOpacity(modle->opaque() ? 1.0 : 0.0);
         m_previewingItem->setHideByWorkspace(!modle->visible());


### PR DESCRIPTION
Add shellSurface() check in stopPreviewing.

Fixes linuxdeepin/treeland#536 crash3

Log: