### PR TITLE
fix: fix user mistakenly marked as logged in when login happened outside ddm

### DIFF
--- a/src/greeter/greeterproxy.cpp
+++ b/src/greeter/greeterproxy.cpp
@@ -295,12 +295,15 @@ void GreeterProxy::onSessionNew(const QString &id, const QDBusObjectPath &path)
                                                      path.path(),
                                                      QDBusConnection::systemBus());
         QString username = session.name();
-        QMetaObject::invokeMethod(this, [this, username, id]() {
-            userModel()->updateUserLoginState(username, true);
-            // userLoggedIn signal is connected with Helper::updateActiveUserSession
-            Q_EMIT d->userModel->userLoggedIn(username, id.toInt());
-            updateLocketState();
-        });
+        QString service = session.service();
+        if (service == QStringLiteral("ddm")) {
+            QMetaObject::invokeMethod(this, [this, username, id]() {
+                userModel()->updateUserLoginState(username, true);
+                // userLoggedIn signal is connected with Helper::updateActiveUserSession
+                Q_EMIT d->userModel->userLoggedIn(username, id.toInt());
+                updateLocketState();
+            });
+        }
     });
 }
 


### PR DESCRIPTION
We listen to SessionNew to register new session and mark the user as logged in, but didn't distinguish if the session is opened by ourselves (ddm) or others (e.g. ssh or TTY login). This will cause problem.

Now we use Service property of the Logind session for the PAM module name, only if it's ddm (defined in ddm/src/daemon/Auth.cpp) it is recorded.

## Summary by Sourcery

Bug Fixes:
- Prevent users from being marked as logged in when their session was created outside the display manager (e.g. SSH or TTY logins).