### PR TITLE
fix: reload cursor image when scale changes

### DIFF
--- a/src/core/qml/PrimaryOutput.qml
+++ b/src/core/qml/PrimaryOutput.qml
@@ -18,7 +18,18 @@ OutputItem {
         id: cursorItem
 
         required property QtObject outputCursor
-        readonly property point position: parent.mapFromGlobal(cursor.position.x, cursor.position.y)
+        readonly property point rawPosition: parent.mapFromGlobal(cursor.position.x, cursor.position.y)
+        readonly property real effectiveScale: rootOutputItem.devicePixelRatio || 1.0
+
+        // Align cursor position to pixel grid to prevent blur on fractional DPR displays
+        function alignToPixelGrid(value) {
+            return Math.round(value * effectiveScale) / effectiveScale
+        }
+
+        readonly property point position: Qt.point(
+            alignToPixelGrid(rawPosition.x),
+            alignToPixelGrid(rawPosition.y)
+        )
 
         cursor: outputCursor.cursor
         output: outputCursor.output.output
@@ -32,7 +43,8 @@ OutputItem {
         OutputLayer.cursorHotSpot: hotSpot
 
         themeName: Helper.config.cursorThemeName
-        sourceSize: Qt.size(Helper.config.cursorSize, Helper.config.cursorSize)
+        // Scale-aware cursor size: automatically updates when output scale changes
+        sourceSize: Qt.size(Helper.config.cursorSize * effectiveScale, Helper.config.cursorSize * effectiveScale)
     }
 
     OutputViewport {

--- a/waylib/src/server/utils/wcursorimage.cpp
+++ b/waylib/src/server/utils/wcursorimage.cpp
@@ -643,6 +643,7 @@ void WCursorImage::setScale(float newScale)
     if (d->manager)
         d->manager->load(d->scale);
 
+    d->updateCursorImage();
     Q_EMIT scaleChanged();
 }
 


### PR DESCRIPTION
The WCursorImage::setScale() method only loaded the theme at new scale but didn't regenerate the cursor image, causing blurry cursor display when scale changed while cursor was inside a window. Fix by calling updateCursorImage() after loading new scale, matching the behavior of setCursorTheme().
Additionally improve cursor rendering with pixel-grid alignment and scale-aware sourceSize in PrimaryOutput.qml.

Tested:
cursor updates immediately when scale changes, no need to move cursor outside window. Works perfectly on fractional scaling (1.25x, 1.5x, 1.75x, etc.)"

## Summary by Sourcery

Improve cursor rendering and responsiveness when display scale changes, especially on fractional scaling setups.

Bug Fixes:
- Ensure cursor images are regenerated when the cursor scale changes so they no longer remain blurry until the cursor leaves the window.

Enhancements:
- Align the cursor position to the pixel grid in QML to avoid blur on fractional device pixel ratios.
- Make cursor source size scale-aware in QML so cursor visuals track output scale changes correctly.