### PR TITLE
fix: systemd warnings caused by invalid directives in socket units.

### DIFF
--- a/misc/systemd/dde-session-pre.target.wants/treeland-sd.socket
+++ b/misc/systemd/dde-session-pre.target.wants/treeland-sd.socket
@@ -10,4 +10,3 @@ Before=dde-session-pre.target
 ListenStream=%t/treeland.socket
 RemoveOnStop=true
 FileDescriptorName=Treeland
-ExecStop=-/usr/bin/systemctl --user unset-environment WAYLAND_DISPLAY

--- a/misc/systemd/dde-session-pre.target.wants/treeland-xwayland.socket
+++ b/misc/systemd/dde-session-pre.target.wants/treeland-xwayland.socket
@@ -10,4 +10,3 @@ Before=dde-session-pre.target
 ListenStream=%t/treeland-xwayland
 RemoveOnStop=true
 FileDescriptorName=Treeland-Xwayland
-ExecStop=-/usr/bin/systemctl --user unset-environment DISPLAY


### PR DESCRIPTION
The treeland-sd.socket and treeland-xwayland.socket units contained ExecStop directives in the [Socket] section. systemd ignores these keys and logs warnings during user session startup.

Remove the invalid directives to comply with systemd socket unit semantics and avoid misleading configuration.

warning info:
/usr/lib/systemd/user/treeland-xwayland.socket:13: Unknown key name 'ExecStop' in section 'Socket', ignoring. 
/usr/lib/systemd/user/treeland-sd.socket:13: Unknown key name 'ExecStop' in section 'Socket', ignoring.

treelnad-xwayland.service
treeland-sd.service已经有了ExecStop的执行命令 这里不需要添加

## Summary by Sourcery

Bug Fixes:
- Resolve systemd warnings caused by unsupported ExecStop directives in treeland-sd.socket and treeland-xwayland.socket configurations.