### PR TITLE
fix: support screen rotation in copy mode

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -613,6 +613,11 @@ void Helper::onOutputTestOrApply(qw_output_configuration_v1 *config, bool onlyTe
             wlr_output_state_set_transform(extraState.get(),
                                           static_cast<wl_output_transform>(state.transform));
             wlr_output_state_set_adaptive_sync_enabled(extraState.get(), state.adaptiveSyncEnabled);
+
+            if (auto outputItem = qobject_cast<WOutputItem*>(viewport->parentItem())) {
+                QMetaObject::invokeMethod(outputItem, "setTransform",
+                    Q_ARG(QVariant, QVariant::fromValue(static_cast<WOutput::Transform>(state.transform))));
+            }
         }
 
         if (!outputHelper->setExtraState(extraState)) {


### PR DESCRIPTION
IgnoreViewport was set to true in CopyOutput, which causes WOutputViewport::renderMatrix() to skip QML transform calculations, making viewport.rotation property completely ignored.

Changes:
- Remove ignoreViewport: true to enable QML rotation transforms
- Add rotationOutput() with RotationAnimation (same as PrimaryOutput)
- Add setTransform()/setScale()/invalidate() public functions
- Fix primaryPixelSize: swap dimensions when primary rotates 90/270 (output.size returns rotated logical size, but framebuffer is always unrotated, causing sourceRect to sample beyond texture boundaries)
- Fix scale calculation: use visual size after proxy rotation

helper.cpp:
- Call setTransform() on OutputItem when applying output transform

## Summary by Sourcery

Support correct screen rotation and scaling in copy mode output previews.

Bug Fixes:
- Correct primary output pixel size calculation by swapping width and height for 90°/270° rotations to avoid sampling outside the framebuffer.
- Fix scaling in the proxy viewport by basing scale on the visually rotated dimensions instead of the unrotated width/height.

Enhancements:
- Enable QML rotation transforms for copy-mode output by removing the viewport ignore flag and wiring rotation changes through the viewport.
- Add animated rotation handling and public transform/scale/invalidate hooks on the copy output item.
- Propagate output transform changes from the seat helper to the associated QML output item so visual state tracks compositor state.