### PR TITLE
refactor: remove branch filter for workflow triggers

### DIFF
--- a/.github/workflows/qwlroots-archlinux-build.yml
+++ b/.github/workflows/qwlroots-archlinux-build.yml
@@ -5,15 +5,11 @@ on:
     paths:
       - 'qwlroots/**'
       - '.github/workflows/qwlroots-archlinux-build.yml'
-    branches:
-      - master
 
   pull_request:
     paths:
       - 'qwlroots/**'
       - '.github/workflows/qwlroots-archlinux-build.yml'
-    branches:
-      - master
 
 jobs:
   container:

--- a/.github/workflows/qwlroots-debian-build.yml
+++ b/.github/workflows/qwlroots-debian-build.yml
@@ -5,15 +5,11 @@ on:
     paths:
       - 'qwlroots/**'
       - '.github/workflows/qwlroots-debian-build.yml'
-    branches:
-      - master
 
   pull_request:
     paths:
       - 'qwlroots/**'
       - '.github/workflows/qwlroots-debian-build.yml'
-    branches:
-      - master
 
 jobs:
   container:

--- a/.github/workflows/treeland-archlinux-build.yml
+++ b/.github/workflows/treeland-archlinux-build.yml
@@ -7,12 +7,8 @@ name: Build treeland on Arch Linux
 
 on:
   push:
-    branches:
-      - master
 
   pull_request:
-    branches:
-      - master
 
 jobs:
   container:

--- a/.github/workflows/waylib-archlinux-build.yml
+++ b/.github/workflows/waylib-archlinux-build.yml
@@ -6,16 +6,12 @@ on:
       - 'waylib/**'
       - 'qwlroots/**'
       - '.github/workflows/waylib-archlinux-build.yml'
-    branches:
-      - master
 
   pull_request:
     paths:
       - 'waylib/**'
       - 'qwlroots/**'
       - '.github/workflows/waylib-archlinux-build.yml'
-    branches:
-      - master
 
 jobs:
   container:

--- a/.github/workflows/waylib-debian-build.yml
+++ b/.github/workflows/waylib-debian-build.yml
@@ -6,16 +6,12 @@ on:
       - 'waylib/**'
       - 'qwlroots/**'
       - '.github/workflows/waylib-debian-build.yml'
-    branches:
-      - master
 
   pull_request:
     paths:
       - 'waylib/**'
       - 'qwlroots/**'
       - '.github/workflows/waylib-debian-build.yml'
-    branches:
-      - master
 
 jobs:
   container:


### PR DESCRIPTION
This commit removes the branch filters from the `on` triggers in several GitHub workflow files. Specifically, the `branches: - master` filter has been removed from the `push` and `pull_request` triggers in `.github/ workflows/qwlroots-archlinux-build.yml`, `.github/workflows/qwlroots- debian-build.yml`, `.github/workflows/treeland-archlinux-build.yml`, `.github/workflows/waylib-archlinux-build.yml`, and `.github/workflows/ waylib-debian-build.yml`.

This change ensures that the workflows are triggered for all branches, including feature branches and release branches, rather than being limited to the `master` branch. This provides better coverage for automated builds and tests whenever changes are pushed or a pull request is created against *any* branch.  This is important as the project evolves beyond relying solely on master and introduces feature branches, ensuring consistent CI across development.

Influence:
1. Verify that all workflows trigger correctly on pushes and pull requests for all branches, not just master.
2. Create a pull request to a new branch and ensure that all relevant workflows are triggered.
3. Push a commit to a new branch and verify that all relevant workflows are triggered.

重构: 移除工作流程触发器的分支筛选器

此提交从多个 GitHub 工作流程文件的 `on` 触发器中删除了分支筛选器。
具体来说，已从 `.github/workflows/qwlroots-archlinux-build.yml`、 `.github/workflows/qwlroots-debian-build.yml`、`.github/workflows/ treeland-archlinux-build.yml`、`.github/workflows/waylib-archlinux- build.yml` 和 `.github/workflows/waylib-debian-build.yml` 中的 `push` 和 `pull_request` 触发器中删除 `branches: - master` 筛选器。

此更改确保工作流程在所有分支（包括功能分支和发布分支）上触发，而不是仅限
于 `master` 分支。 无论何时推送更改或针对*任何*分支创建拉取请求，这都为
自动构建和测试提供了更好的覆盖范围。 这一点很重要，因为项目的发展不仅仅
依赖于 master，还引入了功能分支，确保了整个开发过程中的持续集成。

Influence:
1. 验证所有工作流程是否在所有分支（不仅仅是 master）的推送和拉取请求上正 确触发。
2. 创建一个到新分支的拉取请求，并确保所有相关的工作流程都被触发。
3. 将提交推送到一个新分支，并验证所有相关的工作流程是否被触发。