### PR TITLE
fix: fix crash on logout & hiding of wayland surface on user switch

### DIFF
--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -192,6 +192,8 @@ void ShellHandler::onXdgToplevelSurfaceRemoved(WXdgToplevelSurface *surface)
     if (interface) {
         delete interface;
     }
+    if (!wrapper)
+        return;
     Q_EMIT surfaceWrapperAboutToRemove(wrapper);
     m_rootSurfaceContainer->destroyForSurface(wrapper);
 }

--- a/src/core/treeland.cpp
+++ b/src/core/treeland.cpp
@@ -379,7 +379,11 @@ bool Treeland::ActivateWayland(QDBusUnixFileDescriptor _fd)
     pw = getpwuid(uid);
     QString user{ pw->pw_name };
 
-    auto socket = std::make_shared<WSocket>(true);
+    WSocket *sessionSocket = d->helper->waylandSocketForUid(uid);
+    if (!sessionSocket)
+        return false;
+    std::shared_ptr<WSocket> socket = std::make_shared<WSocket>(sessionSocket);
+
     socket->create(fd->fileDescriptor(), false);
 
     auto userModel =

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -120,7 +120,6 @@ public:
     WSocket *socket = nullptr;
     WXWayland *xwayland = nullptr;
     quint32 noTitlebarAtom = XCB_ATOM_NONE;
-    SurfaceWrapper *lastActivatedSurface = nullptr;
 
     ~Session();
 


### PR DESCRIPTION
This should work as intended.

## Summary by Sourcery

Fix session switching and Wayland activation to prevent crashes and ensure correct surface handling across user changes.

Bug Fixes:
- Prevent crash when removing XDG toplevel surfaces by guarding against a missing surface wrapper before emitting removal signals.
- Avoid crashes and inconsistent behavior on user switch by clearing the activated surface when changing the active session and simplifying session state updates.
- Ensure Wayland activation uses the existing per-user Wayland socket instead of creating a new one, avoiding invalid or duplicate socket usage.

Enhancements:
- Create the main Wayland socket with the updated configuration and always log the active session's listening address when switching users.