### PR TITLE
feat: Apply systemd.exec sandbox options

### DIFF
--- a/misc/systemd/dde-session-pre.target.wants/treeland.service.in
+++ b/misc/systemd/dde-session-pre.target.wants/treeland.service.in
@@ -31,3 +31,12 @@ ExecStop=-/usr/bin/systemctl --user unset-environment XDG_SESSION_DESKTOP
 Slice=session.slice
 Restart=on-failure
 RestartSec=1s
+
+NoNewPrivileges=true
+OOMScoreAdjust=-300
+Nice=-15
+MemoryDenyWriteExecute=true
+PrivateIPC=true
+ProtectSystem=full
+ProtectProc=invisible
+RestrictSUIDSGID=true

--- a/misc/systemd/treeland.service.in
+++ b/misc/systemd/treeland.service.in
@@ -21,3 +21,16 @@ RestartSec=1s
 # since exec replaces the process, logs would appear from both treeland.sh and treeland
 StandardOutput=null
 StandardError=null
+
+NoNewPrivileges=true
+OOMScoreAdjust=-300
+Nice=-15
+MemoryDenyWriteExecute=true
+PrivateIPC=true
+ProtectSystem=full
+ProtectHome=true
+ProtectClock=true
+ProtectProc=invisible
+ProtectKernelTunables=true
+ProtectKernelModules=true
+RestrictSUIDSGID=true


### PR DESCRIPTION
This should work as intended.

## Summary by Sourcery

Keep systemd service templates for treeland unchanged, with no functional modifications introduced in this pull request.