### PR TITLE
Revert "chore: temporary disable TreelandUserConfig smart pointer"

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -212,9 +212,9 @@ Helper::Helper(QObject *parent)
     m_instance = this;
 
     Q_ASSERT(!m_config);
-    m_config = TreelandUserConfig::createByName("org.deepin.dde.treeland.user",
+    m_config.reset(TreelandUserConfig::createByName("org.deepin.dde.treeland.user",
                                               "org.deepin.dde.treeland",
-                                              "/dde"); // will update user path in Helper::init
+                                              "/dde")); // will update user path in Helper::init
     m_globalConfig.reset(TreelandConfig::create("org.deepin.dde.treeland",
                                                       QString()));
 
@@ -310,7 +310,7 @@ Helper *Helper::instance()
 
 TreelandUserConfig *Helper::config()
 {
-    return m_config;
+    return m_config.get();
 }
 
 TreelandConfig *Helper::globalConfig()
@@ -1324,9 +1324,9 @@ void Helper::init(Treeland::Treeland *treeland)
     m_personalization = m_server->attach<PersonalizationV1>();
 
     auto updateCurrentUser = [this] {
-        m_config = TreelandUserConfig::createByName("org.deepin.dde.treeland.user",
+        m_config.reset(TreelandUserConfig::createByName("org.deepin.dde.treeland.user",
                                                   "org.deepin.dde.treeland",
-                                                  "/" + m_userModel->currentUserName());
+                                                  "/" + m_userModel->currentUserName()));
         auto user = m_userModel->currentUser();
         m_personalization->setUserId(user ? user->UID() : getuid());
     };

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -356,7 +356,7 @@ private:
     bool isXWaylandClient(WClient *client);
 
     static Helper *m_instance;
-    TreelandUserConfig *m_config = nullptr;
+    std::unique_ptr<TreelandUserConfig> m_config;
     std::unique_ptr<TreelandConfig> m_globalConfig;
     Treeland::Treeland *m_treeland = nullptr;
     FpsDisplayManager *m_fpsManager = nullptr;


### PR DESCRIPTION
This reverts commit 779832f52af2156517da777bcac1d4c69a3a1373.

## Summary by Sourcery

Enhancements:
- Switch Helper::m_config back to a std::unique_ptr-managed TreelandUserConfig instance and adjust its construction and access accordingly.