### PR TITLE
fix: fix splash screen launch animation

### DIFF
--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -1006,6 +1006,8 @@ void SurfaceWrapper::createNewOrClose(uint direction)
         return;
 
     switch (m_type) {
+    case Type::Undetermined:
+        [[fallthrough]];
     case Type::XdgToplevel:
         [[fallthrough]];
     case Type::XWayland: {
@@ -1232,7 +1234,8 @@ void SurfaceWrapper::onMappedChanged()
     bool mapped = surface()->mapped() && !m_hideByLockScreen;
     if (!m_isProxy) {
         if (mapped) {
-            createNewOrClose(OPEN_ANIMATION);
+            if (!m_prelaunchSplash)
+                createNewOrClose(OPEN_ANIMATION);
             if (m_coverContent) {
                 m_coverContent->setVisible(true);
             }
@@ -1820,6 +1823,11 @@ void SurfaceWrapper::setHasInitializeContainer(bool value)
 {
     Q_ASSERT(!value || m_container != nullptr);
     updateHasActiveCapability(ActiveControlState::HasInitializeContainer, value);
+    if (m_prelaunchSplash && value) {
+        // Start open animation when container initialized
+        // m_prelaunchSplash can't get mapped signal
+        createNewOrClose(OPEN_ANIMATION);
+    }
 }
 
 void SurfaceWrapper::disableWindowAnimation(bool disable)


### PR DESCRIPTION
Fixed splash screen launch animation by handling prelaunch splash windows differently from regular windows. The changes ensure that prelaunch splash windows don't trigger animations on mapped signal but instead start animations when their container is initialized.

Key changes:
1. Added Undetermined type to the createNewOrClose switch statement
2. Skip animation trigger on mapped signal for prelaunch splash windows
3. Add animation trigger when container is initialized for prelaunch splash windows
4. This is necessary because prelaunch splash windows can't receive mapped signals properly

Log: Fixed splash screen animation timing during application startup

Influence:
1. Test application startup with splash screens
2. Verify splash screen animation plays correctly
3. Check that regular window animations still work properly
4. Test with different window types (XdgToplevel, XWayland, Undetermined)
5. Verify no animation issues when locking/unlocking screen
6. Test container initialization timing for splash windows

## Summary by Sourcery

Adjust splash screen window handling to fix launch animation timing for prelaunch splash windows.

Bug Fixes:
- Prevent prelaunch splash windows from incorrectly triggering open animations on mapped events.
- Ensure prelaunch splash windows start their open animation when their container is initialized, preserving correct behavior for regular windows.

Enhancements:
- Treat undetermined surface types like toplevel and XWayland windows in the window creation/closing logic to unify handling across window types.