### PR TITLE
fix: fix build when treeland examples are enabled

### DIFF
--- a/examples/test_multitaskview/CMakeLists.txt
+++ b/examples/test_multitaskview/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(Qt6 REQUIRED COMPONENTS WaylandClient Quick)
+find_package(Qt6 COMPONENTS WaylandClientPrivate QUIET)
 find_package(TreelandProtocols REQUIRED)
 
 set(BIN_NAME test-multitaskview)


### PR DESCRIPTION
Fixes a build failure that occurs when Treeland examples are enabled, specifically in higher versions of Qt6. The issue arises because certain private Qt modules (like `WaylandClientPrivate`) are not automatically included and need to be explicitly specified using `find_package`. Failing to do so results in linker errors during the build process. This change ensures that the necessary private modules are found, allowing the examples to compile successfully.

Influence:
1. Build the `test_multitaskview` example with Treeland examples enabled.
2. Verify that the build completes without any errors related to missing Qt private modules.
3. Confirm that the compiled example runs correctly.

fix: 修复开启 treeland 示例时构建失败的问题

修复了在 Qt6 的较高版本中，启用 Treeland 示例时发生的构建失败。 出现此问
题的原因是某些私有 Qt 模块（如 `WaylandClientPrivate`）不会自动包含，需
要使用 `find_package` 显式指定。 否则，会导致构建过程中出现链接器错误。
此更改确保找到必要的私有模块，从而使示例能够成功编译。

Influence:
1. 在启用 Treeland 示例的情况下构建 `test_multitaskview` 示例。
2. 验证构建是否完成，并且没有与缺少的 Qt 私有模块相关的任何错误。
3. 确认编译后的示例可以正确运行。

## Summary by Sourcery

Bug Fixes:
- Add find_package for Qt6 WaylandClientPrivate module in test_multitaskview to resolve missing private module linker errors