### PR TITLE
feat: Expose XWayland surface process ID

### DIFF
--- a/waylib/src/server/kernel/wglobal.cpp
+++ b/waylib/src/server/kernel/wglobal.cpp
@@ -23,6 +23,25 @@ WClient *WObject::waylandClient() const
     return wclient;
 }
 
+pid_t WObject::pid() const
+{
+    auto client = waylandClient();
+    if (!client)
+        return 0;
+    auto credentials = client->credentials();
+    if (!credentials)
+        return 0;
+    return credentials->pid;
+}
+
+int WObject::pidFD() const
+{
+    auto client = waylandClient();
+    if (!client)
+        return -1;
+    return client->pidFD();
+}
+
 WObject::WObject(WObjectPrivate &dd, WObject *)
     : w_d_ptr(&dd)
 {

--- a/waylib/src/server/kernel/wglobal.h
+++ b/waylib/src/server/kernel/wglobal.h
@@ -99,7 +99,9 @@ public:
         removeAttachedData<T>(owner);
     }
 
-    WClient *waylandClient() const;
+    [[nodiscard]] WClient *waylandClient() const;
+    [[nodiscard]] virtual pid_t pid() const;
+    [[nodiscard]] virtual int pidFD() const;
 
 protected:
     WObject(WObjectPrivate &dd, WObject *parent = nullptr);

--- a/waylib/src/server/protocols/wxwaylandsurface.cpp
+++ b/waylib/src/server/protocols/wxwaylandsurface.cpp
@@ -29,6 +29,11 @@ public:
         initHandle(handle);
     }
 
+    ~WXWaylandSurfacePrivate() {
+        if (pidFD >= 0)
+            close(pidFD);
+    }
+
     WWRAP_HANDLE_FUNCTIONS(qw_xwayland_surface, wlr_xwayland_surface)
 
     inline bool isMaximized() const {
@@ -50,6 +55,8 @@ public:
 
     WSurface *surface = nullptr;
     WXWayland *xwayland = nullptr;
+    mutable int pidFD = -1;
+
     QList<WXWaylandSurface*> children;
     WXWaylandSurface *parent = nullptr;
     QRect lastRequestConfigureGeometry;
@@ -425,6 +432,17 @@ pid_t WXWaylandSurface::pid() const
     W_DC(WXWaylandSurface);
 
     return d->nativeHandle()->pid;
+}
+
+int WXWaylandSurface::pidFD() const
+{
+    W_DC(WXWaylandSurface);
+
+    if (d->pidFD == -1) {
+        d->pidFD = syscall(SYS_pidfd_open, pid(), 0);
+    }
+
+    return d->pidFD;
 }
 
 QRect WXWaylandSurface::requestConfigureGeometry() const

--- a/waylib/src/server/protocols/wxwaylandsurface.h
+++ b/waylib/src/server/protocols/wxwaylandsurface.h
@@ -105,7 +105,8 @@ public:
 
     QString title() const override;
     QString appId() const override;
-    pid_t pid() const;
+    [[nodiscard]] pid_t pid() const override;
+    [[nodiscard]] int pidFD() const override;
 
     QRect requestConfigureGeometry() const;
     ConfigureFlags requestConfigureFlags() const;


### PR DESCRIPTION
This change addresses the issue where the client process ID associated with an XWayland surface could not be directly obtained through `WClient`. Previously, accessing the `WClient` of an XWayland surface always returned the XWayland process itself. To resolve this, two virtual functions, `pid()` and `pidFD()`, have been added to the `WObject` class and overridden in `WXWaylandSurface`. These functions allow retrieving the actual PID and PID file descriptor of the XWayland window's client. The `pidFD` is obtained by using `syscall(SYS_pidfd_open, pid(), 0)`. This approach enables correct identification of the client process owning the XWayland surface.

Influence:
1. Verify that the `pid()` function on a `WXWaylandSurface` object returns the correct process ID of the client application, not the XWayland process.
2. Confirm that `pidFD()` returns a valid file descriptor for the client application's PID. Check the returned file descriptor is valid.
3. Ensure that these new functions do not negatively impact other parts of the Waylib codebase.
4. Test multiple XWayland applications to ensure consistent and accurate PID retrieval.
5. Test on different platforms to ensure `syscall(SYS_pidfd_open, pid(), 0)` is working correctly, and fallback gracefully if not.

feat: 暴露 XWayland surface 进程 ID

此更改解决了无法通过 `WClient` 直接获取与 XWayland surface 关联的客户
端进程 ID 的问题。 以前，访问 XWayland surface 的 `WClient` 始终返回 XWayland 进程本身。 为了解决这个问题，我们在 `WObject` 类中添加了两个虚
函数 `pid()` 和 `pidFD()`，并在 `WXWaylandSurface` 中重写了它们。 这些函 数允许检索 XWayland 窗口客户端的实际 PID 和 PID 文件描述符。 `pidFD` 通 过使用 `syscall(SYS_pidfd_open, pid(), 0)` 获得。 这种方法可以正确识别拥 有 XWayland surface 的客户端进程。

Influence:
1. 验证 `WXWaylandSurface` 对象上的 `pid()` 函数返回客户端应用程序的正确 进程 ID，而不是 XWayland 进程。
2. 确认 `pidFD()` 为客户端应用程序的 PID 返回有效的文件描述符。 检查返回 的文件描述符是否有效。
3. 确保这些新函数不会对 Waylib 代码库的其他部分产生负面影响。
4. 测试多个 XWayland 应用程序，以确保一致且准确的 PID 检索。
5. 在不同平台上进行测试，以确保 `syscall(SYS_pidfd_open, pid(), 0)` 正常 工作，如果不能正常工作，则优雅地回退。