### PR TITLE
fix: redraw when frame callback list updates

### DIFF
--- a/waylib/src/server/kernel/private/wsurface_p.h
+++ b/waylib/src/server/kernel/private/wsurface_p.h
@@ -58,8 +58,10 @@ public:
     uint32_t preferredBufferScale = 1;
     uint32_t explicitPreferredBufferScale = 0;
 
+    bool needsFrame = false;
     std::unique_ptr<QW_NAMESPACE::qw_buffer, QW_NAMESPACE::qw_buffer::unlocker> buffer;
     QVector<WOutput*> outputs;
+    WOutput *framePacingOutput = nullptr;
     QMetaObject::Connection frameDoneConnection;
     QPoint bufferOffset;
 };

--- a/waylib/src/server/kernel/woutput.cpp
+++ b/waylib/src/server/kernel/woutput.cpp
@@ -606,4 +606,9 @@ void WOutput::setForceSoftwareCursor(bool on)
     Q_EMIT forceSoftwareCursorChanged();
 }
 
+void WOutput::scheduleFrame()
+{
+    return handle()->schedule_frame();
+}
+
 WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/kernel/woutput.h
+++ b/waylib/src/server/kernel/woutput.h
@@ -105,6 +105,8 @@ public:
     bool forceSoftwareCursor() const;
     void setForceSoftwareCursor(bool on);
 
+    void scheduleFrame();
+
 Q_SIGNALS:
     void enabledChanged();
     void positionChanged(const QPoint &pos);

--- a/waylib/src/server/kernel/wsurface.h
+++ b/waylib/src/server/kernel/wsurface.h
@@ -30,6 +30,7 @@ class WAYLIB_SERVER_EXPORT WSurface : public WWrapObject
     Q_PROPERTY(bool mapped READ mapped NOTIFY mappedChanged)
     Q_PROPERTY(bool isSubsurface READ isSubsurface NOTIFY isSubsurfaceChanged)
     Q_PROPERTY(bool hasSubsurface READ hasSubsurface NOTIFY hasSubsurfaceChanged)
+    Q_PROPERTY(bool needsFrame READ needsFrame)
     Q_PROPERTY(QList<WSurface*> subsurfaces READ subsurfaces NOTIFY newSubsurface)
     Q_PROPERTY(uint32_t preferredBufferScale READ preferredBufferScale WRITE setPreferredBufferScale RESET resetPreferredBufferScale NOTIFY preferredBufferScaleChanged FINAL)
     QML_NAMED_ELEMENT(WaylandSurface)
@@ -62,10 +63,14 @@ public:
     void setPreferredBufferScale(uint32_t newPreferredBufferScale);
     void resetPreferredBufferScale();
 
+    bool needsFrame() const;
+    bool scheduleFrameIfNeeded();
+
 public Q_SLOTS:
     void enterOutput(WOutput *output);
     void leaveOutput(WOutput *output);
     const QVector<WOutput *> &outputs() const;
+    WOutput *framePacingOutput() const;
     bool inputRegionContains(const QPointF &localPos) const;
 
     void map();
@@ -73,7 +78,6 @@ public Q_SLOTS:
 
 Q_SIGNALS:
     void mappedChanged();
-    void bufferChanged();
     void bufferOffsetChanged();
     void isSubsurfaceChanged();
     void hasSubsurfaceChanged();
@@ -81,6 +85,7 @@ Q_SIGNALS:
     void preferredBufferScaleChanged();
     void outputEntered(WOutput *output);
     void outputLeave(WOutput *output);
+    void commit(quint32 committedState /*wlr_surface_state_field*/);
 
 protected:
     WSurface(WSurfacePrivate &dd, QObject *parent);

--- a/waylib/src/server/qtquick/woutputhelper.h
+++ b/waylib/src/server/qtquick/woutputhelper.h
@@ -35,9 +35,8 @@ class WAYLIB_SERVER_EXPORT WOutputHelper : public QObject, public WObject
 {
     Q_OBJECT
     W_DECLARE_PRIVATE(WOutputHelper)
-    Q_PROPERTY(bool renderable READ renderable NOTIFY renderableChanged)
     Q_PROPERTY(bool contentIsDirty READ contentIsDirty NOTIFY contentIsDirtyChanged)
-    Q_PROPERTY(bool needsFrame READ needsFrame NOTIFY needsFrameChanged FINAL)
+    Q_PROPERTY(bool needsFrame READ needsFrame FINAL)
 
 public:
     explicit WOutputHelper(WOutput *output, QObject *parent = nullptr);
@@ -61,22 +60,19 @@ public:
     bool testCommit();
     bool testCommit(QW_NAMESPACE::qw_buffer *buffer, const wlr_output_layer_state_array &layers);
 
-    bool renderable() const;
     bool contentIsDirty() const;
     bool needsFrame() const;
+    bool framePending() const;
 
-    void resetState(bool resetRenderable);
+    void resetState();
     void update();
+    void scheduleFrame();
 
 protected:
-    WOutputHelper(WOutput *output, bool renderable, bool contentIsDirty, bool needsFrame, QObject *parent = nullptr);
+    WOutputHelper(WOutput *output, bool contentIsDirty, QObject *parent = nullptr);
 
 Q_SIGNALS:
-    void requestRender();
-    void damaged();
-    void renderableChanged();
     void contentIsDirtyChanged();
-    void needsFrameChanged();
 };
 
 WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/qtquick/woutputrenderwindow.h
+++ b/waylib/src/server/qtquick/woutputrenderwindow.h
@@ -65,7 +65,6 @@ public:
 public Q_SLOTS:
     void render();
     void render(WOutputViewport *output, bool doCommit);
-    void scheduleRender();
     void update();
     void update(WOutputViewport *output);
     void setWidth(qreal arg);

--- a/waylib/src/server/qtquick/woutputrenderwindow.h
+++ b/waylib/src/server/qtquick/woutputrenderwindow.h
@@ -77,7 +77,7 @@ Q_SIGNALS:
     void outputViewportInitialized(WAYLIB_SERVER_NAMESPACE::WOutputViewport *output);
     void initialized();
     void disableLayersChanged();
-    void renderEnd();
+    void renderEnd(QList<QPointer<WOutput>> committedOutputs);
     void effectiveDevicePixelRatioChanged(qreal scale);
 
 private:


### PR DESCRIPTION
1.  The previous logic only redrew the surface when the buffer changed, which is insufficient.
2.  Firefox frequently updates the frame callback list using `WLR_SURFACE_STATE_FRAME_CALLBACK_LIST`. Receiving such commits should also trigger a redraw to trigger the frame done event for the surface.
3.  This fixes an issue where Firefox windows would often not refresh until the mouse was moved.

Influence:
1. Verify that Firefox windows now refresh correctly without requiring mouse movement.
2. Ensure that other applications are not negatively affected by this change.
3. Check for any performance regressions related to the increased redraw frequency.

fix: 当帧回调列表更新时重绘

1. 之前的逻辑仅在缓冲区更改时才重绘表面，这不足够。
2. Firefox 经常使用 `WLR_SURFACE_STATE_FRAME_CALLBACK_LIST` 更新帧回调列 表。收到此类提交也应触发重绘，以触发表面的帧完成事件。
3. 这修复了 Firefox 窗口经常不刷新直到鼠标移动的问题。

Influence:
1. 验证 Firefox 窗口现在可以正确刷新，而无需移动鼠标。
2. 确保其他应用程序不会受到此更改的负面影响。
3. 检查与增加的重绘频率相关的任何性能下降。