### PR TITLE
fix: Support layer surfaces on proxy outputs in Copy Mode

### DIFF
--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -111,17 +111,15 @@ void RootSurfaceContainer::addOutput(Output *output)
     if (!m_primaryOutput)
         setPrimaryOutput(output);
 
-    if (output->isPrimary()) {
-        SurfaceContainer::addOutput(output);
-    }
+    // Register all outputs (including primary and proxy/copy) to ensure
+    // LayerSurfaceContainer is initialized for every active display.
+    SurfaceContainer::addOutput(output);
 }
 
 void RootSurfaceContainer::removeOutput(Output *output)
 {
     m_outputModel->removeObject(output);
-    if (output->isPrimary()) {
-        SurfaceContainer::removeOutput(output);
-    }
+    SurfaceContainer::removeOutput(output);
 
     if (moveResizeState.surface && moveResizeState.surface->ownsOutput() == output) {
         endMoveResize();

--- a/src/surface/surfacecontainer.cpp
+++ b/src/surface/surfacecontainer.cpp
@@ -182,7 +182,8 @@ void SurfaceContainer::removeSurface(SurfaceWrapper *surface)
 
 void SurfaceContainer::addOutput(Output *output)
 {
-    Q_ASSERT(output->isPrimary());
+    // Allow all outputs to manage surface containers, ensuring support
+    // for both Primary and Proxy (Copy Mode) displays.
     const auto subContainers = this->subContainers();
     for (auto sub : subContainers) {
         sub->addOutput(output);


### PR DESCRIPTION
Remove the primary-output-only restriction on LayerSurfaceContainer creation. This allows proxy outputs used in Copy Mode to properly manage layer surfaces, fixing crashes when applications like wdisplays attempt to create surfaces on secondary displays.

Changes:
- SurfaceContainer::addOutput(): Remove isPrimary() assertion
- RootSurfaceContainer::addOutput(): Remove isPrimary() condition
- RootSurfaceContainer::removeOutput(): Remove isPrimary() condition

This ensures all outputs (primary and proxy) are treated equally according to the Wayland protocol specification. Proxy outputs no longer trigger assertion failures when layer surfaces are created on them.

Fixes Copy Mode crashes that occurred when:
1. Opening wdisplays and accessing proxy output settings
2. Disabling and re-enabling HDMI display in Copy Mode

## Summary by Sourcery

Bug Fixes:
- Fix crashes in Copy Mode caused by assertion failures when layer surfaces are created on non-primary (proxy) outputs.