### PR TITLE
fix: resolve surface position drift during scale changes

### DIFF
--- a/src/output/output.h
+++ b/src/output/output.h
@@ -144,6 +144,7 @@ private:
     PlaceDirection m_nextPlaceDirection = PlaceDirection::BottomRight;
 
     QMap<SurfaceWrapper*, QPair<QPointF, QRectF>> m_positionCache;
+    QHash<SurfaceWrapper*, QPointF> m_initialWindowPositionRatio;
 };
 
 Q_DECLARE_OPAQUE_POINTER(WAYLIB_SERVER_NAMESPACE::WOutputItem *)


### PR DESCRIPTION
    When the monitor's scaling or resolution changes, the window position may
    shift or even move off-screen. This is due to the accumulation of errors
    caused by incremental calculations of window position.
    This fix addresses this issue by:
    
    1. Saving the window's relative position ratio within the available area,
    instead of absolute coordinates.
    2. Recalculating the window position based on the stored ratio when scaling
    changes, avoiding error accumulation.
    3. Adding dynamic boundary protection to ensure at least 30% of the window
    content remains within the screen's visible range.
    4. Cleaning up related data when the window is removed to prevent memory leaks
    
    Tested scenarios:
    - Multiple scale changes (1.0->1.25->1.0->1.25)
    - Different window states (Normal, Maximized, Fullscreen)
    - Multi-monitor environment
    - Various scale factors
    
    Log: surface position drift during scale changes

## Summary by Sourcery

Prevent cumulative surface position drift during display scale changes by detecting scale transitions, adjusting position calculations, and resynchronizing surface geometry.

Bug Fixes:
- Skip position scaling in arrangeNonLayerSurface when a display scale change is detected to avoid cumulative errors
- Use top-left-based relative positioning in moveSurfacesToOutput instead of center-based offsets
- Reapply and synchronize surface geometry after updateSurfaceSizeRatio to maintain correct window placement across scale changes