### PR TITLE
fix: fix Wayland compositor crash resolver cleanup

### DIFF
--- a/tools/treeland-session-helper/main.cpp
+++ b/tools/treeland-session-helper/main.cpp
@@ -90,10 +90,17 @@ public:
     {
     }
 
+    ~AppIdResolverManager()
+    {
+        cleanupResolver();
+    }
+
     void ensureResolver()
     {
-        if (m_resolver)
+        if (m_resolver) {
+            qInfo() << "Resolver already exists!";
             return;
+        }
         auto *raw = get_resolver();
         if (!raw) {
             qWarning() << "get_resolver returned null";
@@ -101,6 +108,19 @@ public:
         }
         m_resolver = new AppIdResolver(raw, this);
         qInfo() << "Resolver object created";
+    }
+
+    void cleanupResolver()
+    {
+        if (!m_resolver)
+            return;
+        auto *resolver = m_resolver;
+        m_resolver = nullptr;
+        if (isActive() && resolver->isInitialized()) {
+            resolver->destroy();
+        }
+        delete resolver;
+        qInfo() << "Resolver object destroyed";
     }
 
 private:
@@ -119,6 +139,7 @@ int main(int argc, char **argv)
             manager.ensureResolver();
         } else {
             qWarning() << "Resolver manager inactive";
+            manager.cleanupResolver();
         }
     });
 


### PR DESCRIPTION
Fix memory leak and resolver management issue when Wayland compositor crashes
1. Add destructor to AppIdResolverManager for proper cleanup
2. Add explicit cleanupResolver method to destroy resolver properly
3. Ensure resolver is cleaned up when manager becomes inactive
4. Add logging for resolver lifecycle events

Log: Fixed Wayland compositor crash handling

Influence:
1. Test Wayland compositor crash and restart scenarios
2. Verify resolver is properly recreated after compositor restart
3. Check memory usage to ensure no leaks
4. Verify resolver functionality after restart
5. Test inactive state handling for resolver cleanup

fix: 修复Wayland合成器崩溃后解析器清理问题

修复Wayland合成器崩溃时的内存泄漏和解析器管理问题
1. 为AppIdResolverManager添加析构函数进行正确清理
2. 添加显式的cleanupResolver方法正确销毁解析器
3. 确保管理器变为非活动状态时清理解析器
4. 添加解析器生命周期事件的日志记录

Log: 修复Wayland合成器崩溃处理

Influence:
1. 测试Wayland合成器崩溃和重启场景
2. 验证合成器重启后解析器是否正确重建
3. 检查内存使用确保无泄漏
4. 验证重启后解析器功能正常
5. 测试非活动状态下的解析器清理

## Summary by Sourcery

Improve lifecycle management of the Wayland AppId resolver to avoid leaks and clean up correctly when the compositor crashes or the manager becomes inactive.

Bug Fixes:
- Ensure the AppId resolver is properly destroyed when the manager is deactivated or the process exits, preventing memory leaks after Wayland compositor crashes.
- Avoid keeping an initialized resolver alive when the compositor is inactive by explicitly cleaning it up on inactivity events.

Enhancements:
- Add logging around resolver creation, reuse, and destruction to aid in diagnosing resolver lifecycle issues.