### PR TITLE
fix: Put Treeland at the first place for session selection

### DIFF
--- a/src/greeter/sessionmodel.cpp
+++ b/src/greeter/sessionmodel.cpp
@@ -174,7 +174,10 @@ void SessionModel::populate(DDM::Session::Type type, const QStringList &dirPaths
         // TODO: only show support sessions(X-DDE-SINGLE-WAYLAND)
         if (execAllowed) {
             d->displayNames.append(si->displayName());
-            d->sessions.push_back(si);
+            if (si->displayName() == QStringLiteral("Treeland"))
+                d->sessions.prepend(si);
+            else
+                d->sessions.push_back(si);
         } else {
             delete si;
         }


### PR DESCRIPTION
Treeland should be the first candidate of session selection, this commit ensures that.

## Summary by Sourcery

Bug Fixes:
- Prepend 'Treeland' session to the session list before other sessions