### PR TITLE
fix: correct window title visibility condition

### DIFF
--- a/src/plugins/multitaskview/qml/WindowSelectionGrid.qml
+++ b/src/plugins/multitaskview/qml/WindowSelectionGrid.qml
@@ -371,7 +371,7 @@ Item {
                         }
                         width: Math.min(implicitContentWidth + 2 * padding, parent.width)
                         padding: 10
-                        visible: highlighted && wrapper.shellSurface.title !== ""
+                        visible: surfaceItemDelegate.state === "taskview" && wrapper.shellSurface.title !== ""
 
                         contentItem: Text {
                             text: wrapper.shellSurface.title


### PR DESCRIPTION
Changed the visibility condition for window titles in the multitask view from checking 'highlighted' to checking the surfaceItemDelegate state. This ensures titles are only shown when in taskview mode, not during other states like window dragging or animation transitions.

The previous implementation could show titles during transitions when they shouldn't be visible, causing visual artifacts. The new condition properly aligns with the intended UI behavior where titles should only appear in the stable taskview state.

Log: Fixed window titles appearing during transitions in multitask view

Influence:
1. Test multitask view to verify titles only appear in taskview state
2. Check window dragging and transitions to ensure titles remain hidden
3. Verify title visibility with empty/non-empty titles
4. Test with different window states and transitions

fix: 修正窗口标题可见性条件

将多任务视图中窗口标题的可见性条件从检查'highlighted'改为检查
surfaceItemDelegate状态。这确保标题仅在taskview模式下显示，而不是在窗口
拖动或动画过渡等其他状态时显示。

之前的实现在不应显示标题的过渡期间可能会显示标题，导致视觉伪影。新条件正
确符合预期的UI行为，即标题应仅在稳定的taskview状态下出现。

Log: 修复多任务视图中窗口标题在过渡期间出现的问题

Influence:
1. 测试多任务视图，验证标题仅在taskview状态下显示
2. 检查窗口拖动和过渡，确保标题保持隐藏
3. 验证空/非空标题的可见性
4. 测试不同窗口状态和过渡

## Summary by Sourcery

Bug Fixes:
- Prevent window titles from appearing during dragging or animation transitions by checking surfaceItemDelegate.state == "taskview" instead of the highlighted flag.