### PR TITLE
fix: normaize registration and handling of all-modifier keybindings

### DIFF
--- a/src/modules/shortcut/impl/shortcut_manager_impl.cpp
+++ b/src/modules/shortcut/impl/shortcut_manager_impl.cpp
@@ -57,11 +57,11 @@ static void shortcut_manager_handle_bind_key(struct wl_client *client,
         return;
     }
 
-    Q_EMIT manager->requestBindKeySequence(socket,
-                                           QString::fromUtf8(name),
-                                           QKeySequence(QString::fromUtf8(key_sequence), QKeySequence::PortableText),
-                                           mode,
-                                           action);
+    Q_EMIT manager->requestBindKey(socket,
+                                   QString::fromUtf8(name),
+                                   QString::fromUtf8(key_sequence),
+                                   mode,
+                                   action);
 }
 
 static void shortcut_manager_handle_bind_swipe_gesture(struct wl_client *client,

--- a/src/modules/shortcut/impl/shortcut_manager_impl.h
+++ b/src/modules/shortcut/impl/shortcut_manager_impl.h
@@ -44,11 +44,11 @@ public:
 
 Q_SIGNALS:
     void requestUnregisterShortcut(WSocket* sessionSocket, const QString& name);
-    void requestBindKeySequence(WSocket* sessionSocket,
-                                const QString& name,
-                                const QKeySequence& keySequence,
-                                uint mode,
-                                uint action);
+    void requestBindKey(WSocket* sessionSocket,
+                        const QString& name,
+                        const QString& key,
+                        uint mode,
+                        uint action);
     void requestBindSwipeGesture(WSocket* sessionSocket, const QString& name, uint finger, uint direction, uint action);
     void requestBindHoldGesture(WSocket* sessionSocket, const QString& name, uint finger, uint action);
     void requestCommit(WSocket* sessionSocket);

--- a/src/modules/shortcut/shortcutcontroller.h
+++ b/src/modules/shortcut/shortcutcontroller.h
@@ -17,14 +17,14 @@ public:
     explicit ShortcutController(QObject *parent = nullptr);
     ~ShortcutController() override;
 
-    uint registerKeySequence(const QString &name, const QKeySequence &sequence, uint mode, ShortcutAction action);
+    uint registerKey(const QString &name, const QString& key, uint mode, ShortcutAction action);
     uint registerSwipeGesture(const QString &name, uint finger, SwipeGesture::Direction direction, ShortcutAction action);
     uint registerHoldGesture(const QString &name, uint finger, ShortcutAction action);
     void unregisterShortcut(const QString &name);
 
     void clear();
-    bool dispatchKeyPress(const QKeySequence &sequence, bool repeat);
-    bool dispatchKeyRelease(const QKeySequence &sequence);
+    bool dispatchKeyPress(QKeyCombination sequence, bool repeat);
+    bool dispatchKeyRelease(QKeyCombination sequence);
 
 Q_SIGNALS:
     void actionTriggered(ShortcutAction action, const QString &name, bool isGesture, bool isRepeat = false);
@@ -32,8 +32,10 @@ Q_SIGNALS:
     void actionFinished(ShortcutAction action, const QString &name, bool isTriggered);
 
 private:
-    QMap<QKeySequence, QMap<ShortcutAction, std::pair<QString, bool>>> m_keyPressMap;
-    QMap<QKeySequence, QMap<ShortcutAction, QString>> m_keyReleaseMap;
+    static constexpr QKeyCombination normalizeKeyCombination(QKeyCombination combination);
+
+    QMap<int, QMap<ShortcutAction, std::pair<QString, bool>>> m_keyPressMap;
+    QMap<int, QMap<ShortcutAction, QString>> m_keyReleaseMap;
     QMap<std::pair<uint, SwipeGesture::Direction>, QMap<ShortcutAction, QString>> m_gesturemap;
     QMap<std::pair<uint, SwipeGesture::Direction>, QObject*> m_gestures;
     QMap<QString, std::function<void()>> m_deleters;

--- a/src/modules/shortcut/shortcutmanager.cpp
+++ b/src/modules/shortcut/shortcutmanager.cpp
@@ -17,7 +17,7 @@
 struct KeyShortcut {
     uint mode;
     QString name;
-    QKeySequence keySequence;
+    QString key;
     ShortcutAction action;
 };
 
@@ -90,8 +90,8 @@ uint ShortcutManagerV2Private::updateShortcuts(const UserShortcuts& shortcuts, Q
     QList<QString> names;
 
     const auto tryRegisterAll = [&]() {
-        for (const auto& [mode, name, keySequence, action] : std::as_const(shortcuts.keys)) {
-            status = m_controller->registerKeySequence(name, keySequence, mode, action);
+        for (const auto& [mode, name, key, action] : std::as_const(shortcuts.keys)) {
+            status = m_controller->registerKey(name, key, mode, action);
             if (status) {
                 failName = name;
                 return;
@@ -143,8 +143,8 @@ void ShortcutManagerV2::create(WServer *server)
 
     connect(d->m_manager, &treeland_shortcut_manager_v2::requestUnregisterShortcut,
             this, &ShortcutManagerV2::handleUnregisterShortcut);
-    connect(d->m_manager, &treeland_shortcut_manager_v2::requestBindKeySequence,
-            this, &ShortcutManagerV2::handleBindKeySequence);
+    connect(d->m_manager, &treeland_shortcut_manager_v2::requestBindKey,
+            this, &ShortcutManagerV2::handleBindKey);
     connect(d->m_manager, &treeland_shortcut_manager_v2::requestBindSwipeGesture,
             this, &ShortcutManagerV2::handleBindSwipeGesture);
     connect(d->m_manager, &treeland_shortcut_manager_v2::requestBindHoldGesture,
@@ -278,17 +278,17 @@ void ShortcutManagerV2::handleBindSwipeGesture(WSocket* sessionSocket, const QSt
     });
 }
 
-void ShortcutManagerV2::handleBindKeySequence(WSocket* sessionSocket,
-                                              const QString& name,
-                                              const QKeySequence& keySequence,
-                                              uint mode,
-                                              uint action)
+void ShortcutManagerV2::handleBindKey(WSocket* sessionSocket,
+                                      const QString& name,
+                                      const QString& key,
+                                      uint mode,
+                                      uint action)
 {
     Q_D(ShortcutManagerV2);
     d->m_pendingShortcuts[sessionSocket].keys.append(KeyShortcut{
         .mode = mode,
         .name = name,
-        .keySequence = keySequence,
+        .key = key,
         .action = static_cast<ShortcutAction>(action),
     });
 }

--- a/src/modules/shortcut/shortcutmanager.h
+++ b/src/modules/shortcut/shortcutmanager.h
@@ -78,9 +78,9 @@ Q_SIGNALS:
 
 private Q_SLOTS:
     void handleUnregisterShortcut(WSocket* sessionSocket, const QString& name);
-    void handleBindKeySequence(WSocket* sessionSocket,
+    void handleBindKey(WSocket* sessionSocket,
                                const QString& name,
-                               const QKeySequence& keySequence,
+                               const QString& key,
                                uint mode,
                                uint action);
     void handleBindSwipeGesture(WSocket* sessionSocket, const QString& name, uint finger, uint direction, uint action);

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1616,14 +1616,13 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *, QInputEvent *event)
                 break;
             }
 
-            QKeySequence sequence(kevent->modifiers() | kevent->key());
-            qCInfo(treelandShortcut) << "Dispatch shortcut:" << sequence;
+            QKeyCombination combination = kevent->keyCombination();
             if (event->type() == QEvent::KeyPress
-                && m_shortcutManager->controller()->dispatchKeyPress(sequence, kevent->isAutoRepeat())) {
+                && m_shortcutManager->controller()->dispatchKeyPress(combination, kevent->isAutoRepeat())) {
                 return true;
             }
             if (event->type() == QEvent::KeyRelease
-                && m_shortcutManager->controller()->dispatchKeyRelease(sequence)) {
+                && m_shortcutManager->controller()->dispatchKeyRelease(combination)) {
                 return true;
             }
         } while (false);

--- a/src/treeland-shortcut/shortcuts/_dde-launchpad.ini
+++ b/src/treeland-shortcut/shortcuts/_dde-launchpad.ini
@@ -1,5 +1,6 @@
 [Shortcut]
 Shortcut=Meta
+KeybindMode="KeyRelease"
 Type="DBus"
 
 [Type.DBus]

--- a/src/treeland-shortcut/shortcuts/_treeland-taskswitch-enter.ini
+++ b/src/treeland-shortcut/shortcuts/_treeland-taskswitch-enter.ini
@@ -1,5 +1,5 @@
 [Shortcut]
-Shortcut=Alt+Alt
+Shortcut=Alt
 Type="Action"
 
 [Type.Action]


### PR DESCRIPTION
The problem:
- The deserialization of QKeySequence is position-dependent and confusing: ex: "Alt+Meta" and "Meta+Alt" are non-equivalent in QKeySequence parsing. the Control key is parsed as "Control" as a key but "Ctrl" as a modifier.
- All-modifier keybindings fail to match correctly; the comparison result depends on which modifier key was pressed last.

The fix:
- Drop the use of QKeySequence in favor of QKeyCombination for keybindings matching.
- Normaize all-modifier key events to `QKeyCombination(modifiers, Qt::Key_unknown)` during keybinding registration and dispatching.
- Append "+Control" to all-modifier keybinding strings ending with "+Ctrl" since "Ctrl" is not a valid key name for QKeySequence.

Bonus:
- Changed _dde-launchpad to activate on KeyRelease, so launchpad won't pop up when switching workspaces etc.