### PR TITLE
修复退出时断言失败问题

### DIFF
--- a/qwlroots/src/util/qwsignalconnector.h
+++ b/qwlroots/src/util/qwsignalconnector.h
@@ -127,8 +127,8 @@ public:
         }
     }
     void invalidate() {
-        auto tmpList = listenerList;
-        listenerList.clear();
+        QVector<qw_signal_listener*> tmpList;
+        std::swap(tmpList, listenerList);
         auto begin = tmpList.begin();
         while (begin != tmpList.end()) {
             qw_signal_listener *l = *begin;

--- a/src/core/shellhandler.h
+++ b/src/core/shellhandler.h
@@ -98,7 +98,7 @@ private:
     WAYLIB_SERVER_NAMESPACE::WInputMethodHelper *m_inputMethodHelper = nullptr;
     QList<WAYLIB_SERVER_NAMESPACE::WXWayland *> m_xwaylands;
 
-    RootSurfaceContainer *m_rootSurfaceContainer = nullptr;
+    QPointer<RootSurfaceContainer> m_rootSurfaceContainer;
     LayerSurfaceContainer *m_backgroundContainer = nullptr;
     LayerSurfaceContainer *m_bottomContainer = nullptr;
     Workspace *m_workspace = nullptr;

--- a/src/core/treeland.h
+++ b/src/core/treeland.h
@@ -49,6 +49,8 @@ public Q_SLOTS:
     QString XWaylandName();
 
 private:
+    void quit();
+
     std::unique_ptr<TreelandPrivate> d_ptr;
 };
 } // namespace Treeland

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,9 +43,12 @@ int main(int argc, char *argv[])
         return 0;
     Q_ASSERT(qw_buffer::get_objects().isEmpty());
 
-    Treeland::Treeland treeland;
+    int quitCode = 0;
+    {
+        Treeland::Treeland treeland;
 
-    int quitCode = app.exec();
+        quitCode = app.exec();
+    }
 
     Q_ASSERT(qw_buffer::get_objects().isEmpty());
 

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -234,6 +234,7 @@ Q_SIGNALS:
     void currentModeChanged();
 
     void blockActivateSurfaceChanged();
+    void requestQuit();
 
 private Q_SLOTS:
     void onShowDesktop();

--- a/waylib/examples/tinywl/helper.cpp
+++ b/waylib/examples/tinywl/helper.cpp
@@ -531,7 +531,7 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *, QInputEvent *event)
     if (event->type() == QEvent::KeyPress) {
         auto kevent = static_cast<QKeyEvent*>(event);
         if (QKeySequence(kevent->keyCombination()) == QKeySequence::Quit) {
-            qApp->quit();
+            Q_EMIT requestQuit();
             return true;
         } else if (event->modifiers() == Qt::MetaModifier) {
             if (kevent->key() == Qt::Key_Right) {

--- a/waylib/examples/tinywl/helper.h
+++ b/waylib/examples/tinywl/helper.h
@@ -119,6 +119,7 @@ Q_SIGNALS:
 
     void animationSpeedChanged();
     void outputModeChanged();
+    void requestQuit();
 
 private:
     void allowNonDrmOutputAutoChangeMode(WOutput *output);

--- a/waylib/src/server/qtquick/private/wbufferrenderer_p.h
+++ b/waylib/src/server/qtquick/private/wbufferrenderer_p.h
@@ -3,10 +3,12 @@
 
 #pragma once
 
-#include <qwglobal.h>
-#include <qwdamagering.h>
 #include <wglobal.h>
 #include <woutputrenderwindow.h>
+
+#include <qwglobal.h>
+#include <qwdamagering.h>
+#include <qwbuffer.h>
 
 #include <QQuickItem>
 #include <QQuickRenderTarget>
@@ -25,7 +27,6 @@ class Renderer;
 QT_END_NAMESPACE
 
 QW_BEGIN_NAMESPACE
-class qw_buffer;
 class qw_swapchain;
 QW_END_NAMESPACE
 
@@ -140,7 +141,7 @@ private:
         QMatrix4x4 worldTransform;
         QSize pixelSize;
         qreal devicePixelRatio;
-        QW_NAMESPACE::qw_buffer *buffer = nullptr;
+        std::unique_ptr<QW_NAMESPACE::qw_buffer, QW_NAMESPACE::qw_buffer::unlocker> buffer;
         QQuickRenderTarget renderTarget;
         QSGRenderTarget sgRenderTarget;
         QRegion dirty;

--- a/waylib/src/server/qtquick/woutputrenderwindow.cpp
+++ b/waylib/src/server/qtquick/woutputrenderwindow.cpp
@@ -1595,7 +1595,7 @@ WOutputRenderWindow::~WOutputRenderWindow()
 
     renderControl()->disconnect(this);
     renderControl()->invalidate();
-    renderControl()->deleteLater();
+    delete renderControl();
 }
 
 QQuickRenderControl *WOutputRenderWindow::renderControl() const

--- a/waylib/src/server/qtquick/wquickcursor.cpp
+++ b/waylib/src/server/qtquick/wquickcursor.cpp
@@ -151,7 +151,7 @@ public:
 
     mutable CursorTextureProvider *textureProvider = nullptr;
 
-    WCursor *cursor = nullptr;
+    QPointer<WCursor> cursor;
     QPointer<WOutput> output;
     WCursorImage *cursorImage = nullptr;
 


### PR DESCRIPTION
修复退出时断言失败问题

## Summary by Sourcery

Fix exit-time assertion failures and crashes by improving object lifetime management and quit handling.

Bug Fixes:
- Avoid assertion failure on exit by switching quit connections to Qt::QueuedConnection and ensuring objects are destroyed before app termination
- Prevent buffer lifetime issues in WBufferRenderer by managing qw_buffer with unique_ptr and unlocking correctly
- Fix lifetime bug in WOutputRenderWindow by replacing deleteLater() with immediate delete
- Emit requestQuit instead of direct qApp->quit in Helper to centralize and queue quit requests

Enhancements:
- Introduce requestQuit signal in Helper and connect it to controlled quit slots
- Replace raw pointers with smart pointers (std::unique_ptr and QPointer) across multiple classes for safer memory management
- Optimize qwsignalconnector::invalidate by swapping listener list instead of copying

Chores:
- Adjust includes and forward declarations in wbufferrenderer_p.h