### PR TITLE
chore: add ASAN environment variables

### DIFF
--- a/misc/systemd/treeland.service.in
+++ b/misc/systemd/treeland.service.in
@@ -11,6 +11,9 @@ After=seatd.service
 User=dde
 Environment=LIBSEAT_BACKEND=seatd
 Environment=DSG_APP_ID=org.deepin.dde.treeland
+Environment=ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
+# For Debug: if enable asan, you can't get it's log from journalctl, so ensure the log to a file
+Environment=ASAN_OPTIONS=log_path=/tmp/treeland-asan:detect_leaks=0:abort_on_error=1:symbolize=1
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/treeland.sh --lockscreen
 Restart=on-failure
 RestartSec=1s


### PR DESCRIPTION
Add AddressSanitizer (ASAN) environment variables to the treeland systemd service file. This aids in debugging memory-related issues within treeland, particularly when running with ASAN enabled. The `ASAN_SYMBOLIZER_PATH` variable points to the llvm-symbolizer, enabling symbolization of ASAN reports. The `ASAN_OPTIONS` variable configures ASAN to log its output to a specific file (`/tmp/treeland-asan`), disables leak detection (due to false positives in some environments), enables immediate abortion on error, and enables symbolization within the log file. This change facilitates easier debugging of memory corruption and other ASAN-detectable errors.

Influence:
1. Verify that ASAN logs are generated in the specified log file when ASAN is enabled.
2. Ensure that the ASAN logs contain symbolized stack traces.
3. Confirm that treeland aborts when memory errors are detected with ASAN enabled.

chore: 添加 ASAN 环境变量

将 AddressSanitizer (ASAN) 环境变量添加到 treeland systemd 服务文件中。 这有助于调试 treeland 中与内存相关的问题，尤其是在启用 ASAN 的情况下。
`ASAN_SYMBOLIZER_PATH` 变量指向 llvm-symbolizer，从而可以对 ASAN 报告 进行符号化。`ASAN_OPTIONS` 变量配置 ASAN 将其输出记录到特定文件 (`/tmp/ treeland-asan`)，禁用泄漏检测（由于某些环境中的误报），在发生错误时立即
中止，并启用日志文件中的符号化。此更改有助于更轻松地调试内存损坏和其他
ASAN 可检测到的错误。

Influence:
1. 验证启用 ASAN 后，是否在指定的日志文件中生成 ASAN 日志。
2. 确保 ASAN 日志包含符号化的堆栈跟踪。
3. 确认在启用 ASAN 的情况下检测到内存错误时，treeland 会中止。

## Summary by Sourcery

Enhancements:
- Configure ASAN_SYMBOLIZER_PATH and ASAN_OPTIONS in the treeland systemd service file to enable symbolized logs, disable leak detection, and abort on memory errors