### PR TITLE
fix: add window validity checks in releaseResources methods

### DIFF
--- a/waylib/src/server/qtquick/private/wbufferrenderer.cpp
+++ b/waylib/src/server/qtquick/private/wbufferrenderer.cpp
@@ -709,8 +709,14 @@ void WBufferRenderer::cleanTextureProvider()
 
         m_textureProvider->invalidate();
         // Delay clean the textures on the next render after.
-        window()->scheduleRenderJob(new TextureProviderCleanupJob(m_textureProvider.release()),
-                                    QQuickWindow::AfterRenderingStage);
+        // Only schedule render job if window is still valid
+        if (window()) {
+            window()->scheduleRenderJob(new TextureProviderCleanupJob(m_textureProvider.release()),
+                                        QQuickWindow::AfterRenderingStage);
+        } else {
+            // Window is being destroyed, clean up immediately
+            m_textureProvider.reset();
+        }
     }
 }
 

--- a/waylib/src/server/qtquick/wquickcursor.cpp
+++ b/waylib/src/server/qtquick/wquickcursor.cpp
@@ -602,7 +602,10 @@ void WQuickCursor::releaseResources()
     d->invalidate();
 
     // Force to update the contents, avoid to render the invalid textures
-    QQuickItemPrivate::get(this)->dirty(QQuickItemPrivate::Content);
+    // Only mark dirty if we have a valid window to avoid crashes during window destruction
+    if (window()) {
+        QQuickItemPrivate::get(this)->dirty(QQuickItemPrivate::Content);
+    }
 }
 
 WAYLIB_SERVER_END_NAMESPACE


### PR DESCRIPTION
Add window validity checks before calling dirty() or scheduleRenderJob() in releaseResources() methods to prevent crashes during window destruction.

## Summary by Sourcery

Add window validity checks before triggering rendering-related cleanup to avoid crashes during window destruction.

Bug Fixes:
- Guard texture provider cleanup scheduling on window validity to prevent accessing a destroyed window.
- Guard cursor content dirty marking on window validity to avoid crashes when the window is being destroyed.