### PR TITLE
fix: Propagate QT_QUICK_BACKEND environment variable via D-Bus

### DIFF
--- a/src/systemd-socket.cpp
+++ b/src/systemd-socket.cpp
@@ -68,6 +68,7 @@ int main(int argc, char *argv[])
                                         QDBusConnection::sessionBus());
                     StringMap env;
                     env["WAYLAND_DISPLAY"] = "treeland.socket";
+                    env["QT_QUICK_BACKEND"] = "software";
 
                     const auto extraEnvs = qgetenv("TREELAND_SESSION_ENVIRONMENTS");
                     if (!extraEnvs.isEmpty()) {
@@ -94,6 +95,7 @@ int main(int argc, char *argv[])
                                             QDBusConnection::sessionBus());
                         StringMap env;
                         env["DISPLAY"] = xwaylandName;
+                        env["QT_QUICK_BACKEND"] = "software";
                         auto reply =
                             dbus.call("UpdateActivationEnvironment", QVariant::fromValue(env));
 


### PR DESCRIPTION
Update UpdateActivationEnvironment to include QT_QUICK_BACKEND=software for both wayland and xwayland clients, ensuring they use software rendering backend when activated through systemd-socket.

- Add QT_QUICK_BACKEND to wayland activation environment
- Add QT_QUICK_BACKEND to xwayland activation environment

## Summary by Sourcery

Bug Fixes:
- Ensure Wayland and Xwayland clients activated via systemd-socket receive QT_QUICK_BACKEND=software in their environment to avoid incorrect rendering backend selection.