### PR TITLE
fix: fix MultitaskView display problem

### DIFF
--- a/src/plugins/multitaskview/qml/MultitaskviewProxy.qml
+++ b/src/plugins/multitaskview/qml/MultitaskviewProxy.qml
@@ -177,7 +177,7 @@ Multitaskview {
                         multitaskview: root
                         output: outputPlacementItem.output
                         draggedParent: root
-                        workspaceListPadding: Helper.config.workspaceDelegateHeight / output.outputItem.devicePixelRatio
+                        workspaceListPadding: (Helper.config.workspaceThumbHeight + 2 * Helper.config.workspaceThumbMargin) / output.outputItem.devicePixelRatio
                         dragManager: multitaskviewDragManager
                     }
                 }

--- a/src/plugins/multitaskview/qml/WorkspaceSelectionList.qml
+++ b/src/plugins/multitaskview/qml/WorkspaceSelectionList.qml
@@ -16,7 +16,7 @@ Item {
     required property QtObject dragManager
     required property Multitaskview multitaskview
     readonly property real whRatio: output.outputItem.width / output.outputItem.height
-    readonly property real workspaceDelegateHeight: (Helper.config.workspaceThumbHeight + 2 * workspaceThumbMargin) / output.outputItem.devicePixelRatio
+    readonly property real workspaceDelegateHeight: (Helper.config.workspaceThumbHeight + 2 * Helper.config.workspaceThumbMargin) / output.outputItem.devicePixelRatio
     readonly property real workspaceThumbHeight: Helper.config.workspaceThumbHeight / output.outputItem.devicePixelRatio
     readonly property real workspaceThumbMargin: Helper.config.workspaceThumbMargin / output.outputItem.devicePixelRatio
     readonly property real highlightBorderWidth: Helper.config.highlightBorderWidth / output.outputItem.devicePixelRatio


### PR DESCRIPTION
workspaceDelegateHeight property is removed from new TreelandConfig. This commit adapt the change and fixed the MultitaskView display problem.

## Summary by Sourcery

Update MultitaskView QML components to use the new TreelandConfig properties for thumbnail height and margin, restoring correct display and padding after removal of workspaceDelegateHeight.

Bug Fixes:
- Adapt MultitaskView to the removal of workspaceDelegateHeight in TreelandConfig by replacing it with calculations based on workspaceThumbHeight and workspaceThumbMargin
- Fix incorrect workspace list padding in MultitaskviewProxy.qml to use the new config values adjusted by device pixel ratio