### PR TITLE
fix: avoid double removal on session destroy by requesting surface close

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1051,10 +1051,7 @@ void Helper::onSurfaceWrapperAdded(SurfaceWrapper *wrapper)
     bool isXwayland = wrapper->type() == SurfaceWrapper::Type::XWayland;
     bool isLayer = wrapper->type() == SurfaceWrapper::Type::Layer;
 
-    connect(m_activeSession.lock().get(), &Session::aboutToBeDestroyed, wrapper, [this, wrapper]() {
-        onSurfaceWrapperAboutToRemove(wrapper);
-        m_rootSurfaceContainer->destroyForSurface(wrapper);
-    });
+    connect(m_activeSession.lock().get(), &Session::aboutToBeDestroyed, wrapper, &SurfaceWrapper::requestClose);
 
     if (isXdgToplevel || isXdgPopup || isLayer) {
         auto *attached =

--- a/waylib/src/server/protocols/wlayersurface.cpp
+++ b/waylib/src/server/protocols/wlayersurface.cpp
@@ -341,6 +341,11 @@ void WLayerSurface::resize(const QSize &size)
     configureSize(size);
 }
 
+void WLayerSurface::close()
+{
+    closed();
+}
+
 QSize WLayerSurface::desiredSize() const
 {
     W_DC(WLayerSurface);

--- a/waylib/src/server/protocols/wlayersurface.h
+++ b/waylib/src/server/protocols/wlayersurface.h
@@ -83,6 +83,7 @@ public:
     int keyboardFocusPriority() const override;
     bool isInitialized() const override;
     void resize(const QSize &size) override;
+    void close() override;
 
     // layer shell info
     QSize desiredSize() const;


### PR DESCRIPTION
When the active session is destroyed, Helper::onSurfaceWrapperAdded() previously connected Session::aboutToBeDestroyed to a lambda that explicitly called:

    onSurfaceWrapperAboutToRemove(wrapper);
    m_rootSurfaceContainer->destroyForSurface(wrapper);

However, destroying a surface at this stage also causes the corresponding protocol objects (e.g. xdg-toplevel) to be removed, which later triggers ShellHandler::onXdgToplevelSurfaceRemoved(). That path already calls onSurfaceWrapperAboutToRemove(wrapper).

As a result, surface wrappers could be removed twice, leading to double destruction and crashes.

Fix this by changing the session-destroy handling to request a graceful surface close instead of forcefully removing the wrapper. This lets the normal protocol-driven removal path handle cleanup exactly once.

To support this for layer surfaces as well, add WLayerSurface::close() and forward it to the closed() signal, keeping behavior consistent with other surface types.

comment: https://github.com/linuxdeepin/treeland/issues/659#issuecomment-3698732249

https://pms.uniontech.com/bug-view-346031.html

## Summary by Sourcery

Handle session destruction by requesting graceful surface closure instead of forcefully destroying surface wrappers to avoid double removal and crashes.

Bug Fixes:
- Prevent double removal and destruction of surface wrappers when the active session is destroyed.

Enhancements:
- Add a close() implementation for WLayerSurface that triggers the existing closed() signal, aligning its behavior with other surface types.