### PR TITLE
fix: clang compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project(Treeland
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_C_STANDARD 23) # Unnamed parameters in function definition is a C23 extension feature.
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Standard installation paths

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -37,6 +37,19 @@
             }
         },
         {
+            "name": "ci-clang",
+            "displayName": "CI Build Config for clang",
+            "description": "Build configuration with warnings as errors",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++",
+                "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror -Wno-shift-overflow -Wno-overloaded-virtual",
+                "CMAKE_C_FLAGS": "-Wall -Wextra -Werror -Wno-shift-overflow -Wno-overloaded-virtual"
+            }
+        },
+        {
             "name": "deb",
             "displayName": "Debian Package Build Config",
             "description": "Build configuration for Debian packaging with examples enabled",
@@ -62,6 +75,10 @@
         {
             "name": "ci",
             "configurePreset": "ci"
+        },
+        {
+            "name": "ci-clang",
+            "configurePreset": "ci-clang"
         },
         {
             "name": "deb",

--- a/src/core/lockscreen.cpp
+++ b/src/core/lockscreen.cpp
@@ -220,7 +220,7 @@ void LockScreen::onLockSurfaceAdded(WSessionLockSurface *surface)
 
     wrapper->setHasInitializeContainer(true);
 
-    connect(wrapper, &SurfaceWrapper::requestActive, this, [this, wrapper] {
+    connect(wrapper, &SurfaceWrapper::requestActive, this, [wrapper] {
         Helper::instance()->activateSurface(wrapper);
     });
 }

--- a/src/core/qmlengine.cpp
+++ b/src/core/qmlengine.cpp
@@ -194,7 +194,7 @@ QQuickItem *QmlEngine::createDockPreview(QQuickItem *parent)
     return createComponent(dockPreviewComponent, parent);
 }
 
-QQuickItem *QmlEngine::createLockScreen(Output *output, QQuickItem *parent)
+QQuickItem *QmlEngine::createLockScreen([[maybe_unused]] Output *output, [[maybe_unused]] QQuickItem *parent)
 {
 #ifndef DISABLE_DDM
     return createComponent(lockScreenComponent,

--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -198,7 +198,7 @@ WXWayland *ShellHandler::createXWayland(WServer *server,
     m_xwaylands.append(xwayland);
     xwayland->setSeat(seat);
     connect(xwayland, &WXWayland::surfaceAdded, this, &ShellHandler::onXWaylandSurfaceAdded);
-    connect(xwayland, &WXWayland::ready, xwayland, [xwayland, this] {
+    connect(xwayland, &WXWayland::ready, xwayland, [xwayland] {
         auto atomPid = xwayland->atom("_NET_WM_PID");
         xwayland->setAtomSupported(atomPid, true);
         auto atomNoTitlebar = xwayland->atom("_DEEPIN_NO_TITLEBAR");
@@ -531,7 +531,7 @@ void ShellHandler::setupSurfaceActiveWatcher(SurfaceWrapper *wrapper)
         });
         */
     } else if (wrapper->type() == SurfaceWrapper::Type::Layer) {
-        connect(wrapper, &SurfaceWrapper::requestActive, this, [this, wrapper]() {
+        connect(wrapper, &SurfaceWrapper::requestActive, this, [wrapper]() {
             auto layerSurface = qobject_cast<WLayerSurface *>(wrapper->shellSurface());
             if (layerSurface->keyboardInteractivity() == WLayerSurface::KeyboardInteractivity::None)
                 return;
@@ -546,7 +546,7 @@ void ShellHandler::setupSurfaceActiveWatcher(SurfaceWrapper *wrapper)
                 Helper::instance()->activateSurface(wrapper);
         });
 
-        connect(wrapper, &SurfaceWrapper::requestInactive, this, [this, wrapper]() {
+        connect(wrapper, &SurfaceWrapper::requestInactive, this, [this]() {
             Helper::instance()->activateSurface(m_workspace->current()->latestActiveSurface());
         });
     } else { // Xdgtoplevel or X11

--- a/src/core/treeland.cpp
+++ b/src/core/treeland.cpp
@@ -321,7 +321,7 @@ Treeland::Treeland()
     d->init();
 
     if (CmdLine::ref().run().has_value()) {
-        auto exec = [runCmd = CmdLine::ref().run().value(), this, d] {
+        auto exec = [runCmd = CmdLine::ref().run().value(), d] {
             qCInfo(treelandDBus) << "run cmd:" << runCmd;
             if (auto cmdline = CmdLine::ref().unescapeExecArgs(runCmd); cmdline) {
                 auto cmdArgs = cmdline.value();

--- a/src/modules/capture/capture.cpp
+++ b/src/modules/capture/capture.cpp
@@ -725,7 +725,7 @@ void CaptureSourceSelector::mouseMoveEvent(QMouseEvent *event)
     }
 }
 
-static inline WSurfaceItemContent *findItemContent(QQuickItem *item)
+[[maybe_unused]] static inline WSurfaceItemContent *findItemContent(QQuickItem *item)
 {
     QQueue<QQuickItem *> q;
     q.enqueue(item);

--- a/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
+++ b/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
@@ -95,14 +95,14 @@ void ForeignToplevelV1::addSurface(SurfaceWrapper *wrapper)
     connect(handle,
             &treeland_foreign_toplevel_handle_v1::requestActivate,
             wrapper,
-            [wrapper, this]([[maybe_unused]] treeland_foreign_toplevel_handle_v1_activated_event *event) {
+            [wrapper]([[maybe_unused]] treeland_foreign_toplevel_handle_v1_activated_event *event) {
                 Helper::instance()->forceActivateSurface(wrapper);
             });
 
     connect(handle,
             &treeland_foreign_toplevel_handle_v1::requestMaximize,
             wrapper,
-            [wrapper, this](treeland_foreign_toplevel_handle_v1_maximized_event *event) {
+            [wrapper](treeland_foreign_toplevel_handle_v1_maximized_event *event) {
                 if (event->maximized)
                     wrapper->requestMaximize();
                 else
@@ -112,7 +112,7 @@ void ForeignToplevelV1::addSurface(SurfaceWrapper *wrapper)
     connect(handle,
             &treeland_foreign_toplevel_handle_v1::requestMinimize,
             wrapper,
-            [wrapper, this](treeland_foreign_toplevel_handle_v1_minimized_event *event) {
+            [wrapper](treeland_foreign_toplevel_handle_v1_minimized_event *event) {
                 if ((Helper::instance()->showDesktopState()
                      == WindowManagementV1::DesktopState::Show)) {
                     Helper::instance()->forceActivateSurface(wrapper);
@@ -128,20 +128,20 @@ void ForeignToplevelV1::addSurface(SurfaceWrapper *wrapper)
     connect(handle,
             &treeland_foreign_toplevel_handle_v1::requestFullscreen,
             wrapper,
-            [wrapper, this](treeland_foreign_toplevel_handle_v1_fullscreen_event *event) {
+            [wrapper](treeland_foreign_toplevel_handle_v1_fullscreen_event *event) {
                 if (event->fullscreen)
                     wrapper->requestFullscreen();
                 else
                     wrapper->requestCancelFullscreen();
             });
 
-    connect(handle, &treeland_foreign_toplevel_handle_v1::requestClose, surface, [surface, this] {
+    connect(handle, &treeland_foreign_toplevel_handle_v1::requestClose, surface, [surface] {
         surface->close();
     });
     connect(handle,
             &treeland_foreign_toplevel_handle_v1::rectangleChanged,
             wrapper,
-            [wrapper, this](treeland_foreign_toplevel_handle_v1_set_rectangle_event *event) {
+            [wrapper](treeland_foreign_toplevel_handle_v1_set_rectangle_event *event) {
                 auto dockWrapper = Helper::instance()->rootContainer()->getSurface(
                     WSurface::fromHandle(event->surface));
                 wrapper->setIconGeometry(QRect(dockWrapper->x() + event->x,

--- a/src/modules/foreign-toplevel/impl/foreign_toplevel_manager_impl.h
+++ b/src/modules/foreign-toplevel/impl/foreign_toplevel_manager_impl.h
@@ -55,7 +55,10 @@ public:
     treeland_foreign_toplevel_manager_v1 *manager{ nullptr };
     wl_resource *resource{ nullptr };
     wlr_surface *relative_surface{ nullptr };
-    struct wl_listener destroy_listener;
+    struct TDPCPODWrapper {
+        treeland_dock_preview_context_v1 *context;
+        struct wl_listener wrapped_listener;
+    } destroy_listener_wrapper;
     struct wl_client *client{ nullptr };
 
     void enter();

--- a/src/modules/item-selector/itemselector.cpp
+++ b/src/modules/item-selector/itemselector.cpp
@@ -21,7 +21,7 @@ ItemSelector::ItemSelector(QQuickItem *parent)
 #endif
     setKeepMouseGrab(true);
     QQuickItemPrivate::get(this)->anchors()->setFill(parentItem());
-    m_defaultFilter = [this](QQuickItem *item, ItemSelector::ItemTypes selectionHint) {
+    m_defaultFilter = [](QQuickItem *item, ItemSelector::ItemTypes selectionHint) {
         if (!item->isVisible())
             return false;
         if (qobject_cast<WOutputItem *>(item) && selectionHint.testFlag(ItemType::Output)) {

--- a/src/modules/personalization/impl/appearance_impl.h
+++ b/src/modules/personalization/impl/appearance_impl.h
@@ -9,9 +9,9 @@
 
 #include <functional>
 
-class treeland_personalization_manager_v1;
+struct treeland_personalization_manager_v1;
 
-class personalization_appearance_context_v1 : public QObject
+struct personalization_appearance_context_v1 : public QObject
 {
 
     Q_OBJECT

--- a/src/modules/personalization/impl/font_impl.h
+++ b/src/modules/personalization/impl/font_impl.h
@@ -12,7 +12,7 @@
 #include <QObject>
 #include <QStringList>
 
-class treeland_personalization_manager_v1;
+struct treeland_personalization_manager_v1;
 
 struct personalization_font_context_v1 : public QObject
 {

--- a/src/modules/personalization/impl/personalization_manager_impl.h
+++ b/src/modules/personalization/impl/personalization_manager_impl.h
@@ -18,8 +18,8 @@ struct personalization_window_context_v1;
 struct personalization_wallpaper_context_v1;
 struct personalization_cursor_context_v1;
 struct wlr_surface;
-class personalization_appearance_context_v1;
-class personalization_font_context_v1;
+struct personalization_appearance_context_v1;
+struct personalization_font_context_v1;
 
 struct treeland_personalization_manager_v1 : public QObject
 {

--- a/src/modules/personalization/personalizationmanager.cpp
+++ b/src/modules/personalization/personalizationmanager.cpp
@@ -160,37 +160,37 @@ void PersonalizationV1::onAppearanceContextCreated(personalization_appearance_co
 
     m_appearanceContexts.push_back(context);
 
-    connect(context, &Appearance::roundCornerRadiusChanged, this, [this, context](int32_t radius) {
+    connect(context, &Appearance::roundCornerRadiusChanged, this, [this](int32_t radius) {
         Helper::instance()->config()->setWindowRadius(radius);
         for (auto *context : m_appearanceContexts) {
             context->sendRoundCornerRadius(radius);
         }
     });
-    connect(context, &Appearance::iconThemeChanged, this, [this, context](const QString &theme) {
+    connect(context, &Appearance::iconThemeChanged, this, [this](const QString &theme) {
         Helper::instance()->config()->setIconThemeName(theme);
         for (auto *context : m_appearanceContexts) {
             context->sendIconTheme(theme.toUtf8());
         }
     });
-    connect(context, &Appearance::activeColorChanged, this, [this, context](const QString &color) {
+    connect(context, &Appearance::activeColorChanged, this, [this](const QString &color) {
         Helper::instance()->config()->setActiveColor(color);
         for (auto *context : m_appearanceContexts) {
             context->sendActiveColor(color.toUtf8());
         }
     });
-    connect(context, &Appearance::windowOpacityChanged, this, [this, context](uint32_t opacity) {
+    connect(context, &Appearance::windowOpacityChanged, this, [this](uint32_t opacity) {
         Helper::instance()->config()->setWindowOpacity(opacity);
         for (auto *context : m_appearanceContexts) {
             context->sendWindowOpacity(opacity);
         }
     });
-    connect(context, &Appearance::windowThemeTypeChanged, this, [this, context](int32_t type) {
+    connect(context, &Appearance::windowThemeTypeChanged, this, [this](int32_t type) {
         Helper::instance()->config()->setWindowThemeType(type);
         for (auto *context : m_appearanceContexts) {
             context->sendWindowThemeType(type);
         }
     });
-    connect(context, &Appearance::titlebarHeightChanged, this, [this, context](uint32_t height) {
+    connect(context, &Appearance::titlebarHeightChanged, this, [this](uint32_t height) {
         Helper::instance()->config()->setWindowTitlebarHeight(height);
         for (auto *context : m_appearanceContexts) {
             context->sendWindowTitlebarHeight(height);
@@ -205,19 +205,19 @@ void PersonalizationV1::onAppearanceContextCreated(personalization_appearance_co
         context->setIconTheme(iconTheme().toUtf8());
     });
 
-    connect(context, &Appearance::requestActiveColor, context, [this, context] {
+    connect(context, &Appearance::requestActiveColor, context, [context] {
         context->setActiveColor(Helper::instance()->config()->activeColor().toUtf8());
     });
 
-    connect(context, &Appearance::requestWindowOpacity, context, [this, context] {
+    connect(context, &Appearance::requestWindowOpacity, context, [context] {
         context->setWindowOpacity(Helper::instance()->config()->windowOpacity());
     });
 
-    connect(context, &Appearance::requestWindowThemeType, context, [this, context] {
+    connect(context, &Appearance::requestWindowThemeType, context, [context] {
         context->setWindowThemeType(Helper::instance()->config()->windowThemeType());
     });
 
-    connect(context, &Appearance::requestWindowTitlebarHeight, context, [this, context] {
+    connect(context, &Appearance::requestWindowTitlebarHeight, context, [context] {
         context->setWindowTitlebarHeight(Helper::instance()->config()->windowTitlebarHeight());
     });
 

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2511,7 +2511,7 @@ void Helper::handleWindowPicker(WindowPickerInterface *picker)
         connect(windowPicker,
                 &WindowPicker::windowPicked,
                 this,
-                [this, picker, windowPicker](WSurfaceItem *surfaceItem) {
+                [picker, windowPicker](WSurfaceItem *surfaceItem) {
                     if (surfaceItem) {
                         auto credentials = WClient::getCredentials(
                             surfaceItem->surface()->waylandClient()->handle());

--- a/src/xsettings/xsettings.cpp
+++ b/src/xsettings/xsettings.cpp
@@ -315,7 +315,7 @@ void XSettings::setSettings(const QByteArray &data)
 {
     xcb_grab_server(m_connection);
 
-    foreach (xcb_window_t win, m_windows) {
+    for (const xcb_window_t &win : std::as_const(m_windows)) {
         xcb_change_property(m_connection,
                             XCB_PROP_MODE_REPLACE,
                             win,

--- a/waylib/examples/blur/main.cpp
+++ b/waylib/examples/blur/main.cpp
@@ -56,7 +56,7 @@ void Helper::initProtocols(WOutputRenderWindow *window, QQmlEngine *qmlEngine)
         qFatal("Failed to create renderer");
     }
 
-    connect(m_backend, &WBackend::outputAdded, this, [this, window, qmlEngine] (WOutput *output) {
+    connect(m_backend, &WBackend::outputAdded, this, [this, qmlEngine] (WOutput *output) {
         auto initProperties = qmlEngine->newObject();
         initProperties.setProperty("waylandOutput", qmlEngine->toScriptValue(output));
         initProperties.setProperty("layout", qmlEngine->toScriptValue(m_outputLayout));

--- a/waylib/examples/outputviewport/main.cpp
+++ b/waylib/examples/outputviewport/main.cpp
@@ -57,7 +57,7 @@ void Helper::initProtocols(WOutputRenderWindow *window, QQmlEngine *qmlEngine)
         qFatal("Failed to create renderer");
     }
 
-    connect(m_backend, &WBackend::outputAdded, this, [this, window, qmlEngine] (WOutput *output) {
+    connect(m_backend, &WBackend::outputAdded, this, [this, qmlEngine] (WOutput *output) {
         auto initProperties = qmlEngine->newObject();
         initProperties.setProperty("waylandOutput", qmlEngine->toScriptValue(output));
         initProperties.setProperty("layout", qmlEngine->toScriptValue(m_outputLayout));

--- a/waylib/examples/tinywl/helper.cpp
+++ b/waylib/examples/tinywl/helper.cpp
@@ -273,7 +273,7 @@ void Helper::init()
 
     auto *sessionLockManager = m_server->attach<WSessionLockManager>();
     m_lockContainer->setVisible(false);
-    sessionLockManager->safeConnect(&WSessionLockManager::lockCreated, this, [this, sessionLockManager](WSessionLock *lock) {
+    sessionLockManager->safeConnect(&WSessionLockManager::lockCreated, this, [this](WSessionLock *lock) {
         if (m_lockContainer->isVisible()) {
             qWarning() << "Only one session lock is allowed!";
             lock->finish();
@@ -286,7 +286,7 @@ void Helper::init()
             auto geometry = output->geometry();
             wrapper->resize(geometry.size());
             wrapper->setPosition(geometry.topLeft());
-            connect(output->outputItem(), &WOutputItem::geometryChanged, this, [this, output, wrapper] {
+            connect(output->outputItem(), &WOutputItem::geometryChanged, this, [output, wrapper] {
                 auto geometry = output->geometry();
                 wrapper->resize(geometry.size());
                 wrapper->setPosition(geometry.topLeft());
@@ -355,7 +355,7 @@ void Helper::init()
 
             // Setup title and decoration
             auto xwayland = qobject_cast<WXWaylandSurface *>(wrapper->shellSurface());
-            auto updateDecorationTitleBar = [this, wrapper, xwayland]() {
+            auto updateDecorationTitleBar = [wrapper, xwayland]() {
                 if (!xwayland->isBypassManager()) {
                     wrapper->setNoTitleBar(xwayland->decorationsFlags()
                                            & WXWaylandSurface::DecorationsNoTitle);
@@ -450,7 +450,7 @@ void Helper::init()
     }
 
     auto gammaControlManager = qw_gamma_control_manager_v1::create(*m_server->handle());
-    connect(gammaControlManager, &qw_gamma_control_manager_v1::notify_set_gamma, this, [this]
+    connect(gammaControlManager, &qw_gamma_control_manager_v1::notify_set_gamma, this, []
             (wlr_gamma_control_manager_v1_set_gamma_event *event) {
         auto *qwOutput = qw_output::from(event->output);
         size_t ramp_size = 0;

--- a/waylib/examples/tinywl/rootsurfacecontainer.cpp
+++ b/waylib/examples/tinywl/rootsurfacecontainer.cpp
@@ -259,7 +259,7 @@ void RootSurfaceContainer::addBySubContainer(SurfaceContainer *sub, SurfaceWrapp
         Q_ASSERT(surface);
         startResize(surface, edges);
     });
-    connect(surface, &SurfaceWrapper::surfaceStateChanged, this, [surface, this] {
+    connect(surface, &SurfaceWrapper::surfaceStateChanged, this, [surface] {
         if (surface->surfaceState() == SurfaceWrapper::State::Minimized
             || surface->surfaceState() == SurfaceWrapper::State::Tiling)
             return;

--- a/waylib/src/server/kernel/wcursor.cpp
+++ b/waylib/src/server/kernel/wcursor.cpp
@@ -653,11 +653,11 @@ void WCursor::setLayout(WOutputLayout *layout)
             o->addCursor(this);
     }
 
-    connect(d->outputLayout, &WOutputLayout::outputAdded, this, [this, d] (WOutput *o) {
+    connect(d->outputLayout, &WOutputLayout::outputAdded, this, [this] (WOutput *o) {
         o->addCursor(this);
     });
 
-    connect(d->outputLayout, &WOutputLayout::outputRemoved, this, [this, d] (WOutput *o) {
+    connect(d->outputLayout, &WOutputLayout::outputRemoved, this, [this] (WOutput *o) {
         o->removeCursor(this);
     });
 

--- a/waylib/src/server/kernel/woutputlayout.cpp
+++ b/waylib/src/server/kernel/woutputlayout.cpp
@@ -69,8 +69,6 @@ WOutputLayout::WOutputLayout(WOutputLayoutPrivate &dd, WServer *server)
     auto h = new qw_output_layout(*server->handle());
     initHandle(h);
 
-    W_D(WOutputLayout);
-
     handle()->set_data(this, this);
 }
 

--- a/waylib/src/server/kernel/wseat.cpp
+++ b/waylib/src/server/kernel/wseat.cpp
@@ -850,7 +850,7 @@ void WSeat::detachInputDevice(WInputDevice *device)
         d->updateCapabilities();
 }
 
-inline static WSeat *getSeat(QInputEvent *event)
+[[maybe_unused]] inline static WSeat *getSeat(QInputEvent *event)
 {
     auto inputDevice = WInputDevice::from(event->device());
     if (Q_UNLIKELY(!inputDevice))
@@ -966,9 +966,9 @@ bool WSeat::sendEvent(WSurface *target, QObject *shellObject, QObject *eventObje
         switch (e->gestureType()) {
             case Qt::NativeGestureType::BeginNativeGesture:
                 if (e->libInputGestureType() == WGestureEvent::WLibInputGestureType::SwipeGesture)
-                d->gesture->send_swipe_begin(d->nativeHandle(), e->timestamp(), e->fingerCount());
+                    d->gesture->send_swipe_begin(d->nativeHandle(), e->timestamp(), e->fingerCount());
                 if (e->libInputGestureType() == WGestureEvent::WLibInputGestureType::PinchGesture)
-                d->gesture->send_pinch_begin(d->nativeHandle(), e->timestamp(), e->fingerCount());
+                    d->gesture->send_pinch_begin(d->nativeHandle(), e->timestamp(), e->fingerCount());
                 if (e->libInputGestureType() == WGestureEvent::WLibInputGestureType::HoldGesture)
                     d->gesture->send_hold_begin(d->nativeHandle(), e->timestamp(), e->fingerCount());
                 break;
@@ -1328,7 +1328,6 @@ void WSeat::notifyHoldEnd(WCursor *cursor, WInputDevice *device, uint32_t time_m
 
 void WSeat::notifyTouchDown(WCursor *cursor, WInputDevice *device, int32_t touch_id, [[maybe_unused]] uint32_t time_msec)
 {
-    W_D(WSeat);
     auto qwDevice = qobject_cast<QPointingDevice*>(device->qtDevice());
     Q_ASSERT(qwDevice);
     const QPointF &globalPos = cursor->position();
@@ -1366,8 +1365,6 @@ void WSeat::notifyTouchDown(WCursor *cursor, WInputDevice *device, int32_t touch
 
 void WSeat::notifyTouchMotion(WCursor *cursor, WInputDevice *device, int32_t touch_id, [[maybe_unused]] uint32_t time_msec)
 {
-
-    W_DC(WSeat);
     auto qwDevice = qobject_cast<QPointingDevice*>(device->qtDevice());
     Q_ASSERT(qwDevice);
 
@@ -1396,7 +1393,6 @@ void WSeat::notifyTouchMotion(WCursor *cursor, WInputDevice *device, int32_t tou
 
 void WSeat::notifyTouchUp(WCursor *cursor, WInputDevice *device, int32_t touch_id, [[maybe_unused]] uint32_t time_msec)
 {
-    W_DC(WSeat);
     auto qwDevice = qobject_cast<QPointingDevice*>(device->qtDevice());
     Q_ASSERT(qwDevice);
 

--- a/waylib/src/server/kernel/wserver.cpp
+++ b/waylib/src/server/kernel/wserver.cpp
@@ -339,7 +339,6 @@ void WServer::initializeProxyQPA(int &argc, char **argv, const QStringList &prox
 {
     Q_ASSERT(!proxyPlatformPlugins.isEmpty());
 
-    W_DC(WServer);
     QPlatformIntegration *proxy = nullptr;
     for (const QString &name : std::as_const(proxyPlatformPlugins)) {
         if (name.isEmpty())

--- a/waylib/src/server/kernel/wsocket.cpp
+++ b/waylib/src/server/kernel/wsocket.cpp
@@ -742,8 +742,6 @@ WClient *WSocket::addClient(wl_client *client, bool isWlClientOwned)
 
 bool WSocket::removeClient(wl_client *client)
 {
-    W_D(WSocket);
-
     if (auto c = WClient::get(client))
         return removeClient(c);
     return false;

--- a/waylib/src/server/kernel/wsocket.h
+++ b/waylib/src/server/kernel/wsocket.h
@@ -51,7 +51,7 @@ public Q_SLOTS:
 
 private:
     friend class WSocket;
-    friend class WlClientDestroyListener;
+    friend struct WlClientDestroyListener;
     explicit WClient(wl_client *client, WSocket *socket, bool isWlClientOwned = true);
     ~WClient() = default;
     using QObject::deleteLater;

--- a/waylib/src/server/protocols/private/winputmethodv2.cpp
+++ b/waylib/src/server/protocols/private/winputmethodv2.cpp
@@ -75,7 +75,6 @@ public:
 WInputMethodV2::WInputMethodV2(qw_input_method_v2 *h, QObject *parent) :
     WWrapObject(*new WInputMethodV2Private(h, this), parent)
 {
-    W_D(WInputMethodV2);
     connect(handle(), &qw_input_method_v2::notify_commit, this, &WInputMethodV2::committed);
     connect(handle(), &qw_input_method_v2::notify_grab_keyboard, this, [this](wlr_input_method_keyboard_grab_v2 *grab) {
         Q_EMIT newKeyboardGrab(qw_input_method_keyboard_grab_v2::from(grab));

--- a/waylib/src/server/protocols/private/wtextinputv1.cpp
+++ b/waylib/src/server/protocols/private/wtextinputv1.cpp
@@ -213,7 +213,6 @@ void WTextInputV1::sendDeleteSurroundingText(int index, uint length)
 WTextInputV1::WTextInputV1(QObject *parent)
     : WTextInput(*new WTextInputV1Private(this), parent)
 {
-    W_D(WTextInputV1);
     connect(this, &WTextInputV1::activate, this, &WTextInputV1::requestFocus);
     connect(this, &WTextInputV1::deactivate, this, [this] {
         // Disconnect all signals excluding requestFocus, as text input may be activated again in
@@ -439,7 +438,6 @@ static void text_input_manager_bind(wl_client *wl_client, void *data, uint32_t v
 
 void WTextInputManagerV1::create(WServer *server)
 {
-    W_D(WTextInputManagerV1);
     m_global = wl_global_create(server->handle()->handle(),
                                 &zwp_text_input_manager_v1_interface,
                                 1,

--- a/waylib/src/server/protocols/private/wtextinputv2.cpp
+++ b/waylib/src/server/protocols/private/wtextinputv2.cpp
@@ -316,7 +316,6 @@ QByteArrayView WTextInputManagerV2::interfaceName() const
 
 void WTextInputManagerV2::create(WServer *server)
 {
-    W_D(WTextInputManagerV2);
     m_global = wl_global_create(server->handle()->handle(), &zwp_text_input_manager_v2_interface, 1, this, text_input_manager_bind);
     Q_ASSERT(m_global);
     m_handle = this;
@@ -364,13 +363,11 @@ int WTextInputV2::surroundingAnchor() const
 
 IME::ContentHints WTextInputV2::contentHints() const
 {
-    W_DC(WTextInputV2);
     return IME::ContentHints();
 }
 
 IME::ContentPurpose WTextInputV2::contentPurpose() const
 {
-    W_DC(WTextInputV2);
     return IME::ContentPurpose();
 }
 

--- a/waylib/src/server/protocols/private/wtextinputv3.cpp
+++ b/waylib/src/server/protocols/private/wtextinputv3.cpp
@@ -52,7 +52,7 @@ void WTextInputManagerV3::create(WServer *server)
         auto ti = new WTextInputV3(text_input_v3, this);
         d->textInputs.append(ti);
         Q_EMIT this->newTextInput(ti);
-        connect(text_input_v3, &qw_text_input_v3::before_destroy, ti, [this, ti, d]{
+        connect(text_input_v3, &qw_text_input_v3::before_destroy, ti, [ti, d]{
             Q_EMIT ti->entityAboutToDestroy();
             d->textInputs.removeOne(ti);
             ti->deleteLater();
@@ -101,13 +101,11 @@ WTextInputV3::WTextInputV3(qw_text_input_v3 *h, QObject *parent)
 
 WSeat *WTextInputV3::seat() const
 {
-    W_DC(WTextInputV3);
     return WSeat::fromHandle(qw_seat::from(handle()->handle()->seat));
 }
 
 WSurface *WTextInputV3::focusedSurface() const
 {
-    W_DC(WTextInputV3);
     return WSurface::fromHandle(handle()->handle()->focused_surface);
 }
 

--- a/waylib/src/server/protocols/private/wvirtualkeyboardv1.cpp
+++ b/waylib/src/server/protocols/private/wvirtualkeyboardv1.cpp
@@ -33,7 +33,6 @@ QByteArrayView WVirtualKeyboardManagerV1::interfaceName() const
 
 void WVirtualKeyboardManagerV1::create(WServer *server)
 {
-    W_D(WVirtualKeyboardManagerV1);
     auto manager = qw_virtual_keyboard_manager_v1::create(*server->handle());
     Q_ASSERT(manager);
     m_handle = manager;

--- a/waylib/src/server/protocols/wcursorshapemanagerv1.cpp
+++ b/waylib/src/server/protocols/wcursorshapemanagerv1.cpp
@@ -134,11 +134,9 @@ QByteArrayView WCursorShapeManagerV1::interfaceName() const
 
 void WCursorShapeManagerV1::create(WServer *server)
 {
-    W_D(WCursorShapeManagerV1);
-
     if (!m_handle) {
         m_handle = qw_cursor_shape_manager_v1::create(*server->handle(), CURSOR_SHAPE_MANAGER_V1_VERSION);
-        QObject::connect(handle(), &qw_cursor_shape_manager_v1::notify_request_set_shape, this, [this]
+        QObject::connect(handle(), &qw_cursor_shape_manager_v1::notify_request_set_shape, this, []
                          (wlr_cursor_shape_manager_v1_request_set_shape_event *event) {
             if (auto *seat = WSeat::fromHandle(QW_NAMESPACE::qw_seat::from(event->seat_client->seat))) {
                 seat->setCursorShape(event->seat_client, wpToWCursorShape(event->shape));

--- a/waylib/src/server/protocols/wextforeigntoplevellistv1.cpp
+++ b/waylib/src/server/protocols/wextforeigntoplevellistv1.cpp
@@ -121,8 +121,6 @@ QByteArrayView WExtForeignToplevelListV1::interfaceName() const
 
 void WExtForeignToplevelListV1::create(WServer *server)
 {
-    W_D(WExtForeignToplevelListV1);
-
     m_handle = qw_ext_foreign_toplevel_list_v1::create(*server->handle(), EXT_FOREIGN_TOPLEVEL_LIST_V1_VERSION);
 }
 

--- a/waylib/src/server/protocols/wforeigntoplevelv1.cpp
+++ b/waylib/src/server/protocols/wforeigntoplevelv1.cpp
@@ -102,13 +102,13 @@ public:
 
         surface->surface()->safeConnect(&WSurface::outputEntered,
                                         handle,
-                                        [this, handle](WOutput *output) {
+                                        [handle](WOutput *output) {
                                             handle->output_enter(output->nativeHandle());
                                         });
 
         surface->surface()->safeConnect(&WSurface::outputLeave,
                                         handle,
-                                        [this, handle](WOutput *output) {
+                                        [handle](WOutput *output) {
                                             handle->output_leave(output->nativeHandle());
                                         });
 
@@ -218,8 +218,6 @@ QByteArrayView WForeignToplevel::interfaceName() const
 
 void WForeignToplevel::create(WServer *server)
 {
-    W_D(WForeignToplevel);
-
     m_handle = qw_foreign_toplevel_manager_v1::create(*server->handle());
 }
 

--- a/waylib/src/server/protocols/winputmethodhelper.cpp
+++ b/waylib/src/server/protocols/winputmethodhelper.cpp
@@ -213,7 +213,7 @@ void WInputMethodHelper::handleNewKGV2(qw_input_method_keyboard_grab_v2 *kgv2)
 {
     W_D(WInputMethodHelper);
     Q_ASSERT(d->seat);
-    auto endGrab = [this, d](qw_input_method_keyboard_grab_v2 *kgv2) {
+    auto endGrab = [d](qw_input_method_keyboard_grab_v2 *kgv2) {
         if (!d->seat)
             return;
         if (kgv2->handle()->keyboard) {
@@ -221,7 +221,7 @@ void WInputMethodHelper::handleNewKGV2(qw_input_method_keyboard_grab_v2 *kgv2)
         }
         d->seat->handle()->keyboard_end_grab();
     };
-    auto setKeyboard = [this, d](qw_input_method_keyboard_grab_v2 *kgv2, WInputDevice *keyboard) {
+    auto setKeyboard = [](qw_input_method_keyboard_grab_v2 *kgv2, WInputDevice *keyboard) {
         if (keyboard) {
             auto *virtualKeyboard = wlr_input_device_get_virtual_keyboard(*keyboard->handle());
             // refer to:
@@ -287,7 +287,7 @@ void WInputMethodHelper::handleNewVKV1(wlr_virtual_keyboard_v1 *vkv1)
     WInputDevice *keyboard = new WInputDevice(qw_input_device::from(&vkv1->keyboard.base));
     d->virtualKeyboards.append(keyboard);
     d->seat->attachInputDevice(keyboard);
-    keyboard->safeConnect(&qw_input_device::before_destroy, this, [d, this, keyboard] () {
+    keyboard->safeConnect(&qw_input_device::before_destroy, this, [d, keyboard] () {
         if (d->seat) d->seat->detachInputDevice(keyboard);
         d->virtualKeyboards.removeOne(keyboard);
         keyboard->safeDeleteLater();
@@ -324,7 +324,6 @@ void WInputMethodHelper::connectToTI(WTextInput *ti)
 void WInputMethodHelper::disableTI(WTextInput *ti)
 {
     Q_ASSERT(ti);
-    W_D(WInputMethodHelper);
     if (enabledTextInput() == ti) {
         // Should we consider the case when the same text input is disabled and then enabled at the same time.
         auto im = inputMethod();
@@ -369,7 +368,6 @@ void WInputMethodHelper::handleTIEnabled()
 {
     WTextInput *ti = qobject_cast<WTextInput*>(sender());
     Q_ASSERT(ti);
-    W_D(WInputMethodHelper);
     auto im = inputMethod();
     auto activeTI = enabledTextInput();
     if (activeTI == ti)

--- a/waylib/src/server/protocols/winputpopupsurface.cpp
+++ b/waylib/src/server/protocols/winputpopupsurface.cpp
@@ -46,7 +46,6 @@ WInputPopupSurface::WInputPopupSurface(qw_input_popup_surface_v2 *surface, WSurf
 
 bool WInputPopupSurface::hasCapability(Capability cap) const
 {
-    W_DC(WInputPopupSurface);
     switch (cap) {
         using enum Capability;
     case Focus:

--- a/waylib/src/server/protocols/wlayersurface.cpp
+++ b/waylib/src/server/protocols/wlayersurface.cpp
@@ -108,7 +108,7 @@ void WLayerSurfacePrivate::connect()
     });
 }
 
-static inline void debugOutput(wlr_layer_surface_v1_state s)
+[[maybe_unused]] static inline void debugOutput(wlr_layer_surface_v1_state s)
 {
     qDebug() << "committed: " << s.committed << " "
              << "configure_serial: " << s.configure_serial << "\n"
@@ -437,8 +437,6 @@ void WLayerSurface::closed()
 
 bool WLayerSurface::checkNewSize(const QSize &size,  QSize *clipedSize)
 {
-    W_D(WLayerSurface);
-
     // If the width or height arguments are zero, it means the client should decide its own window dimension.
     if (size.width() < 0 || size.height() < 0) {
         if (clipedSize)

--- a/waylib/src/server/protocols/wsecuritycontextmanager.cpp
+++ b/waylib/src/server/protocols/wsecuritycontextmanager.cpp
@@ -564,7 +564,6 @@ WSecurityContextManager::WSecurityContextManager()
 
 void WSecurityContextManager::create(WServer *server)
 {
-    W_D(WSecurityContextManager);
     m_handle = wlr_security_context_manager_v1_create(*server->handle());
 }
 

--- a/waylib/src/server/protocols/wsessionlock.cpp
+++ b/waylib/src/server/protocols/wsessionlock.cpp
@@ -166,7 +166,6 @@ WSessionLock::LockState WSessionLock::lockState() const
 
 bool WSessionLock::isLocked() const
 {
-    W_DC(WSessionLock);
     return lockState() == LockState::Locked;
 }
 

--- a/waylib/src/server/protocols/wsessionlocksurface.cpp
+++ b/waylib/src/server/protocols/wsessionlocksurface.cpp
@@ -141,7 +141,6 @@ int WSessionLockSurface::keyboardFocusPriority() const
 
 uint32_t WSessionLockSurface::configureSize(const QSize &newSize)
 {
-    W_D(WSessionLockSurface);
     return handle()->configure(newSize.width(), newSize.height());
 }
 

--- a/waylib/src/server/protocols/wxdgoutput.cpp
+++ b/waylib/src/server/protocols/wxdgoutput.cpp
@@ -403,7 +403,6 @@ qreal WXdgOutputManager::scaleOverride() const
 
 void WXdgOutputManager::resetScaleOverride()
 {
-    Q_D(WXdgOutputManager);
     setScaleOverride(0.0);
 }
 

--- a/waylib/src/server/protocols/wxdgpopupsurface.cpp
+++ b/waylib/src/server/protocols/wxdgpopupsurface.cpp
@@ -147,7 +147,6 @@ void WXdgPopupSurface::close()
 
 QRect WXdgPopupSurface::getContentGeometry() const
 {
-    W_DC(WXdgPopupSurface);
     auto xdgSurface = qw_xdg_surface::from(handle()->handle()->base);
     qw_box tmp = qw_box(xdgSurface->handle()->geometry);
     return tmp.toQRect();

--- a/waylib/src/server/protocols/wxdgtoplevelsurface.cpp
+++ b/waylib/src/server/protocols/wxdgtoplevelsurface.cpp
@@ -262,7 +262,6 @@ bool WXdgToplevelSurface::isFullScreen() const
 
 QRect WXdgToplevelSurface::getContentGeometry() const
 {
-    W_DC(WXdgToplevelSurface);
     auto xdgSurface = qw_xdg_surface::from(handle()->handle()->base);
     qw_box tmp = qw_box(xdgSurface->handle()->geometry);
     return tmp.toQRect();
@@ -306,8 +305,6 @@ bool WXdgToplevelSurface::isInitialized() const
 
 WXdgToplevelSurface *WXdgToplevelSurface::parentXdgSurface() const
 {
-    W_DC(WXdgToplevelSurface);
-
     auto parent = handle()->handle()->parent;
     if (!parent)
         return nullptr;

--- a/waylib/src/server/protocols/wxwayland.cpp
+++ b/waylib/src/server/protocols/wxwayland.cpp
@@ -131,7 +131,6 @@ WXWayland::WXWayland(qw_compositor *compositor, bool lazy)
 
 QByteArray WXWayland::displayName() const
 {
-    W_DC(WXWayland);
     return isValid() ? QByteArray(std::as_const(handle()->handle()->display_name)) : QByteArray();
 }
 
@@ -191,7 +190,6 @@ QVarLengthArray<xcb_atom_t> WXWayland::supportedAtoms() const
 
 void WXWayland::setSupportedAtoms(const QVarLengthArray<xcb_atom_t> &atoms)
 {
-    W_D(WXWayland);
     auto xcb_conn = xcbConnection();
     auto root = xcbScreen()->root;
 
@@ -202,7 +200,6 @@ void WXWayland::setSupportedAtoms(const QVarLengthArray<xcb_atom_t> &atoms)
 
 void WXWayland::setAtomSupported(xcb_atom_t atom, bool supported)
 {
-    W_D(WXWayland);
     auto xcb_conn = xcbConnection();
     auto root = xcbScreen()->root;
 
@@ -220,14 +217,12 @@ void WXWayland::setAtomSupported(xcb_atom_t atom, bool supported)
 
 void WXWayland::setSeat(WSeat *seat)
 {
-    W_D(WXWayland);
     if (auto handle = this->handle())
         handle->set_seat(*seat->handle());
 }
 
 WSeat *WXWayland::seat() const
 {
-    W_DC(WXWayland);
     if (!handle())
         return nullptr;
     if (!handle()->handle()->seat)

--- a/waylib/src/server/protocols/wxwaylandsurface.cpp
+++ b/waylib/src/server/protocols/wxwaylandsurface.cpp
@@ -127,7 +127,7 @@ void WXWaylandSurfacePrivate::init()
         }
     });
     QObject::connect(handle(), &qw_xwayland_surface::notify_request_minimize,
-                     q, [this, q] (wlr_xwayland_minimize_event *event) {
+                     q, [q] (wlr_xwayland_minimize_event *event) {
         if (event->minimize) {
             Q_EMIT q->requestMinimize();
         } else {

--- a/waylib/src/server/qtquick/wlayersurfaceitem.cpp
+++ b/waylib/src/server/qtquick/wlayersurfaceitem.cpp
@@ -22,7 +22,7 @@ WLayerSurface *WLayerSurfaceItem::layerSurface() const {
     return qobject_cast<WLayerSurface*>(shellSurface());
 }
 
-inline static int32_t getValidSize(int32_t size, int32_t fallback) {
+[[maybe_unused]] inline static int32_t getValidSize(int32_t size, int32_t fallback) {
     return size > 0 ? size : fallback;
 }
 

--- a/waylib/src/server/qtquick/woutputitem.cpp
+++ b/waylib/src/server/qtquick/woutputitem.cpp
@@ -338,8 +338,6 @@ QList<QQuickItem *> WOutputItem::cursorItems() const
 
 void WOutputItem::classBegin()
 {
-    W_D(WOutputItem);
-
     QQuickItem::classBegin();
 }
 
@@ -356,8 +354,6 @@ void WOutputItem::componentComplete()
 
 void WOutputItem::releaseResources()
 {
-    W_D(WOutputItem);
-
     WQuickObserver::releaseResources();
 }
 

--- a/waylib/src/server/qtquick/woutputrenderwindow.cpp
+++ b/waylib/src/server/qtquick/woutputrenderwindow.cpp
@@ -1287,7 +1287,6 @@ void WOutputRenderWindowPrivate::init()
 
 void WOutputRenderWindowPrivate::init(OutputHelper *helper)
 {
-    W_Q(WOutputRenderWindow);
     QMetaObject::invokeMethod(helper, &WOutputHelper::scheduleFrame, Qt::QueuedConnection);
     helper->init();
     QObject::connect(helper->output(), &WOutputViewport::dependsChanged, helper, [this] {
@@ -1301,7 +1300,7 @@ void WOutputRenderWindowPrivate::init(OutputHelper *helper)
     }
 }
 
-inline static QByteArrayList fromCStyleList(size_t count, const char **list) {
+[[maybe_unused]] inline static QByteArrayList fromCStyleList(size_t count, const char **list) {
     QByteArrayList al;
     al.reserve(count);
     for (size_t i = 0; i < count; ++i) {
@@ -2002,8 +2001,6 @@ void WOutputRenderWindow::componentComplete()
 
 bool WOutputRenderWindow::event(QEvent *event)
 {
-    Q_D(WOutputRenderWindow);
-
     if (QW::RenderWindow::beforeDisposeEventFilter(this, event)) {
         event->accept();
         QW::RenderWindow::afterDisposeEventFilter(this, event);

--- a/waylib/src/server/qtquick/woutputviewport.cpp
+++ b/waylib/src/server/qtquick/woutputviewport.cpp
@@ -77,8 +77,6 @@ void WOutputViewportPrivate::updateImplicitSize()
 
 void WOutputViewportPrivate::updateRenderBufferSource()
 {
-    W_Q(WOutputViewport);
-
     QList<QQuickItem*> sources;
 
     if (input) {

--- a/waylib/src/server/qtquick/wquickoutputlayout.cpp
+++ b/waylib/src/server/qtquick/wquickoutputlayout.cpp
@@ -49,7 +49,6 @@ void WQuickOutputLayout::add(WOutputItem *output)
     add(output->output(), output->globalPosition().toPoint());
 
     auto updateOutput = [d, this] {
-        W_D(WQuickOutputLayout);
         auto *output = qobject_cast<WOutputItem*>(sender());
         if (!output) // Maybe output has destroyed but event still in queue
             return;

--- a/waylib/src/server/qtquick/wrenderhelper.cpp
+++ b/waylib/src/server/qtquick/wrenderhelper.cpp
@@ -379,9 +379,9 @@ public:
     QW_INTERFACE(get_dmabuf, bool ,wlr_dmabuf_attributes *attribs);
 
 private:
-    VkInstance m_instance;
-    VkDevice m_device;
-    QSGTexture *m_texture;
+    [[maybe_unused]] VkInstance m_instance;
+    [[maybe_unused]] VkDevice m_device;
+    [[maybe_unused]] QSGTexture *m_texture;
 };
 
 VkTextureBuffer::VkTextureBuffer(VkInstance instance, VkDevice device, QSGTexture *texture)
@@ -750,7 +750,7 @@ static inline quint64 vkimage_cast(void *image) {
     return reinterpret_cast<quintptr>(image);
 }
 
-static inline quint64 vkimage_cast(quint64 image) {
+[[maybe_unused]] static inline quint64 vkimage_cast(quint64 image) {
     return image;
 }
 

--- a/waylib/src/server/qtquick/wsurfaceitem.cpp
+++ b/waylib/src/server/qtquick/wsurfaceitem.cpp
@@ -1215,7 +1215,6 @@ void WSurfaceItemPrivate::onHasSubsurfaceChanged()
 
 void WSurfaceItemPrivate::updateSubsurfaceItem()
 {
-    Q_Q(WSurfaceItem);
     auto surface = this->surface->handle()->handle();
     Q_ASSERT(surface);
     Q_ASSERT(contentContainer);
@@ -1246,8 +1245,6 @@ void WSurfaceItemPrivate::updateSubsurfaceItem()
 
 void WSurfaceItemPrivate::onPaddingsChanged()
 {
-    W_Q(WSurfaceItem);
-
     if (!surface || !surfaceState)
         return;
 

--- a/waylib/src/server/qtquick/wxwaylandsurfaceitem.cpp
+++ b/waylib/src/server/qtquick/wxwaylandsurfaceitem.cpp
@@ -86,8 +86,6 @@ WXWaylandSurface *WXWaylandSurfaceItem::xwaylandSurface() const
 
 bool WXWaylandSurfaceItem::setShellSurface(WToplevelSurface *surface)
 {
-    Q_D(WXWaylandSurfaceItem);
-
     if (!WSurfaceItem::setShellSurface(surface))
         return false;
 
@@ -97,7 +95,7 @@ bool WXWaylandSurfaceItem::setShellSurface(WToplevelSurface *surface)
             WSurfaceItem::setSurface(xwaylandSurface()->surface());
         });
 
-        auto updateGeometry = [this, d] {
+        auto updateGeometry = [this] {
             const auto rm = resizeMode();
             if (rm != SizeFromSurface)
                 return;
@@ -214,7 +212,6 @@ void WXWaylandSurfaceItem::onSurfaceCommit()
 
 void WXWaylandSurfaceItem::initSurface()
 {
-    Q_D(WXWaylandSurfaceItem);
     WSurfaceItem::initSurface();
     Q_ASSERT(xwaylandSurface());
     connect(xwaylandSurface(), &WWrapObject::aboutToBeInvalidated,


### PR DESCRIPTION
Fix warnings including:
 + Unused private field.
 + Unused function.
 + Unused captured variable in lambda.
 + Q_FOREACH on std::vector.
 + offsetof on non-POD object treeland_dock_preview_context
 + Overloaded virtual function.