### PR TITLE
refactor: replace PopupSurfaceContainer with SurfaceContainer for popup

### DIFF
--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -43,7 +43,7 @@ ShellHandler::ShellHandler(RootSurfaceContainer *rootContainer)
     , m_workspace(new Workspace(rootContainer))
     , m_topContainer(new LayerSurfaceContainer(rootContainer))
     , m_overlayContainer(new LayerSurfaceContainer(rootContainer))
-    , m_popupContainer(new PopupSurfaceContainer(rootContainer))
+    , m_popupContainer(new SurfaceContainer(rootContainer))
 {
     m_backgroundContainer->setZ(RootSurfaceContainer::BackgroundZOrder);
     m_bottomContainer->setZ(RootSurfaceContainer::BottomZOrder);

--- a/src/core/shellhandler.h
+++ b/src/core/shellhandler.h
@@ -104,6 +104,8 @@ private:
     Workspace *m_workspace = nullptr;
     LayerSurfaceContainer *m_topContainer = nullptr;
     LayerSurfaceContainer *m_overlayContainer = nullptr;
-    PopupSurfaceContainer *m_popupContainer = nullptr;
+    // FIXME: https://github.com/linuxdeepin/treeland/pull/428 Caused damage to the tooltip
+    // Need to find a better way to handle popup click events
+    SurfaceContainer *m_popupContainer = nullptr;
     QObject *m_windowMenu = nullptr;
 };


### PR DESCRIPTION
handling

Changed m_popupContainer from PopupSurfaceContainer to SurfaceContainer to fix tooltip damage issue caused by PR #428. This is a temporary fix while a better solution for handling popup click events is being developed.

Log: Fixed tooltip display issues by changing popup container implementation

Influence:
1. Test tooltip display functionality across different applications
2. Verify popup windows and menus still work correctly
3. Check for any regression in popup interaction behavior
4. Test various popup types including context menus and tooltips
5. Verify z-ordering of popup elements remains correct

refactor: 将弹出窗口容器从 PopupSurfaceContainer 替换为 SurfaceContainer

将 m_popupContainer 从 PopupSurfaceContainer 改为 SurfaceContainer，以修 复 PR #428 导致的工具提示损坏问题。这是一个临时修复方案，同时正在开发更
好的弹出窗口点击事件处理方案。

Log: 通过更改弹出窗口容器实现修复了工具提示显示问题

Influence:
1. 测试不同应用程序中的工具提示显示功能
2. 验证弹出窗口和菜单是否仍能正常工作
3. 检查弹出窗口交互行为是否有回归问题
4. 测试各种弹出类型，包括上下文菜单和工具提示
5. 验证弹出元素的 Z 轴排序是否保持正确

## Summary by Sourcery

Enhancements:
- Replace PopupSurfaceContainer with SurfaceContainer for the popup container to resolve tooltip rendering issues