### PR TITLE
refactor: Use swap member function instead of std::swap

### DIFF
--- a/qwlroots/src/util/qwsignalconnector.h
+++ b/qwlroots/src/util/qwsignalconnector.h
@@ -128,7 +128,7 @@ public:
     }
     void invalidate() {
         QVector<qw_signal_listener*> tmpList;
-        std::swap(tmpList, listenerList);
+        tmpList.swap(listenerList);
         auto begin = tmpList.begin();
         while (begin != tmpList.end()) {
             qw_signal_listener *l = *begin;

--- a/waylib/src/server/qtquick/private/wbufferrenderer.cpp
+++ b/waylib/src/server/qtquick/private/wbufferrenderer.cpp
@@ -621,7 +621,7 @@ void WBufferRenderer::endRender()
     Q_ASSERT(state.buffer.get());
     {
         std::unique_ptr<qw_buffer, qw_buffer::unlocker> buffer;
-        std::swap(buffer, state.buffer);
+        buffer.swap(state.buffer);
         state.renderer = nullptr;
         state.batchRenderer = nullptr;
 

--- a/waylib/src/server/qtquick/private/wrenderbuffernode.cpp
+++ b/waylib/src/server/qtquick/private/wrenderbuffernode.cpp
@@ -211,7 +211,7 @@ protected:
             manager->cleanJob = nullptr;
 
             QList<std::shared_ptr<Data>> tmp;
-            std::swap(manager->dataList, tmp);
+            tmp.swap(manager->dataList);
             manager->dataList.reserve(tmp.size());
 
             for (const auto &data : std::as_const(tmp)) {

--- a/waylib/src/server/qtquick/woutputitem.cpp
+++ b/waylib/src/server/qtquick/woutputitem.cpp
@@ -154,7 +154,7 @@ void WOutputItemPrivate::updateCursors()
         tmpCursors.append(std::make_pair(cursor, oc));
     }
 
-    std::swap(tmpCursors, cursors);
+    tmpCursors.swap(cursors);
     // clean needless cursors
     for (auto i : std::as_const(tmpCursors)) {
         if (cursors.contains(i))

--- a/waylib/src/server/qtquick/woutputrenderwindow.cpp
+++ b/waylib/src/server/qtquick/woutputrenderwindow.cpp
@@ -545,7 +545,7 @@ void OutputHelper::sortLayers()
 void OutputHelper::cleanLayerCompositor()
 {
     QList<QPointer<BufferRendererProxy>> tmpList;
-    std::swap(m_layerProxys, tmpList);
+    tmpList.swap(m_layerProxys);
 
     for (auto proxy : std::as_const(tmpList)) {
         if (!proxy)


### PR DESCRIPTION
1. Replaced `std::swap` with the member function `swap` for `QVector` and `std::unique_ptr`.
2. This change improves code clarity and readability, as the member function `swap` is the preferred way to swap these objects in C++. It also avoids potential issues with argument-dependent lookup (ADL) that might occur with `std::swap` in some cases. The `swap` member function is guaranteed to provide the noexcept guarantee in c++17.

Influence:
1. Verify that all usages of `std::swap` on `QVector` and `std::unique_ptr` have been correctly replaced with the member function `swap`.
2. Run existing tests to ensure no regressions were introduced.

refactor: 使用 swap 成员函数替代 std::swap

1. 将 `std::swap` 替换为 `QVector` 和 `std::unique_ptr` 的成员函数 `swap`。
2. 此更改提高了代码的清晰度和可读性，因为成员函数 `swap` 是在 C++ 中交 换这些对象的首选方法。它还避免了在某些情况下使用 `std::swap` 可能出现
的与参数相关的查找 (ADL) 的潜在问题。`swap` 成员函数保证在 c++17 中提供
noexcept 保证。

Influence:
1. 验证所有对 `QVector` 和 `std::unique_ptr` 使用 `std::swap` 的地方都已 正确替换为成员函数 `swap`。
2. 运行现有测试以确保没有引入回归。