### PR TITLE
refactor: move session related functionality out of Helper

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -166,6 +166,8 @@ qt_add_qml_module(libtreeland
         output/outputlifecyclemanager.h
         seat/helper.cpp
         seat/helper.h
+        session/session.cpp
+        session/session.h
         surface/surfacecontainer.cpp
         surface/surfacecontainer.h
         surface/surfacefilterproxymodel.cpp
@@ -303,6 +305,7 @@ target_include_directories(libtreeland
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/interfaces>
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/output>
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/seat>
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/session>
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/surface>
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/workspace>
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/utils>

--- a/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
+++ b/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
@@ -142,7 +142,7 @@ void ForeignToplevelV1::addSurface(SurfaceWrapper *wrapper)
             &treeland_foreign_toplevel_handle_v1::rectangleChanged,
             wrapper,
             [wrapper](treeland_foreign_toplevel_handle_v1_set_rectangle_event *event) {
-                auto dockWrapper = Helper::instance()->rootContainer()->getSurface(
+                auto dockWrapper = Helper::instance()->rootSurfaceContainer()->getSurface(
                     WSurface::fromHandle(event->surface));
                 wrapper->setIconGeometry(QRect(dockWrapper->x() + event->x,
                                                dockWrapper->y() + event->y,

--- a/src/modules/shortcut/shortcutmanager.cpp
+++ b/src/modules/shortcut/shortcutmanager.cpp
@@ -7,12 +7,11 @@
 #include "common/treelandlogging.h"
 #include "shortcutcontroller.h"
 #include "seat/helper.h"
+#include "session/session.h"
 #include "input/gestures.h"
 
 #include <qwdisplay.h>
 #include <wsocket.h>
-
-#include <optional>
 
 #define TREELAND_SHORTCUT_MANAGER_V2_VERSION 1
 
@@ -416,12 +415,12 @@ void ShortcutManagerV2::sendActivated(const QString& name, uint keyFlags)
 void ShortcutManagerV2::onSessionChanged()
 {
     QString commitFailName;
-    auto session = Helper::instance()->activeSession().lock();
+    auto session = Helper::instance()->sessionManager()->activeSession().lock();
     if (!session) {
         return;
     }
 
-    auto *socket = session->socket;
+    auto *socket = session->socket();
 
     if (d->m_activeSessionSocket == socket)
         return;
@@ -434,8 +433,8 @@ void ShortcutManagerV2::onSessionChanged()
         if (status) {
             qCWarning(treelandShortcut) << "Failed to restore shortcuts" << commitFailName
                                         << "by reason" << status
-                                        << "for session" << session->id
-                                        << "for user" << session->uid;
+                                        << "for session" << session->id()
+                                        << "for user" << session->username();
         }
         return;
     }

--- a/src/modules/shortcut/shortcutrunner.cpp
+++ b/src/modules/shortcut/shortcutrunner.cpp
@@ -344,7 +344,7 @@ void ShortcutRunner::taskswitchAction(bool isRepeat, bool isSameApp, bool isPrev
 
     if (helper->m_taskSwitch.isNull()) {
         auto contentItem = helper->window()->contentItem();
-        auto output = helper->rootContainer()->primaryOutput();
+        auto output = helper->rootSurfaceContainer()->primaryOutput();
         helper->m_taskSwitch = helper->qmlEngine()->createTaskSwitcher(output, contentItem);
         helper->restoreFromShowDesktop();
         QObject::connect(helper->m_taskSwitch, SIGNAL(switchOnChanged()), helper, SLOT(deleteTaskSwitch()));

--- a/src/plugins/multitaskview/qml/MultitaskviewProxy.qml
+++ b/src/plugins/multitaskview/qml/MultitaskviewProxy.qml
@@ -120,7 +120,7 @@ Multitaskview {
     }
 
     Repeater {
-        model: Helper.rootContainer.outputModel
+        model: Helper.rootSurfaceContainer.outputModel
         Item {
             id: outputPlacementItem
             required property int index

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -22,133 +22,112 @@
 #include <QList>
 #include <optional>
 
-Q_MOC_INCLUDE(<wtoplevelsurface.h>)
-Q_MOC_INCLUDE(<wxdgsurface.h>)
+Q_MOC_INCLUDE(<QDBusObjectPath>)
 Q_MOC_INCLUDE(<qwgammacontorlv1.h>)
 Q_MOC_INCLUDE(<qwoutputmanagementv1.h>)
-Q_MOC_INCLUDE("surface/surfacewrapper.h")
-Q_MOC_INCLUDE("workspace/workspace.h")
+Q_MOC_INCLUDE(<wlayersurface.h>)
+Q_MOC_INCLUDE(<wtoplevelsurface.h>)
+Q_MOC_INCLUDE(<wxdgsurface.h>)
 Q_MOC_INCLUDE("core/rootsurfacecontainer.h")
 Q_MOC_INCLUDE("modules/capture/capture.h")
-Q_MOC_INCLUDE(<wlayersurface.h>)
-Q_MOC_INCLUDE(<QDBusObjectPath>)
+Q_MOC_INCLUDE("surface/surfacewrapper.h")
+Q_MOC_INCLUDE("workspace/workspace.h")
 Q_MOC_INCLUDE("treelandconfig.hpp")
 Q_MOC_INCLUDE("treelanduserconfig.hpp")
 
 QT_BEGIN_NAMESPACE
-class QQuickItem;
 class QDBusObjectPath;
+class QQuickItem;
 QT_END_NAMESPACE
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
-class WServer;
-class WOutputRenderWindow;
-class WOutputLayout;
+class WBackend;
 class WClientPrivate;
 class WCursor;
-class WBackend;
-class WOutputItem;
-class WOutputViewport;
-class WOutputLayer;
+class WExtForeignToplevelListV1;
+class WForeignToplevel;
+class WLayerSurface;
 class WOutput;
-class WXWayland;
-class WXdgDecorationManager;
+class WOutputItem;
+class WOutputLayer;
+class WOutputLayout;
+class WOutputManagerV1;
+class WOutputRenderWindow;
+class WOutputViewport;
+class WServer;
+class WSessionLock;
+class WSessionLockManager;
 class WSocket;
 class WSurface;
-class WToplevelSurface;
 class WSurfaceItem;
-class WForeignToplevel;
-class WExtForeignToplevelListV1;
-class WOutputManagerV1;
-class WLayerSurface;
-class WSessionLockManager;
-class WSessionLock;
+class WToplevelSurface;
+class WXdgDecorationManager;
+class WXWayland;
 WAYLIB_SERVER_END_NAMESPACE
 
 QW_BEGIN_NAMESPACE
-class qw_renderer;
 class qw_allocator;
 class qw_compositor;
-class qw_idle_notifier_v1;
+class qw_ext_foreign_toplevel_image_capture_source_manager_v1;
 class qw_idle_inhibit_manager_v1;
+class qw_idle_inhibitor_v1;
+class qw_idle_notifier_v1;
 class qw_output_configuration_v1;
 class qw_output_power_manager_v1;
-class qw_idle_inhibitor_v1;
+class qw_renderer;
 QW_END_NAMESPACE
 
 WAYLIB_SERVER_USE_NAMESPACE
 QW_USE_NAMESPACE
 
-class Output;
-class SurfaceWrapper;
-class SurfaceContainer;
-class RootSurfaceContainer;
-class ForeignToplevelV1;
-class LockScreen;
-class ShortcutManagerV2;
-class ShortcutRunner;
-class PersonalizationV1;
-class WallpaperColorV1;
-class WindowManagementV1;
-class Multitaskview;
-class DDEShellManagerInterfaceV1;
-class PrelaunchSplash;
-class WindowPickerInterface;
-class VirtualOutputV1;
-class ShellHandler;
-class OutputManagerV1;
 class CaptureSourceSelector;
-class treeland_window_picker_v1;
-class IMultitaskView;
-class LockScreenInterface;
+class DDEShellManagerInterfaceV1;
+class DDMInterfaceV1;
+class ForeignToplevelV1;
+class FpsDisplayManager;
 class ILockScreen;
-class UserModel;
+class IMultitaskView;
+class LockScreen;
+class LockScreenInterface;
+class Multitaskview;
+class Output;
 class OutputConfigState;
 class OutputLifecycleManager;
-class DDMInterfaceV1;
+class OutputManagerV1;
+class PersonalizationV1;
+class PrelaunchSplash;
+class RootSurfaceContainer;
+class ScreensaverInterfaceV1;
+class SessionManager;
+class SettingManager;
+class ShellHandler;
+class ShortcutManagerV2;
+class ShortcutRunner;
+class SurfaceContainer;
+class SurfaceWrapper;
 class TreelandConfig;
 class TreelandUserConfig;
-class FpsDisplayManager;
-class ScreensaverInterfaceV1;
-class SettingManager;
+class treeland_window_picker_v1;
+class UserModel;
+class VirtualOutputV1;
+class WallpaperColorV1;
+class WindowManagementV1;
+class WindowPickerInterface;
 
+struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request;
 struct wlr_idle_inhibitor_v1;
 struct wlr_output_power_v1_set_mode_event;
-struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request;
 
 namespace Treeland {
 class Treeland;
 }
-
-QW_BEGIN_NAMESPACE
-class qw_ext_foreign_toplevel_image_capture_source_manager_v1;
-QW_END_NAMESPACE
-
-struct Session : QObject {
-    Q_OBJECT
-public:
-    int id = 0;
-    uid_t uid = 0;
-    QString username = {};
-    WSocket *socket = nullptr;
-    WXWayland *xwayland = nullptr;
-    quint32 noTitlebarAtom = XCB_ATOM_NONE;
-    SettingManager *settingManager = nullptr;
-    QThread *settingManagerThread = nullptr;
-
-    ~Session();
-
-Q_SIGNALS:
-    void aboutToBeDestroyed();
-};
 
 class Helper : public WSeatEventFilter
 {
     friend class RootSurfaceContainer;
     friend class ShortcutRunner;
     Q_OBJECT
-    Q_PROPERTY(bool socketEnabled READ socketEnabled WRITE setSocketEnabled NOTIFY socketEnabledChanged FINAL)
-    Q_PROPERTY(RootSurfaceContainer* rootContainer READ rootContainer CONSTANT FINAL)
+    Q_PROPERTY(RootSurfaceContainer* rootSurfaceContainer READ rootSurfaceContainer CONSTANT FINAL)
     Q_PROPERTY(float animationSpeed READ animationSpeed WRITE setAnimationSpeed NOTIFY animationSpeedChanged FINAL)
     Q_PROPERTY(OutputMode outputMode READ outputMode WRITE setOutputMode NOTIFY outputModeChanged FINAL)
     Q_PROPERTY(SurfaceWrapper* activatedSurface READ activatedSurface NOTIFY activatedSurfaceChanged FINAL)
@@ -184,6 +163,7 @@ public:
     TreelandUserConfig *config();
     TreelandConfig *globalConfig();
 
+    SessionManager *sessionManager() const;
     QmlEngine *qmlEngine() const;
     WOutputRenderWindow *window() const;
     ShellHandler *shellHandler() const;
@@ -191,10 +171,7 @@ public:
 
     void init(Treeland::Treeland *treeland);
 
-    bool socketEnabled() const;
-    void setSocketEnabled(bool newSocketEnabled);
-
-    RootSurfaceContainer *rootContainer() const;
+    RootSurfaceContainer *rootSurfaceContainer() const;
     Output *getOutput(WOutput *output) const;
 
     float animationSpeed() const;
@@ -205,19 +182,8 @@ public:
     Q_INVOKABLE void addOutput();
 
     void addSocket(WSocket *socket);
+    [[nodiscard]] WXWayland *createXWayland();
     void removeXWayland(WXWayland *xwayland);
-    void removeSession(std::shared_ptr<Session> session);
-    WXWayland *xwaylandForUid(uid_t uid) const;
-    WSocket *waylandSocketForUid(uid_t uid) const;
-    std::shared_ptr<Session> sessionForId(int id) const;
-    std::shared_ptr<Session> sessionForUid(uid_t uid) const;
-    std::shared_ptr<Session> sessionForUser(const QString &username) const;
-    std::shared_ptr<Session> sessionForXWayland(WXWayland *xwayland) const;
-    std::shared_ptr<Session> sessionForSocket(WSocket *socket) const;
-    std::weak_ptr<Session> activeSession() const;
-
-    WSocket *globalWaylandSocket() const;
-    WXWayland *globalXWayland() const;
 
     PersonalizationV1 *personalization() const;
 
@@ -230,8 +196,6 @@ public:
     Q_INVOKABLE bool isLaunchpad(WLayerSurface *surface) const;
 
     void handleWindowPicker(WindowPickerInterface *picker);
-
-    RootSurfaceContainer *rootSurfaceContainer() const;
 
     void setMultitaskViewImpl(IMultitaskView *impl);
     void setLockScreenImpl(ILockScreen *impl);
@@ -272,12 +236,10 @@ public Q_SLOTS:
     bool surfaceBelongsToCurrentSession(SurfaceWrapper *wrapper);
 
 Q_SIGNALS:
-    void socketEnabledChanged();
     void primaryOutputChanged();
     void activatedSurfaceChanged();
 
     void animationSpeedChanged();
-    void socketFileChanged();
     void outputModeChanged();
 
     void currentModeChanged();
@@ -355,10 +317,6 @@ private:
     void setWorkspaceVisible(bool visible);
     void restoreFromShowDesktop(SurfaceWrapper *activeSurface = nullptr);
     void setNoAnimation(bool noAnimation);
-
-    std::shared_ptr<Session> ensureSession(int id, QString username);
-    void updateActiveUserSession(const QString &username, int id);
-    bool isXWaylandClient(WClient *client);
     void configureNumlock();
 
     static Helper *m_instance;
@@ -366,12 +324,9 @@ private:
     std::unique_ptr<TreelandConfig> m_globalConfig;
     Treeland::Treeland *m_treeland = nullptr;
     FpsDisplayManager *m_fpsManager = nullptr;
+    SessionManager *m_sessionManager = nullptr;
 
     CurrentMode m_currentMode{ CurrentMode::Normal };
-
-    // Sessions
-    std::weak_ptr<Session> m_activeSession;
-    QList<std::shared_ptr<Session>> m_sessions;
 
     // qtquick helper
     WOutputRenderWindow *m_renderWindow = nullptr;

--- a/src/session/session.cpp
+++ b/src/session/session.cpp
@@ -1,0 +1,412 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "session.h"
+
+#include "common/treelandlogging.h"
+#include "core/rootsurfacecontainer.h"
+#include "core/shellhandler.h"
+#include "seat/helper.h"
+#include "workspace/workspace.h"
+#include "xsettings/settingmanager.h"
+
+#include <woutputrenderwindow.h>
+#include <wsocket.h>
+#include <wxwayland.h>
+
+#include <pwd.h>
+
+#define _DEEPIN_NO_TITLEBAR "_DEEPIN_NO_TITLEBAR"
+
+static xcb_atom_t internAtom(xcb_connection_t *connection, const char *name, bool onlyIfExists)
+{
+    if (!name || *name == 0)
+        return XCB_NONE;
+
+    xcb_intern_atom_cookie_t cookie = xcb_intern_atom(connection, onlyIfExists, strlen(name), name);
+    xcb_intern_atom_reply_t *reply = xcb_intern_atom_reply(connection, cookie, 0);
+
+    if (!reply)
+        return XCB_NONE;
+
+    xcb_atom_t atom = reply->atom;
+    free(reply);
+
+    return atom;
+}
+
+Session::~Session()
+{
+    qCDebug(treelandCore) << "Deleting session for uid:" << m_uid << m_socket;
+    Q_EMIT aboutToBeDestroyed();
+
+    if (m_settingManagerThread) {
+        m_settingManagerThread->quit();
+        m_settingManagerThread->wait(QDeadlineTimer(25000));
+    }
+
+    if (m_settingManager) {
+        delete m_settingManager;
+        m_settingManager = nullptr;
+    }
+    if (m_xwayland)
+        Helper::instance()->shellHandler()->removeXWayland(m_xwayland);
+    if (m_socket)
+        delete m_socket;
+}
+
+int Session::id() const
+{
+    return m_id;
+}
+
+uid_t Session::uid() const
+{
+    return m_uid;
+}
+
+const QString &Session::username() const
+{
+    return m_username;
+}
+
+WSocket *Session::socket() const
+{
+    return m_socket;
+}
+
+WXWayland *Session::xwayland() const
+{
+    return m_xwayland;
+}
+
+quint32 Session::noTitlebarAtom() const
+{
+    return m_noTitlebarAtom;
+}
+
+SessionManager::SessionManager(QObject *parent)
+    : QObject(parent)
+{
+}
+
+SessionManager::~SessionManager()
+{
+    m_sessions.clear();
+}
+
+const QList<std::shared_ptr<Session>> &SessionManager::sessions() const
+{
+    return m_sessions;
+}
+
+/**
+ * Get the currently active session
+ *
+ * @returns weak_ptr to the active session
+ */
+std::weak_ptr<Session> SessionManager::activeSession() const
+{
+    return m_activeSession;
+}
+
+/**
+ * Get the default session
+ *
+ * The default session is the session for the "dde" user.
+ * It manages the default Wayland socket and XWayland instance.
+ *
+ * @returns shared_ptr to the default session
+ */
+std::shared_ptr<Session> SessionManager::globalSession() const
+{
+    return sessionForUser("dde");
+}
+
+/**
+ * Check if the active session's WSocket is enabled
+ *
+ * @returns true if enabled, false otherwise
+ */
+bool SessionManager::activeSocketEnabled() const
+{
+    auto ptr = m_activeSession.lock();
+    if (ptr && ptr->m_socket)
+        return ptr->m_socket->isEnabled();
+    return false;
+}
+
+/**
+ * Set the active session's WSocket enabled state
+ *
+ * @param newEnabled New enabled state
+ */
+void SessionManager::setActiveSocketEnabled(bool newEnabled)
+{
+    auto ptr = m_activeSession.lock();
+    if (ptr && ptr->m_socket)
+        ptr->m_socket->setEnabled(newEnabled);
+    else
+        qCWarning(treelandCore) << "Can't set enabled for empty socket!";
+}
+
+/**
+ * Remove a session from the session list
+ *
+ * @param session The session to remove
+ */
+void SessionManager::removeSession(std::shared_ptr<Session> session)
+{
+    if (!session)
+        return;
+
+    if (m_activeSession.lock() == session) {
+        m_activeSession.reset();
+        Helper::instance()->workspace()->clearActivedSurface();
+        Helper::instance()->activateSurface(nullptr);
+    }
+
+    for (auto s : std::as_const(m_sessions)) {
+        if (s.get() == session.get()) {
+            m_sessions.removeOne(s);
+            break;
+        }
+    }
+}
+
+/**
+ * Ensure a session exists for the given username, creating it if necessary
+ *
+ * @param id An existing logind session ID
+ * @param username Username to ensure session for
+ * @returns Session for the given username, or nullptr on failure
+ */
+std::shared_ptr<Session> SessionManager::ensureSession(int id, QString username)
+{
+    // Helper lambda to create WSocket and WXWayland
+    auto createWSocket = [this]() {
+        // Create WSocket
+        auto socket = new WSocket(true, nullptr);
+        if (!socket->autoCreate()) {
+            qCCritical(treelandCore) << "Failed to create Wayland socket";
+            delete socket;
+            return static_cast<WSocket *>(nullptr);
+        }
+        // Connect signals
+        connect(socket, &WSocket::fullServerNameChanged, this, [this] {
+            if (m_activeSession.lock())
+                Q_EMIT socketFileChanged();
+        });
+        // Add socket to server
+        Helper::instance()->addSocket(socket);
+        return socket;
+    };
+    auto createXWayland = [this](WSocket *socket) {
+        // Create xwayland
+        auto *xwayland = Helper::instance()->createXWayland();
+        if (!xwayland) {
+            qCCritical(treelandCore) << "Failed to create XWayland instance";
+            return static_cast<WXWayland *>(nullptr);
+        }
+        // Bind xwayland to socket
+        xwayland->setOwnsSocket(socket);
+        // Connect signals
+        connect(xwayland, &WXWayland::ready, this, [this, xwayland] {
+            if (auto session = sessionForXWayland(xwayland)) {
+                session->m_noTitlebarAtom =
+                    internAtom(session->m_xwayland->xcbConnection(), _DEEPIN_NO_TITLEBAR, false);
+                if (!session->m_noTitlebarAtom) {
+                    qCWarning(treelandInput) << "Failed to intern atom:" << _DEEPIN_NO_TITLEBAR;
+                }
+                session->m_settingManager = new SettingManager(session->m_xwayland->xcbConnection());
+                session->m_settingManagerThread = new QThread();
+
+                session->m_settingManager->moveToThread(session->m_settingManagerThread);
+
+                const qreal scale = Helper::instance()->rootSurfaceContainer()->window()->effectiveDevicePixelRatio();
+                const auto renderWindow = Helper::instance()->window();
+                connect(session->m_settingManagerThread, &QThread::started,
+                        this,
+                        [settingManager = QPointer(session->m_settingManager),
+                         scale, renderWindow] {
+                            QMetaObject::invokeMethod(
+                                settingManager,
+                                [settingManager, scale]() {
+                                    settingManager->setGlobalScale(scale);
+                                    settingManager->apply();
+                                },
+                                Qt::QueuedConnection);
+                            QObject::connect(
+                                renderWindow,
+                                &WOutputRenderWindow::effectiveDevicePixelRatioChanged,
+                                settingManager,
+                                [settingManager](qreal dpr) {
+                                    settingManager->setGlobalScale(dpr);
+                                    settingManager->apply();
+                                },
+                                Qt::QueuedConnection);
+                });
+                connect(session->m_settingManagerThread, &QThread::finished, session->m_settingManagerThread, &QThread::deleteLater);
+                session->m_settingManagerThread->start();
+            }
+        });
+        return xwayland;
+    };
+    // Check if session already exists for user
+    if (auto session = sessionForUser(username)) {
+        // Ensure it has a socket and xwayland
+        if (!session->m_socket) {
+            auto *socket = createWSocket();
+            if (!socket) {
+                m_sessions.removeOne(session);
+                return nullptr;
+            }
+            session->m_socket = socket;
+        }
+        if (!session->m_xwayland) {
+            auto *xwayland = createXWayland(session->m_socket);
+            if (!xwayland) {
+                delete session->m_socket;
+                session->m_socket = nullptr;
+                m_sessions.removeOne(session);
+                return nullptr;
+            }
+
+            session->m_xwayland = xwayland;
+        }
+
+        return session;
+    }
+    // Session does not exist, create new session with deleter
+    auto passwd = getpwnam(username.toLocal8Bit().data());
+    if (!passwd) {
+        qCWarning(treelandCore) << "Failed to get passwd entry for user:" << username;
+        return nullptr;
+    }
+    auto session = std::make_shared<Session>();
+    session->m_id = id;
+    session->m_username = username;
+    session->m_uid = passwd->pw_uid;
+
+    session->m_socket = createWSocket();
+    if (!session->m_socket)
+        return nullptr;
+
+    session->m_xwayland = createXWayland(session->m_socket);
+    if (!session->m_xwayland)
+        return nullptr;
+
+    // Add session to list
+    m_sessions.append(session);
+    return session;
+}
+
+
+/**
+ * Find the session for the given logind session id
+ *
+ * @param id Session ID to find session for
+ * @returns Session for the given id, or nullptr if not found
+ */
+std::shared_ptr<Session> SessionManager::sessionForId(int id) const
+{
+    for (auto session : m_sessions) {
+        if (session && session->m_id == id)
+            return session;
+    }
+    return nullptr;
+}
+
+/**
+ * Find the session for the given uid
+ *
+ * @param uid User ID to find session for
+ * @returns Session for the given uid, or nullptr if not found
+ */
+std::shared_ptr<Session> SessionManager::sessionForUid(uid_t uid) const
+{
+    for (auto session : m_sessions) {
+        if (session && session->m_uid == uid)
+            return session;
+    }
+    return nullptr;
+}
+
+/**
+ * Find the session for the given username
+ *
+ * @param username Username to find session for
+ * @returns Session for the given username, or nullptr if not found
+ */
+std::shared_ptr<Session> SessionManager::sessionForUser(const QString &username) const
+{
+    for (auto session : m_sessions) {
+        if (session && session->m_username == username)
+            return session;
+    }
+    return nullptr;
+}
+
+/**
+ * Find the session for the given WXWayland
+ *
+ * @param xwayland WXWayland to find session for
+ * @returns Session for the given xwayland, or nullptr if not found
+ */
+std::shared_ptr<Session> SessionManager::sessionForXWayland(WXWayland *xwayland) const
+{
+    for (auto session : m_sessions) {
+        if (session && session->m_xwayland == xwayland)
+            return session;
+    }
+    return nullptr;
+}
+
+/**
+ * Find the session for the given WSocket
+ *
+ * @param socket WSocket to find session for
+ * @returns Session for the given socket, or nullptr if not found
+ */
+std::shared_ptr<Session> SessionManager::sessionForSocket(WSocket *socket) const
+{
+    for (auto session : m_sessions) {
+        if (session && session->m_socket == socket)
+            return session;
+    }
+    return nullptr;
+}
+
+/**
+ * Update the active session to the given uid, creating it if necessary.
+ * This will update XWayland visibility and emit socketFileChanged if the
+ * active session changed.
+ *
+ * @param username Username to set as active session
+ */
+void SessionManager::updateActiveUserSession(const QString &username, int id)
+{
+    // Get previous active session
+    auto previous = m_activeSession.lock();
+    // Get new session for uid, creating if necessary
+    auto session = ensureSession(id, username);
+    if (!session) {
+        qCWarning(treelandInput) << "Failed to ensure session for user" << username;
+        return;
+    }
+    if (previous != session) {
+        // Update active session
+        m_activeSession = session;
+        // Clear activated surface
+        // TODO: Each Wayland socket's active surface needs to be cleaned up individually.
+        Helper::instance()->activateSurface(nullptr);
+        // Emit signal and update socket enabled state
+        if (previous && previous->m_socket)
+            previous->m_socket->setEnabled(false);
+        session->m_socket->setEnabled(true);
+        Q_EMIT socketFileChanged();
+        // Notify session changed through DBus, treeland-sd will listen it to update envs
+        Q_EMIT sessionChanged();
+    }
+    qCInfo(treelandCore) << "Listening on:" << session->m_socket->fullServerName();
+}

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -1,0 +1,81 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include "wglobal.h"
+
+#include <xcb/xproto.h>
+
+WAYLIB_SERVER_BEGIN_NAMESPACE
+class WSocket;
+class WXWayland;
+WAYLIB_SERVER_END_NAMESPACE
+
+WAYLIB_SERVER_USE_NAMESPACE
+
+class SettingManager;
+
+class Session : public QObject {
+    Q_OBJECT
+public:
+    ~Session();
+
+    int id() const;
+    uid_t uid() const;
+    const QString &username() const;
+    WSocket *socket() const;
+    WXWayland *xwayland() const;
+    quint32 noTitlebarAtom() const;
+
+Q_SIGNALS:
+    void aboutToBeDestroyed();
+
+private:
+    friend class SessionManager;
+
+    int m_id = 0;
+    uid_t m_uid = 0;
+    QString m_username = {};
+    WSocket *m_socket = nullptr;
+    WXWayland *m_xwayland = nullptr;
+    quint32 m_noTitlebarAtom = XCB_ATOM_NONE;
+    SettingManager *m_settingManager = nullptr;
+    QThread *m_settingManagerThread = nullptr;
+};
+
+/**
+ * SessionManager manages user sessions, including their associated
+ * WSocket and WXWayland instances.
+ */
+class SessionManager : public QObject {
+    Q_OBJECT
+public:
+    explicit SessionManager(QObject *parent = nullptr);
+    ~SessionManager();
+
+    const QList<std::shared_ptr<Session>> &sessions() const;
+    std::weak_ptr<Session> activeSession() const;
+    std::shared_ptr<Session> globalSession() const;
+
+    bool activeSocketEnabled() const;
+    void setActiveSocketEnabled(bool newEnabled);
+
+    void updateActiveUserSession(const QString &username, int id);
+    void removeSession(std::shared_ptr<Session> session);
+    std::shared_ptr<Session> sessionForId(int id) const;
+    std::shared_ptr<Session> sessionForUid(uid_t uid) const;
+    std::shared_ptr<Session> sessionForUser(const QString &username) const;
+    std::shared_ptr<Session> sessionForXWayland(WXWayland *xwayland) const;
+    std::shared_ptr<Session> sessionForSocket(WSocket *socket) const;
+
+Q_SIGNALS:
+    void socketFileChanged();
+    void sessionChanged();
+
+private:
+    std::shared_ptr<Session> ensureSession(int id, QString username);
+
+    std::weak_ptr<Session> m_activeSession;
+    QList<std::shared_ptr<Session>> m_sessions;
+};


### PR DESCRIPTION
Changes:
- reordered header & forward class decls alphabetically in helper.h and helper.cpp
- Moved `class Session` and session management related member functions into the new `class SessionManager`

SessionManager is designed to be an independent singleton that exclusively manages session creation, invalidation and its related WSockets and WWayland instances.

## Summary by Sourcery

Extract session and socket management from Helper into a dedicated SessionManager singleton and update callers to use it.

Enhancements:
- Introduce a SessionManager singleton that owns Session objects and encapsulates session, WSocket, and WXWayland lifecycle and lookup logic.
- Simplify Helper by removing embedded session management, exposing only minimal hooks needed by SessionManager and renaming the root container property to rootSurfaceContainer.
- Refine includes and Q_MOC_INCLUDE ordering for helper-related files to be more consistent and organized.

Build:
- Register the new session/session.cpp and session/session.h sources in the core CMake target so the SessionManager is built.