### PR TITLE
Disable minimize / maximize animation for window that doesn't belongs to current user

### DIFF
--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -1038,6 +1038,8 @@ void SurfaceWrapper::startMinimizeAnimation(const QRectF &iconGeometry, uint dir
 {
     if (m_minimizeAnimation)
         return;
+    if (!Helper::instance()->surfaceBelongsToCurrentUser(this))
+        return;
 
     m_minimizeAnimation =
         m_engine->createMinimizeAnimation(this, container(), iconGeometry, direction);


### PR DESCRIPTION
This should work as intended

## Summary by Sourcery

Bug Fixes:
- Prevent minimize animation on surfaces that aren’t owned by the active user