### PR TITLE
fix: fix treeland get stuck in lockscreen after crash recovery

### DIFF
--- a/src/greeter/greeterproxy.cpp
+++ b/src/greeter/greeterproxy.cpp
@@ -483,6 +483,19 @@ void GreeterProxy::readyRead()
 
             qCInfo(treelandGreeter) << "activate successfully: " << user;
         } break;
+        case DaemonMessages::UserLoggedIn: {
+            QString user;
+            input >> user;
+
+            // This will happen after a crash recovery of treeland
+            qCInfo(treelandGreeter) << "User " << user << " is already logged in";
+            auto userPtr = d->userModel->getUser(user);
+            if (userPtr) {
+                userPtr.get()->setLogined(true);
+            } else {
+                qCWarning(treelandGreeter) << "User " << user << " logged in but not found";
+            }
+        } break;
         default: {
             qCWarning(treelandGreeter) << "Unknown message received from daemon." << message;
         }


### PR DESCRIPTION
Treeland will stuck in lockscreen after crash recovery, which is caused by unintended login request for (for DDM) already logined user. This commit adds a new DaemonMessages type, which is used to convey logined users from DDM after socket connected, to avoid this problem.

## Summary by Sourcery

Handle already logged-in users after daemon crash recovery to prevent Treeland from getting stuck on the lockscreen.

Bug Fixes:
- Detect and mark users as logged in upon receiving a new UserLogined message to avoid unintended login prompts post-crash.

Enhancements:
- Introduce a new DaemonMessages::UserLogined message type to convey existing login state from the daemon.