### PR TITLE
refactor: extract common surface container update logic

### DIFF
--- a/src/core/shellhandler.h
+++ b/src/core/shellhandler.h
@@ -112,6 +112,9 @@ private:
                                                  const QString &appId);
     void initXwaylandWrapperCommon(WAYLIB_SERVER_NAMESPACE::WXWaylandSurface *surface,
                                    SurfaceWrapper *wrapper);
+    // Unified parent/container update for Xdg & XWayland toplevel wrappers.
+    void updateWrapperContainer(SurfaceWrapper *wrapper,
+                                WAYLIB_SERVER_NAMESPACE::WSurface *parentSurface);
 
     WAYLIB_SERVER_NAMESPACE::WXdgShell *m_xdgShell = nullptr;
     WAYLIB_SERVER_NAMESPACE::WLayerShell *m_layerShell = nullptr;


### PR DESCRIPTION
Extracted duplicate parent surface and container update logic
from Xdg and XWayland wrapper initialization into a unified
updateWrapperContainer method. This eliminates code duplication and
improves maintainability. The method handles proper surface hierarchy
management including parent surface relationships and container
assignments.

Influence:
1. Test Xdg toplevel surfaces with and without parent surfaces
2. Test XWayland surfaces with parent surface relationships
3. Verify surface container assignments work correctly
4. Test surface hierarchy changes and parent updates
5. Verify workspace assignments for orphaned surfaces

refactor: 提取公共表面容器更新逻辑

将 Xdg 和 XWayland 包装器初始化中的重复父表面和容器更新逻辑提取到统一的
updateWrapperContainer 方法中。这消除了代码重复并提高了可维护性。该方法
处理正确的表面层次结构管理，包括父表面关系和容器分配。

Influence:
1. 测试带和不带父表面的 Xdg 顶层表面
2. 测试具有父表面关系的 XWayland 表面
3. 验证表面容器分配是否正确工作
4. 测试表面层次结构更改和父表面更新
5. 验证孤立表面的工作区分配