### PR TITLE
fix: occasional crash during recording toplevel

### DIFF
--- a/waylib/src/server/utils/wextimagecapturesourcev1impl.cpp
+++ b/waylib/src/server/utils/wextimagecapturesourcev1impl.cpp
@@ -309,9 +309,8 @@ void WExtImageCaptureSourceV1Impl::copy_frame(wlr_ext_image_copy_capture_frame_v
         qw_ext_image_copy_capture_frame_v1::from(dst_frame)->fail(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
         return;
     }
-    
-    // Get internal buffer
-    auto buffer = m_surfaceContent->surface()->buffer();
+
+    auto buffer = textureProvider->qwBuffer();
     if (!buffer) {
         qCWarning(qLcImageCapture) << "No internal buffer available";
         qw_ext_image_copy_capture_frame_v1::from(dst_frame)->fail(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);

--- a/waylib/src/server/utils/wextimagecapturesourcev1impl.h
+++ b/waylib/src/server/utils/wextimagecapturesourcev1impl.h
@@ -37,7 +37,7 @@ private Q_SLOTS:
     void handleRenderEnd();
 
 private:
-    WSurfaceItemContent *m_surfaceContent;
+    QPointer<WSurfaceItemContent> m_surfaceContent;
     WOutput *m_output;
     bool m_capturing;
     QMetaObject::Connection m_renderEndConnection;


### PR DESCRIPTION
determine whether WSurface is nullptr before getting qw_buffer.

Fixes: linuxdeepin/treeland#603

Log

## Summary by Sourcery

Prevent crashes during toplevel recording by validating the surface pointer before frame copying.

Bug Fixes:
- Add a guard to check if the WSurface pointer is null before accessing it.
- Log a warning and gracefully fail the capture request when no surface is available.