### PR TITLE
fix: Fix possible stuck on DBus when user logging in

### DIFF
--- a/src/greeter/greeterproxy.h
+++ b/src/greeter/greeterproxy.h
@@ -88,8 +88,8 @@ private Q_SLOTS:
     void disconnected();
     void readyRead();
     void error();
-    void onSessionAdded(const QDBusObjectPath &session);
-    void onSessionRemoved(const QDBusObjectPath &session);
+    void onSessionNew(const QString &id, const QDBusObjectPath &session);
+    void onSessionRemoved(const QString &id, const QDBusObjectPath &session);
 
 Q_SIGNALS:
     void informationMessage(const QString &message);
@@ -113,6 +113,7 @@ private:
     bool localValidation(const QString &user, const QString &password) const;
     void updateAuthSocket();
     void updateLocketState();
+    void updateUserLoginState(const QDBusObjectPath &path, bool loggedIn);
 
 private:
     GreeterProxyPrivate *d{ nullptr };


### PR DESCRIPTION
1. Listen to org.freedesktop.login1 instead of org.deepin.DisplayManager, which is more reliable;
2. Put DBus call in separate thread to avoid blocking main thread

## Summary by Sourcery

Switch session tracking in the greeter to use logind’s org.freedesktop.login1 sessions and handle them asynchronously to avoid blocking the main thread on DBus.

Bug Fixes:
- Prevent the greeter from getting stuck by moving DBus session queries and user lookup to background threads and queuing UI updates back to the main thread.

Enhancements:
- Replace deprecated/less reliable DisplayManager-based session monitoring with org.freedesktop.login1 signals and APIs for session add/remove handling.