### PR TITLE
refactor: reduce cursor-related log verbosity

### DIFF
--- a/waylib/src/server/kernel/wcursor.cpp
+++ b/waylib/src/server/kernel/wcursor.cpp
@@ -36,11 +36,11 @@ WAYLIB_SERVER_BEGIN_NAMESPACE
 // Cursor management and movement
 Q_LOGGING_CATEGORY(waylibCursor, "waylib.server.cursor", QtInfoMsg)
 // Cursor input events (motion, buttons, etc.)
-Q_LOGGING_CATEGORY(waylibCursorInput, "waylib.server.cursor.input", QtDebugMsg)
+Q_LOGGING_CATEGORY(waylibCursorInput, "waylib.server.cursor.input", QtInfoMsg)
 // Cursor gesture events (pinch, swipe, etc.)
 Q_LOGGING_CATEGORY(waylibCursorGesture, "waylib.server.cursor.gesture", QtDebugMsg)
 // Cursor touch events
-Q_LOGGING_CATEGORY(waylibCursorTouch, "waylib.server.cursor.touch", QtDebugMsg)
+Q_LOGGING_CATEGORY(waylibCursorTouch, "waylib.server.cursor.touch", QtInfoMsg)
 
 WCursorPrivate::WCursorPrivate(WCursor *qq)
     : WWrapObjectPrivate(qq)


### PR DESCRIPTION
The verbosity of cursor input and touch event logs has been reduced from `QtDebugMsg` to `QtInfoMsg`.  The high volume of debug logs was overwhelming during development and debugging, making it difficult to identify important information.  By reducing the default log level, only essential cursor-related information will be displayed unless debug logging is specifically enabled. This change improves the clarity and usability of log output during development.

Influence:
1. Verify cursor functionality remains unaffected by the log level change.
2. Confirm that important cursor events are still logged at the `QtInfoMsg` level.
3. Enable debug logging to ensure detailed cursor information is available when needed.
4. Test with different input devices (mouse, touchpad, touch screen) to ensure consistent behavior.

refactor: 降低光标相关日志的详细程度

光标输入和触摸事件日志的详细程度已从 `QtDebugMsg` 降低到 `QtInfoMsg`。
大量的调试日志在开发和调试过程中造成了信息过载，难以识别重要信息。 通过
降低默认日志级别，除非专门启用调试日志记录，否则只会显示基本的光标相关信
息。 此更改提高了开发期间日志输出的清晰度和可用性。

Influence:
1. 验证光标功能是否未受日志级别更改的影响。
2. 确认重要的光标事件仍然以 `QtInfoMsg` 级别记录。
3. 启用调试日志记录以确保在需要时可以使用详细的光标信息。
4. 使用不同的输入设备（鼠标、触摸板、触摸屏）进行测试，以确保行为一致。

## Summary by Sourcery

Lower cursor event logging level to reduce verbosity and improve log clarity during development.

Enhancements:
- Reduce cursor input event log severity from QtDebugMsg to QtInfoMsg
- Reduce cursor touch event log severity from QtDebugMsg to QtInfoMsg