### PR TITLE
fix: shortcuts: allow listening to only non-repeat key release events

### DIFF
--- a/src/modules/shortcut/shortcutcontroller.h
+++ b/src/modules/shortcut/shortcutcontroller.h
@@ -7,8 +7,10 @@
 #include "input/gestures.h"
 
 #include <QMap>
-#include <QKeySequence>
+#include <QKeyCombination>
+
 class Gesture;
+class QKeyEvent;
 
 class ShortcutController : public QObject
 {
@@ -17,25 +19,23 @@ public:
     explicit ShortcutController(QObject *parent = nullptr);
     ~ShortcutController() override;
 
-    uint registerKey(const QString &name, const QString& key, uint mode, ShortcutAction action);
+    uint registerKey(const QString &name, const QString& key, uint keybindFlags, ShortcutAction action);
     uint registerSwipeGesture(const QString &name, uint finger, SwipeGesture::Direction direction, ShortcutAction action);
     uint registerHoldGesture(const QString &name, uint finger, ShortcutAction action);
     void unregisterShortcut(const QString &name);
 
     void clear();
-    bool dispatchKeyPress(QKeyCombination sequence, bool repeat);
-    bool dispatchKeyRelease(QKeyCombination sequence);
+    bool dispatchKeyEvent(const QKeyEvent *event);
 
 Q_SIGNALS:
-    void actionTriggered(ShortcutAction action, const QString &name, bool isGesture, bool isRepeat = false);
+    void actionTriggered(ShortcutAction action, const QString &name, bool isGesture, uint keyFlags = 0u);
     void actionProgress(ShortcutAction action, qreal progress, const QString &name);
     void actionFinished(ShortcutAction action, const QString &name, bool isTriggered);
 
 private:
     static constexpr QKeyCombination normalizeKeyCombination(QKeyCombination combination);
 
-    QMap<int, QMap<ShortcutAction, std::pair<QString, bool>>> m_keyPressMap;
-    QMap<int, QMap<ShortcutAction, QString>> m_keyReleaseMap;
+    QMap<int, QMap<ShortcutAction, std::pair<QString, uint>>> m_keyMap;
     QMap<std::pair<uint, SwipeGesture::Direction>, QMap<ShortcutAction, QString>> m_gesturemap;
     QMap<std::pair<uint, SwipeGesture::Direction>, QObject*> m_gestures;
     QMap<QString, std::function<void()>> m_deleters;

--- a/src/modules/shortcut/shortcutmanager.h
+++ b/src/modules/shortcut/shortcutmanager.h
@@ -61,7 +61,7 @@ public:
     QByteArrayView interfaceName() const override;
 
     ShortcutController* controller();
-    void sendActivated(const QString& name, bool repeat = false);
+    void sendActivated(const QString& name, uint keyFlags = 0);
 
 public Q_SLOTS:
     void onSessionChanged();

--- a/src/modules/shortcut/shortcutrunner.cpp
+++ b/src/modules/shortcut/shortcutrunner.cpp
@@ -15,12 +15,14 @@
 #include "woutputrenderwindow.h"
 #include "output/output.h"
 
+#include "qwayland-server-treeland-shortcut-manager-v2.h"
+
 ShortcutRunner::ShortcutRunner(QObject *parent)
     : QObject(parent)
 {
 }
 
-void ShortcutRunner::onActionTrigger(ShortcutAction action, const QString &name, bool isGesture, bool isRepeat)
+void ShortcutRunner::onActionTrigger(ShortcutAction action, const QString &name, bool isGesture, uint keyFlags)
 {
     Q_UNUSED(isGesture)
     auto *helper = Helper::instance();
@@ -31,7 +33,7 @@ void ShortcutRunner::onActionTrigger(ShortcutAction action, const QString &name,
 
     switch (action) {
     case ShortcutAction::Notify:
-        helper->m_shortcutManager->sendActivated(name, isRepeat);
+        helper->m_shortcutManager->sendActivated(name, keyFlags);
         break;
     case ShortcutAction::Workspace1:
         helper->restoreFromShowDesktop();
@@ -164,7 +166,7 @@ void ShortcutRunner::onActionTrigger(ShortcutAction action, const QString &name,
     case ShortcutAction::TaskSwitchSameAppPrev: {
         const bool isSameApp = (action == ShortcutAction::TaskSwitchSameAppNext || action == ShortcutAction::TaskSwitchSameAppPrev);
         const bool isPrev = (action == ShortcutAction::TaskSwitchPrev || action == ShortcutAction::TaskSwitchSameAppPrev);
-        taskswitchAction(isRepeat, isSameApp, isPrev);
+        taskswitchAction(keyFlags & QtWaylandServer::treeland_shortcut_manager_v2::keybind_flag_repeat, isSameApp, isPrev);
         break;
     }
     default:

--- a/src/modules/shortcut/shortcutrunner.h
+++ b/src/modules/shortcut/shortcutrunner.h
@@ -13,7 +13,7 @@ public:
     explicit ShortcutRunner(QObject *parent = nullptr);
 
 public Q_SLOTS:
-    void onActionTrigger(ShortcutAction action, const QString &name, bool isGesture, bool isRepeat);
+    void onActionTrigger(ShortcutAction action, const QString &name, bool isGesture, uint keyFlags = 0u);
     void onActionProgress(ShortcutAction action, qreal progress, const QString &name);
     void onActionFinish(ShortcutAction action, const QString &name, bool isTriggered);
 

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1722,15 +1722,8 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *, QInputEvent *event)
                 break;
             }
 
-            QKeyCombination combination = kevent->keyCombination();
-            if (event->type() == QEvent::KeyPress
-                && m_shortcutManager->controller()->dispatchKeyPress(combination, kevent->isAutoRepeat())) {
+            if (m_shortcutManager->controller()->dispatchKeyEvent(kevent))
                 return true;
-            }
-            if (event->type() == QEvent::KeyRelease
-                && m_shortcutManager->controller()->dispatchKeyRelease(combination)) {
-                return true;
-            }
         } while (false);
     }
 

--- a/src/treeland-shortcut/shortcut.cpp
+++ b/src/treeland-shortcut/shortcut.cpp
@@ -47,10 +47,11 @@ static const QMap<QString, ShortcutV2::action> ActionMap = {
     {"TaskswitchSameAppPrev", ShortcutV2::action_taskswitch_sameapp_prev},
 };
 
-static const QMap<QString, ShortcutV2::keybind_mode> KeybindModeMap = {
-    {"KeyRelease", ShortcutV2::keybind_mode_key_release},
-    {"KeyPress", ShortcutV2::keybind_mode_key_press},
-    {"KeyPressRepeat", ShortcutV2::keybind_mode_key_press_repeat},
+static const QMap<QString, uint> KeybindModeMap = {
+    {"KeyPress", ShortcutV2::keybind_flag_key_press},
+    {"KeyRelease", ShortcutV2::keybind_flag_key_release},
+    {"KeyPressRepeat", ShortcutV2::keybind_flag_key_press | ShortcutV2::keybind_flag_repeat},
+    {"KeyReleaseRepeat", ShortcutV2::keybind_flag_key_release | ShortcutV2::keybind_flag_repeat},
 };
 
 static const QMap<QString, ShortcutV2::direction> GestureDirectionMap = {
@@ -288,12 +289,12 @@ void Shortcut::registerForManager(ShortcutV2 *manager)
     if (!shortcut.isEmpty()) {
         auto keybindName = QString("%1_key").arg(m_shortcutName);
 
-        ShortcutV2::keybind_mode mode = ShortcutV2::keybind_mode_key_press;
+        uint keybindFlags = ShortcutV2::keybind_flag_key_press;
         auto modeStr = m_settings.value("Shortcut/KeybindMode").toString();
         if (KeybindModeMap.contains(modeStr)) {
-            mode = KeybindModeMap.value(modeStr);
+            keybindFlags = KeybindModeMap.value(modeStr);
         }
-        manager->bind_key(keybindName, shortcut, mode, action);
+        manager->bind_key(keybindName, shortcut, keybindFlags, action);
         m_registeredBindings.append(keybindName);
     }
 


### PR DESCRIPTION
This PR is coupled with an update in treeland-protocols. See: https://github.com/linuxdeepin/treeland-protocols/pull/39

Since treeland repeats both pressed and released key events, we should allow the client to decide whether to only listen to non-repeat key release events as well, mirroring the behavior when binding to key press events.

## Summary by Sourcery

Support configurable repeat handling for key release shortcuts and plumb repeat information through dispatch and protocol mapping.

New Features:
- Allow key release shortcuts to opt into or out of handling auto‑repeat events, mirroring key press behavior.

Bug Fixes:
- Ensure invalid keybind mode combinations are rejected when registering shortcuts.

Enhancements:
- Unify keybind mode handling using bitmask flags for release and repeat and propagate repeat state in key release dispatch.
- Extend shortcut protocol keybind mode mapping to support combined release+repeat bindings.