### PR TITLE
fix: improve surface proxy handling for splash screens

### DIFF
--- a/src/core/qml/SwitchViewDelegate.qml
+++ b/src/core/qml/SwitchViewDelegate.qml
@@ -63,9 +63,10 @@ Item {
                         Layout.fillWidth: true
                         Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
                         text: {
-                            const xdg = windowItem.surface.shellSurface
-                            const wholeTitle = xdg.title
-                            wholeTitle
+                            const wrapper = windowItem.surface
+                            const xdg = wrapper.shellSurface
+                            const title = xdg ? xdg.title : ""
+                            return title && title.length > 0 ? title : wrapper.appId
                         }
                         elide: Qt.ElideRight
                     }

--- a/src/plugins/multitaskview/multitaskview.cpp
+++ b/src/plugins/multitaskview/multitaskview.cpp
@@ -644,7 +644,13 @@ void MultitaskviewSurfaceModel::monitorUnreadySurface(SurfaceWrapper *surface)
 
 bool MultitaskviewSurfaceModel::surfaceReady(SurfaceWrapper *surface)
 {
-    return surface->surface()->mapped() && surfaceGeometry(surface).isValid();
+    if (surface->type() != SurfaceWrapper::Type::SplashScreen) {
+        auto surf = surface->surface();
+        if (!surf || !surf->mapped()) {
+            return false;
+        }
+    }
+    return surfaceGeometry(surface).isValid();
 }
 
 QRectF MultitaskviewSurfaceModel::surfaceGeometry(SurfaceWrapper *surface)

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1196,8 +1196,10 @@ void Helper::onSurfaceWrapperAboutToRemove(SurfaceWrapper *wrapper)
 bool Helper::surfaceBelongsToCurrentSession(SurfaceWrapper *wrapper)
 {
     if (wrapper->type() == SurfaceWrapper::Type::SplashScreen) {
-        // TODO(rewine): Support splash in multitaskview.
-        return false;
+        // TODO(rewine): Determine which user the splash screen belongs to by invoking the client of the prelaunch-splash protocol.
+        // Currently, treeland does not support logging in with multiple users at the same time
+        // so it is temporarily assumed that the splash screen must belong to the current user.
+        return true;
     }
     WClient *client = wrapper->surface()->waylandClient();
     WSocket *socket = client ? client->socket()->rootSocket() : nullptr;

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -40,7 +40,7 @@ class SurfaceWrapper : public QQuickItem
     Q_PROPERTY(qreal implicitHeight READ implicitHeight NOTIFY implicitHeightChanged FINAL)
     Q_PROPERTY(WAYLIB_SERVER_NAMESPACE::WSurface* surface READ surface CONSTANT)
     Q_PROPERTY(WAYLIB_SERVER_NAMESPACE::WToplevelSurface* shellSurface READ shellSurface CONSTANT)
-    Q_PROPERTY(WAYLIB_SERVER_NAMESPACE::WSurfaceItem* surfaceItem READ surfaceItem NOTIFY surfaceItemChanged)
+    Q_PROPERTY(WAYLIB_SERVER_NAMESPACE::WSurfaceItem* surfaceItem READ surfaceItem NOTIFY surfaceItemCreated)
     Q_PROPERTY(QQuickItem* prelaunchSplash READ prelaunchSplash NOTIFY prelaunchSplashChanged)
     Q_PROPERTY(QRectF boundingRect READ boundingRect NOTIFY boundingRectChanged)
     Q_PROPERTY(QRectF geometry READ geometry NOTIFY geometryChanged FINAL)
@@ -332,7 +332,7 @@ Q_SIGNALS:
     void coverEnabledChanged();
     void aboutToBeInvalidated();
     void acceptKeyboardFocusChanged();
-    void surfaceItemChanged();
+    void surfaceItemCreated(); // Emitted once after surfaceItem is constructed
     void prelaunchSplashChanged();
     void typeChanged();
 


### PR DESCRIPTION
Fixed window title display in SwitchViewDelegate to handle cases where shellSurface might be null. Added fallback to use appId when title is empty. Refactored surface proxy connection management to use range-based for loop and improved delegate synchronization. Enhanced SurfaceWrapper constructor to properly handle prelaunch splash screens and surface item changes.

Log: Improved window title display and window management stability

Influence:
1. Test window switching with applications that have empty titles
2. Verify window titles display correctly in task switcher
3. Test window proxy behavior during live/non-live transitions
4. Verify delegate synchronization between source and proxy surfaces
5. Test prelaunch splash screen handling for new windows

fix: 改进窗口标题显示和表面代理处理

修复了SwitchViewDelegate中窗口标题显示问题，处理shellSurface可能为空的情 况。当标题为空时使用appId作为回退。重构了表面代理连接管理，使用基于范围
的for循环并改进了委托同步。增强了SurfaceWrapper构造函数以正确处理预启动
闪屏和表面项变化。

Log: 改进窗口标题显示和窗口管理稳定性

Influence:
1. 测试标题为空的应用的窗口切换功能
2. 验证任务切换器中窗口标题正确显示
3. 测试实时/非实时转换期间的窗口代理行为
4. 验证源表面和代理表面之间的委托同步
5. 测试新窗口的预启动闪屏处理

## Summary by Sourcery

Improve window title handling in the task switcher and make surface proxy/splash screen management more robust.

Bug Fixes:
- Ensure SwitchViewDelegate displays a window title even when the shell surface is null or its title is empty by falling back to the appId.

Enhancements:
- Refine SurfaceProxy delegate and flag synchronization between source and proxy surfaces, including reacting to surface item and delegate changes over the surface lifetime.
- Enhance SurfaceWrapper construction to better support prelaunch splash screens by mirroring size, icon, and transitioning cleanly to the real shell surface.
- Modernize SurfaceProxy connection cleanup by using a range-based loop.