### PR TITLE
fix: use safeConnect for aboutToBeInvalidated

### DIFF
--- a/waylib/src/server/qtquick/wsurfaceitem.cpp
+++ b/waylib/src/server/qtquick/wsurfaceitem.cpp
@@ -1128,8 +1128,8 @@ void WSurfaceItemPrivate::initForSurface()
     if (!surfaceState)
         surfaceState.reset(new SurfaceState());
 
-    QObject::connect(surface, &WWrapObject::aboutToBeInvalidated, q,
-                     &WSurfaceItem::releaseResources, Qt::DirectConnection);
+    surface->safeConnect(&WSurface::aboutToBeInvalidated, q,
+                         &WSurfaceItem::releaseResources, Qt::DirectConnection);
     surface->safeConnect(&WSurface::hasSubsurfaceChanged, q, [this]{ onHasSubsurfaceChanged(); });
     surface->safeConnect(&qw_surface::notify_commit, q, &WSurfaceItem::onSurfaceCommit);
 


### PR DESCRIPTION
The WSurface's `aboutToBeInvalidated` signal connection was incorrectly using `QObject::connect` instead of `safeConnect`. This could lead to issues when the WSurface object is modified using `setSurface`, as the previous object's `aboutToBeInvalidated` signal would not be disconnected, potentially causing a crash or unexpected behavior. This change replaces the regular `QObject::connect` with `safeConnect` to ensure proper disconnection and avoid potential issues when the surface is replaced.

Influence:
1. Test replacing a WSurface multiple times with different WSurface objects using `setSurface`.
2. Verify that the `releaseResources` function is only called when the current WSurface is truly invalidated and not prematurely.
3. Observe application behavior under heavy WSurface replacement scenarios to ensure stability and prevent crashes.

fix: 使用 safeConnect 连接 aboutToBeInvalidated 信号

WSurface 的 `aboutToBeInvalidated` 信号连接错误地使用了
`QObject::connect` 而不是 `safeConnect`。当使用 `setSurface` 修改 WSurface 对象时，这可能导致问题，因为前一个对象的 `aboutToBeInvalidated` 信号不会断开，可能导致崩溃或意外行为。此更改将常规的 `QObject::connect`
替换为 `safeConnect`，以确保正确断开连接并避免在表面替换时出现潜在问题。

Influence:
1. 使用 `setSurface` 多次用不同的 WSurface 对象替换 WSurface。
2. 验证 `releaseResources` 函数仅在当前 WSurface 真正失效时才被调用，而 不是过早调用。
3. 观察在大量 WSurface 替换场景下的应用程序行为，以确保稳定并防止崩溃。

## Summary by Sourcery

Bug Fixes:
- Replace QObject::connect with safeConnect for the aboutToBeInvalidated signal in WSurfaceItem to avoid stale connections and unexpected behavior when setting a new surface.