### PR TITLE
chore: change Debian build environment to unstable

### DIFF
--- a/.github/workflows/qwlroots-debian-build.yml
+++ b/.github/workflows/qwlroots-debian-build.yml
@@ -1,4 +1,4 @@
-name: Build qwlroots on Debian experimental (independent)
+name: Build qwlroots on Debian unstable (independent)
 
 on:
   push:
@@ -14,15 +14,15 @@ on:
 jobs:
   container:
     runs-on: ubuntu-latest
-    container: debian:experimental
+    container: debian:unstable
     steps:
       - uses: actions/checkout@v4
 
       - name: Install build dependencies
         working-directory: qwlroots
         run: |
-          # Configure apt sources for experimental
-          echo "deb http://deb.debian.org/debian experimental main" > /etc/apt/sources.list
+          # Configure apt sources for unstable
+          echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.list
           echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list
 
           apt-get update

--- a/.github/workflows/waylib-debian-build.yml
+++ b/.github/workflows/waylib-debian-build.yml
@@ -1,4 +1,4 @@
-name: Build waylib on Debian experimental (independent)
+name: Build waylib on Debian unstable (independent)
 
 on:
   push:
@@ -16,15 +16,15 @@ on:
 jobs:
   container:
     runs-on: ubuntu-latest
-    container: debian:experimental
+    container: debian:unstable
     steps:
       - uses: actions/checkout@v4
 
       - name: Build qwlroots first
         working-directory: qwlroots
         run: |
-          # Configure apt sources for experimental
-          echo "deb http://deb.debian.org/debian experimental main" > /etc/apt/sources.list
+          # Configure apt sources for unstable
+          echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.list
           echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list
 
           apt-get update


### PR DESCRIPTION
The Debian build environment in the CI workflows for both qwlroots and waylib has been changed from `experimental` to `unstable`. This change was necessary because the `experimental` environment was proving to be unstable, frequently causing CI failures. Debian `unstable` is more reliable and now provides wlroots 0.19 which meets the required version. The apt sources in the build workflows have been updated to reflect this change.

Influence:
1. Monitor CI build stability for both qwlroots and waylib on the Debian unstable environment.
2. Verify that the builds are successful and that the required dependencies, including wlroots 0.19, are correctly installed.
3. Check for any compatibility issues introduced by the change in the build environment.

chore: 更改 Debian 构建环境为 unstable

qwlroots 和 waylib 的 CI 工作流程中的 Debian 构建环境已从 `experimental` 更改为 `unstable`。 这一更改是必要的，因为 `experimental` 环境被证明不
稳定，经常导致 CI 失败。 Debian `unstable` 更加可靠，现在提供 wlroots 0.19，满足了所需的版本。 构建工作流程中的 apt 源已更新以反映此更改。

Influence:
1. 监控 Debian unstable 环境上 qwlroots 和 waylib 的 CI 构建稳定性。
2. 验证构建是否成功，以及是否正确安装了所需的依赖项，包括 wlroots 0.19。
3. 检查构建环境更改引入的任何兼容性问题。

## Summary by Sourcery

Switch Debian CI environment from experimental to unstable for qwlroots and waylib to improve build stability and obtain the required wlroots version.

CI:
- Update Debian container image from experimental to unstable in qwlroots and waylib workflows
- Adjust apt sources to use Debian unstable in build steps for both projects