### PR TITLE
修复多屏崩溃

### DIFF
--- a/src/core/qml/CopyOutput.qml
+++ b/src/core/qml/CopyOutput.qml
@@ -35,13 +35,6 @@ OutputItem {
                 return size.width / isize.width;
             }
         }
-
-        Text {
-            anchors.horizontalCenter: parent.horizontalCenter
-            text: "I'm a duplicate of the primary screen"
-            font.pointSize: 18
-            color: "yellow"
-        }
     }
 
     OutputViewport {

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -679,9 +679,19 @@ void Helper::onSetCopyOutput(treeland_virtual_output_v1 *virtual_output)
 
 void Helper::onRestoreCopyOutput(treeland_virtual_output_v1 *virtual_output)
 {
+    const QString targetName = virtual_output->outputList.at(0);
+    if (!std::any_of(m_outputList.constBegin(), m_outputList.constEnd(),
+                     [&targetName](const Output *output) { return output->output()->name() == targetName; })) {
+        virtual_output->send_error(
+            TREELAND_VIRTUAL_OUTPUT_V1_ERROR_INVALID_OUTPUT,
+            qPrintable(QString("Target output %1 does not exist!").arg(targetName))
+        );
+        return;
+    }
+
     for (int i = 0; i < m_outputList.size(); i++) {
         Output *currentOutput = m_outputList.at(i);
-        if (currentOutput->output()->name() == virtual_output->outputList.at(0))
+        if (currentOutput->output()->name() == targetName)
             continue;
 
         Output *o = createNormalOutput(m_outputList.at(i)->output());


### PR DESCRIPTION
1、enhance output validation in restore copy mode
2、Delete useless display text in copy mode

## Summary by Sourcery

Validate the target output in restore copy mode to prevent invalid access and remove redundant UI text in copy mode.

Bug Fixes:
- Validate that the target output exists before restoring copy mode and return an error if it doesn't.

Enhancements:
- Remove the unnecessary "duplicate of the primary screen" label from the copy mode UI.