### PR TITLE
fix: fix potential crash in moveResizeState surface handling

### DIFF
--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -198,7 +198,7 @@ void RootSurfaceContainer::endMoveResize()
         auto o = moveResizeState.surface->ownsOutput();
         moveResizeState.surface->shellSurface()->setResizeing(false);
 
-        if (!o || !moveResizeState.surface->surface()->outputs().contains(o->output())) {
+        if (!o || !moveResizeState.surface->outputs().contains(o->output())) {
             o = cursorOutput();
             Q_ASSERT(o);
             moveResizeState.surface->setOwnsOutput(o);

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -647,6 +647,18 @@ void SurfaceWrapper::setOutputs(const QList<WOutput *> &outputs)
     }
 }
 
+const QList<WOutput *> &SurfaceWrapper::outputs() const
+{
+    if (m_type == Type::Undetermined) {
+        return m_prelaunchOutputs;
+    }
+    if (!surface()) {
+        static const QList<WOutput *> empty;
+        return empty;
+    }
+    return surface()->outputs();
+}
+
 QRectF SurfaceWrapper::geometry() const
 {
     return QRectF(position(), size());

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -5,8 +5,9 @@
 #include <wsurfaceitem.h>
 #include <wtoplevelsurface.h>
 
-#include <QQuickItem>
+#include <QList>
 #include <QPointer>
+#include <QQuickItem>
 #include <QString>
 
 Q_MOC_INCLUDE(<woutput.h>)
@@ -82,7 +83,7 @@ public:
         XWayland,
         Layer,
         InputPopup,
-        Undetermined,  // Used for pre-launch splash screen
+        Undetermined, // Used for pre-launch splash screen
     };
     Q_ENUM(Type)
 
@@ -118,8 +119,9 @@ public:
                             Type type,
                             QQuickItem *parent = nullptr,
                             bool isProxy = false);
-    
-    // Constructor for pre-launch splash; allows passing an initial window size to stabilize UI early
+
+    // Constructor for pre-launch splash; allows passing an initial window size to stabilize UI
+    // early
     explicit SurfaceWrapper(QmlEngine *qmlEngine,
                             QQuickItem *parent,
                             const QSize &initialSize,
@@ -143,6 +145,7 @@ public:
     Output *ownsOutput() const;
     void setOwnsOutput(Output *newOwnsOutput);
     void setOutputs(const QList<WOutput *> &outputs);
+    const QList<WOutput *> &outputs() const;
 
     QRectF geometry() const;
     QRectF normalGeometry() const;
@@ -328,9 +331,10 @@ private:
     void setBoundedRect(const QRectF &newBoundedRect);
     void setContainer(SurfaceContainer *newContainer);
     void setVisibleDecoration(bool newVisibleDecoration);
-    
+
     void setup(); // Initialize m_surfaceItem related features
-    void convertToNormalSurface(WToplevelSurface *shellSurface, Type type); // Transition from pre-launch mode to normal mode
+    void convertToNormalSurface(WToplevelSurface *shellSurface,
+                                Type type); // Transition from pre-launch mode to normal mode
     void updateBoundingRect();
     void updateVisible();
     void updateSubSurfaceStacking();
@@ -371,7 +375,7 @@ private:
     QPointer<QQuickItem> m_geometryAnimation;
     QPointer<QQuickItem> m_coverContent;
     QPointer<QQuickItem> m_prelaunchSplash; // Pre-launch splash item
-    QList<WOutput *> m_prelaunchOutputs; // Outputs for pre-launch splash
+    QList<WOutput *> m_prelaunchOutputs;    // Outputs for pre-launch splash
     QRectF m_boundedRect;
     QRectF m_normalGeometry;
     QRectF m_maximizedGeometry;

--- a/waylib/src/server/kernel/private/wsurface_p.h
+++ b/waylib/src/server/kernel/private/wsurface_p.h
@@ -60,7 +60,7 @@ public:
 
     bool needsFrame = false;
     std::unique_ptr<QW_NAMESPACE::qw_buffer, QW_NAMESPACE::qw_buffer::unlocker> buffer;
-    QVector<WOutput*> outputs;
+    QList<WOutput*> outputs;
     WOutput *framePacingOutput = nullptr;
     QMetaObject::Connection frameDoneConnection;
     QPoint bufferOffset;

--- a/waylib/src/server/kernel/wbackend.cpp
+++ b/waylib/src/server/kernel/wbackend.cpp
@@ -49,8 +49,8 @@ public:
 
     W_DECLARE_PUBLIC(WBackend)
 
-    QVector<WOutput*> outputList;
-    QVector<WInputDevice*> inputList;
+    QList<WOutput*> outputList;
+    QList<WInputDevice*> inputList;
 
     struct Keyboard {
         Keyboard(WBackendPrivate *self, wlr_input_device *d)
@@ -152,13 +152,13 @@ qw_session *WBackend::session() const
     return d->session;
 }
 
-QVector<WOutput*> WBackend::outputList() const
+QList<WOutput*> WBackend::outputList() const
 {
     W_DC(WBackend);
     return d->outputList;
 }
 
-QVector<WInputDevice *> WBackend::inputDeviceList() const
+QList<WInputDevice *> WBackend::inputDeviceList() const
 {
     W_DC(WBackend);
     return d->inputList;

--- a/waylib/src/server/kernel/wbackend.h
+++ b/waylib/src/server/kernel/wbackend.h
@@ -30,8 +30,8 @@ public:
     QW_NAMESPACE::qw_backend *handle() const;
     QW_NAMESPACE::qw_session *session() const;
 
-    QVector<WOutput*> outputList() const;
-    QVector<WInputDevice*> inputDeviceList() const;
+    QList<WOutput*> outputList() const;
+    QList<WInputDevice*> inputDeviceList() const;
 
     bool hasDrm() const;
     bool hasX11() const;

--- a/waylib/src/server/kernel/wsurface.cpp
+++ b/waylib/src/server/kernel/wsurface.cpp
@@ -372,7 +372,7 @@ void WSurface::leaveOutput(WOutput *output)
     Q_EMIT outputLeave(output);
 }
 
-const QVector<WOutput *> &WSurface::outputs() const
+const QList<WOutput *> &WSurface::outputs() const
 {
     W_DC(WSurface);
     return d->outputs;

--- a/waylib/src/server/kernel/wsurface.h
+++ b/waylib/src/server/kernel/wsurface.h
@@ -69,7 +69,7 @@ public:
 public Q_SLOTS:
     void enterOutput(WOutput *output);
     void leaveOutput(WOutput *output);
-    const QVector<WOutput *> &outputs() const;
+    const QList<WOutput *> &outputs() const;
     WOutput *framePacingOutput() const;
     bool inputRegionContains(const QPointF &localPos) const;
 


### PR DESCRIPTION
Fixed a potential crash when accessing surface outputs during move/resize operations. The issue occurred when moveResizeState.surface->surface() returned a null pointer, causing a crash when trying to access its outputs. Added a new outputs() method in SurfaceWrapper that safely handles null surface pointers by returning an empty list. Also unified container types from QVector to QList for consistency across the codebase.

Log: Fixed potential crash during window move/resize operations

Influence:
1. Test window move and resize operations to ensure no crashes occur
2. Verify that surfaces properly track output changes during movement
3. Check that pre-launch splash screens handle outputs correctly
4. Test multi-monitor scenarios with window movement between outputs
5. Verify output list consistency across different surface types

fix: 修复moveResizeState表面处理中的潜在崩溃问题

修复了在移动/调整大小操作期间访问表面输出时可能发生的崩溃问题。该问题出
现在moveResizeState.surface->surface()返回空指针时，尝试访问其输出会导致 崩溃。在SurfaceWrapper中添加了新的outputs()方法，通过返回空列表安全处理
空表面指针。同时将容器类型从QVector统一为QList，以保持代码库的一致性。

Log: 修复了窗口移动/调整大小操作期间的潜在崩溃问题

Influence:
1. 测试窗口移动和调整大小操作，确保不会发生崩溃
2. 验证表面在移动过程中是否正确跟踪输出变化
3. 检查预启动闪屏是否正确处理输出
4. 测试多显示器场景下窗口在输出设备间的移动
5. 验证不同表面类型的输出列表一致性

## Summary by Sourcery

Fix potential crash in window move/resize operations by guarding null surfaces when accessing outputs and unify container types to QList for consistency.

Bug Fixes:
- Prevent crash in move/resize flow by handling null surface pointers when retrieving outputs.

Enhancements:
- Add SurfaceWrapper::outputs() to return an empty list on null surfaces.
- Replace QVector with QList for output and input device lists across backend and surface classes for container consistency.