### PR TITLE
fix: Fix Qt6::QuickPrivate module not found for CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,20 @@ set(QML_IMPORT_PATH "${LOCAL_QML_IMPORT_PATH}" CACHE STRING "For LSP" FORCE)
 find_package(PkgConfig REQUIRED)
 find_package(Qt6 CONFIG REQUIRED Core DBus Gui Qml Quick QuickControls2 LinguistTools Test QuickTest)
 
+# Check for optional Qt6::QuickPrivate
+find_package(Qt6 CONFIG QUIET COMPONENTS QuickPrivate)
+if(TARGET Qt6::QuickPrivate)
+    set(QT6_QUICKPRIVATE_FOUND TRUE)
+else()
+    set(QT6_QUICKPRIVATE_FOUND FALSE)
+endif()
+
+if(TARGET Qt6::WaylandClientPrivate)
+    set(QT6_WAYLANDCLIENTPRIVATE_FOUND TRUE)
+else()
+    set(QT6_WAYLANDCLIENTPRIVATE_FOUND FALSE)
+endif()
+
 pkg_check_modules(WLROOTS REQUIRED IMPORTED_TARGET wlroots-0.19)
 
 qt_standard_project_setup(REQUIRES 6.8)

--- a/cmake/DefineTarget.cmake
+++ b/cmake/DefineTarget.cmake
@@ -32,24 +32,31 @@ function(impl_treeland)
             $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     )
 
+    set(PRIVATE_LIBS
+        # TODO: remove this
+        Dtk6::Core
+        Dtk6::Declarative
+        Dtk6::SystemSettings
+        Waylib::WaylibServer
+        Qt6::Quick
+        Qt6::QuickControls2
+        Qt6::DBus
+        Qt6::Concurrent
+        PkgConfig::PIXMAN
+        PkgConfig::WAYLAND
+        PkgConfig::LIBINPUT
+        # TODO: end remove
+        )
+
+    # Conditionally link Qt6::QuickPrivate if available
+    if(QT6_QUICKPRIVATE_FOUND)
+        list(APPEND PRIVATE_LIBS Qt6::QuickPrivate)
+    endif()
+
     target_link_libraries(${PARSE_ARG_PREFIX_NAME}
         INTERFACE
             ${PARSE_ARG_PREFIX_LINK}
-
-            # TODO: remove this
-            Dtk6::Core
-            Dtk6::Declarative
-            Dtk6::SystemSettings
-            Waylib::WaylibServer
-            Qt6::Quick
-            Qt6::QuickControls2
-            Qt6::QuickPrivate
-            Qt6::DBus
-            Qt6::Concurrent
-            PkgConfig::PIXMAN
-            PkgConfig::WAYLAND
-            PkgConfig::LIBINPUT
-            # TODO: end remove
+            ${PRIVATE_LIBS}
     )
 
     target_link_libraries(libtreeland

--- a/examples/test_capture/CMakeLists.txt
+++ b/examples/test_capture/CMakeLists.txt
@@ -31,16 +31,24 @@ qt6_generate_wayland_protocol_client_sources(test-capture
         ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-capture-unstable-v1.xml
 )
 
-target_link_libraries(test-capture
-    PRIVATE
-        Qt6::Core
-        Qt6::Gui
-        Qt6::WaylandClient
-        Qt6::WaylandClientPrivate
-        Qt6::Quick
-        Qt6::QuickPrivate
-        Qt6::QuickControls2
-        PkgConfig::EGL
+set(PRIVATE_LIBS
+    Qt6::Core
+    Qt6::Gui
+    Qt6::WaylandClient
+    Qt6::Quick
+    Qt6::QuickControls2
+    PkgConfig::EGL
 )
+
+# Conditionally link Qt6::QuickPrivate if available
+if(QT6_QUICKPRIVATE_FOUND)
+    list(APPEND PRIVATE_LIBS Qt6::QuickPrivate)
+endif()
+
+if(QT6_WAYLANDCLIENTPRIVATE_FOUND)
+    list(APPEND PRIVATE_LIBS Qt6::WaylandClientPrivate)
+endif()
+
+target_link_libraries(test-capture PRIVATE ${PRIVATE_LIBS})
 
 install(TARGETS test-capture RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/examples/test_multitaskview/CMakeLists.txt
+++ b/examples/test_multitaskview/CMakeLists.txt
@@ -28,7 +28,13 @@ target_link_libraries(${BIN_NAME}
     PRIVATE
         Qt6::Quick
         Qt6::WaylandClient
-        Qt6::WaylandClientPrivate
 )
+
+if(QT6_WAYLANDCLIENTPRIVATE_FOUND)
+    target_link_libraries(${BIN_NAME}
+        PRIVATE
+            Qt6::WaylandClientPrivate
+    )
+endif()
 
 install(TARGETS ${BIN_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/examples/test_show_desktop/CMakeLists.txt
+++ b/examples/test_show_desktop/CMakeLists.txt
@@ -18,7 +18,13 @@ target_link_libraries(${BIN_NAME}
         Qt6::Widgets
         Qt6::WaylandClient
         Qt6::GuiPrivate
-        Qt6::WaylandClientPrivate
 )
+
+if(QT6_WAYLANDCLIENTPRIVATE_FOUND)
+    target_link_libraries(${BIN_NAME}
+        PRIVATE
+            Qt6::WaylandClientPrivate
+    )
+endif()
 
 install(TARGETS ${BIN_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/examples/test_super_overlay_surface/CMakeLists.txt
+++ b/examples/test_super_overlay_surface/CMakeLists.txt
@@ -19,8 +19,13 @@ target_link_libraries(${BIN_NAME}
         Qt6::Gui
         Qt6::Widgets
         Qt6::WaylandClient
-        Qt6::WaylandClientPrivate
 )
 
-install(TARGETS ${BIN_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+if(QT6_WAYLANDCLIENTPRIVATE_FOUND)
+    target_link_libraries(${BIN_NAME}
+        PRIVATE
+            Qt6::WaylandClientPrivate
+    )
+endif()
 
+install(TARGETS ${BIN_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/examples/test_virtual_output/CMakeLists.txt
+++ b/examples/test_virtual_output/CMakeLists.txt
@@ -18,8 +18,13 @@ target_link_libraries(${BIN_NAME}
         Qt6::Widgets
         Qt6::WaylandClient
         Qt6::GuiPrivate
-        Qt6::WaylandClientPrivate
 )
 
-install(TARGETS ${BIN_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+if(QT6_WAYLANDCLIENTPRIVATE_FOUND)
+    target_link_libraries(${BIN_NAME}
+        PRIVATE
+            Qt6::WaylandClientPrivate
+    )
+endif()
 
+install(TARGETS ${BIN_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/examples/test_window_bg/CMakeLists.txt
+++ b/examples/test_window_bg/CMakeLists.txt
@@ -18,7 +18,13 @@ target_link_libraries(${BIN_NAME}
         Qt6::Widgets
         Qt6::WaylandClient
         Qt6::GuiPrivate
-        Qt6::WaylandClientPrivate
 )
+
+if(QT6_WAYLANDCLIENTPRIVATE_FOUND)
+    target_link_libraries(${BIN_NAME}
+        PRIVATE
+            Qt6::WaylandClientPrivate
+    )
+endif()
 
 install(TARGETS ${BIN_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/examples/test_window_overlapped/CMakeLists.txt
+++ b/examples/test_window_overlapped/CMakeLists.txt
@@ -20,8 +20,13 @@ target_link_libraries(${BIN_NAME}
         Qt6::GuiPrivate
         Qt6::Widgets
         Qt6::WaylandClient
-        Qt6::WaylandClientPrivate
 )
 
-install(TARGETS ${BIN_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+if(QT6_WAYLANDCLIENTPRIVATE_FOUND)
+    target_link_libraries(${BIN_NAME}
+        PRIVATE
+            Qt6::WaylandClientPrivate
+    )
+endif()
 
+install(TARGETS ${BIN_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/examples/test_window_picker/CMakeLists.txt
+++ b/examples/test_window_picker/CMakeLists.txt
@@ -28,7 +28,13 @@ target_link_libraries(${BIN_NAME}
     PRIVATE
         Qt6::Quick
         Qt6::WaylandClient
-        Qt6::WaylandClientPrivate
 )
+
+if(QT6_WAYLANDCLIENTPRIVATE_FOUND)
+    target_link_libraries(${BIN_NAME}
+        PRIVATE
+            Qt6::WaylandClientPrivate
+    )
+endif()
 
 install(TARGETS ${BIN_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -269,6 +269,25 @@ target_include_directories(libtreeland
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/treeland>
 )
 
+set(PRIVATE_LIBS
+    Qt6::Quick
+    Qt6::QuickControls2
+    Qt6::DBus
+    Qt6::Concurrent
+    PkgConfig::PIXMAN
+    PkgConfig::WAYLAND
+    PkgConfig::LIBINPUT
+    PkgConfig::XCB
+    $<$<NOT:$<BOOL:${DISABLE_DDM}>>:DDM::Auth>
+    $<$<NOT:$<BOOL:${DISABLE_DDM}>>:DDM::Common>
+    $<$<NOT:$<BOOL:${DISABLE_DDM}>>:PkgConfig::PAM>
+)
+
+# Conditionally link Qt6::QuickPrivate if available
+if(QT6_QUICKPRIVATE_FOUND)
+    list(APPEND PRIVATE_LIBS Qt6::QuickPrivate)
+endif()
+
 target_link_libraries(libtreeland
     PUBLIC
         Dtk6::Core
@@ -276,18 +295,7 @@ target_link_libraries(libtreeland
         Dtk6::SystemSettings
         Waylib::WaylibServer
     PRIVATE
-        Qt6::Quick
-        Qt6::QuickControls2
-        Qt6::QuickPrivate
-        Qt6::DBus
-        Qt6::Concurrent
-        PkgConfig::PIXMAN
-        PkgConfig::WAYLAND
-        PkgConfig::LIBINPUT
-        PkgConfig::XCB
-        $<$<NOT:$<BOOL:${DISABLE_DDM}>>:DDM::Auth>
-        $<$<NOT:$<BOOL:${DISABLE_DDM}>>:DDM::Common>
-        $<$<NOT:$<BOOL:${DISABLE_DDM}>>:PkgConfig::PAM>
+        ${PRIVATE_LIBS}
 )
 
 add_subdirectory(plugins)

--- a/src/modules/capture/CMakeLists.txt
+++ b/src/modules/capture/CMakeLists.txt
@@ -46,15 +46,20 @@ PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
 
-target_link_libraries(${MODULE_NAME}
-    PRIVATE
-        PkgConfig::WLROOTS
-        Waylib::WaylibServer
-        Qt6::Core
-        Qt6::Gui
-        Qt6::Quick
-        Qt6::QuickPrivate
+set(PRIVATE_LIBS
+    PkgConfig::WLROOTS
+    Waylib::WaylibServer
+    Qt6::Core
+    Qt6::Gui
+    Qt6::Quick
 )
+
+# Conditionally link Qt6::QuickPrivate if available
+if(QT6_QUICKPRIVATE_FOUND)
+    list(APPEND PRIVATE_LIBS Qt6::QuickPrivate)
+endif()
+
+target_link_libraries(${MODULE_NAME} PRIVATE ${PRIVATE_LIBS})
 
 impl_treeland(
     NAME

--- a/src/surface/surfacefilterproxymodel.cpp
+++ b/src/surface/surfacefilterproxymodel.cpp
@@ -12,8 +12,14 @@ SurfaceFilterProxyModel::SurfaceFilterProxyModel(QObject *parent)
 
 void SurfaceFilterProxyModel::setFilterAppId(const QString &appid)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+    beginFilterChange();
+    m_filterAppId = appid;
+    endFilterChange(QSortFilterProxyModel::Direction::Rows);
+#else
     m_filterAppId = appid;
     invalidateFilter();
+#endif
 }
 
 int SurfaceFilterProxyModel::activeIndex()

--- a/src/treeland-shortcut/CMakeLists.txt
+++ b/src/treeland-shortcut/CMakeLists.txt
@@ -21,10 +21,16 @@ target_link_libraries(treeland-shortcut
         Qt6::Widgets
         Qt6::DBus
         Qt6::WaylandClient
-        Qt6::WaylandClientPrivate
         PkgConfig::WAYLAND_CLIENT
         PkgConfig::Systemd
 )
+
+if(QT6_WAYLANDCLIENTPRIVATE_FOUND)
+    target_link_libraries(treeland-shortcut
+        PRIVATE
+            Qt6::WaylandClientPrivate
+    )
+endif()
 
 install(TARGETS treeland-shortcut RUNTIME DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}")
 install(DIRECTORY "shortcuts" DESTINATION "${TREELAND_DATA_DIR}")

--- a/tests/test_window_picker/CMakeLists.txt
+++ b/tests/test_window_picker/CMakeLists.txt
@@ -28,7 +28,13 @@ target_link_libraries(${BIN_NAME}
     PRIVATE
         Qt6::Quick
         Qt6::WaylandClient
-        Qt6::WaylandClientPrivate
 )
+
+if(QT6_WAYLANDCLIENTPRIVATE_FOUND)
+    target_link_libraries(${BIN_NAME}
+        PRIVATE
+            Qt6::WaylandClientPrivate
+    )
+endif()
 
 install(TARGETS ${BIN_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/waylib/CMakeLists.txt
+++ b/waylib/CMakeLists.txt
@@ -17,12 +17,21 @@ option(INSTALL_TINYWL "A minimum viable product Wayland compositor based on wayl
 option(ADDRESS_SANITIZER "Enable address sanitize" OFF)
 option(WAYLIB_USE_PERCOMPILE_HEADERS "Use precompile headers to build waylib" OFF)
 
-if(QT_VERSION VERSION_GREATER "6.8.0")
-    set(QT_COMPONENTS Core Gui Quick GuiPrivate QuickPrivate)
-else()
-    set(QT_COMPONENTS Core Gui Quick)
-endif()
+set(QT_COMPONENTS Core Gui Quick)
+
+# Find required Qt components first
 find_package(Qt6 COMPONENTS ${QT_COMPONENTS} REQUIRED)
+
+# Try to find optional Private modules
+find_package(Qt6 CONFIG QUIET COMPONENTS GuiPrivate)
+if(TARGET Qt6::GuiPrivate)
+    list(APPEND QT_COMPONENTS GuiPrivate)
+endif()
+
+find_package(Qt6 CONFIG QUIET COMPONENTS QuickPrivate)
+if(TARGET Qt6::QuickPrivate)
+    list(APPEND QT_COMPONENTS QuickPrivate)
+endif()
 if(WITH_SUBMODULE_QWLROOTS)
     # Use qwlroots from project root directory
     include(${CMAKE_SOURCE_DIR}/qwlroots/cmake/WaylandScannerHelpers.cmake)

--- a/waylib/examples/tinywl/CMakeLists.txt
+++ b/waylib/examples/tinywl/CMakeLists.txt
@@ -1,4 +1,8 @@
 find_package(Qt6 COMPONENTS Quick QuickControls2 REQUIRED)
+
+# Try to find optional QuickPrivate module
+find_package(Qt6 CONFIG QUIET COMPONENTS QuickPrivate)
+
 qt_standard_project_setup(REQUIRES 6.4)
 
 if(QT_KNOWN_POLICY_QTP0001) # this policy was introduced in Qt 6.5
@@ -70,11 +74,16 @@ target_link_libraries(${TARGET}
     PRIVATE
     Qt6::Quick
     Qt6::QuickControls2
-    Qt6::QuickPrivate
     Waylib::WaylibServer
     PkgConfig::PIXMAN
     PkgConfig::WAYLAND
 )
+
+# Add QuickPrivate include directories and link library if available
+if(TARGET Qt6::QuickPrivate)
+    target_link_libraries(${TARGET} PRIVATE Qt6::QuickPrivate)
+    target_include_directories(${TARGET} PRIVATE ${Qt6Quick_PRIVATE_INCLUDE_DIRS})
+endif()
 
 if (INSTALL_TINYWL)
     install(TARGETS ${TARGET} DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/waylib/src/server/CMakeLists.txt
+++ b/waylib/src/server/CMakeLists.txt
@@ -9,12 +9,21 @@ set(WAYLIB_INCLUDE_INSTALL_DIR
     CACHE STRING "Install directory for waylib headers"
 )
 
-if(QT_VERSION VERSION_GREATER "6.8.0")
-    set(QT_COMPONENTS Core Gui Quick GuiPrivate QuickPrivate)
-else()
-    set(QT_COMPONENTS Core Gui Quick)
-endif()
+set(QT_COMPONENTS Core Gui Quick)
+
+# Find required Qt components first
 find_package(Qt6 COMPONENTS ${QT_COMPONENTS} REQUIRED)
+
+# Try to find optional Private modules
+find_package(Qt6 CONFIG QUIET COMPONENTS GuiPrivate)
+if(TARGET Qt6::GuiPrivate)
+    list(APPEND QT_COMPONENTS GuiPrivate)
+endif()
+
+find_package(Qt6 CONFIG QUIET COMPONENTS QuickPrivate)
+if(TARGET Qt6::QuickPrivate)
+    list(APPEND QT_COMPONENTS QuickPrivate)
+endif()
 
 qt_standard_project_setup(REQUIRES 6.6)
 


### PR DESCRIPTION
Recently Arch linux has upgraded their Qt to 6.10, which breaks private module linking. This commit should make it work as intended again.

## Summary by Sourcery

Adapt CMake scripts to only include Qt6::QuickPrivate when available, restoring build compatibility with Qt 6.10

Bug Fixes:
- Guard linking of Qt6::QuickPrivate behind availability to fix CI builds on newer Qt versions

Enhancements:
- Refactor private dependency lists by introducing PRIVATE_LIBS variables for targets
- Unify conditional appending of Qt6::QuickPrivate across project modules

Build:
- Add find_package(Qt6 CONFIG QUIET COMPONENTS QuickPrivate) and set QT6_QUICKPRIVATE_FOUND flag in root CMakeLists