### PR TITLE
refactor: remove redundant virtual qualifiers from lockscreen interface

### DIFF
--- a/src/modules/dde-shell/ddeshellmanagerinterfacev1.cpp
+++ b/src/modules/dde-shell/ddeshellmanagerinterfacev1.cpp
@@ -795,9 +795,9 @@ public:
 protected:
     void treeland_lockscreen_v1_destroy_resource([[maybe_unused]] Resource *resource) override;
     void treeland_lockscreen_v1_destroy([[maybe_unused]] Resource *resource) override;
-    virtual void treeland_lockscreen_v1_lock([[maybe_unused]] Resource *resource) override;
-    virtual void treeland_lockscreen_v1_shutdown([[maybe_unused]] Resource *resource) override;
-    virtual void treeland_lockscreen_v1_switch_user([[maybe_unused]] Resource *resource) override;
+    void treeland_lockscreen_v1_lock([[maybe_unused]] Resource *resource) override;
+    void treeland_lockscreen_v1_shutdown([[maybe_unused]] Resource *resource) override;
+    void treeland_lockscreen_v1_switch_user([[maybe_unused]] Resource *resource) override;
 };
 
 void LockScreenInterfacePrivate::treeland_lockscreen_v1_lock([[maybe_unused]] Resource *resource)


### PR DESCRIPTION
Log:

## Summary by Sourcery

Enhancements:
- Remove redundant virtual qualifiers from overridden lockscreen interface methods to align with modern C++ style.