### PR TITLE
fix: compile errors on Arch for forward declared class

### DIFF
--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -26,6 +26,7 @@ Q_MOC_INCLUDE("core/rootsurfacecontainer.h")
 Q_MOC_INCLUDE("modules/capture/capture.h")
 Q_MOC_INCLUDE(<wlayersurface.h>)
 Q_MOC_INCLUDE(<QDBusObjectPath>)
+Q_MOC_INCLUDE("treelandconfig.hpp")
 
 QT_BEGIN_NAMESPACE
 class QQuickItem;


### PR DESCRIPTION
`TreelandConfig` became a forward declaration on
fa1e1e6a18876d76e1bf75fe94ae1b1c5285cebd which breaks moc compilation on Arch with the following errors. Let's use `Q_MOC_INCLUDE` like the others to workaround it. Note that `Q_DECLARE_OPAQUE_POINTER` should be avoided here because `TreelandConfig` is a `Q_OBJECT`.

```
[585/700] Building CXX object src/CMakeFiles/libtreeland.dir/libtreeland_autogen/mocs_compilation.cpp.o
FAILED: src/CMakeFiles/libtreeland.dir/libtreeland_autogen/mocs_compilation.cpp.o
/usr/bin/c++ -DDDECLARATIVE_TRANSLATIONS_DIR=\"dtk6/DDeclarative/translations\" -DDSG_DATA_DIR=\"/usr/share/dsg\" -DDSYSINFO_PREFIX=\"\" -DDTK_QML_APP_PLUGIN_PATH=\"/usr/lib/dtk6declarative/qml-app\" -DDTK_QML_APP_PLUGIN_SUBPATH=\"dtkdeclarative/plugins\" -DPREFIX=\"/usr\" -DQT_CONCURRENT_LIB -DQT_CORE_LIB -DQT_DBUS_LIB -DQT_FORCE_ASSERTS -DQT_GUI_LIB -DQT_MESSAGELOGCONTEXT -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_OPENGL_LIB -DQT_QMLINTEGRATION_LIB -DQT_QMLMETA_LIB -DQT_QMLMODELS_LIB -DQT_QMLWORKERSCRIPT_LIB -DQT_QML_LIB -DQT_QUICKCONTROLS2_LIB -DQT_QUICK_LIB -DQT_XML_LIB -DTREELAND_COMPONENTS_TRANSLATION_DIR=\"/usr/share/treeland/translations\" -DTREELAND_DATA_DIR=\"/usr/share/treeland\" -DTREELAND_PLUGINS_INSTALL_PATH=\"/usr/lib/treeland/plugins\" -DTREELAND_PLUGINS_OUTPUT_PATH=\"/build/treeland/src/treeland/lib/plugins\" -DWLR_USE_UNSTABLE -Dlibtreeland_EXPORTS -I/build/treeland/src/treeland/src -I/build/treeland/src/treeland/src/libtreeland_autogen/include -I/build/treeland/src/treeland/protocols -I/build/treeland/src/treeland/src/config -I/build/treeland/src/treeland/src/core -I/build/treeland/src/treeland/src/effects -I/build/treeland/src/treeland/src/greeter -I/build/treeland/src/treeland/src/input -I/build/treeland/src/treeland/src/interfaces -I/build/treeland/src/treeland/src/output -I/build/treeland/src/treeland/src/seat -I/build/treeland/src/treeland/src/surface -I/build/treeland/src/treeland/src/workspace -I/build/treeland/src/treeland/src/utils -I/build/treeland/src/treeland/src/wallpaper -I/build/treeland/src/treeland/waylib/src/server/kernel -I/build/treeland/src/treeland/waylib/src/server/qtquick -I/build/treeland/src/treeland/waylib/src/server/qtquick/private -I/build/treeland/src/treeland/waylib/src/server/utils -I/build/treeland/src/treeland/waylib/src/server/protocols -I/build/treeland/src/treeland/waylib/src/server/protocols/private -I/build/treeland/src/treeland/waylib/qwlroots/src/generate -I/build/treeland/src/treeland/qwlroots/src -I/build/treeland/src/treeland/qwlroots/src/render -I/build/treeland/src/treeland/qwlroots/src/types -I/build/treeland/src/treeland/qwlroots/src/util -I/build/treeland/src/treeland/qwlroots/src/interfaces -I/build/treeland/src/treeland/src/modules/foreign-toplevel -I/build/treeland/src/treeland/src/modules/primary-output -I/build/treeland/src/treeland/src/modules/personalization -I/build/treeland/src/treeland/src/modules/shortcut -I/build/treeland/src/treeland/src/modules/wallpaper-color -I/build/treeland/src/treeland/src/modules/window-management -I/build/treeland/src/treeland/src/modules/virtual-output -I/build/treeland/src/treeland/src/modules/dde-shell -I/build/treeland/src/treeland/src/modules/capture -I/build/treeland/src/treeland/src/modules/item-selector -I/build/treeland/src/treeland/src/modules/ddm -isystem /usr/include/qt6/QtQml/6.9.2 -isystem /usr/include/qt6/QtQml/6.9.2/QtQml -isystem /usr/include/qt6/QtCore/6.9.2 -isystem /usr/include/qt6/QtCore/6.9.2/QtCore -isystem /usr/include/qt6/QtCore -isystem /usr/include/qt6 -isystem /usr/lib/qt6/mkspecs/linux-g++ -isystem /usr/include/qt6/QtQml -isystem /usr/include/qt6/QtQmlIntegration -isystem /usr/include/qt6/QtNetwork -isystem /usr/include/dtk6/DCore -isystem /usr/include/qt6/QtDBus -isystem /usr/include/qt6/QtXml -isystem /usr/include/dtk6/DLog -isystem /usr/include/dtk6/DDeclarative -isystem /usr/include/qt6/QtQuick -isystem /usr/include/qt6/QtGui -isystem /usr/include/qt6/QtQmlMeta -isystem /usr/include/qt6/QtQmlModels -isystem /usr/include/qt6/QtQmlWorkerScript -isystem /usr/include/qt6/QtOpenGL -isystem /usr/include/dtk6/DGui -isystem /usr/include/dtk6/DSystemSettings -isystem /usr/include/wlroots-0.19 -isystem /usr/include/pixman-1 -isystem /usr/include/libdrm -isystem /usr/include/qt6/QtQuickControls2 -isystem /usr/include/qt6/QtQuick/6.9.2 -isystem /usr/include/qt6/QtQuick/6.9.2/QtQuick -isystem /usr/include/qt6/QtGui/6.9.2 -isystem /usr/include/qt6/QtGui/6.9.2/QtGui -isystem /usr/include/qt6/QtQmlModels/6.9.2 -isystem /usr/include/qt6/QtQmlModels/6.9.2/QtQmlModels -isystem /usr/include/qt6/QtQmlMeta/6.9.2 -isystem /usr/include/qt6/QtQmlMeta/6.9.2/QtQmlMeta -isystem /usr/include/qt6/QtQmlWorkerScript/6.9.2 -isystem /usr/include/qt6/QtQmlWorkerScript/6.9.2/QtQmlWorkerScript -isystem /usr/include/qt6/QtConcurrent -isystem /usr/include/ddm/auth -isystem /usr/include/ddm/common -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection         -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -Wp,-D_GLIBCXX_ASSERTIONS -g -ffile-prefix-map=/build/treeland/src=/usr/src/debug/treeland -flto=auto -std=gnu++20 -fPIC -mno-direct-extern-access -MD -MT src/CMakeFiles/libtreeland.dir/libtreeland_autogen/mocs_compilation.cpp.o -MF src/CMakeFiles/libtreeland.dir/libtreeland_autogen/mocs_compilation.cpp.o.d -o src/CMakeFiles/libtreeland.dir/libtreeland_autogen/mocs_compilation.cpp.o -c /build/treeland/src/treeland/src/libtreeland_autogen/mocs_compilation.cpp
In file included from /usr/include/qt6/QtCore/qobject.h:18,
                 from /usr/include/qt6/QtCore/qabstractanimation.h:8,
                 from /usr/include/qt6/QtCore/QtCore:19,
                 from /usr/include/qt6/QtQmlIntegration/QtQmlIntegrationDepends:3,
                 from /usr/include/qt6/QtQmlIntegration/QtQmlIntegration:3,
                 from /build/treeland/src/treeland/waylib/src/server/kernel/wglobal.h:8,
                 from /build/treeland/src/treeland/waylib/src/server/qtquick/wsurfaceitem.h:6,
                 from /build/treeland/src/treeland/src/surface/surfacewrapper.h:5,
                 from /build/treeland/src/treeland/src/surface/surfacecontainer.h:5,
                 from /build/treeland/src/treeland/src/libtreeland_autogen/TAC5DWH4SE/../../core/lockscreen.h:6,
                 from /build/treeland/src/treeland/src/libtreeland_autogen/TAC5DWH4SE/moc_lockscreen.cpp:9,
                 from /build/treeland/src/treeland/src/libtreeland_autogen/mocs_compilation.cpp:2:
/usr/include/qt6/QtCore/qmetatype.h: In instantiation of ‘constexpr bool QtPrivate::checkTypeIsSuitableForMetaType() [with X = TreelandConfig*]’:
/usr/include/qt6/QtCore/qmetatype.h:2661:43:   required from ‘constexpr const QtPrivate::QMetaTypeInterface* QtPrivate::qTryMetaTypeInterfaceForType() [with Unique = void; T = TreelandConfig*]’
 2661 |         checkTypeIsSuitableForMetaType<Ty>();
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/usr/include/qt6/QtCore/qtmochelpers.h:170:51:   required from ‘static constexpr void QtMocHelpers::detail::MetaTypeList<TypeMustBeComplete, T>::copyTo(Result&, uint&) [with Unique = void; Result = QtMocHelpers::MetaObjectContents<255, 112, 807, 45>; bool TypeMustBeComplete = true; T = {TreelandConfig*}; uint = unsigned int]’
  170 |                 qTryMetaTypeInterfaceForType<U, T>()...
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/usr/include/qt6/QtCore/qtmochelpers.h:262:65:   required from ‘constexpr const QtMocHelpers::MetaObjectContents<255, 112, 807, 45> Helper::qt_staticMetaObjectContent<{anonymous}::qt_meta_tag_ZN6HelperE_t>’
  262 |             decltype(input.metaTypes())::template copyTo<Unique>(result, metatypeoffset);
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
/build/treeland/src/treeland/src/libtreeland_autogen/LTNFY7LWQW/../../seat/helper.h:106:5:   required from ‘constexpr const auto Helper::qt_staticMetaObjectStaticContent<{anonymous}::qt_meta_tag_ZN6HelperE_t>’
  106 |     Q_OBJECT
      |     ^~~~~~~~
/build/treeland/src/treeland/src/libtreeland_autogen/LTNFY7LWQW/moc_helper.cpp:217:5:   required from here
  217 |     qt_staticMetaObjectStaticContent<qt_meta_tag_ZN6HelperE_t>.stringdata,
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/treeland/src/treeland/src/libtreeland_autogen/LTNFY7LWQW/../../seat/helper.h:106:5:   in ‘constexpr’ expansion of ‘Helper::qt_create_metaobjectdata<{anonymous}::qt_meta_tag_ZN6HelperE_t>()’
/build/treeland/src/treeland/src/libtreeland_autogen/LTNFY7LWQW/moc_helper.cpp:212:54:   in ‘constexpr’ expansion of ‘QtMocHelpers::metaObjectData<Helper, void, StringRefStorage<char [7], char [12], char [5], char [14], char [5], char [21], char [1], char [21], char [24], char [22], char [18], char [18], char [19], char [28], char [16], char [16], char [8], char [16], char [7], char [21], char [36], char [8], char [28], char [14], char [17], char [18], char [6], char [13], char [10], char [16], char [11], char [10], char [12], char [15], char [14], char [14], char [22], char [15], char [11], char [11], char [21], char [18], char [14], char [17], char [10], char [11], char [7], char [16], char [21], char [5], char [10], char [12], char [7], char [11], char [13], char [14]>, UintData<SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SlotData<void(SurfaceWrapper*, Qt::FocusReason)>, SlotData<void(SurfaceWrapper*)>, SlotData<void(SurfaceWrapper*, Qt::FocusReason)>, SlotData<void(SurfaceWrapper*)>, SlotData<void(SurfaceWrapper*)>, SlotData<bool(SurfaceWrapper*)>, SlotData<void()>, SlotData<void()>, SlotData<void(bool)>, SlotData<void(const QString&, const QDBusObjectPath&)>, MethodData<void()>, MethodData<bool(Waylib::Server::WLayerSurface*) const> >, UintData<PropertyData<bool>, PropertyData<RootSurfaceContainer*>, PropertyData<float>, PropertyData<Helper::OutputMode>, PropertyData<TogglableGesture*>, PropertyData<TogglableGesture*>, PropertyData<SurfaceWrapper*>, PropertyData<Workspace*>, PropertyData<TreelandConfig*>, PropertyData<bool> >, UintData<EnumData<Helper::OutputMode, 2>, EnumData<Helper::CurrentMode, 4> >, UintData<>, ClassInfos<2> >(0, qt_stringData, qt_methods, qt_properties, qt_enums, qt_constructors, qt_classinfo)’
/usr/include/qt6/QtCore/qtmochelpers.h:550:39:   in ‘constexpr’ expansion of ‘(& properties)->QtMocHelpers::UintData<QtMocHelpers::PropertyData<bool>, QtMocHelpers::PropertyData<RootSurfaceContainer*>, QtMocHelpers::PropertyData<float>, QtMocHelpers::PropertyData<Helper::OutputMode>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<SurfaceWrapper*>, QtMocHelpers::PropertyData<Workspace*>, QtMocHelpers::PropertyData<TreelandConfig*>, QtMocHelpers::PropertyData<bool> >::copyTo<void, QtMocHelpers::MetaObjectContents<255, 112, 807, 45> >(result, ((size_t)dataoffset), metatypeoffset)’
/usr/include/qt6/QtCore/qtmochelpers.h:255:21:   in ‘constexpr’ expansion of ‘((const QtMocHelpers::UintData<QtMocHelpers::PropertyData<bool>, QtMocHelpers::PropertyData<RootSurfaceContainer*>, QtMocHelpers::PropertyData<float>, QtMocHelpers::PropertyData<Helper::OutputMode>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<SurfaceWrapper*>, QtMocHelpers::PropertyData<Workspace*>, QtMocHelpers::PropertyData<TreelandConfig*>, QtMocHelpers::PropertyData<bool> >*)this)->QtMocHelpers::UintData<QtMocHelpers::PropertyData<bool>, QtMocHelpers::PropertyData<RootSurfaceContainer*>, QtMocHelpers::PropertyData<float>, QtMocHelpers::PropertyData<Helper::OutputMode>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<SurfaceWrapper*>, QtMocHelpers::PropertyData<Workspace*>, QtMocHelpers::PropertyData<TreelandConfig*>, QtMocHelpers::PropertyData<bool> >::data.QtMocHelpers::detail::UintDataStorage<std::integer_sequence<int, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9>, QtMocHelpers::PropertyData<bool>, QtMocHelpers::PropertyData<RootSurfaceContainer*>, QtMocHelpers::PropertyData<float>, QtMocHelpers::PropertyData<Helper::OutputMode>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<SurfaceWrapper*>, QtMocHelpers::PropertyData<Workspace*>, QtMocHelpers::PropertyData<TreelandConfig*>, QtMocHelpers::PropertyData<bool> >::forEach<QtMocHelpers::UintData<QtMocHelpers::PropertyData<bool>, QtMocHelpers::PropertyData<RootSurfaceContainer*>, QtMocHelpers::PropertyData<float>, QtMocHelpers::PropertyData<Helper::OutputMode>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<SurfaceWrapper*>, QtMocHelpers::PropertyData<Workspace*>, QtMocHelpers::PropertyData<TreelandConfig*>, QtMocHelpers::PropertyData<bool> >::copyTo<void, QtMocHelpers::MetaObjectContents<255, 112, 807, 45> >(QtMocHelpers::MetaObjectContents<255, 112, 807, 45>&, size_t, uint&) const::<lambda(const auto:60&)> >(<lambda closure object>QtMocHelpers::UintData<QtMocHelpers::PropertyData<bool>, QtMocHelpers::PropertyData<RootSurfaceContainer*>, QtMocHelpers::PropertyData<float>, QtMocHelpers::PropertyData<Helper::OutputMode>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<SurfaceWrapper*>, QtMocHelpers::PropertyData<Workspace*>, QtMocHelpers::PropertyData<TreelandConfig*>, QtMocHelpers::PropertyData<bool> >::copyTo<void, QtMocHelpers::MetaObjectContents<255, 112, 807, 45> >(QtMocHelpers::MetaObjectContents<255, 112, 807, 45>&, size_t, uint&) const::<lambda(const auto:60&)>{ptr, dataoffset, payloadoffset, (* & metatypeoffset), (* & result)})’
/usr/include/qt6/QtCore/qtmochelpers.h:204:19:   in ‘constexpr’ expansion of ‘invoke.QtMocHelpers::detail::UintDataStorage<std::integer_sequence<int, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9>, QtMocHelpers::PropertyData<bool>, QtMocHelpers::PropertyData<RootSurfaceContainer*>, QtMocHelpers::PropertyData<float>, QtMocHelpers::PropertyData<Helper::OutputMode>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<SurfaceWrapper*>, QtMocHelpers::PropertyData<Workspace*>, QtMocHelpers::PropertyData<TreelandConfig*>, QtMocHelpers::PropertyData<bool> >::forEach<QtMocHelpers::UintData<QtMocHelpers::PropertyData<bool>, QtMocHelpers::PropertyData<RootSurfaceContainer*>, QtMocHelpers::PropertyData<float>, QtMocHelpers::PropertyData<Helper::OutputMode>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<SurfaceWrapper*>, QtMocHelpers::PropertyData<Workspace*>, QtMocHelpers::PropertyData<TreelandConfig*>, QtMocHelpers::PropertyData<bool> >::copyTo<void, QtMocHelpers::MetaObjectContents<255, 112, 807, 45> >(QtMocHelpers::MetaObjectContents<255, 112, 807, 45>&, size_t, uint&) const::<lambda(const auto:60&)> >(QtMocHelpers::UintData<QtMocHelpers::PropertyData<bool>, QtMocHelpers::PropertyData<RootSurfaceContainer*>, QtMocHelpers::PropertyData<float>, QtMocHelpers::PropertyData<Helper::OutputMode>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<SurfaceWrapper*>, QtMocHelpers::PropertyData<Workspace*>, QtMocHelpers::PropertyData<TreelandConfig*>, QtMocHelpers::PropertyData<bool> >::copyTo<void, QtMocHelpers::MetaObjectContents<255, 112, 807, 45> >(QtMocHelpers::MetaObjectContents<255, 112, 807, 45>&, size_t, uint&) const::<lambda(const auto:60&)>&&) const::<lambda(const auto:59&)>(((const QtMocHelpers::detail::UintDataStorage<std::integer_sequence<int, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9>, QtMocHelpers::PropertyData<bool>, QtMocHelpers::PropertyData<RootSurfaceContainer*>, QtMocHelpers::PropertyData<float>, QtMocHelpers::PropertyData<Helper::OutputMode>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<SurfaceWrapper*>, QtMocHelpers::PropertyData<Workspace*>, QtMocHelpers::PropertyData<TreelandConfig*>, QtMocHelpers::PropertyData<bool> >*)this)->QtMocHelpers::detail::UintDataStorage<std::integer_sequence<int, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9>, QtMocHelpers::PropertyData<bool>, QtMocHelpers::PropertyData<RootSurfaceContainer*>, QtMocHelpers::PropertyData<float>, QtMocHelpers::PropertyData<Helper::OutputMode>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<SurfaceWrapper*>, QtMocHelpers::PropertyData<Workspace*>, QtMocHelpers::PropertyData<TreelandConfig*>, QtMocHelpers::PropertyData<bool> >::QtMocHelpers::detail::UintDataEntry<8, QtMocHelpers::PropertyData<TreelandConfig*> >)’
/usr/include/qt6/QtCore/qtmochelpers.h:201:67:   in ‘constexpr’ expansion of ‘(& f)->QtMocHelpers::UintData<QtMocHelpers::PropertyData<bool>, QtMocHelpers::PropertyData<RootSurfaceContainer*>, QtMocHelpers::PropertyData<float>, QtMocHelpers::PropertyData<Helper::OutputMode>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<TogglableGesture*>, QtMocHelpers::PropertyData<SurfaceWrapper*>, QtMocHelpers::PropertyData<Workspace*>, QtMocHelpers::PropertyData<TreelandConfig*>, QtMocHelpers::PropertyData<bool> >::copyTo<void, QtMocHelpers::MetaObjectContents<255, 112, 807, 45> >(QtMocHelpers::MetaObjectContents<255, 112, 807, 45>&, size_t, uint&) const::<lambda(const auto:60&)>(entry.QtMocHelpers::detail::UintDataEntry<8, QtMocHelpers::PropertyData<TreelandConfig*> >::entry)’
/usr/include/qt6/QtCore/qmetatype.h:1209:55: error: static assertion failed: Pointer Meta Types must either point to fully-defined types or be declared with Q_DECLARE_OPAQUE_POINTER(T *)
 1209 |             static_assert(is_complete<Pointed, void>::value,
      |                                                       ^~~~~
/usr/include/qt6/QtCore/qmetatype.h:1209:55: note: ‘std::integral_constant<bool, false>::value’ evaluates to false
/usr/include/qt6/QtCore/qmetatype.h: In instantiation of ‘constexpr bool QtPrivate::checkTypeIsSuitableForMetaType() [with X = TreelandConfig]’:
/usr/include/qt6/QtCore/qmetatype.h:2678:49:   required from ‘static constexpr QMetaType QMetaType::fromType() [with T = TreelandConfig]’
 2678 |     QtPrivate::checkTypeIsSuitableForMetaType<T>();
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/usr/include/qt6/QtCore/qtmochelpers.h:559:88:   required from ‘constexpr auto QtMocHelpers::metaObjectData(uint, const Strings&, const Methods&, const Properties&, const Enums&, const Constructors&, const ClassInfo&) [with ObjectType = TreelandConfig; Unique = {anonymous}::qt_meta_tag_ZN14TreelandConfigE_t; Strings = StringRefStorage<char [15], char [15], char [752], char [16], char [20], char [19], char [4], char [23], char [1], char [20], char [7], char [24], char [13], char [4], char [9], char [6], char [19], char [24], char [19], char [23], char [18], char [23], char [25], char [24], char [27], char [23], char [12], char [16], char [27], char [28], char [21], char [18], char [20], char [37], char [16], char [38], char [40], char [32], char [36], char [37], char [31], char [35], char [37], char [26], char [20], char [18], char [18], char [17], char [28], char [24], char [21], char [20], char [23], char [28], char [34], char [28], char [28], char [20], char [19], char [15], char [8], char [15], char [26], char [31], char [26], char [30], char [25], char [30], char [32], char [31], char [34], char [30], char [19], char [23], char [34], char [35], char [28], char [25], char [27], char [44], char [23], char [45], char [47], char [39], char [43], char [44], char [38], char [42], char [44], char [33], char [27], char [25], char [25], char [24], char [35], char [31], char [28], char [27], char [30], char [35], char [41], char [35], char [35], char [12], char [17], char [12], char [16], char [11], char [16], char [18], char [17], char [20], char [16], char [5], char [9], char [20], char [21], char [14], char [11], char [13], char [30], char [9], char [31], char [33], char [25], char [29], char [30], char [24], char [28], char [30], char [19], char [13], char [11], char [11], char [10], char [21], char [17], char [14], char [13], char [16], char [21], char [27], char [21], char [21]>; Methods = UintData<SignalData<void(Dtk::Core::DConfig*)>, SignalData<void(Dtk::Core::DConfig*)>, SignalData<void(const QString&, const QVariant&)>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, SignalData<void()>, MethodData<Dtk::Core::DConfig*() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<QList<QString>() const>, MethodData<bool(const QString&) const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const>, MethodData<bool() const> >; Properties = UintData<PropertyData<QString>, PropertyData<long long int>, PropertyData<bool>, PropertyData<long long int>, PropertyData<long long int>, PropertyData<QString>, PropertyData<QString>, PropertyData<long long int>, PropertyData<long long int>, PropertyData<long long int>, PropertyData<QString>, PropertyData<long long int>, PropertyData<bool>, PropertyData<long long int>, PropertyData<QString>, PropertyData<QString>, PropertyData<long long int>, PropertyData<long long int>, PropertyData<QString>, PropertyData<long long int>, PropertyData<long long int>, PropertyData<long long int>, PropertyData<long long int>, PropertyData<long long int>, PropertyData<double>, PropertyData<double>, PropertyData<long long int>, PropertyData<long long int>, PropertyData<long long int>, PropertyData<bool>, PropertyData<bool>, PropertyData<QString>, PropertyData<long long int>, PropertyData<long long int>, PropertyData<long long int>, PropertyData<long long int>, PropertyData<long long int>, PropertyData<long long int>, PropertyData<long long int>, PropertyData<long long int>, PropertyData<long long int> >; Enums = UintData<>; Constructors = UintData<>; ClassInfo = ClassInfos<3>; uint = unsigned int]’
  559 |     result.relocatingData.metaTypes[metatypeoffset++] = QMetaType::fromType<ObjectType>().iface();
      |                                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/build/treeland/src/treeland/src/libtreeland_autogen/EWIEGA46WW/moc_treelandconfig.cpp:482:91:   required from here
  482 |     return QtMocHelpers::metaObjectData<TreelandConfig, qt_meta_tag_ZN14TreelandConfigE_t>(QMC::MetaObjectFlag{}, qt_stringData,
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  483 |             qt_methods, qt_properties, qt_enums, qt_constructors, qt_classinfo);
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/qt6/QtCore/qmetatype.h:1203:51: error: static assertion failed: Meta Types must be fully defined
 1203 |         static_assert(is_complete<T, void>::value || std::is_void_v<T>,
      |                                             ~~~~~~^~~~~~~~~~~~~~~~~~~~
/usr/include/qt6/QtCore/qmetatype.h:1203:51: note: ‘(((bool)std::integral_constant<bool, false>::value) || ((bool)std::is_void_v<TreelandConfig>))’ evaluates to false
```

## Summary by Sourcery

Bug Fixes:
- Add Q_MOC_INCLUDE("treelandconfig.hpp") in seat/helper.h to ensure TreelandConfig is available to moc