### PR TITLE
chore(debian): update version to 0.7.2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+treeland (0.7.2) unstable; urgency=medium
+
+  * fix: crash on startup due to uninitialized m_config pointer
+
+ -- rewine <luhongxu@uniontech.com>  Fri, 19 Sep 2025 10:06:51 +0800
+
 treeland (0.7.1) unstable; urgency=medium
 
   * fix: Fix socket blocking issue in Wayland server connection handling


### PR DESCRIPTION
fix: crash on startup due to uninitialized m_config

## Summary by Sourcery

Update Debian packaging to version 0.7.2 and record the startup crash fix

Bug Fixes:
- Fix crash on startup due to uninitialized m_config

Build:
- Bump Debian changelog version to 0.7.2 and update timestamp