### PR TITLE
fix: improve output configuration reliability and error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode/
 .cache/
 build*/
+.qtcreator/
 
 *.user
 

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -15,6 +15,7 @@
 #include <wseat.h>
 #include <wxdgdecorationmanager.h>
 #include <wextforeigntoplevellistv1.h>
+#include <woutputmanagerv1.h>
 
 #include <xcb/xproto.h>
 
@@ -292,7 +293,6 @@ private:
 
 private:
     void allowNonDrmOutputAutoChangeMode(WOutput *output);
-
     int indexOfOutput(WOutput *output) const;
 
     SurfaceWrapper *keyboardFocusSurface() const;
@@ -410,4 +410,14 @@ private:
     bool m_blockActivateSurface{ false };
 
     bool m_noAnimation{ false };
+
+    struct PendingOutputConfig {
+        qw_output_configuration_v1 *config = nullptr;
+        QList<WOutputState> states;
+        int pendingCommits = 0;
+        bool allSuccess = true;
+    };
+    PendingOutputConfig m_pendingOutputConfig;
+
+    void onOutputCommitFinished(qw_output_configuration_v1 *config, bool success);
 };

--- a/waylib/src/server/qtquick/woutputrenderwindow.cpp
+++ b/waylib/src/server/qtquick/woutputrenderwindow.cpp
@@ -1423,8 +1423,12 @@ WOutputRenderWindowPrivate::doRenderOutputs(qw_output *needsFrameOutput, const Q
             if (helper->framePending())
                 continue;
 
+            // Render if output will be enabled OR has extraState to commit
+            // Note: Even when disabling, we need to render once to commit the disabled state
+            // (extraState will contain the ENABLED=false change)
+            bool shouldRender = helper->willBeEnabled() || helper->extraState();
             if (Q_UNLIKELY(!WOutputViewportPrivate::get(helper->output())->renderable())
-                || !helper->output()->output()->isEnabled())
+                || !shouldRender)
                 continue;
 
             if (!(helper->needsFrame() || helper->contentIsDirty()))
@@ -1789,6 +1793,12 @@ QList<WOutputLayer *> WOutputRenderWindow::hardwareLayers(const WOutputViewport 
             list << l->layer->layer;
 
     return list;
+}
+
+WOutputHelper *WOutputRenderWindow::getOutputHelper(WOutputViewport *output) const
+{
+    Q_D(const WOutputRenderWindow);
+    return d->getOutputHelper(output);
 }
 
 void WOutputRenderWindow::setOutputScale(WOutputViewport *output, float scale)

--- a/waylib/src/server/qtquick/woutputrenderwindow.h
+++ b/waylib/src/server/qtquick/woutputrenderwindow.h
@@ -17,6 +17,7 @@ WAYLIB_SERVER_BEGIN_NAMESPACE
 class WOutputViewport;
 class WOutputLayer;
 class WBufferRenderer;
+class WOutputHelper;
 class WOutputRenderWindowPrivate;
 class WAYLIB_SERVER_EXPORT WOutputRenderWindow : public QQuickWindow, public QQmlParserStatus
 {
@@ -42,9 +43,12 @@ public:
                 WOutputViewport *mapFrom, QQuickItem *mapTo);
     void detach(WOutputLayer *layer, WOutputViewport *output);
 
+    WOutputHelper *getOutputHelper(WOutputViewport *output) const;
+
+    // TODO: Deprecate these convenience methods in favor of getOutputHelper() + setExtraState()
+    // for atomic multi-property operations. These are kept for simple QML use cases.
     void setOutputScale(WOutputViewport *output, float scale);
     void rotateOutput(WOutputViewport *output, WOutput::Transform t);
-    void setOutputEnabled(WOutputViewport *output, bool enabled);
 
     void init(QW_NAMESPACE::qw_renderer *renderer, QW_NAMESPACE::qw_allocator *allocator);
     QW_NAMESPACE::qw_renderer *renderer() const;


### PR DESCRIPTION
refactor: implement atomic multi-output configuration

    - Use WOutputRenderWindow interface for output configuration
    - Complete output state management with all properties
    - Ensure settings only saved when configuration succeeds

## Summary by Sourcery

Overhaul the multi-output configuration flow to use atomic test/apply phases, track individual commit outcomes, extend rendering APIs for output state changes, and ensure output settings are only persisted upon successful configuration

Bug Fixes:
- Prevent partial application of multi-output configurations by cancelling pending configs on error
- Avoid writing output settings on failure and ensure settings saved only after all commits succeed

Enhancements:
- Refactor Helper::onOutputTestOrApply to separate test and apply phases with pending commit tracking
- Add onOutputCommitFinished to aggregate commit results and atomically update settings
- Extend WOutputHelper and WOutputRenderWindow with API for atomic state changes (mode, custom mode, scale, transform, adaptive sync, enable) and commit listeners
- Enhance WOutputManagerV1 to fully populate output state, defer updating current state until config succeeds, and schedule reconfiguration through the event loop