### PR TITLE
fix: fix crash on logout

### DIFF
--- a/src/core/treeland.cpp
+++ b/src/core/treeland.cpp
@@ -327,10 +327,10 @@ Treeland::Treeland()
                 auto cmdArgs = cmdline.value();
 
                 auto envs = QProcessEnvironment::systemEnvironment();
-                envs.insert("WAYLAND_DISPLAY", d->helper->defaultWaylandSocket()->fullServerName());
+                envs.insert("WAYLAND_DISPLAY", d->helper->globalWaylandSocket()->fullServerName());
                 if (auto *xwayland = d->helper->xwaylandForUid(getuid())) {
                     envs.insert("DISPLAY", xwayland->displayName());
-                } else if (auto *current = d->helper->defaultXWaylandSocket()) {
+                } else if (auto *current = d->helper->globalXWayland()) {
                     envs.insert("DISPLAY", current->displayName());
                 }
                 envs.insert("XDG_SESSION_DESKTOP", "Treeland");
@@ -348,7 +348,7 @@ Treeland::Treeland()
         auto con =
             connect(d->helper, &Helper::socketFileChanged, this, exec, Qt::SingleShotConnection);
 
-        WSocket *defaultSocket = d->helper->defaultWaylandSocket();
+        WSocket *defaultSocket = d->helper->globalWaylandSocket();
         if (defaultSocket && defaultSocket->isValid()) {
             QObject::disconnect(con);
             exec();

--- a/src/greeter/greeterproxy.cpp
+++ b/src/greeter/greeterproxy.cpp
@@ -274,7 +274,7 @@ void GreeterProxy::connected()
     qCDebug(treelandGreeter) << "Connected to the daemon.";
 
     SocketWriter(d->socket) << quint32(GreeterMessages::Connect)
-                            << Helper::instance()->defaultWaylandSocket()->fullServerName();
+                            << Helper::instance()->globalWaylandSocket()->fullServerName();
 }
 
 void GreeterProxy::disconnected()

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2353,7 +2353,7 @@ std::shared_ptr<Session> Helper::ensureSession(int id, uid_t uid)
  * @param uid User ID to get WXWayland for
  * @returns WXWayland for the given uid, or nullptr if not found/created
  */
-WXWayland *Helper::xwaylandForUid(uid_t uid)
+WXWayland *Helper::xwaylandForUid(uid_t uid) const
 {
     auto session = sessionForUid(uid);
     return session ? session->xwayland : nullptr;
@@ -2365,36 +2365,32 @@ WXWayland *Helper::xwaylandForUid(uid_t uid)
  * @param uid User ID to get WSocket for
  * @returns WSocket for the given uid, or nullptr if not found/created
  */
-WSocket *Helper::waylandSocketForUid(uid_t uid)
+WSocket *Helper::waylandSocketForUid(uid_t uid) const
 {
     auto session = sessionForUid(uid);
     return session ? session->socket : nullptr;
 }
 
 /** 
- * Get the WSocket for the active session
+ * Get the global WSocket, which is not relative with any session and
+ * always available.
  * 
- * @returns WSocket for the active session, or nullptr if none active
+ * @returns The global WSocket, or nullptr if it's not created yet.
  */
-WSocket *Helper::defaultWaylandSocket() const
+WSocket *Helper::globalWaylandSocket() const
 {
-    auto ptr = m_activeSession.lock();
-    if (ptr && ptr->socket)
-        return ptr->socket;
-    return nullptr;
+    return waylandSocketForUid(getpwnam("dde")->pw_uid);
 }
 
 /**
- * Get the WXWayland for the active session
+ * Get the global WXWayland, which is not relative with any session and
+ * always available.
  * 
- * @returns WXWayland for the active session, or nullptr if none active
+ * @returns The global WXWayland, or nullptr if none active
  */
-WXWayland *Helper::defaultXWaylandSocket() const
+WXWayland *Helper::globalXWayland() const
 {
-    auto ptr = m_activeSession.lock();
-    if (ptr && ptr->xwayland)
-        return ptr->xwayland;
-    return nullptr;
+    return xwaylandForUid(getpwnam("dde")->pw_uid);
 }
 
 /**

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -206,15 +206,15 @@ public:
     void addSocket(WSocket *socket);
     void removeXWayland(WXWayland *xwayland);
     void removeSession(std::shared_ptr<Session> session);
-    WXWayland *xwaylandForUid(uid_t uid);
-    WSocket *waylandSocketForUid(uid_t uid);
+    WXWayland *xwaylandForUid(uid_t uid) const;
+    WSocket *waylandSocketForUid(uid_t uid) const;
     std::shared_ptr<Session> sessionForUid(uid_t uid) const;
     std::shared_ptr<Session> sessionForXWayland(WXWayland *xwayland) const;
     std::shared_ptr<Session> sessionForSocket(WSocket *socket) const;
     std::weak_ptr<Session> activeSession() const;
 
-    WSocket *defaultWaylandSocket() const;
-    WXWayland *defaultXWaylandSocket() const;
+    WSocket *globalWaylandSocket() const;
+    WXWayland *globalXWayland() const;
 
     PersonalizationV1 *personalization() const;
 


### PR DESCRIPTION
The reason of crash is that the treeland cannot find fullServerName for default WSocket. We should provide an always-available WSocket in defaultWaylandSocket() method, instead of the socket of current session.

## Summary by Sourcery

Ensure the default Wayland socket lookup uses a reserved, always-available socket instead of the active session socket to prevent crashes on logout.

Bug Fixes:
- Fix crash on logout by resolving the default Wayland socket from a dedicated user-specific socket rather than the active session socket.

Enhancements:
- Mark Helper socket and XWayland lookup methods as const-qualified for safer read-only access.