### PR TITLE
fix: handle surface null case in setOutputs

### DIFF
--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -324,6 +324,13 @@ void SurfaceWrapper::convertToNormalSurface(WToplevelSurface *shellSurface, Type
 
     // Call setup() to initialize surfaceItem related features
     setup();
+
+    // If outputs were set during prelaunch, apply them now
+    if (m_prelaunchOutputs.size() > 0) {
+        setOutputs(m_prelaunchOutputs);
+        m_prelaunchOutputs.clear();
+    }
+
     // setNoDecoration not called updateTitleBar when type is Undetermined
     updateTitleBar();
 
@@ -610,10 +617,13 @@ void SurfaceWrapper::setOutputs(const QList<WOutput *> &outputs)
     if (m_wrapperAboutToRemove)
         return;
     if (m_type == Type::Undetermined) {
-        // TODO: set output when setup
+        m_prelaunchOutputs = outputs;
         return;
     }
-    Q_ASSERT(surface());
+    if (!surface()) {
+        qCDebug(treelandSurface) << "SurfaceWrapper::setOutputs called but surface() is null!";
+        return;
+    }
     auto oldOutputs = surface()->outputs();
     for (auto output : oldOutputs) {
         if (outputs.contains(output)) {

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -367,6 +367,7 @@ private:
     QPointer<QQuickItem> m_geometryAnimation;
     QPointer<QQuickItem> m_coverContent;
     QPointer<QQuickItem> m_prelaunchSplash; // Pre-launch splash item
+    QList<WOutput *> m_prelaunchOutputs; // Outputs for pre-launch splash
     QRectF m_boundedRect;
     QRectF m_normalGeometry;
     QRectF m_maximizedGeometry;


### PR DESCRIPTION
1. Added null check for surface() in setOutputs method to prevent
crashes when surface is null
2. Added prelaunch outputs storage to preserve output settings during
surface initialization phase
3. Applied prelaunch outputs when converting to normal surface to ensure
proper output assignment
4. This fixes a race condition where WSurface could be null while
WXWaylandSurface still exists

Influence:
1. Test surface creation and output assignment during prelaunch phase
2. Verify that surfaces properly inherit output settings when converted
to normal surfaces
3. Test edge cases where surfaces might be destroyed while operations
are pending
4. Validate that no crashes occur when setting outputs on null surfaces

fix: 修复 setOutputs 中 surface 为 null 的情况处理

1. 在 setOutputs 方法中添加了对 surface() 的空检查，防止 surface 为 null
时崩溃
2. 添加了预启动输出存储功能，在 surface 初始化阶段保留输出设置
3. 在转换为普通 surface 时应用预启动输出，确保正确的输出分配
4. 修复了 WSurface 可能为 null 而 WXWaylandSurface 仍存在的竞态条件

Influence:
1. 测试预启动阶段的 surface 创建和输出分配
2. 验证 surface 转换为普通 surface 时是否正确继承输出设置
3. 测试 surface 可能被销毁而操作仍在挂起的边缘情况
4. 确认在 null surface 上设置输出时不会发生崩溃

## Summary by Sourcery

Add null-safe handling and prelaunch output caching in SurfaceWrapper to prevent crashes and ensure correct output assignment when surfaces initialize.

Bug Fixes:
- Prevent crashes in setOutputs when surface() is null by adding a null check.
- Fix race condition where outputs could be applied before the surface was initialized.

Enhancements:
- Cache output settings during the prelaunch phase and apply them upon conversion to a normal surface.