### PR TITLE
fix: Display issues with scaling and resolution switching in copy mode

### DIFF
--- a/src/core/qml/CopyOutput.qml
+++ b/src/core/qml/CopyOutput.qml
@@ -8,31 +8,73 @@ OutputItem {
     id: outputItem
 
     required property PrimaryOutput targetOutputItem
-    property OutputViewport screenViewport: targetOutputItem.screenViewport
+    property OutputViewport screenViewport: viewport
+
+    property OutputViewport primaryScreenViewport: targetOutputItem.screenViewport
+
+    // Constants for fallback and precision thresholds
+    readonly property int fallbackSize: 100
+    readonly property real sizeMatchTolerance: 0.1
+    readonly property real scaleEpsilon: 0.001
+
+    // Helper property: primary screen pixel size (physical size in pixels)
+    // Formula: pixelSize = effectiveSize * scale
+    // - output.size returns effectiveSize (logical size)
+    // - scale is the devicePixelRatio
+    // - pixelSize is the actual framebuffer size in pixels
+    // Fallback is used during component initialization or if primary output is not ready
+    readonly property size primaryPixelSize: {
+        if (!primaryScreenViewport || !primaryScreenViewport.output) {
+            console.warn("CopyOutput: Primary viewport not ready, using fallback size");
+            return Qt.size(fallbackSize, fallbackSize);
+        }
+        const effectiveSize = primaryScreenViewport.output.size;
+        const scale = primaryScreenViewport.output.scale;
+        // Calculate pixel size: effectiveSize * scale
+        return Qt.size(effectiveSize.width * scale, effectiveSize.height * scale);
+    }
 
     devicePixelRatio: output?.scale ?? devicePixelRatio
 
     Rectangle {
         id: content
         anchors.fill: parent
-        color: "red"
+        color: "black"
 
         TextureProxy {
             id: proxy
-            sourceItem: screenViewport
+            sourceItem: primaryScreenViewport
             anchors.centerIn: parent
-            rotation: targetOutputItem.keepAllOutputRotation ? 0 : screenViewport.rotation
-            width: screenViewport.implicitWidth
-            height: screenViewport.implicitHeight
+            rotation: targetOutputItem.keepAllOutputRotation ? 0 : primaryScreenViewport.rotation
+
+            width: primaryPixelSize.width
+            height: primaryPixelSize.height
+            sourceRect: Qt.rect(0, 0, primaryPixelSize.width, primaryPixelSize.height)
+
             smooth: true
             transformOrigin: Item.Center
+
             scale: {
-                const isize = targetOutputItem.keepAllOutputRotation
-                            ? Qt.size(width, height)
-                            : Qt.size(targetOutputItem.width, targetOutputItem.height);
-                const osize = Qt.size(outputItem.width, outputItem.height);
-                const size = WaylibHelper.scaleSize(isize, osize, Qt.KeepAspectRatio);
-                return size.width / isize.width;
+                if (!primaryScreenViewport || !primaryScreenViewport.output) {
+                    return 1.0;
+                }
+                if (!content.width || !content.height) {
+                    return 1.0;
+                }
+
+                // Wait for TextureProxy size to sync with primary pixel size
+                if (Math.abs(width - primaryPixelSize.width) > sizeMatchTolerance ||
+                    Math.abs(height - primaryPixelSize.height) > sizeMatchTolerance) {
+                    return 1.0;
+                }
+
+                // Calculate scale: content size / primary screen pixel size
+                const scaleX = content.width / primaryPixelSize.width;
+                const scaleY = content.height / primaryPixelSize.height;
+                const finalScale = Math.min(scaleX, scaleY);
+
+                // Fix floating-point precision issues
+                return Math.abs(finalScale - 1.0) < scaleEpsilon ? 1.0 : finalScale;
             }
         }
     }
@@ -41,7 +83,7 @@ OutputItem {
         id: viewport
 
         anchors.centerIn: parent
-        depends: [screenViewport]
+        depends: [primaryScreenViewport]
         devicePixelRatio: outputItem.devicePixelRatio
         input: content
         output: outputItem.output

--- a/src/core/qml/SurfaceContent.qml
+++ b/src/core/qml/SurfaceContent.qml
@@ -36,7 +36,9 @@ Item {
         smooth: root.surface?.smooth ?? true
 
         onDevicePixelRatioChanged: {
-            wrapper.updateSurfaceSizeRatio()
+            if (wrapper) {
+                wrapper.updateSurfaceSizeRatio()
+            }
         }
     }
 

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -332,6 +332,7 @@ private:
     bool doGesture(QInputEvent *event);
     Output *createNormalOutput(WOutput *output);
     Output *createCopyOutput(WOutput *output, Output *proxy);
+    WOutputViewport *getOwnOutputViewport(WOutput *output);
     QList<SurfaceWrapper *> getWorkspaceSurfaces(Output *filterOutput = nullptr);
     void moveSurfacesToOutput(const QList<SurfaceWrapper *> &surfaces,
                               Output *targetOutput,


### PR DESCRIPTION
Issue Description:
1. The secondary screen displays a distorted image when switching the main screen resolution in copy mode.
2. The secondary screen displays excessively large and incomplete content when setting the main screen scaling factor.
3. The secondary screen only displays a portion of the main screen content when setting the secondary screen scaling factor.

Root Causes:
1. Asynchronous updates to QML properties cause TextureProxy to use the wrong size in an intermediate state.
2. Confusion between physical size and effective size (output.size returns effectiveSize).
3. Incorrect scale calculation in TextureProxy.

## Summary by Sourcery

Fix display distortions in copy mode by correcting viewport selection and texture sizing calculations to properly handle resolution and scaling changes

Bug Fixes:
- Retrieve the correct OutputViewport in copy mode by finding the direct child viewport instead of using the primary output’s screenViewport
- Correct distorted and incomplete secondary display content by computing TextureProxy width, height, sourceRect, and scale from the output’s effective size and scale
- Prevent intermediate-state sizing errors by adding fallbacks and floating-point precision checks

Enhancements:
- Introduce a primaryScreenViewport property and update TextureProxy logic to distinguish between physical and effective sizes
- Guard SurfaceContent’s updateSurfaceSizeRatio call against null wrapper instances