### PR TITLE
feat: Release 0.5.21.3-test-multi-seat

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+treeland (0.5.21.3-test-multi) unstable; urgency=medium
+
+  * Release 0.5.21.3-test-multi-seat.
+
+ -- Lu YaNing <luyaning@uniontech.com>  Mon, 03 Nov 2025 11:31:17 +0800
+
 treeland (0.5.21.2-test-multi-seat) unstable; urgency=medium
 
   * feat: Add FPS display.


### PR DESCRIPTION
Release 0.5.21.3-test-multi-seat

## Summary by Sourcery

Prepare and document the 0.5.21.3-test-multi-seat Debian package release.

Build:
- Bump Debian package version to 0.5.21.3-test-multi-seat.

Documentation:
- Update Debian changelog to reflect the new multi-seat test release.