### PR TITLE
fix: correct primary output disable handling in copy mode

### DIFF
--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -343,6 +343,7 @@ private:
     void moveSurfacesToOutput(const QList<SurfaceWrapper *> &surfaces,
                               Output *targetOutput,
                               Output *sourceOutput);
+    void handleCopyModeOutputDisable(Output *affectedOutput);
     bool isNvidiaCardPresent();
     void setWorkspaceVisible(bool visible);
     void restoreFromShowDesktop(SurfaceWrapper *activeSurface = nullptr);


### PR DESCRIPTION
When the primary output is disabled while in Copy mode:
- Force switch to Extension mode to prevent invalid states.
- Convert remaining copy outputs to normal independent outputs.
- Retain the disabled output in `m_outputList` temporarily to ensure the disable state is correctly propagated to wlroots.
- Move windows to the new primary output to maintain input focus.

## Summary by Sourcery

Handle disabling the primary output while in Copy mode by transitioning to a valid output configuration and preserving focus.

Bug Fixes:
- Prevent invalid output states when the primary output is disabled in Copy mode by switching to Extension mode and converting copy outputs to independent outputs.
- Ensure the disabled primary output remains tracked long enough for its disable state to be propagated correctly to wlroots.
- Maintain window focus by moving surfaces to a new primary output when the current primary is disabled in Copy mode.
- Avoid processing configuration for outputs that have been removed during Copy mode transitions.