### PR TITLE
fix: use separate TreelandConfig for each user

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -955,6 +955,9 @@ void Helper::init()
     m_personalization = m_server->attach<PersonalizationV1>();
 
     auto updateCurrentUser = [this] {
+        m_config = TreelandConfig::createByName("org.deepin.treeland",
+                                                "org.deepin.treeland",
+                                                "/" + m_userModel->currentUserName());
         auto user = m_userModel->currentUser();
         m_personalization->setUserId(user ? user->UID() : getuid());
     };


### PR DESCRIPTION
This should work as intended.

## Summary by Sourcery

Bug Fixes:
- Use TreelandConfig::createByName with the current user name to ensure per-user configurations