### PR TITLE
fix: prevent crash in SurfaceListModel::data when accessing childItem…

### DIFF
--- a/src/surface/surfacecontainer.cpp
+++ b/src/surface/surfacecontainer.cpp
@@ -43,6 +43,9 @@ QVariant SurfaceListModel::data(const QModelIndex &index, int role) const
     if (role == Qt::InitialSortOrderRole) {
         auto surface = surfaces().at(index.row());
         auto container = surface->container();
+        if (!container) {
+            return QVariant();
+        }
         const auto orderIndex = container->childItems().indexOf(surface);
         Q_ASSERT(orderIndex >= 0);
         return orderIndex;


### PR DESCRIPTION
fix: surface guard against null container in SurfaceListModel::data

SurfaceListModel::data() may be queried before a SurfaceWrapper
is fully attached to a workspace container.

After application startup, ShellHandler::matchOrCreateXdgWrapper()
and ShellHandler::matchOrCreateXwaylandWrapper() add wrappers into
the workspace. At this stage, Workspace::addSurface() is called
with surface->container() still unset, which is expected and
asserted by:

    Q_ASSERT(surface && !surface->container());

However, QML may access SurfaceListModel and request
Qt::InitialSortOrderRole before the container is initialized.
This leads to a null pointer dereference when accessing
container->childItems().

Fix this by explicitly checking for a null container in
SurfaceListModel::data() and returning an invalid QVariant
until the surface is fully initialized.

This prevents crashes during early QML evaluation while keeping
the existing initialization order unchanged.

issue: https://github.com/linuxdeepin/treeland/issues/659
comment: https://github.com/linuxdeepin/treeland/issues/659#issuecomment-3691417028