### PR TITLE
fix: show lockscreen only if the logind session is removed

### DIFF
--- a/src/greeter/greeterproxy.cpp
+++ b/src/greeter/greeterproxy.cpp
@@ -299,6 +299,7 @@ void GreeterProxy::onSessionNew(const QString &id, const QDBusObjectPath &path)
                 userModel()->updateUserLoginState(username, true);
                 // userLoggedIn signal is connected with Helper::updateActiveUserSession
                 Q_EMIT d->userModel->userLoggedIn(username, id.toInt());
+                Q_EMIT loginSucceeded(username);
                 updateLocketState();
             });
         }
@@ -471,9 +472,9 @@ void GreeterProxy::updateLocketState()
     if (!d->userModel)
         return;
     qCInfo(treelandGreeter) << "Update lock state";
-    bool locked = false;
+    bool locked = d->isLocked;
     if (auto user = d->userModel->currentUser()) {
-        locked = user->logined();
+        locked = !user->logined();
     }
 
     if (d->isLocked != locked) {


### PR DESCRIPTION
This will work as intended.

Since updateLocketState will do its things, no additional changes needed. Only remove redundant code is enough.

## Summary by Sourcery

Bug Fixes:
- Prevent the lockscreen state from being updated prematurely on logout by removing redundant login state changes.