### PR TITLE
fix: load vulkan library with version number

### DIFF
--- a/waylib/src/server/platformplugin/qwlrootsintegration.cpp
+++ b/waylib/src/server/platformplugin/qwlrootsintegration.cpp
@@ -559,7 +559,7 @@ public:
     VulkanInstance(QVulkanInstance *instance)
         : m_instance(instance)
     {
-        loadVulkanLibrary(QStringLiteral("vulkan"));
+        loadVulkanLibrary(QStringLiteral("vulkan"), 1);
     }
 
     void createOrAdoptInstance() override {


### PR DESCRIPTION
Fixes an issue where the vulkan library might not be loaded correctly if the system does not provide `libvulkan.so` directly but provides versioned libraries like `libvulkan.so.1`. The change ensures that the library loading mechanism can locate and load the vulkan library even when it is versioned. This improves robustness when finding and loading the Vulkan library.

Influence:
1. Verify that the application can successfully initialize and use Vulkan on systems with only versioned vulkan libraries (e.g., `libvulkan.so.1`).
2. Test that the application still works correctly on systems with `libvulkan.so`.

fix: 加载带版本号的 vulkan 库

修复了系统未直接提供 `libvulkan.so`，而是提供了带版本号的库（如
`libvulkan.so.1`）时，vulkan 库可能无法正确加载的问题。此更改确保即使
在 vulkan 库带有版本号时，库加载机制也能定位并加载它。这提高了查找和加载
Vulkan 库时的稳健性。

Influence:
1. 验证应用程序是否可以在仅具有版本化 vulkan 库（例如 `libvulkan.so.1`） 的系统上成功初始化和使用 Vulkan。
2. 测试应用程序在具有 `libvulkan.so` 的系统上是否仍然可以正常工作。

## Summary by Sourcery

Bug Fixes:
- Allow loading Vulkan libraries with versioned filenames (e.g., libvulkan.so.1) by passing a version argument to the loader