### PR TITLE
fix: prevent crash when surface destroyed before async AppId resolve

### DIFF
--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -196,16 +196,24 @@ void ShellHandler::onXdgToplevelSurfaceAdded(WXdgToplevelSurface *surface)
     if (!m_prelaunchWrappers.isEmpty() && m_appIdResolverManager) {
         int pidfd = surface->pidFD();
         if (pidfd >= 0) {
-            if (m_appIdResolverManager->resolvePidfd(
-                    pidfd,
-                    [this, surface](const QString &appId) {
-                        SurfaceWrapper *w = matchOrCreateXdgWrapper(surface, appId);
-                        initXdgWrapperCommon(surface, w);
-                    })) {
-                qCDebug(treelandShell)
-                    << "AppIdResolver request sent (callback) pidfd=" << pidfd;
-                return;
+            // Register pending before starting async resolve (unified list)
+            m_pendingAppIdResolveToplevels.append(surface);
+
+            bool started = m_appIdResolverManager->resolvePidfd(
+                pidfd,
+                [this, surface](const QString &appId) {
+                    int idx = m_pendingAppIdResolveToplevels.indexOf(surface);
+                    if (idx < 0)
+                        return; // removed before callback
+                    SurfaceWrapper *w = matchOrCreateXdgWrapper(surface, appId);
+                    initXdgWrapperCommon(surface, w);
+                    m_pendingAppIdResolveToplevels.removeAt(idx);
+                });
+            if (started) {
+                qCDebug(treelandShell) << "AppIdResolver request sent (callback) pidfd=" << pidfd;
+                return; // async path handles creation
             } else {
+                m_pendingAppIdResolveToplevels.removeOne(surface);
                 qCDebug(treelandShell)
                     << "AppIdResolverManager present but requestResolve failed pidfd=" << pidfd;
             }
@@ -288,6 +296,14 @@ void ShellHandler::initXdgWrapperCommon(WXdgToplevelSurface *surface, SurfaceWra
 void ShellHandler::onXdgToplevelSurfaceRemoved(WXdgToplevelSurface *surface)
 {
     auto wrapper = m_rootSurfaceContainer->getSurface(surface);
+    // If async resolve still pending, cancel it. If wrapper never created, just return: compositor
+    // never exposed this surface (from treeland's perspective).
+    if (m_pendingAppIdResolveToplevels.removeOne(surface)) {
+        qCInfo(treelandShell) << "Cancelled pending AppId resolve for surface:" << surface;
+        if (!wrapper) {
+            return; // wrapper was never created; nothing to persist or destroy
+        }
+    }
     auto interface = DDEShellSurfaceInterface::get(surface->surface());
     if (interface) {
         delete interface;
@@ -357,16 +373,23 @@ void ShellHandler::onXWaylandSurfaceAdded(WXWaylandSurface *surface)
         if (!m_prelaunchWrappers.isEmpty() && m_appIdResolverManager) {
             int pidfd = surface->pidFD();
             if (pidfd >= 0) {
-                if (m_appIdResolverManager->resolvePidfd(
-                        pidfd,
-                        [this, surface](const QString &appId) {
-                            SurfaceWrapper *w = matchOrCreateXwaylandWrapper(surface, appId);
-                            initXwaylandWrapperCommon(surface, w);
-                        })) {
+                m_pendingAppIdResolveToplevels.append(surface);
+                bool started = m_appIdResolverManager->resolvePidfd(
+                    pidfd,
+                    [this, surface](const QString &appId) {
+                        int idx = m_pendingAppIdResolveToplevels.indexOf(surface);
+                        if (idx < 0)
+                            return; // removed before callback
+                        SurfaceWrapper *w = matchOrCreateXwaylandWrapper(surface, appId);
+                        initXwaylandWrapperCommon(surface, w);
+                        m_pendingAppIdResolveToplevels.removeAt(idx);
+                    });
+                if (started) {
                     qCDebug(treelandShell)
                         << "(XWayland) AppIdResolver request sent (callback)";
-                    return; // Waiting for async callback
+                    return; // async path
                 } else {
+                    m_pendingAppIdResolveToplevels.removeOne(surface);
                     qCDebug(treelandShell)
                         << "(XWayland) requestResolve failed pidfd=" << pidfd;
                 }
@@ -379,8 +402,14 @@ void ShellHandler::onXWaylandSurfaceAdded(WXWaylandSurface *surface)
     surface->safeConnect(&qw_xwayland_surface::notify_dissociate, this, [this, surface] {
         auto wrapper = m_rootSurfaceContainer->getSurface(surface->surface());
         qCDebug(treelandShell) << "WXWayland::notify_dissociate" << surface << wrapper;
-
-        // Persist XWayland window size
+        // Cancel pending async resolve if still present. If wrapper never created, return.
+        if (m_pendingAppIdResolveToplevels.removeOne(surface)) {
+            qCInfo(treelandShell) << "Cancelled pending AppId resolve (XWayland) for surface:" << surface;
+            if (!wrapper) {
+                return; // never created
+            }
+        }
+        // Persist XWayland window size (only if wrapper exists)
         if (m_windowSizeStore && wrapper
             && !wrapper->property("prelaunchAppId").toString().isEmpty()) {
             QSizeF sz = wrapper->normalGeometry().size();
@@ -392,7 +421,6 @@ void ShellHandler::onXWaylandSurfaceAdded(WXWaylandSurface *surface)
                 m_windowSizeStore->saveSize(wrapper->property("prelaunchAppId").toString(), s);
             }
         }
-
         Q_EMIT surfaceWrapperAboutToRemove(wrapper);
         m_rootSurfaceContainer->destroyForSurface(wrapper);
     });

--- a/src/core/shellhandler.h
+++ b/src/core/shellhandler.h
@@ -128,6 +128,9 @@ private:
     QObject *m_windowMenu = nullptr;
     // 保存预启动(尚未绑定真实 shellSurface) 的 wrapper 列表
     QVector<SurfaceWrapper *> m_prelaunchWrappers;
+    // Pending toplevel surfaces (XDG or XWayland) awaiting asynchronous AppId resolve.
+    // A callback only proceeds if the surface pointer is still present in this list.
+    QVector<WAYLIB_SERVER_NAMESPACE::WToplevelSurface *> m_pendingAppIdResolveToplevels;
     // New protocol based app id resolver (optional, may be null if module not loaded)
     AppIdResolverManager *m_appIdResolverManager = nullptr;
     WindowSizeStore *m_windowSizeStore = nullptr; // 持久化窗口尺寸


### PR DESCRIPTION
The crash occurred when a surface was destroyed before the async AppId
resolution callback could complete. The callback would attempt to create
a SurfaceWrapper for a surface that no longer existed, leading to null
pointer access in subsequent operations.

Changes:
1. Added m_pendingAppIdResolveToplevels list to track surfaces
undergoing async AppId resolution
2. Check if surface is still valid before creating wrapper in callback
3. Remove surface from pending list when destroyed or when resolution
completes
4. Handle surface removal properly by checking pending list and avoiding
wrapper operations if never created

Log: Fixed crash when closing window before AppId resolution completes

Influence:
1. Test opening and quickly closing applications to trigger async
resolution scenarios
2. Verify no crashes occur when windows are destroyed during AppId
resolution
3. Check that window management functions correctly for both XDG and
XWayland surfaces
4. Test prelaunch wrapper functionality with quick window operations
5. Verify window size persistence still works correctly for valid cases

fix: 修复在异步AppId解析完成前销毁表面导致的崩溃问题

当表面在异步AppId解析回调完成前被销毁时会发生崩溃。回调会尝试为已不存在
的表面创建SurfaceWrapper，导致后续操作中出现空指针访问。

变更内容：
1. 添加m_pendingAppIdResolveToplevels列表来跟踪正在进行异步AppId解析的
表面
2. 在回调中创建包装器前检查表面是否仍然有效
3. 当表面被销毁或解析完成时从待处理列表中移除
4. 正确处理表面移除，检查待处理列表，如果包装器从未创建则避免相关操作

Log: 修复在AppId解析完成前关闭窗口导致的崩溃问题

Influence:
1. 测试打开并快速关闭应用程序以触发异步解析场景
2. 验证在AppId解析期间销毁窗口不会发生崩溃
3. 检查窗口管理功能对XDG和XWayland表面是否正常工作
4. 测试快速窗口操作下的预启动包装器功能
5. 验证窗口大小持久化在有效情况下仍正常工作

## Summary by Sourcery

Manage asynchronous AppId resolution for toplevel surfaces by tracking pending requests, handling success and failure paths, and cancelling stale callbacks to ensure proper surface wrapper initialization

Enhancements:
- Maintain a pending list for XDG and XWayland surfaces awaiting asynchronous AppId resolution
- Cancel pending AppId resolution callbacks when surfaces are removed or dissociated
- Clean up pending entries on resolution failures to prevent stale requests
- Unify the async resolve handling for XDG and XWayland surface initialization