### PR TITLE
fix: fix private module inclusion on lower version of Qt

### DIFF
--- a/waylib/CMakeLists.txt
+++ b/waylib/CMakeLists.txt
@@ -17,7 +17,11 @@ option(INSTALL_TINYWL "A minimum viable product Wayland compositor based on wayl
 option(ADDRESS_SANITIZER "Enable address sanitize" OFF)
 option(WAYLIB_USE_PERCOMPILE_HEADERS "Use precompile headers to build waylib" OFF)
 
-set(QT_COMPONENTS Core Gui Quick GuiPrivate QuickPrivate)
+if(QT_VERSION VERSION_GREATER "6.8.0")
+    set(QT_COMPONENTS Core Gui Quick GuiPrivate QuickPrivate)
+else()
+    set(QT_COMPONENTS Core Gui Quick)
+endif()
 find_package(Qt6 COMPONENTS ${QT_COMPONENTS} REQUIRED)
 if(WITH_SUBMODULE_QWLROOTS)
     # Use qwlroots from project root directory

--- a/waylib/src/server/CMakeLists.txt
+++ b/waylib/src/server/CMakeLists.txt
@@ -9,7 +9,11 @@ set(WAYLIB_INCLUDE_INSTALL_DIR
     CACHE STRING "Install directory for waylib headers"
 )
 
-set(QT_COMPONENTS Core Gui Quick GuiPrivate QuickPrivate)
+if(QT_VERSION VERSION_GREATER "6.8.0")
+    set(QT_COMPONENTS Core Gui Quick GuiPrivate QuickPrivate)
+else()
+    set(QT_COMPONENTS Core Gui Quick)
+endif()
 find_package(Qt6 COMPONENTS ${QT_COMPONENTS} REQUIRED)
 
 qt_standard_project_setup(REQUIRES 6.6)


### PR DESCRIPTION
GuiPrivate and QuickPrivate cannot be found under Qt <= 6.8. This commit should work as intended.

## Summary by Sourcery

Update CMake configuration to include Qt6 private modules only on Qt versions above 6.8.0 to prevent missing module errors on lower versions.

Bug Fixes:
- Fix build errors on Qt versions ≤ 6.8 by avoiding inclusion of GuiPrivate and QuickPrivate modules when they are unavailable

Build:
- Conditionally find Qt6 private modules (GuiPrivate, QuickPrivate) only for Qt versions > 6.8.0 in both top-level and server CMakeLists