### PR TITLE
fix: fix unused parameter

### DIFF
--- a/src/modules/screensaver/screensaverinterfacev1.cpp
+++ b/src/modules/screensaver/screensaverinterfacev1.cpp
@@ -11,12 +11,12 @@
 
 // request implementation
 
-static void inhibit(struct wl_client *client, struct wl_resource *resource, const char *appName, const char *reason) {
+static void inhibit([[maybe_unused]] struct wl_client *client, struct wl_resource *resource, const char *appName, const char *reason) {
     auto screensaver = static_cast<ScreensaverInterfaceV1 *>(wl_resource_get_user_data(resource));
     screensaver->inhibit(resource, appName, reason);
 }
 
-static void uninhibit(struct wl_client *client, struct wl_resource *resource) {
+static void uninhibit([[maybe_unused]] struct wl_client *client, struct wl_resource *resource) {
     auto screensaver = static_cast<ScreensaverInterfaceV1 *>(wl_resource_get_user_data(resource));
     screensaver->uninhibit(resource);
 }

--- a/src/treeland-screensaver/screensaver.cpp
+++ b/src/treeland-screensaver/screensaver.cpp
@@ -118,8 +118,8 @@ static void onServiceUnregistered(const QString &service) {
 }
 
 static void onServiceOwnerChanged(const QString &service,
-                                  const QString &oldOwner,
-                                  const QString &newOwner) {
+                                  [[maybe_unused]] const QString &oldOwner,
+                                  [[maybe_unused]] const QString &newOwner) {
     DISCONNECTED(service);
 }
 


### PR DESCRIPTION
To suppress warning

## Summary by Sourcery

Bug Fixes:
- Mark unused parameters in the screensaver service owner change callback to eliminate compiler warnings.