### PR TITLE
feat: add real-time FPS display

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,6 +148,8 @@ qt_add_qml_module(libtreeland
         utils/propertymonitor.h
         utils/loginddbustypes.h
         utils/loginddbustypes.cpp
+        utils/fpsdisplaymanager.cpp
+        utils/fpsdisplaymanager.h
         wallpaper/wallpapercontroller.cpp
         wallpaper/wallpapercontroller.h
         wallpaper/wallpaperimage.cpp
@@ -174,6 +176,7 @@ qt_add_qml_module(libtreeland
         core/qml/OutputMenuBar.qml
         core/qml/WorkspaceSwitcher.qml
         core/qml/WorkspaceProxy.qml
+        core/qml/FpsDisplay.qml
         core/qml/Animations/GeometryAnimation.qml
         core/qml/Animations/NewAnimation.qml
         core/qml/Animations/MinimizeAnimation.qml

--- a/src/common/treelandlogging.cpp
+++ b/src/common/treelandlogging.cpp
@@ -57,3 +57,6 @@ Q_LOGGING_CATEGORY(treelandQml, "treeland.qml")
 
 // Greeter module
 Q_LOGGING_CATEGORY(treelandGreeter, "treeland.greeter")
+
+// FPS display
+Q_LOGGING_CATEGORY(treelandFpsDisplay, "treeland.fpsdisplay")

--- a/src/common/treelandlogging.h
+++ b/src/common/treelandlogging.h
@@ -62,4 +62,7 @@ Q_DECLARE_LOGGING_CATEGORY(treelandQml)
 // Greeter module
 Q_DECLARE_LOGGING_CATEGORY(treelandGreeter)
 
+// FPS display
+Q_DECLARE_LOGGING_CATEGORY(treelandFpsDisplay)
+
 #endif // TREELAND_LOGGING_H

--- a/src/core/qml/FpsDisplay.qml
+++ b/src/core/qml/FpsDisplay.qml
@@ -1,0 +1,92 @@
+// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Window
+
+Item {
+    id: root
+    anchors.fill: parent
+
+    property real scaleFactor: 1.0
+    property var targetWindow: null
+    property alias fpsManager: internalManager
+
+    FpsDisplayManager {
+        id: internalManager
+    }
+
+    Component.onCompleted: {
+        targetWindow = parent && parent.Window ? parent.Window.window : Window.window
+    }
+
+    onTargetWindowChanged: {
+        if (internalManager.running) {
+            internalManager.stop()
+        }
+        if (targetWindow) {
+            internalManager.setTargetWindow(targetWindow)
+            internalManager.start()
+        }
+    }
+
+    Component.onDestruction: {
+        internalManager.stop()
+    }
+
+    Rectangle {
+        id: fpsDisplay
+        width: Math.max(200 * scaleFactor, 180)
+        height: Math.max(80 * scaleFactor, 70)
+        color: "transparent"
+        radius: 8 * scaleFactor
+        border.color: "transparent"
+        border.width: 0
+
+        anchors {
+            top: parent.top
+            right: parent.right
+            margins: 20 * scaleFactor
+        }
+
+        Behavior on opacity {
+            NumberAnimation { duration: 200; easing.type: Easing.OutCubic }
+        }
+
+        Behavior on scale {
+            NumberAnimation { duration: 200; easing.type: Easing.OutCubic }
+        }
+
+        Column {
+            anchors.centerIn: parent
+            spacing: 2 * scaleFactor
+
+            Text {
+                id: currentLabel
+                text: qsTr("Current FPS: %1").arg(fpsManager ? fpsManager.currentFps : 0)
+                color: "#000000"
+                font.pixelSize: Math.max(16 * scaleFactor, 14)
+                font.weight: Font.Medium
+                font.family: "monospace"
+                horizontalAlignment: Text.AlignHCenter
+                anchors.horizontalCenter: parent.horizontalCenter
+                style: Text.Raised
+                styleColor: "#FFFFFF"
+            }
+
+            Text {
+                id: maximumLabel
+                text: qsTr("Maximum FPS: %1").arg(fpsManager ? fpsManager.maximumFps : 0)
+                color: "#000000"
+                font.pixelSize: Math.max(16 * scaleFactor, 14)
+                font.weight: Font.Medium
+                font.family: "monospace"
+                horizontalAlignment: Text.AlignHCenter
+                anchors.horizontalCenter: parent.horizontalCenter
+                style: Text.Raised
+                styleColor: "#FFFFFF"
+            }
+        }
+    }
+}

--- a/src/core/qmlengine.cpp
+++ b/src/core/qmlengine.cpp
@@ -42,6 +42,7 @@ QmlEngine::QmlEngine(QObject *parent)
     , launchpadCoverComponent(this, "Treeland", "LaunchpadCover")
     , layershellAnimationComponent(this, "Treeland", "LayerShellAnimation")
     , lockScreenFallbackComponent(this, "Treeland", "LockScreenFallback")
+    , fpsDisplayComponent(this, "Treeland", "FpsDisplay")
 {
 }
 
@@ -247,4 +248,8 @@ QQuickItem *QmlEngine::createWindowPicker(QQuickItem *parent)
 QQuickItem *QmlEngine::createLockScreenFallback(QQuickItem *parent, const QVariantMap &properties)
 {
     return createComponent(lockScreenFallbackComponent, parent, properties);
+}
+QQuickItem *QmlEngine::createFpsDisplay(QQuickItem *parent)
+{
+    return createComponent(fpsDisplayComponent, parent);
 }

--- a/src/core/qmlengine.h
+++ b/src/core/qmlengine.h
@@ -64,6 +64,7 @@ public:
     QQuickItem *createCaptureSelector(QQuickItem *parent, CaptureManagerV1 *captureManager);
     QQuickItem *createWindowPicker(QQuickItem *parent);
     QQuickItem *createLockScreenFallback(QQuickItem *parent, const QVariantMap &properties = QVariantMap());
+    QQuickItem *createFpsDisplay(QQuickItem *parent);
 
     QQmlComponent *surfaceContentComponent()
     {
@@ -95,4 +96,5 @@ private:
     QQmlComponent launchpadCoverComponent;
     QQmlComponent layershellAnimationComponent;
     QQmlComponent lockScreenFallbackComponent;
+    QQmlComponent fpsDisplayComponent;
 };

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -5,6 +5,7 @@
 
 #include "modules/capture/capture.h"
 #include "utils/cmdline.h"
+#include "utils/fpsdisplaymanager.h"
 #include "modules/dde-shell/ddeshellattached.h"
 #include "modules/dde-shell/ddeshellmanagerinterfacev1.h"
 #include "input/inputdevice.h"
@@ -1327,6 +1328,10 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *, QInputEvent *event)
             == QKeySequence(Qt::META | Qt::Key_F12)) {
             Q_EMIT requestQuit();
             return true;
+        } else if (QKeySequence(kevent->modifiers() | kevent->key())
+            == QKeySequence(Qt::META | Qt::Key_F11)) {
+            toggleFpsDisplay();
+            return true;
         } else if (m_captureSelector) {
             if (event->modifiers() == Qt::NoModifier && kevent->key() == Qt::Key_Escape)
                 m_captureSelector->cancelSelection();
@@ -2335,4 +2340,14 @@ void Helper::setNoAnimation(bool noAnimation) {
         return;
     m_noAnimation = noAnimation;
     emit noAnimationChanged();
+}
+void Helper::toggleFpsDisplay()
+{
+    if (m_fpsDisplay) {
+        m_fpsDisplay->deleteLater();
+        m_fpsDisplay = nullptr;
+        return;
+    }
+
+    m_fpsDisplay = qmlEngine()->createFpsDisplay(m_renderWindow->contentItem());
 }

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -8,6 +8,7 @@
 #include "input/togglablegesture.h"
 #include "modules/virtual-output/virtualoutputmanager.h"
 #include "modules/window-management/windowmanagement.h"
+#include "utils/fpsdisplaymanager.h"
 
 #include <wglobal.h>
 #include <wqmlcreator.h>
@@ -94,6 +95,7 @@ class ILockScreen;
 class UserModel;
 class DDMInterfaceV1;
 class TreelandConfig;
+class FpsDisplayManager;
 struct wlr_idle_inhibitor_v1;
 struct wlr_output_power_v1_set_mode_event;
 struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request;
@@ -219,6 +221,7 @@ public:
     void setBlockActivateSurface(bool block);
     bool blockActivateSurface() const;
     bool noAnimation() const;
+    void toggleFpsDisplay();
 
 public Q_SLOTS:
     void activateSurface(SurfaceWrapper *wrapper, Qt::FocusReason reason = Qt::OtherFocusReason);
@@ -312,12 +315,14 @@ private:
 
     static Helper *m_instance;
     TreelandConfig *m_config = nullptr;
+    FpsDisplayManager *m_fpsManager = nullptr;
 
     CurrentMode m_currentMode{ CurrentMode::Normal };
 
     // qtquick helper
     WOutputRenderWindow *m_renderWindow = nullptr;
     QQuickItem *m_dockPreview = nullptr;
+    QQuickItem *m_fpsDisplay = nullptr;
 
     // gesture
     WServer *m_server = nullptr;

--- a/src/utils/fpsdisplaymanager.cpp
+++ b/src/utils/fpsdisplaymanager.cpp
@@ -1,0 +1,331 @@
+// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "fpsdisplaymanager.h"
+#include <QDateTime>
+#include <QQuickWindow>
+#include <woutputrenderwindow.h>
+#include <woutput.h>
+#include <woutputviewport.h>
+
+FpsDisplayManager::FpsDisplayManager(QObject *parent)
+    : QObject(parent)
+    , m_updateTimer(this)
+    , m_vsyncTimer(this)
+{
+    m_timer.start();
+
+    m_updateTimer.setInterval(kUpdateIntervalMs);
+    m_updateTimer.setSingleShot(false);
+    connect(&m_updateTimer, &QTimer::timeout, this, &FpsDisplayManager::updateFps);
+
+    updateRefreshAndInterval();
+    m_vsyncTimer.setInterval(qRound(m_preciseVSyncInterval));
+    m_vsyncTimer.setSingleShot(false);
+    connect(&m_vsyncTimer, &QTimer::timeout, this, &FpsDisplayManager::onVSyncTimer);
+}
+
+FpsDisplayManager::~FpsDisplayManager()
+{
+    m_updateTimer.stop();
+    m_vsyncTimer.stop();
+
+    if (m_targetWindow) {
+        disconnect(m_targetWindow, nullptr, this, nullptr);
+    }
+}
+
+void FpsDisplayManager::setTargetWindow(QQuickWindow *window)
+{
+    if (m_targetWindow == window)
+        return;
+
+    if (m_targetWindow) {
+        disconnect(m_targetWindow, nullptr, this, nullptr);
+    }
+
+    invalidateCache();
+    m_targetWindow = window;
+
+    if (m_targetWindow) {
+        updateRefreshAndInterval();
+        connect(m_targetWindow, &QQuickWindow::screenChanged,
+                this, &FpsDisplayManager::onScreenChanged, Qt::UniqueConnection);
+    }
+}
+
+void FpsDisplayManager::start()
+{
+    reset();
+    updateRefreshAndInterval();
+    m_vsyncTimer.setInterval(qRound(m_preciseVSyncInterval));
+    m_updateTimer.start();
+    m_vsyncTimer.start();
+}
+
+void FpsDisplayManager::stop()
+{
+    m_updateTimer.stop();
+    m_vsyncTimer.stop();
+}
+
+void FpsDisplayManager::onVSyncTimer()
+{
+    qint64 currentTime = m_timer.elapsed();
+    if (m_lastVSyncTime_precise > 0) {
+        qint64 actualInterval = currentTime - m_lastVSyncTime_precise;
+        double expectedInterval = m_preciseVSyncInterval;
+
+        // Filter out timer jitter: reject intervals shorter than 70% of expected
+        if (actualInterval < expectedInterval * 0.7) {
+            return;
+        }
+
+        if (actualInterval > expectedInterval * 2.5) {
+            m_lastVSyncTime_precise = currentTime;
+            return;
+        }
+    }
+
+    m_vSyncTimes.enqueue(currentTime);
+    m_lastVSyncTime_precise = currentTime;
+
+    // Keep at least 30 samples or 1 second worth of data for accuracy
+    int maxSamples = qMax(30, m_displayRefreshRate);
+    while (m_vSyncTimes.size() > maxSamples) {
+        m_vSyncTimes.dequeue();
+    }
+}
+
+void FpsDisplayManager::reset()
+{
+    m_currentFps = 0.0;
+    m_maximumFps = 0.0;
+    m_lastUpdateTime = m_timer.elapsed();
+    m_vSyncTimes.clear();
+    m_lastVSyncTime_precise = 0;
+
+    updateFpsText();
+}
+
+void FpsDisplayManager::updateFps()
+{
+    if (m_vSyncTimes.isEmpty()) {
+        if (m_currentFps != 0 || m_maximumFps != 0) {
+            m_currentFps = 0;
+            m_maximumFps = 0;
+            updateFpsText();
+        }
+        return;
+    }
+
+    qint64 currentTime = m_timer.elapsed();
+    qint64 timeDiff = currentTime - m_lastUpdateTime;
+
+    if (timeDiff < kUpdateIntervalMs) {
+        return;
+    }
+
+    qreal calculatedFps = 0.0;
+    if (m_vSyncTimes.size() >= 2) {
+        qint64 totalTimeSpan = m_vSyncTimes.last() - m_vSyncTimes.first();
+        if (totalTimeSpan > 0) {
+            calculatedFps = ((m_vSyncTimes.size() - 1) * 1000.0) / totalTimeSpan;
+        }
+    }
+
+    if (calculatedFps <= 0) {
+        calculatedFps = m_displayRefreshRate;
+    }
+
+    calculatedFps = qBound(1.0, calculatedFps, (qreal)m_displayRefreshRate);
+    if (qAbs(calculatedFps - m_displayRefreshRate) < m_displayRefreshRate * 0.1) {
+        calculatedFps = m_displayRefreshRate;
+    }
+
+    // Apply exponential smoothing to reduce fluctuations (15% new, 85% old)
+    const qreal smoothingFactor = 0.15;
+    if (m_currentFps == 0.0) {
+        m_currentFps = calculatedFps;
+    } else {
+        m_currentFps = m_currentFps * (1.0 - smoothingFactor) + calculatedFps * smoothingFactor;
+    }
+
+    m_currentFps = qMin(m_currentFps, (qreal)m_displayRefreshRate);
+    if (m_currentFps > m_maximumFps) {
+        qreal maxAllowedFps = m_displayRefreshRate * 1.05; // Allow 5% measurement error
+        m_maximumFps = qMin(m_currentFps, maxAllowedFps);
+    }
+
+    m_maximumFps = qMin(m_maximumFps, (qreal)m_displayRefreshRate * 1.05);
+    m_lastUpdateTime = currentTime;
+    updateFpsText();
+}
+
+void FpsDisplayManager::detectDisplayRefreshRate()
+{
+    if (m_targetWindow) {
+        if (auto output = getOutputForWindow()) {
+            if (auto qwoutput = output->handle()) {
+                if (auto mode = qwoutput->preferred_mode()) {
+                    int32_t refresh = mode->refresh;
+                    if (refresh > 0) {
+                        m_displayRefreshRate = qRound(refresh / 1000.0);
+                    }
+                }
+            }
+        }
+    }
+
+    // Environment variable override for debugging/testing
+    QString envRefreshRate = qgetenv("TREELAND_REFRESH_RATE");
+    if (!envRefreshRate.isEmpty()) {
+        bool ok;
+        int rate = envRefreshRate.toInt(&ok);
+        if (ok && rate > 0 && rate <= 240) {
+            m_displayRefreshRate = rate;
+        }
+    }
+}
+
+void FpsDisplayManager::updateFpsText()
+{
+    int current = currentFps();
+    int maximum = maximumFps();
+
+    if (current != m_lastReportedCurrentFps) {
+        m_lastReportedCurrentFps = current;
+        emit currentFpsChanged();
+    }
+
+    if (maximum != m_lastReportedMaximumFps) {
+        m_lastReportedMaximumFps = maximum;
+        emit maximumFpsChanged();
+    }
+}
+
+void FpsDisplayManager::onScreenChanged(QScreen *screen)
+{
+    Q_UNUSED(screen);
+
+    invalidateCache();
+    int oldRate = m_displayRefreshRate;
+    updateRefreshAndInterval();
+
+    if (m_displayRefreshRate != oldRate) {
+        if (m_vsyncTimer.isActive()) {
+            m_vsyncTimer.stop();
+            m_vsyncTimer.start();
+        }
+
+        m_vSyncTimes.clear();
+        m_lastVSyncTime_precise = 0;
+        m_currentFps = 0.0;
+    }
+}
+
+void FpsDisplayManager::updateTimerIntervals()
+{
+    m_preciseVSyncInterval = 1000.0 / m_displayRefreshRate;
+    int vsyncInterval = qRound(m_preciseVSyncInterval);
+
+    // Use pre-calculated intervals for common refresh rates to avoid rounding errors
+    if (m_displayRefreshRate == 60) {
+        vsyncInterval = 17;  // 16.67ms rounded up for stability
+    } else if (m_displayRefreshRate == 90) {
+        vsyncInterval = 11;  // 11.11ms
+    } else if (m_displayRefreshRate == 120) {
+        vsyncInterval = 8;   // 8.33ms
+    } else if (m_displayRefreshRate == 144) {
+        vsyncInterval = 7;   // 6.94ms
+    }
+
+    vsyncInterval = qMax(1, vsyncInterval);
+    m_vsyncTimer.setInterval(vsyncInterval);
+}
+
+void FpsDisplayManager::updateRefreshAndInterval()
+{
+    int oldRate = m_displayRefreshRate;
+    detectDisplayRefreshRate();
+
+    if (m_displayRefreshRate != oldRate) {
+        updateTimerIntervals();
+        emit refreshRateChanged();
+    }
+}
+
+WOutput *FpsDisplayManager::findBestOutput(const QVector<WOutput*> &outputs) const
+{
+    if (outputs.isEmpty()) {
+        return nullptr;
+    }
+
+    if (outputs.size() == 1) {
+        return outputs.first();
+    }
+
+    for (auto output : outputs) {
+        if (output && output->isEnabled()) {
+            return output;
+        }
+    }
+    WOutput *bestOutput = outputs.first();
+    int maxRefreshRate = 0;
+
+    for (auto output : outputs) {
+        if (!output) continue;
+
+        if (auto qwoutput = output->handle()) {
+            if (auto mode = qwoutput->preferred_mode()) {
+                int refreshRate = qRound(mode->refresh / 1000.0);
+                if (refreshRate > maxRefreshRate) {
+                    maxRefreshRate = refreshRate;
+                    bestOutput = output;
+                }
+            }
+        }
+    }
+
+    return bestOutput;
+}
+
+void FpsDisplayManager::invalidateCache()
+{
+    m_cachedOutput = nullptr;
+    m_cacheTimestamp = 0;
+}
+
+WOutput *FpsDisplayManager::getOutputForWindow() const
+{
+    if (!m_targetWindow)
+        return nullptr;
+
+    qint64 currentTime = QDateTime::currentMSecsSinceEpoch();
+    if (m_cachedOutput && (currentTime - m_cacheTimestamp) < kCacheValidityMs) {
+        return m_cachedOutput;
+    }
+
+    auto renderWindow = qobject_cast<WOutputRenderWindow *>(m_targetWindow);
+    if (!renderWindow) {
+        return nullptr;
+    }
+
+    QVector<WOutput*> outputs;
+    for (auto child : renderWindow->children()) {
+        if (auto viewport = qobject_cast<WOutputViewport*>(child)) {
+            if (auto output = viewport->output()) {
+                outputs.append(output);
+            }
+        }
+    }
+
+    WOutput *bestOutput = nullptr;
+    if (!outputs.isEmpty()) {
+        bestOutput = findBestOutput(outputs);
+    }
+
+    m_cachedOutput = bestOutput;
+    m_cacheTimestamp = currentTime;
+    return bestOutput;
+}

--- a/src/utils/fpsdisplaymanager.h
+++ b/src/utils/fpsdisplaymanager.h
@@ -1,0 +1,91 @@
+// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <wglobal.h>
+
+#include <QObject>
+#include <QTimer>
+#include <QElapsedTimer>
+#include <QQueue>
+#include <QPointer>
+
+class QQuickItem;
+class QQuickWindow;
+class QScreen;
+
+WAYLIB_SERVER_BEGIN_NAMESPACE
+class WOutput;
+WAYLIB_SERVER_END_NAMESPACE
+
+WAYLIB_SERVER_USE_NAMESPACE
+
+class FpsDisplayManager : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(int currentFps READ currentFps NOTIFY currentFpsChanged)
+    Q_PROPERTY(int maximumFps READ maximumFps NOTIFY maximumFpsChanged)
+    Q_PROPERTY(int displayRefreshRate READ displayRefreshRate NOTIFY refreshRateChanged)
+    QML_ELEMENT
+
+public:
+    explicit FpsDisplayManager(QObject *parent = nullptr);
+    ~FpsDisplayManager();
+
+    Q_INVOKABLE void setTargetWindow(QQuickWindow *window);
+    // TODO: Add setTargetOutput(WOutput* output) method for multi-screen FPS display support
+    Q_INVOKABLE void start();
+    Q_INVOKABLE void stop();
+    Q_INVOKABLE void reset();
+
+    int currentFps() const { return qRound(m_currentFps); }
+    int maximumFps() const { return qRound(m_maximumFps); }
+    int displayRefreshRate() const { return m_displayRefreshRate; }
+
+signals:
+    void currentFpsChanged();
+    void maximumFpsChanged();
+    void refreshRateChanged();
+
+private Q_SLOTS:
+    void updateFps();
+    void onVSyncTimer();
+    void onScreenChanged(QScreen *screen);
+
+private:
+    void updateRefreshAndInterval();
+    void updateTimerIntervals();
+    void updateFpsText();
+    void detectDisplayRefreshRate();
+    WOutput *getOutputForWindow() const;
+    WOutput *findBestOutput(const QVector<WOutput*> &outputs) const;
+    void invalidateCache();
+
+    QPointer<QQuickWindow> m_targetWindow;
+
+    QElapsedTimer m_timer;
+    QTimer m_updateTimer;
+    QTimer m_vsyncTimer;
+    QQueue<qint64> m_vSyncTimes;
+
+    qreal m_currentFps = 0.0;
+    qreal m_averageFps = 0.0;
+    qreal m_maximumFps = 0.0;
+    qint64 m_lastUpdateTime = 0;
+    qint64 m_lastVSyncTime_precise = 0;
+
+    int m_displayRefreshRate = 60;              // Display refresh rate in Hz
+    double m_preciseVSyncInterval = 16.67;      // Precise VSync interval in milliseconds
+    // Constants
+    static constexpr int kUpdateIntervalMs = 500;     // UI update frequency in milliseconds
+    static constexpr qint64 kCacheValidityMs = 5000;  // Cache validity: 5 seconds
+
+    // Cache for change detection
+    int m_lastReportedCurrentFps = -1;
+    int m_lastReportedMaximumFps = -1;
+
+    // Output caching for performance optimization
+    mutable QPointer<WOutput> m_cachedOutput;
+    mutable qint64 m_cacheTimestamp = 0;
+};


### PR DESCRIPTION
Introduces an on-screen FPS overlay with timer-based sampling aligned to the active screen’s refresh rate. automatic refresh-rate handling on screen changes.

## Summary by Sourcery

Add a real-time, on-screen FPS display feature with a manager that samples vsync timings, a QML overlay for rendering FPS metrics, and a keyboard shortcut to toggle visibility while handling dynamic refresh rates

New Features:
- Add FpsDisplayManager for sampling vsync events and computing real-time FPS metrics
- Introduce a QML FpsDisplay overlay to show current and maximum FPS, toggleable with Meta+F11
- Automatically detect and adapt to the active screen’s refresh rate when computing FPS

Build:
- Include fpsdisplaymanager sources and FpsDisplay.qml in the project’s CMakeLists