### PR TITLE
refactor: replace dynamic property with member variable for appId

### DIFF
--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -103,7 +103,7 @@ void ShellHandler::handlePrelaunchSplashRequested(const QString &appId)
     // If a prelaunch wrapper with the same appId already exists, skip creating a duplicate
     for (int i = 0; i < m_prelaunchWrappers.size(); ++i) {
         auto *w = m_prelaunchWrappers.at(i);
-        if (w && w->property("prelaunchAppId").toString() == appId) {
+        if (w && w->appId() == appId) {
             return;
         }
     }
@@ -114,8 +114,7 @@ void ShellHandler::handlePrelaunchSplashRequested(const QString &appId)
             initialSize = last;
         }
     }
-    auto *wrapper = new SurfaceWrapper(Helper::instance()->qmlEngine(), nullptr, initialSize);
-    wrapper->setProperty("prelaunchAppId", appId);
+    auto *wrapper = new SurfaceWrapper(Helper::instance()->qmlEngine(), nullptr, initialSize, appId);
     m_workspace->addSurface(wrapper);
     m_prelaunchWrappers.append(wrapper);
 
@@ -126,7 +125,7 @@ void ShellHandler::handlePrelaunchSplashRequested(const QString &appId)
             return; // Already matched or removed earlier
         }
         qCDebug(treelandShell) << "Prelaunch splash timeout, destroy wrapper appId="
-                               << wrapper->property("prelaunchAppId").toString();
+                               << wrapper->appId();
         m_prelaunchWrappers.removeAt(idx);
         m_rootSurfaceContainer->destroyForSurface(wrapper);
     });
@@ -264,7 +263,7 @@ SurfaceWrapper *ShellHandler::matchOrCreateXdgWrapper(WXdgToplevelSurface *surfa
     if (!targetAppId.isEmpty()) {
         for (int i = 0; i < m_prelaunchWrappers.size(); ++i) {
             auto *candidate = m_prelaunchWrappers[i];
-            if (candidate->property("prelaunchAppId").toString() == targetAppId) {
+            if (candidate->appId() == targetAppId) {
                 qCDebug(treelandShell) << "match prelaunch xdg" << targetAppId;
                 m_prelaunchWrappers.remove(i);
                 wrapper = candidate;
@@ -317,14 +316,14 @@ void ShellHandler::onXdgToplevelSurfaceRemoved(WXdgToplevelSurface *surface)
         delete interface;
     }
     // Persist the last size of a normal window (prefer normalGeometry) when an appId is present
-    if (m_windowSizeStore && wrapper && !wrapper->property("prelaunchAppId").toString().isEmpty()) {
+    if (m_windowSizeStore && wrapper && !wrapper->appId().isEmpty()) {
         QSizeF sz = wrapper->normalGeometry().size();
         if (!sz.isValid() || sz.isEmpty()) {
             sz = wrapper->geometry().size();
         }
         const QSize s = sz.toSize();
         if (s.isValid() && s.width() > 0 && s.height() > 0) {
-            m_windowSizeStore->saveSize(wrapper->property("prelaunchAppId").toString(), s);
+            m_windowSizeStore->saveSize(wrapper->appId(), s);
         }
     }
     Q_EMIT surfaceWrapperAboutToRemove(wrapper);
@@ -419,14 +418,14 @@ void ShellHandler::onXWaylandSurfaceAdded(WXWaylandSurface *surface)
         }
         // Persist XWayland window size (only if wrapper exists)
         if (m_windowSizeStore && wrapper
-            && !wrapper->property("prelaunchAppId").toString().isEmpty()) {
+            && !wrapper->appId().isEmpty()) {
             QSizeF sz = wrapper->normalGeometry().size();
             if (!sz.isValid() || sz.isEmpty()) {
                 sz = wrapper->geometry().size();
             }
             const QSize s = sz.toSize();
             if (s.isValid() && s.width() > 0 && s.height() > 0) {
-                m_windowSizeStore->saveSize(wrapper->property("prelaunchAppId").toString(), s);
+                m_windowSizeStore->saveSize(wrapper->appId(), s);
             }
         }
         Q_EMIT surfaceWrapperAboutToRemove(wrapper);
@@ -441,7 +440,7 @@ SurfaceWrapper *ShellHandler::matchOrCreateXwaylandWrapper(WXWaylandSurface *sur
     if (!targetAppId.isEmpty()) {
         for (int i = 0; i < m_prelaunchWrappers.size(); ++i) {
             auto *candidate = m_prelaunchWrappers[i];
-            if (candidate->property("prelaunchAppId").toString() == targetAppId) {
+            if (candidate->appId() == targetAppId) {
                 qCDebug(treelandShell) << "match prelaunch xwayland" << targetAppId;
                 m_prelaunchWrappers.remove(i);
                 wrapper = candidate;

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -56,13 +56,14 @@ SurfaceWrapper::SurfaceWrapper(QmlEngine *qmlEngine,
     , m_hideByLockScreen(false)
     , m_confirmHideByLockScreen(false)
     , m_blur(false)
+    , m_appId(shellSurface->appId())
 {
     QQmlEngine::setContextForObject(this, qmlEngine->rootContext());
     setup();
 }
 
 // Constructor used for the prelaunch splash
-SurfaceWrapper::SurfaceWrapper(QmlEngine *qmlEngine, QQuickItem *parent, const QSize &initialSize)
+SurfaceWrapper::SurfaceWrapper(QmlEngine *qmlEngine, QQuickItem *parent, const QSize &initialSize, const QString &appId)
     : QQuickItem(parent)
     , m_engine(qmlEngine)
     , m_shellSurface(nullptr)
@@ -86,6 +87,7 @@ SurfaceWrapper::SurfaceWrapper(QmlEngine *qmlEngine, QQuickItem *parent, const Q
     , m_hideByLockScreen(false)
     , m_confirmHideByLockScreen(false)
     , m_blur(false)
+    , m_appId(appId)
 {
     QQmlEngine::setContextForObject(this, qmlEngine->rootContext());
     if (initialSize.isValid() && initialSize.width() > 0 && initialSize.height() > 0) {
@@ -112,6 +114,7 @@ SurfaceWrapper::~SurfaceWrapper()
     Q_ASSERT(!m_container);
     Q_ASSERT(!m_parentSurface);
     Q_ASSERT(m_subSurfaces.isEmpty());
+
     if (m_titleBar) {
         delete m_titleBar;
         m_titleBar = nullptr;
@@ -424,6 +427,11 @@ WSurfaceItem *SurfaceWrapper::surfaceItem() const
 QQuickItem *SurfaceWrapper::prelaunchSplash() const
 {
     return m_prelaunchSplash;
+}
+
+QString SurfaceWrapper::appId() const
+{
+    return m_appId;
 }
 
 bool SurfaceWrapper::resize(const QSizeF &size)

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -7,6 +7,7 @@
 
 #include <QQuickItem>
 #include <QPointer>
+#include <QString>
 
 Q_MOC_INCLUDE(<woutput.h>)
 Q_MOC_INCLUDE(<output / output.h>)
@@ -27,6 +28,7 @@ class SurfaceWrapper : public QQuickItem
     QML_ELEMENT
     QML_UNCREATABLE("SurfaceWrapper objects are created by c++")
     Q_PROPERTY(Type type READ type NOTIFY surfaceItemChanged)
+    Q_PROPERTY(QString appId READ appId CONSTANT)
     // make to read only
     Q_PROPERTY(qreal implicitWidth READ implicitWidth NOTIFY implicitWidthChanged FINAL)
     Q_PROPERTY(qreal implicitHeight READ implicitHeight NOTIFY implicitHeightChanged FINAL)
@@ -119,8 +121,9 @@ public:
     
     // Constructor for pre-launch splash; allows passing an initial window size to stabilize UI early
     explicit SurfaceWrapper(QmlEngine *qmlEngine,
-                            QQuickItem *parent = nullptr,
-                            const QSize &initialSize = QSize());
+                            QQuickItem *parent,
+                            const QSize &initialSize,
+                            const QString &appId);
 
     void setFocus(bool focus, Qt::FocusReason reason);
 
@@ -128,6 +131,7 @@ public:
     WToplevelSurface *shellSurface() const;
     WSurfaceItem *surfaceItem() const;
     QQuickItem *prelaunchSplash() const;
+    QString appId() const;
     bool resize(const QSizeF &size);
 
     QRectF titlebarGeometry() const;
@@ -430,6 +434,7 @@ private:
     bool m_socketEnabled{ false };
     bool m_windowAnimationEnabled{ true };
     bool m_acceptKeyboardFocus{ true };
+    const QString m_appId;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(SurfaceWrapper::ActiveControlStates)


### PR DESCRIPTION
Replace the use of QObject dynamic property "prelaunchAppId" with a dedicated member variable m_appId in SurfaceWrapper class. The appId is now passed through constructor for prelaunch wrappers and accessed via a new appId() getter method. This improves type safety and performance by avoiding string-based property lookups.

Log: Improved window management performance and reliability

Influence:
1. Test prelaunch splash functionality with various applications
2. Verify window matching between prelaunch and actual surfaces still works correctly
3. Check window size persistence for both XDG and XWayland surfaces
4. Test application launching and window creation workflows
5. Verify no regression in window management behavior

refactor: 使用成员变量替代动态属性存储应用ID

将 QObject 动态属性 "prelaunchAppId" 替换为 SurfaceWrapper 类中的专用 成员变量 m_appId。应用ID现在通过构造函数传递给预启动包装器，并通过新的
appId() 获取方法访问。这通过避免基于字符串的属性查找来提高类型安全性和
性能。

Log: 提升了窗口管理性能和可靠性

Influence:
1. 测试各种应用程序的预启动闪屏功能
2. 验证预启动和实际表面之间的窗口匹配仍然正常工作
3. 检查 XDG 和 XWayland 表面的窗口大小持久化
4. 测试应用程序启动和窗口创建工作流程
5. 验证窗口管理行为没有回归

## Summary by Sourcery

Replace the dynamic “prelaunchAppId” QObject property with a dedicated member variable and constructor argument in SurfaceWrapper, and update ShellHandler to use the new appId() getter for improved type safety and performance.

Enhancements:
- Store appId in a SurfaceWrapper member variable instead of a dynamic property
- Add appId constructor parameter and corresponding getter in SurfaceWrapper
- Update ShellHandler to pass and compare appId via the new getter instead of property lookups