### PR TITLE
fix: correct workspace change detection logic

### DIFF
--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -1715,8 +1715,8 @@ void SurfaceWrapper::setWorkspaceId(int newWorkspaceId)
     if (m_workspaceId == newWorkspaceId)
         return;
 
-    bool onAllWorkspaceHasChanged = m_workspaceId == Workspace::ShowOnAllWorkspaceId
-        || newWorkspaceId == Workspace::ShowOnAllWorkspaceId;
+    bool onAllWorkspaceHasChanged = (m_workspaceId == Workspace::ShowOnAllWorkspaceId)
+        != (newWorkspaceId == Workspace::ShowOnAllWorkspaceId);
     m_workspaceId = newWorkspaceId;
 
     if (onAllWorkspaceHasChanged)

--- a/waylib/examples/tinywl/surfacewrapper.cpp
+++ b/waylib/examples/tinywl/surfacewrapper.cpp
@@ -1002,7 +1002,7 @@ void SurfaceWrapper::setWorkspaceId(int newWorkspaceId)
     if (m_workspaceId == newWorkspaceId)
         return;
 
-    bool onAllWorkspaceHasChanged = m_workspaceId == 0 || newWorkspaceId == 0;
+    bool onAllWorkspaceHasChanged = (m_workspaceId == 0) != (newWorkspaceId == 0);
     m_workspaceId = newWorkspaceId;
 
     if (onAllWorkspaceHasChanged)


### PR DESCRIPTION
The logic for detecting when workspace changes require special handling was incorrect. Previously, it used OR condition which would trigger when either workspace was the special "all workspaces" value. This was wrong because it should only trigger when transitioning between normal workspace and all-workspaces state.

Changed from OR to XOR (implemented as !=) to properly detect when the workspace state changes between normal workspace and all-workspaces mode. This ensures that workspace change notifications are only sent when actually transitioning between these two states, not when moving between normal workspaces.

修复工作区变更检测逻辑错误

工作区变更需要特殊处理的检测逻辑存在错误。之前使用 OR 条件会在任一工作区
为特殊"所有工作区"值时触发，这是不正确的，应该只在普通工作区和所有工作区
状态之间转换时触发。

将 OR 改为 XOR（通过 != 实现）以正确检测工作区状态在普通工作区和所有工
作区模式之间的变化。这确保工作区变更通知只在真正在这两种状态之间转换时发
送，而不是在普通工作区之间移动时发送。

## Summary by Sourcery

Bug Fixes:
- Correct workspace change detection to avoid triggering special handling when moving between normal workspaces without changing the all-workspaces state.