### PR TITLE
feat(core): Add support for XDG toplevel surface and XDG shell in RootSurfaceContainer

### DIFF
--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -12,6 +12,7 @@
 #include <woutputitem.h>
 #include <woutputlayout.h>
 #include <wxdgpopupsurface.h>
+#include <wxdgtoplevelsurface.h>
 
 #include <qwoutputlayout.h>
 
@@ -193,18 +194,21 @@ void RootSurfaceContainer::endMoveResize()
     if (!moveResizeState.surface)
         return;
 
-    auto o = moveResizeState.surface->ownsOutput();
-    moveResizeState.surface->shellSurface()->setResizeing(false);
+    if (moveResizeState.surface->shellSurface()->isInitialized()) {
+        auto o = moveResizeState.surface->ownsOutput();
+        moveResizeState.surface->shellSurface()->setResizeing(false);
 
-    if (!o || !moveResizeState.surface->surface()->outputs().contains(o->output())) {
-        o = cursorOutput();
-        Q_ASSERT(o);
-        moveResizeState.surface->setOwnsOutput(o);
+        if (!o || !moveResizeState.surface->surface()->outputs().contains(o->output())) {
+            o = cursorOutput();
+            Q_ASSERT(o);
+            moveResizeState.surface->setOwnsOutput(o);
+        }
+
+        ensureSurfaceNormalPositionValid(moveResizeState.surface);
+
+        moveResizeState.surface->setXwaylandPositionFromSurface(true);
     }
 
-    ensureSurfaceNormalPositionValid(moveResizeState.surface);
-
-    moveResizeState.surface->setXwaylandPositionFromSurface(true);
     moveResizeState.surface = nullptr;
     Q_EMIT moveResizeFinised();
 }

--- a/waylib/src/server/kernel/wtoplevelsurface.h
+++ b/waylib/src/server/kernel/wtoplevelsurface.h
@@ -80,6 +80,9 @@ public:
         // Should always be 0 except layer surface
         return 0;
     }
+    virtual bool isInitialized() const {
+        return true;
+    };
 
 public Q_SLOTS:
     virtual void setMaximize([[maybe_unused]] bool on) {

--- a/waylib/src/server/protocols/wlayersurface.cpp
+++ b/waylib/src/server/protocols/wlayersurface.cpp
@@ -331,6 +331,11 @@ int WLayerSurface::keyboardFocusPriority() const
     return 0;
 }
 
+bool WLayerSurface::isInitialized() const
+{
+    return handle()->handle()->initialized;
+}
+
 void WLayerSurface::resize(const QSize &size)
 {
     configureSize(size);

--- a/waylib/src/server/protocols/wlayersurface.h
+++ b/waylib/src/server/protocols/wlayersurface.h
@@ -81,6 +81,7 @@ public:
 
     QRect getContentGeometry() const override;
     int keyboardFocusPriority() const override;
+    bool isInitialized() const override;
     void resize(const QSize &size) override;
 
     // layer shell info

--- a/waylib/src/server/protocols/wxdgpopupsurface.cpp
+++ b/waylib/src/server/protocols/wxdgpopupsurface.cpp
@@ -158,6 +158,12 @@ bool WXdgPopupSurface::checkNewSize(const QSize &size, [[maybe_unused]] QSize *c
     return size.isValid();
 }
 
+bool WXdgPopupSurface::isInitialized() const
+{
+    W_DC(WXdgPopupSurface);
+    return d->nativeHandle()->base->initialized;
+}
+
 WSurface *WXdgPopupSurface::parentSurface() const
 {
     W_DC(WXdgPopupSurface);

--- a/waylib/src/server/protocols/wxdgpopupsurface.h
+++ b/waylib/src/server/protocols/wxdgpopupsurface.h
@@ -39,6 +39,8 @@ public:
     QRect getContentGeometry() const override;
     bool checkNewSize(const QSize &size, QSize *clipedSize = nullptr) override;
 
+    bool isInitialized() const override;
+
 public Q_SLOTS:
     void resize(const QSize &size) override;
     void close() override;

--- a/waylib/src/server/protocols/wxdgsurface.h
+++ b/waylib/src/server/protocols/wxdgsurface.h
@@ -15,6 +15,9 @@ class WAYLIB_SERVER_EXPORT WXdgSurface : public WToplevelSurface
 protected:
     explicit WXdgSurface(WToplevelSurfacePrivate &d, QObject *parent = nullptr);
     ~WXdgSurface();
+
+public:
+    virtual bool isInitialized() const = 0;
 };
 
 WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/protocols/wxdgtoplevelsurface.cpp
+++ b/waylib/src/server/protocols/wxdgtoplevelsurface.cpp
@@ -298,6 +298,12 @@ QString WXdgToplevelSurface::appId() const
     return QString::fromLocal8Bit(d->nativeHandle()->app_id);
 }
 
+bool WXdgToplevelSurface::isInitialized() const
+{
+    W_DC(WXdgToplevelSurface);
+    return d->nativeHandle()->base->initialized;
+}
+
 WXdgToplevelSurface *WXdgToplevelSurface::parentXdgSurface() const
 {
     W_DC(WXdgToplevelSurface);

--- a/waylib/src/server/protocols/wxdgtoplevelsurface.h
+++ b/waylib/src/server/protocols/wxdgtoplevelsurface.h
@@ -53,6 +53,8 @@ public:
     QString title() const override;
     QString appId() const override;
 
+    bool isInitialized() const override;
+
 public Q_SLOTS:
     void setResizeing(bool resizeing) override;
     void setMaximize(bool on) override;


### PR DESCRIPTION
- Added include for `wxdgtoplevelsurface.h`
- Added include for `qwxdgshell.h`
- Handled initialization check for XDG toplevel surface
- Updated logic to set owns output and ensure surface position validity for XDG toplevel surface
- Added support to set Xwayland position from surface when initialized

Background:
When the window is destroyed while being dragged, `endMoveResize` is triggered. If `config` function is called after the window is destroyed, it will crash. Therefore, the check for `initialized` is added due to its reset in `reset_xdg_surface` where an `xdg_surface` implementation is reset under the following conditions:
1) A surface is unmapped due to a commit with NULL buffer
2) The `xdg_surface` role object is destroyed
3) `wlr_xdg_surface` is destroyed

## Summary by Sourcery

Add support for XDG toplevel surfaces and QWXdgShell in RootSurfaceContainer, guard endMoveResize logic with XDG initialization checks, and refine output ownership and positioning.

New Features:
- Add support for XDG toplevel surfaces and QWXdgShell in RootSurfaceContainer

Bug Fixes:
- Prevent crash in endMoveResize when an XDG surface is destroyed by checking its initialized state before proceeding

Enhancements:
- Validate ownsOutput and ensure the surface is mapped to a valid output for XDG surfaces
- Ensure normal surface positioning and set Xwayland position from surface upon initialization

close: https://github.com/linuxdeepin/treeland/issues/544