### PR TITLE
fix: shortcuts not recovered after session crash recovery

### DIFF
--- a/src/modules/shortcut/shortcutmanager.cpp
+++ b/src/modules/shortcut/shortcutmanager.cpp
@@ -244,6 +244,13 @@ void ShortcutManagerV2Private::treeland_shortcut_manager_v2_acquire(Resource *re
         return;
     }
 
+    // remove stale shortcuts
+    m_shortcuts.remove(socket);
+    m_pendingShortcuts.remove(socket);
+    m_pendingCommittedShortcuts.remove(socket);
+    m_pendingDeletes.remove(socket);
+    if (m_activeSessionSocket == socket)
+        m_controller->clear();
     ownerClients.insert(socket, resource);
 }
 

--- a/src/treeland-shortcut/shortcut.h
+++ b/src/treeland-shortcut/shortcut.h
@@ -27,6 +27,9 @@ protected:
     void treeland_shortcut_manager_v2_commit_success() override;
     void treeland_shortcut_manager_v2_commit_failure(const QString &name, uint32_t error) override;
     void treeland_shortcut_manager_v2_activated(const QString &name, uint32_t repeat) override;
+private:
+    void registerAllShortcuts();
+    QList<Shortcut*> m_shortcuts;
 };
 
 class Shortcut

--- a/src/treeland-shortcut/shortcuts/_deepin-system-monitor.ini
+++ b/src/treeland-shortcut/shortcuts/_deepin-system-monitor.ini
@@ -1,5 +1,5 @@
 [Shortcut]
-Shortcut=Control+Alt+Escape
+Shortcut=Ctrl+Alt+Escape
 Type="Application"
 
 [Type.Application]


### PR DESCRIPTION
This commit addresses an issue where treeland-shortcut failed to re-register shortcuts after a session crash recovery.

This is strictly a bug within the Qt framework's Wayland platform plugin, which contains a race condition where the `QWaylandClientExtension::isActive` signal could be sent before initialization of `WaylandEventThread`, on wayland socket reconnection.

However, the effects can be mitigated by deferring wayland protocol interactions to the next event loop. (see modifications in `shortcut.cpp`)

## Summary by Sourcery

Mitigate a QtWayland race condition so treeland shortcuts are correctly re-registered after a Wayland session crash and cleanup stale shortcut state on reconnection.

Bug Fixes:
- Ensure shortcut protocol interactions are deferred to the next event loop so shortcuts are correctly re-registered after a session recovery.
- Clear stale shortcut state and controller bindings when a new treeland_shortcut manager session is acquired to avoid leftover registrations.
- Fix the Deepin System Monitor default shortcut definition to use the correct Ctrl+Alt+Escape notation.