### PR TITLE
fix: fix MultitaskView display problem caused by refactoring TreelandConfig

### DIFF
--- a/src/core/qml/TitleBar.qml
+++ b/src/core/qml/TitleBar.qml
@@ -19,7 +19,7 @@ Control {
     property D.Palette outerShadowColor: DS.Style.highlightPanel.dropShadow
     property D.Palette innerShadowColor: DS.Style.highlightPanel.innerShadow
 
-    height: TreelandConfig.windowTitlebarHeight
+    height: Helper.config.windowTitlebarHeight
     width: surfaceItem.width
 
     // Ensure title bar does not accept keyboard focus

--- a/src/plugins/multitaskview/qml/MultitaskviewProxy.qml
+++ b/src/plugins/multitaskview/qml/MultitaskviewProxy.qml
@@ -83,9 +83,9 @@ Multitaskview {
     transitions: Transition {
         to: "initial, taskview"
         NumberAnimation {
-            duration: TreelandConfig.multitaskviewAnimationDuration
+            duration: Helper.config.multitaskviewAnimationDuration
             property: "taskviewVal"
-            easing.type: TreelandConfig.multitaskviewEasingCurveType
+            easing.type: Helper.config.multitaskviewEasingCurveType
         }
     }
 
@@ -177,7 +177,7 @@ Multitaskview {
                         multitaskview: root
                         output: outputPlacementItem.output
                         draggedParent: root
-                        workspaceListPadding: TreelandConfig.workspaceDelegateHeight / output.outputItem.devicePixelRatio
+                        workspaceListPadding: Helper.config.workspaceDelegateHeight / output.outputItem.devicePixelRatio
                         dragManager: multitaskviewDragManager
                     }
                 }

--- a/src/plugins/multitaskview/qml/WindowSelectionGrid.qml
+++ b/src/plugins/multitaskview/qml/WindowSelectionGrid.qml
@@ -500,7 +500,7 @@ Item {
         } else if (event.modifiers === Qt.AltModifier) {
             if (event.key === Qt.Key_Minus && Helper.workspace.count > 1) {
                 Helper.workspace.removeModel(Helper.workspace.currentIndex)
-            } else if (event.key === Qt.Key_Equal && Helper.workspace.count < TreelandConfig.maxWorkspace) {
+            } else if (event.key === Qt.Key_Equal && Helper.workspace.count < Helper.config.maxWorkspace) {
                 Helper.workspace.createModel()
                 Helper.workspace.switchTo(Helper.workspace.count - 1)
             }

--- a/src/plugins/multitaskview/qml/WorkspaceSelectionList.qml
+++ b/src/plugins/multitaskview/qml/WorkspaceSelectionList.qml
@@ -16,7 +16,7 @@ Item {
     required property QtObject dragManager
     required property Multitaskview multitaskview
     readonly property real whRatio: output.outputItem.width / output.outputItem.height
-    readonly property real workspaceDelegateHeight: Helper.config.workspaceDelegateHeight / output.outputItem.devicePixelRatio
+    readonly property real workspaceDelegateHeight: (Helper.config.workspaceThumbHeight + 2 * workspaceThumbMargin) / output.outputItem.devicePixelRatio
     readonly property real workspaceThumbHeight: Helper.config.workspaceThumbHeight / output.outputItem.devicePixelRatio
     readonly property real workspaceThumbMargin: Helper.config.workspaceThumbMargin / output.outputItem.devicePixelRatio
     readonly property real highlightBorderWidth: Helper.config.highlightBorderWidth / output.outputItem.devicePixelRatio
@@ -353,7 +353,7 @@ Item {
 
     D.RoundButton {
         id: wsCreateBtn
-        visible: Helper.workspace.count < TreelandConfig.maxWorkspace
+        visible: Helper.workspace.count < Helper.config.maxWorkspace
         anchors {
             right: parent.right
             verticalCenter: parent.verticalCenter
@@ -395,7 +395,7 @@ Item {
             top: root.top
             bottom: root.bottom
         }
-        visible: Helper.workspace.count < TreelandConfig.maxWorkspace
+        visible: Helper.workspace.count < Helper.config.maxWorkspace
         HoverHandler {
             onHoveredChanged: {
                 if (hovered) {


### PR DESCRIPTION
This commit cleans up changes left from refactoring TreelandConfig, which caused MultitaskView display incorrectly.

## Summary by Sourcery

Fix config references and layout calculations in MultitaskView and related QML components after TreelandConfig refactor

Bug Fixes:
- Replace TreelandConfig properties with Helper.config for animation duration, easing, padding, maxWorkspace, and titlebar height across MultitaskViewProxy, WindowSelectionGrid, and TitleBar QML files

Enhancements:
- Update workspaceDelegateHeight in WorkspaceSelectionList to include workspaceThumbMargin for accurate layout