### PR TITLE
fix: Remove unused config references

### DIFF
--- a/src/greeter/usermodel.cpp
+++ b/src/greeter/usermodel.cpp
@@ -110,7 +110,6 @@ UserModel::UserModel(QObject *parent)
 
     // find out index of the last user
     auto lastUserName = stateConfig.Last.User.get();
-    const auto &facesDir = mainConfig.Theme.FacesDir.get();
 
     for (const auto &user : d->users) {
         if (user->userName() == lastUserName) {
@@ -218,11 +217,6 @@ QVariant UserModel::data(const QModelIndex &index, int role) const
     default:
         return {};
     }
-}
-
-int UserModel::disableAvatarsThreshold()
-{
-    return mainConfig.Theme.DisableAvatarsThreshold.get();
 }
 
 bool UserModel::containsAllUsers() const

--- a/src/greeter/usermodel.h
+++ b/src/greeter/usermodel.h
@@ -38,7 +38,6 @@ class UserModel : public QAbstractListModel
     Q_PROPERTY(int lastIndex READ lastIndex CONSTANT)
     Q_PROPERTY(QString lastUser READ lastUser CONSTANT)
     Q_PROPERTY(int count READ rowCount NOTIFY countChanged)
-    Q_PROPERTY(int disableAvatarsThreshold READ disableAvatarsThreshold CONSTANT)
     Q_PROPERTY(bool containsAllUsers READ containsAllUsers CONSTANT)
     QML_NAMED_ELEMENT(UserModel)
     QML_SINGLETON
@@ -79,7 +78,6 @@ public:
     void setCurrentUserName(const QString &userName) noexcept;
     void updateUserLoginState(const QString &username, bool logined);
     void clearUserLoginState();
-    [[nodiscard]] static int disableAvatarsThreshold();
     [[nodiscard]] bool containsAllUsers() const;
 
 Q_SIGNALS:


### PR DESCRIPTION
These configuration fields is actually not used in anywhere, and will be removed by recent ddm refactor.

## Summary by Sourcery

Remove unused user avatar configuration references from the greeter user model.

Enhancements:
- Remove unused theme configuration access in UserModel constructor.
- Drop unused disableAvatarsThreshold property and static accessor from UserModel interface.