### PR TITLE
fix: resolve window remove/resize blur on fractional DPR displays

### DIFF
--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -136,6 +136,9 @@ public:
     QRectF geometry() const;
     QRectF normalGeometry() const;
     void moveNormalGeometryInOutput(const QPointF &position);
+    QPointF alignToPixelGrid(const QPointF &pos) const;
+    QRectF alignGeometryToPixelGrid(const QRectF &geometry) const;
+    qreal getOutputDevicePixelRatio(const QPointF &pos) const;
 
     QRectF maximizedGeometry() const;
     void setMaximizedGeometry(const QRectF &newMaximizedGeometry);


### PR DESCRIPTION
- Add pixel-grid alignment functions for fractional coordinate handling
- Fix coordinate alignment in doMoveResize() for smooth window operations
- Implement DPR-aware geometry adjustments in filterSurfaceGeometryChanged()
- Support multi-output environments with per-output DPR detection

## Summary by Sourcery

Add DPR-aware pixel grid alignment to surface geometry operations, apply it in window move and resize paths to eliminate blur on fractional DPI screens and support multi-output setups

New Features:
- Add alignToPixelGrid, alignGeometryToPixelGrid and getOutputDevicePixelRatio functions for fractional DPR handling

Bug Fixes:
- Prevent blur and misalignment during window move/resize on fractional DPR displays

Enhancements:
- Apply pixel-grid alignment in SurfaceWrapper for move, resize and animation operations
- Integrate DPR-aware geometry adjustments in RootSurfaceContainer’s move/resize logic
- Support per-output device pixel ratio detection in multi-output environments