### PR TITLE
chore: update find_package calls for Qt private modules for building with Qt 6.10

### DIFF
--- a/examples/test_capture/CMakeLists.txt
+++ b/examples/test_capture/CMakeLists.txt
@@ -1,5 +1,6 @@
 find_package(PkgConfig REQUIRED)
 find_package(Qt6 REQUIRED COMPONENTS Core Gui WaylandClient Quick)
+find_package(Qt6 COMPONENTS WaylandClientPrivate QuickPrivate QUIET)
 find_package(TreelandProtocols REQUIRED)
 pkg_check_modules(EGL REQUIRED IMPORTED_TARGET egl gl)
 qt_add_executable(test-capture

--- a/examples/test_show_desktop/CMakeLists.txt
+++ b/examples/test_show_desktop/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(Qt6 REQUIRED COMPONENTS WaylandClient Widgets)
+find_package(Qt6 COMPONENTS GuiPrivate WaylandClientPrivate QUIET)
 find_package(TreelandProtocols REQUIRED)
 
 set(BIN_NAME test-show-desktop)

--- a/examples/test_super_overlay_surface/CMakeLists.txt
+++ b/examples/test_super_overlay_surface/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(Qt6 REQUIRED COMPONENTS WaylandClient Widgets)
+find_package(Qt6 COMPONENTS WaylandClientPrivate QUIET)
 find_package(TreelandProtocols REQUIRED)
 
 set(BIN_NAME test-super-overlay-surface)

--- a/examples/test_virtual_output/CMakeLists.txt
+++ b/examples/test_virtual_output/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(Qt6 REQUIRED COMPONENTS WaylandClient Widgets)
+find_package(Qt6 COMPONENTS GuiPrivate WaylandClientPrivate QUIET)
 find_package(TreelandProtocols REQUIRED)
 
 set(BIN_NAME test-virtual-output)

--- a/examples/test_window_bg/CMakeLists.txt
+++ b/examples/test_window_bg/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(Qt6 REQUIRED COMPONENTS WaylandClient Widgets)
+find_package(Qt6 COMPONENTS GuiPrivate WaylandClientPrivate QUIET)
 find_package(TreelandProtocols REQUIRED)
 
 set(BIN_NAME test-window-bg)

--- a/examples/test_window_overlapped/CMakeLists.txt
+++ b/examples/test_window_overlapped/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(Qt6 REQUIRED COMPONENTS WaylandClient Gui Widgets)
+find_package(Qt6 COMPONENTS GuiPrivate WaylandClientPrivate QUIET)
 find_package(TreelandProtocols REQUIRED)
 
 set(BIN_NAME test-window-overlapped)

--- a/examples/test_window_picker/CMakeLists.txt
+++ b/examples/test_window_picker/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(Qt6 REQUIRED COMPONENTS WaylandClient Quick)
+find_package(Qt6 COMPONENTS WaylandClientPrivate QUIET)
 find_package(TreelandProtocols REQUIRED)
 
 set(BIN_NAME test-window-picker)

--- a/src/modules/capture/CMakeLists.txt
+++ b/src/modules/capture/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(MODULE_NAME capture)
 
 find_package(TreelandProtocols REQUIRED)
+find_package(Qt6 COMPONENTS QuickPrivate QUIET)
 
 ws_generate_local(server ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-capture-unstable-v1.xml treeland-capture-unstable-v1-protocol)
 

--- a/tests/test_window_picker/CMakeLists.txt
+++ b/tests/test_window_picker/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(Qt6 REQUIRED COMPONENTS WaylandClient Quick)
+find_package(Qt6 COMPONENTS WaylandClientPrivate QUIET)
 find_package(TreelandProtocols REQUIRED)
 
 set(BIN_NAME test-window-picker)


### PR DESCRIPTION
Qt 6.10 now requires find_package() for private modules.
https://doc-snapshots.qt.io/qt6-6.10/qtguiprivate-module.html#details

## Summary by Sourcery

Build:
- Add find_package(Qt6 COMPONENTS WaylandClientPrivate, GuiPrivate, and QuickPrivate QUIET) to example, module, and test CMakeLists.txt files