### PR TITLE
chore(debian): update version to 0.8.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.25.0)
 
 project(Treeland
-    VERSION 0.7.0
+    VERSION 0.8.1
     LANGUAGES CXX C)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+treeland (0.8.1) unstable; urgency=medium
+
+  * fix: update treeland-protocol structure names (#690)
+  * fix: systemd warnings caused by invalid directives in socket units.
+  * fix: fix user mistakenly marked as logged in when login happened
+    outside ddm
+  * fix: fix user cannot login after logout once
+  * fix: missing license LGPL-2.1-or-later for kde keystate protocol
+  * feat: adopt kde-keystate-v5 to expose states of stateful keys
+  * fix: fix treeland crash on virtual machine
+
+ -- rewine <luhongxu@uniontech.com>  Thu, 15 Jan 2026 11:07:00 +0800
+
 treeland (0.8.0) unstable; urgency=medium
 
   * chore: temporary disable TreelandUserConfig smart pointer

--- a/src/modules/screensaver/CMakeLists.txt
+++ b/src/modules/screensaver/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(TreelandProtocols REQUIRED)
+find_package(TreelandProtocols 0.5.3 REQUIRED)
 
 ws_generate_local(server ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-screensaver-v1.xml treeland-screensaver-v1-protocol)
 


### PR DESCRIPTION
Log: update

## Summary by Sourcery

Bump the project version and align the screensaver module with a specific TreelandProtocols dependency version.

Build:
- Update the CMake project version to 0.8.1.
- Require TreelandProtocols version 0.5.3 for the screensaver module.