### PR TITLE
fix: include Qt private modules for Qt 6.11

### DIFF
--- a/waylib/CMakeLists.txt
+++ b/waylib/CMakeLists.txt
@@ -17,7 +17,7 @@ option(INSTALL_TINYWL "A minimum viable product Wayland compositor based on wayl
 option(ADDRESS_SANITIZER "Enable address sanitize" OFF)
 option(WAYLIB_USE_PERCOMPILE_HEADERS "Use precompile headers to build waylib" OFF)
 
-set(QT_COMPONENTS Core Gui Quick)
+set(QT_COMPONENTS Core Gui Quick GuiPrivate QuickPrivate)
 find_package(Qt6 COMPONENTS ${QT_COMPONENTS} REQUIRED)
 if(WITH_SUBMODULE_QWLROOTS)
     # Use qwlroots from project root directory

--- a/waylib/src/server/CMakeLists.txt
+++ b/waylib/src/server/CMakeLists.txt
@@ -9,7 +9,7 @@ set(WAYLIB_INCLUDE_INSTALL_DIR
     CACHE STRING "Install directory for waylib headers"
 )
 
-set(QT_COMPONENTS Core Gui Quick)
+set(QT_COMPONENTS Core Gui Quick GuiPrivate QuickPrivate)
 find_package(Qt6 COMPONENTS ${QT_COMPONENTS} REQUIRED)
 
 qt_standard_project_setup(REQUIRES 6.6)

--- a/waylib/src/server/platformplugin/qwlrootsintegration.cpp
+++ b/waylib/src/server/platformplugin/qwlrootsintegration.cpp
@@ -39,7 +39,11 @@
 #include <qpa/qplatformsurface.h>
 #include <qpa/qwindowsysteminterface.h>
 #include <qpa/qplatformoffscreensurface.h>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+#include <private/qgenericunixtheme_p.h>
+#else
 #include <private/qgenericunixthemes_p.h>
+#endif
 
 #ifndef QT_NO_OPENGL
 #include <qpa/qplatformopenglcontext.h>


### PR DESCRIPTION
This commit explicitly includes `GuiPrivate` and `QuickPrivate` Qt modules in `CMakeLists.txt` for both the `waylib` and `waylib/src/ server` directories. This is necessary because Qt 6.11 and later versions no longer implicitly include these private modules. Failing to include them results in build failures due to missing headers and symbols.

Log: Fixed build issue with Qt 6.11 and later versions by explicitly including necessary private Qt modules.

Influence:
1. Verify that the project builds successfully with Qt versions 6.11 and later.
2. Ensure that all functionalities relying on Qt private modules (e.g., custom QML components, internal Qt API usage) continue to work as expected.
3. Test on different platforms (Linux, Windows, macOS) where Qt is used.

fix: 为 Qt 6.11 包含 Qt 私有模块

此提交在 `waylib` 和 `waylib/src/server` 目录的 `CMakeLists.txt` 中显式 包含 `GuiPrivate` 和 `QuickPrivate` Qt 模块。 这是必要的，因为 Qt 6.11 及更高版本不再隐式包含这些私有模块。 未能包含它们会导致由于缺少头文件和
符号而导致构建失败。

Log: 通过显式包含必要的私有 Qt 模块，修复了 Qt 6.11 及更高版本的构建
问题。

Influence:
1. 验证项目是否可以使用 Qt 6.11 及更高版本成功构建。
2. 确保所有依赖于 Qt 私有模块的功能（例如，自定义 QML 组件、内部 Qt API 使用）继续按预期工作。
3. 在使用 Qt 的不同平台（Linux、Windows、macOS）上进行测试。