### PR TITLE
fix: send events after activate if available

### DIFF
--- a/waylib/src/server/protocols/winputmethodhelper.cpp
+++ b/waylib/src/server/protocols/winputmethodhelper.cpp
@@ -385,6 +385,13 @@ void WInputMethodHelper::handleTIEnabled()
     // Try to activate input method.
     if (im) {
         im->sendActivate();
+        if (ti->features().testFlag(IME::F_SurroundingText)) {
+            im->sendSurroundingText(ti->surroundingText(), ti->surroundingCursor(), ti->surroundingAnchor());
+        }
+        im->sendTextChangeCause(ti->textChangeCause());
+        if (ti->features().testFlag(IME::F_ContentType)) {
+            im->sendContentType(ti->contentHints().toInt(), ti->contentPurpose());
+        }
         im->sendDone();
     }
 }


### PR DESCRIPTION
https://wayland.app/protocols/input-method-unstable-v2#zwp_input_method_v2:event:activate
https://github.com/hyprwm/Hyprland/blob/main/src/managers/input/TextInput.cpp#L233

Log: as title
Influence: input method
Signed-off-by: Yixue Wang <wangyixue@uniontech.com>

## Summary by Sourcery

Bug Fixes:
- Send surrounding text, text change cause, and content type events after input method activation when supported by the text input.