### PR TITLE
fix: forward appId changes in fallback mode

### DIFF
--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -264,6 +264,13 @@ void SurfaceWrapper::setup()
 
     Q_EMIT surfaceItemChanged();
 
+    // Forward WToplevelSurface appId changes when using fallback mode
+    if (m_appId.isEmpty()) {
+        m_shellSurface->safeConnect(&WToplevelSurface::appIdChanged, this, [this]() {
+            Q_EMIT appIdChanged();
+        });
+    }
+
     if (!m_prelaunchSplash || !m_prelaunchSplash->isVisible()) {
         setImplicitSize(m_surfaceItem->implicitWidth(), m_surfaceItem->implicitHeight());
         connect(m_surfaceItem, &WSurfaceItem::implicitWidthChanged, this, [this] {
@@ -484,7 +491,13 @@ QQuickItem *SurfaceWrapper::prelaunchSplash() const
 
 QString SurfaceWrapper::appId() const
 {
-    return m_appId;
+    // TODO: Need to consider `engineName` to ensure the uniqueness of appid.
+    if (!m_appId.isEmpty())
+        return m_appId;
+    // TODO: consider to use "xdg-shell/" + m_shellSurface->appId(), need dde-shell adaptation
+    if (m_shellSurface)
+        return m_shellSurface->appId();
+    return QString();
 }
 
 bool SurfaceWrapper::resize(const QSizeF &size)

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -34,7 +34,7 @@ class SurfaceWrapper : public QQuickItem
     QML_ELEMENT
     QML_UNCREATABLE("SurfaceWrapper objects are created by c++")
     Q_PROPERTY(Type type READ type NOTIFY typeChanged)
-    Q_PROPERTY(QString appId READ appId CONSTANT)
+    Q_PROPERTY(QString appId READ appId NOTIFY appIdChanged)
     // make to read only
     Q_PROPERTY(qreal implicitWidth READ implicitWidth NOTIFY implicitWidthChanged FINAL)
     Q_PROPERTY(qreal implicitHeight READ implicitHeight NOTIFY implicitHeightChanged FINAL)
@@ -293,6 +293,7 @@ public Q_SLOTS:
 Q_SIGNALS:
     void boundingRectChanged();
     void ownsOutputChanged();
+    void appIdChanged();
     void normalGeometryChanged();
     void maximizedGeometryChanged();
     void fullscreenGeometryChanged();


### PR DESCRIPTION
Added signal forwarding for WToplevelSurface appId changes when using fallback mode (m_appId is empty). The appId property now emits appIdChanged signal and returns the shell surface's appId when m_appId is empty, ensuring proper property updates in QML bindings.

Previously, when using fallback mode (m_appId.isEmpty()), the appId property would not update when the underlying WToplevelSurface's appId changed. This fix connects to the WToplevelSurface::appIdChanged signal and forwards it as SurfaceWrapper::appIdChanged. The appId() getter now properly falls back to returning m_shellSurface->appId() when m_appId is empty.

Log: Fixed appId property updates in fallback mode

Influence:
1. Test applications that use fallback appId mode to ensure appId changes propagate correctly
2. Verify QML bindings using appId property update properly
3. Check that surface identification works correctly in fallback scenarios
4. Test window management features that rely on appId updates

fix: 在回退模式下转发 appId 变更

添加了在回退模式（m_appId 为空）下对 WToplevelSurface appId 变更的信号 转发。appId 属性现在会发出 appIdChanged 信号，并在 m_appId 为空时返回
shell surface 的 appId，确保 QML 绑定中的属性正确更新。

先前在使用回退模式（m_appId.isEmpty()）时，当底层的
WToplevelSurface 的 appId 发生变化时，appId 属性不会更新。
此修复连接到 WToplevelSurface::appIdChanged 信号并将其转发为
SurfaceWrapper::appIdChanged。appId() getter 现在在 m_appId 为空时正确回 退到返回 m_shellSurface->appId()。

Log: 修复回退模式下 appId 属性更新问题

Influence:
1. 测试使用回退 appId 模式的应用程序，确保 appId 变更正确传播
2. 验证使用 appId 属性的 QML 绑定是否正确更新
3. 检查回退场景下的表面标识功能是否正常工作
4. 测试依赖 appId 更新的窗口管理功能

## Summary by Sourcery

Ensure SurfaceWrapper forwards appId changes from WToplevelSurface and exposes a dynamically updating appId property.

Bug Fixes:
- Fix missing appId updates in fallback mode by forwarding WToplevelSurface::appIdChanged when no explicit appId is set.

Enhancements:
- Make the appId QML property notify on changes and fall back to the shell surface appId when the local appId is empty.