### PR TITLE
fix: fix WorkspaceSelectionList animation's highlight border size

### DIFF
--- a/src/plugins/multitaskview/qml/WorkspaceSelectionList.qml
+++ b/src/plugins/multitaskview/qml/WorkspaceSelectionList.qml
@@ -41,7 +41,7 @@ Item {
         anchors.margins: workspaceThumbMargin - highlightBorderWidth
         Rectangle {
             width: workspaceThumbHeight * root.whRatio + 2 * highlightBorderWidth
-            height: workspaceThumbHeight + 2 * highlightBorderWidth
+            height: workspaceDelegateHeight + 2 * highlightBorderWidth - 2 * workspaceThumbMargin
             border.width: highlightBorderWidth
             border.color: "blue"
             color: "transparent"


### PR DESCRIPTION
The calculation of the rectangle is incorrect, and the rectangle will be wider than its content. Fix it using correct calculation.

## Summary by Sourcery

Bug Fixes:
- Adjust the rectangle height formula to use workspaceDelegateHeight and margins instead of workspaceThumbHeight