### PR TITLE
fix: resolve multiple critical crashes in Qt Quick rendering

### DIFF
--- a/waylib/src/server/qtquick/wbufferitem.cpp
+++ b/waylib/src/server/qtquick/wbufferitem.cpp
@@ -184,7 +184,10 @@ void WBufferItem::releaseResources()
 
     d->cleanTextureProvider();
     // Keep last buffer cached; just force content dirty to avoid stale nodes.
-    QQuickItemPrivate::get(this)->dirty(QQuickItemPrivate::Content);
+    // Only mark dirty if we have a valid window to avoid crashes during window destruction
+    if (window()) {
+        QQuickItemPrivate::get(this)->dirty(QQuickItemPrivate::Content);
+    }
 }
 
 void WBufferItem::invalidateSceneGraph()


### PR DESCRIPTION
This commit fixes three critical crash scenarios reported in issue #659:

1. DataManager CleanJob use-after-free crash (#659 comment 1)

   Problem:
   - In CleanJob::run(), calling manager->get()->destroy() could trigger shared_ptr<Data> destruction, which might delete the DataManager itself
   - Subsequent loop iterations would access the freed manager pointer

   Solution:
   - Collect items to destroy in a separate list first
   - Only destroy items after the loop completes and we're done accessing manager
   - Add null check before destruction to handle edge cases

2. Buffer double-unlock crash (#659 comment 5) Problem:
   - When Wayland surface commits the same buffer repeatedly (pointer unchanged), the code would call pendingBuffer.reset(newBuffer) where newBuffer points to the same object as pendingBuffer.get()
   - std::unique_ptr::reset() ALWAYS calls the deleter (unlocker) even when old_ptr == new_ptr, causing:
       * Step 1: deleter(old_ptr) → wlr_buffer_unlock(A) → n_locks: 1 → 0
       * Step 2: ptr = new_ptr (same object A) * Step 3: lock() → wlr_buffer_lock(A) → n_locks: 0 → 1 - The unlock in step 1 triggers assert(buffer->n_locks > 0) in wlroots

   Why not lock before reset?
   - Scenario 1 (same pointer): Creates temporary incorrect ref count
     * lock() → n_locks: 1 → 2 (but only 1 actual holder!)
     * reset() → unlock() → n_locks: 2 → 1 * Result: Temporarily inaccurate ref count, potential race conditions

   - Scenario 2 (different pointer): Locks wrong buffer! * pendingBuffer → A, newBuffer → B * lock() → A.n_locks: 1 → 2 (locking old buffer A!) * reset(B) → unlock(A) → A.n_locks: 2 → 1 * Result: B has n_locks=0 (not locked!), A has leaked reference

   Solution:
   - Check if pointer actually changed before calling reset()
   - Only perform reset + lock sequence when pointers differ
   - When pointers are same, skip the operation entirely

3. QSGNode markDirty crash during window destruction (#659 comment 6)

   Problem:
   - releaseResources() is called during window destruction
   - Calling QQuickItemPrivate::dirty() tries to mark scene graph nodes dirty
   - But window and scene graph may already be destroyed at this point
   - Accessing destroyed nodes causes crash

   Solution:
   - Only call dirty() if window() returns non-null
   - This ensures scene graph is still valid before marking nodes dirty

## Summary by Sourcery

Fix multiple crash scenarios in Qt Quick Wayland rendering by hardening buffer management, deferred destruction, and scene graph updates during window teardown.

Bug Fixes:
- Prevent double-unlock and inconsistent reference counting by only resetting Wayland buffers when the underlying pointer actually changes in live and non-live modes.
- Avoid use-after-free in DataManager cleanup by deferring destruction of released items until after manager data structures are no longer being accessed.
- Prevent crashes during window destruction by only marking items dirty when a valid window and scene graph are still available in WSurfaceItemContent and WBufferItem.