### PR TITLE
fix: second user cannot login

### DIFF
--- a/src/greeter/greeterproxy.cpp
+++ b/src/greeter/greeterproxy.cpp
@@ -301,6 +301,7 @@ void GreeterProxy::onSessionNew(const QString &id, const QDBusObjectPath &path)
                 userModel()->updateUserLoginState(username, true);
                 // userLoggedIn signal is connected with Helper::updateActiveUserSession
                 Q_EMIT d->userModel->userLoggedIn(username, id.toInt());
+                Q_EMIT loginSucceeded(username);
                 updateLocketState();
             });
         }
@@ -473,9 +474,9 @@ void GreeterProxy::updateLocketState()
     if (!d->userModel)
         return;
     qCInfo(treelandGreeter) << "Update lock state";
-    bool locked = false;
+    bool locked = d->isLocked;
     if (auto user = d->userModel->currentUser()) {
-        locked = user->logined();
+        locked = !user->logined();
     }
 
     if (d->isLocked != locked) {


### PR DESCRIPTION
There's a bunch of shit in this obsolete code, but this quickfix can temporarily make it behave well...

## Summary by Sourcery

Fix login flow and lock state handling in greeter when a user session starts.

Bug Fixes:
- Emit a login success signal when a user session is created so subsequent users can log in correctly.
- Correct lock state calculation to reflect whether the current user is actually logged in, fixing erroneous lock/unlock behavior.