### PR TITLE
fix: crash on startup due to uninitialized m_config pointer

### DIFF
--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -302,7 +302,7 @@ private:
     void updateIdleInhibitor();
 
     static Helper *m_instance;
-    TreelandConfig *m_config;
+    TreelandConfig *m_config = nullptr;
 
     CurrentMode m_currentMode{ CurrentMode::Normal };
 


### PR DESCRIPTION
The m_config member variable contained garbage value instead of nullptr because C++ doesn't auto-initialize pointer members. This caused invalid memory access and crash during startup.

Initialize m_config to nullptr to ensure proper initial state.

## Summary by Sourcery

Bug Fixes:
- Initialize m_config member to nullptr to avoid invalid memory access on startup