### PR TITLE
fix: fix dde-session not started after ddm restart or crash recover

### DIFF
--- a/src/core/treeland.h
+++ b/src/core/treeland.h
@@ -30,20 +30,6 @@ class Treeland
 {
     Q_OBJECT
     Q_DECLARE_PRIVATE(Treeland)
-    Q_CLASSINFO("D-Bus Interface", "org.deepin.Compositor1")
-    Q_CLASSINFO("D-Bus Introspection",
-                "  <interface name=\"org.deepin.Compositor1\">\n"
-                "    <method name=\"ActivateWayland\">\n"
-                "      <arg direction=\"in\" type=\"h\" name=\"fd\"/>\n"
-                "      <arg direction=\"out\" type=\"b\" name=\"result\"/>\n"
-                "    </method>\n"
-                "    <method name=\"XWaylandName\">\n"
-                "      <arg direction=\"out\" type=\"s\" name=\"result\"/>\n"
-                "      <arg direction=\"out\" type=\"ay\" name=\"auth\"/>\n"
-                "    </method>\n"
-                "    <signal name=\"SessionChanged\"/>\n"
-                "  </interface>\n"
-                "")
 
 public:
     explicit Treeland();

--- a/src/greeter/greeterproxy.cpp
+++ b/src/greeter/greeterproxy.cpp
@@ -434,13 +434,15 @@ void GreeterProxy::readyRead()
         } break;
         case DaemonMessages::UserLoggedIn: {
             QString user;
-            input >> user;
+            int sessionId;
+            input >> user >> sessionId;
 
             // This will happen after a crash recovery of treeland
             qCInfo(treelandGreeter) << "User " << user << " is already logged in";
             auto userPtr = d->userModel->getUser(user);
             if (userPtr) {
                 userPtr.get()->setLogined(true);
+                Q_EMIT d->userModel->userLoggedIn(user, sessionId);
             } else {
                 qCWarning(treelandGreeter) << "User " << user << " logged in but not found";
             }

--- a/src/systemd-socket.cpp
+++ b/src/systemd-socket.cpp
@@ -144,24 +144,12 @@ int main(int argc, char *argv[])
             }
         };
 
-        QDBusServiceWatcher *compositorWatcher =
-            new QDBusServiceWatcher("org.deepin.Compositor1",
-                                    connection,
-                                    QDBusServiceWatcher::WatchForRegistration);
-
-        QObject::connect(compositorWatcher,
-                         &QDBusServiceWatcher::serviceRegistered,
-                         compositorWatcher,
-                         activateFd);
-
-        // Listen to SessionChanged signal and activate fd when session changed
         connection.connect("org.deepin.Compositor1",
                            "/org/deepin/Compositor1",
                            "org.deepin.Compositor1",
                            "SessionChanged",
                            new SignalReceiver(activateFd),
                            SLOT(onSessionChanged()));
-
         activateFd();
     };
 


### PR DESCRIPTION
This commit is boundled with a ddm update commit.

## Summary by Sourcery

Ensure dde-session is correctly reactivated when the compositor restarts or recovers from a crash and propagate existing user login state with session identifiers after daemon recovery.

Bug Fixes:
- Trigger fd activation on compositor DBus owner changes with a short delay to handle compositor restarts or crash recovery.
- Emit userLoggedIn with the associated session ID when receiving UserLoggedIn messages during crash recovery so existing sessions are restored correctly.