### PR TITLE
feat: support start sessions other than treeland

### DIFF
--- a/misc/wayland-sessions/treeland-user.desktop.in
+++ b/misc/wayland-sessions/treeland-user.desktop.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=Treeland
+Name=Treeland User
 Comment=This session is DDE single wayland
 Exec=${CMAKE_INSTALL_FULL_BINDIR}/treeland-user-wrapper
 TryExec=${CMAKE_INSTALL_FULL_BINDIR}/treeland

--- a/src/greeter/greeterproxy.h
+++ b/src/greeter/greeterproxy.h
@@ -46,6 +46,7 @@ class GreeterProxy : public QObject
     Q_PROPERTY(SessionModel* sessionModel READ sessionModel WRITE setSessionModel NOTIFY sessionModelChanged)
     Q_PROPERTY(UserModel* userModel READ userModel WRITE setUserModel NOTIFY userModelChanged)
     Q_PROPERTY(bool     isLocked        READ isLocked       NOTIFY isLockedChanged)
+    Q_PROPERTY(bool     isLoggedIn      READ isLoggedIn     NOTIFY isLoggedInChanged)
 
 public:
     explicit GreeterProxy(QObject *parent = nullptr);
@@ -60,6 +61,7 @@ public:
     bool canHybridSleep() const;
 
     bool isConnected() const;
+    bool isLoggedIn() const;
 
     SessionModel *sessionModel() const;
     void setSessionModel(SessionModel *model);
@@ -106,6 +108,7 @@ Q_SIGNALS:
     void loginSucceeded(const QString &user);
     void switchToGreeter();
     void isLockedChanged();
+    void isLoggedInChanged();
 
 private:
     bool localValidation(const QString &user, const QString &password) const;

--- a/src/greeter/sessionmodel.cpp
+++ b/src/greeter/sessionmodel.cpp
@@ -172,7 +172,7 @@ void SessionModel::populate(Session::Type type, const QStringList &dirPaths)
         }
         // add to sessions list
         // TODO: only show support sessions(X-DDE-SINGLE-WAYLAND)
-        if (si->isSingleMode() && execAllowed) {
+        if (execAllowed) {
             d->displayNames.append(si->displayName());
             d->sessions.push_back(si);
         } else {

--- a/src/plugins/lockscreen/qml/ControlAction.qml
+++ b/src/plugins/lockscreen/qml/ControlAction.qml
@@ -16,6 +16,34 @@ RowLayout {
     property bool powerVisible: powerList.visible
     required property Item rootItem
     signal lock()
+
+    // TODO: Design the interface of session selection
+    D.Button {
+        id: sessionItem
+        Layout.alignment: Qt.AlignHCenter
+        visible: !GreeterModel.proxy.isLoggedIn
+
+        contentItem: D.IconLabel {
+            text: SessionModel.data(SessionModel.index(GreeterModel.currentSession, 0), SessionModel.NameRole)
+            color: "white"
+        }
+
+        SessionList {
+            id: sessionList
+            x: (sessionItem.width - sessionList.width) / 2 - 10
+            y: -sessionList.height - 10
+        }
+
+        background: RoundBlur {
+            radius: parent.width / 2
+            color: Qt.rgba(1.0, 1.0, 1.0, 0.3)
+        }
+
+        onClicked: {
+            sessionList.open()
+        }
+    }
+
     function showUserList()
     {
         userItem.expand = true

--- a/src/plugins/lockscreen/qml/SessionList.qml
+++ b/src/plugins/lockscreen/qml/SessionList.qml
@@ -9,9 +9,10 @@ import Treeland
 import LockScreen
 
 Popup {
+    id: popup
     modal: true
     width: 220
-    height: 140
+    height: 280
     background: RoundBlur {
         radius: 12
     }
@@ -29,8 +30,18 @@ Popup {
         y: 10
         clip: true
         model: SessionModel
+
+        ScrollBar.vertical: ScrollBar {
+            id: verticalScrollBar
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            policy: ScrollBar.AlwaysOn
+        }
+
         delegate: Item {
             required property string name
+            required property int index
             width: parent.width
             height: 60
             MouseArea {
@@ -45,7 +56,8 @@ Popup {
                 }
                 onClicked: (mouse) => {
                     mouse.accepted = false
-                    updateCurrentSession(list.currentIndex)
+                    updateCurrentSession(index)
+                    popup.close()
                 }
             }
 


### PR DESCRIPTION
This commit fixed the SessionModel and SessionList, and enabled session selection by adding a button to ControlAction.qml. Thus treeland can act as a greeter of ddm, guide the start of other desktop environment.

## Summary by Sourcery

Enable treeland to serve as a greeter for the display manager by adding UI and model support for selecting and launching non-treeland sessions

New Features:
- Add a session selection button to the lock screen control panel for choosing desktop sessions
- Enable session list popup with scrollable entries to switch between available sessions

Bug Fixes:
- Remove single-mode restriction in SessionModel to include all executable sessions
- Fix last session lookup in SessionModel to match on exec command instead of file name

Enhancements:
- Increase session list popup height and introduce a vertical scrollbar for better usability
- Automatically close the session list popup upon session selection