### PR TITLE
fix: fix user cannot login after logout once

### DIFF
--- a/src/greeter/greeterproxy.h
+++ b/src/greeter/greeterproxy.h
@@ -113,7 +113,6 @@ private:
     bool localValidation(const QString &user, const QString &password) const;
     void updateAuthSocket();
     void updateLocketState();
-    void updateUserLoginState(const QDBusObjectPath &path, bool loggedIn);
 
 private:
     GreeterProxyPrivate *d{ nullptr };

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -129,6 +129,7 @@ struct Session : QObject {
 public:
     int id = 0;
     uid_t uid = 0;
+    QString username = {};
     WSocket *socket = nullptr;
     WXWayland *xwayland = nullptr;
     quint32 noTitlebarAtom = XCB_ATOM_NONE;
@@ -208,7 +209,9 @@ public:
     void removeSession(std::shared_ptr<Session> session);
     WXWayland *xwaylandForUid(uid_t uid) const;
     WSocket *waylandSocketForUid(uid_t uid) const;
+    std::shared_ptr<Session> sessionForId(int id) const;
     std::shared_ptr<Session> sessionForUid(uid_t uid) const;
+    std::shared_ptr<Session> sessionForUser(const QString &username) const;
     std::shared_ptr<Session> sessionForXWayland(WXWayland *xwayland) const;
     std::shared_ptr<Session> sessionForSocket(WSocket *socket) const;
     std::weak_ptr<Session> activeSession() const;
@@ -351,7 +354,7 @@ private:
     void restoreFromShowDesktop(SurfaceWrapper *activeSurface = nullptr);
     void setNoAnimation(bool noAnimation);
 
-    std::shared_ptr<Session> ensureSession(int id, uid_t uid);
+    std::shared_ptr<Session> ensureSession(int id, QString username);
     void updateActiveUserSession(const QString &username, int id);
     bool isXWaylandClient(WClient *client);
 


### PR DESCRIPTION
We've commit a mistake that we tried to fetch logind session name from an already-removed session. Fix that.

There's also some API change to make internal function calling more straightforward btw.

## Summary by Sourcery

Fix login/logout session handling and align greeter-helper interactions with username-based sessions.

Bug Fixes:
- Prevent users from being unable to log in again after logging out by avoiding access to removed sessions and correctly tracking session removal via logind signals.

Enhancements:
- Track sessions by username in addition to UID, updating session creation and lookup APIs accordingly.
- Simplify greeter logic by inlining login state updates into logind session new/removed handlers and emitting user login updates directly from those callbacks.