### PR TITLE
fix: compilation issues due to update in treeland-dde-shell-v1 protocol

### DIFF
--- a/examples/test_monitor_active_event/CMakeLists.txt
+++ b/examples/test_monitor_active_event/CMakeLists.txt
@@ -8,6 +8,7 @@ qt_add_executable(${BIN_NAME}
 )
 
 qt_generate_wayland_protocol_client_sources(${BIN_NAME}
+    NO_INCLUDE_CORE_ONLY
     FILES
         ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-dde-shell-v1.xml
 )

--- a/examples/test_multitaskview/CMakeLists.txt
+++ b/examples/test_multitaskview/CMakeLists.txt
@@ -21,6 +21,7 @@ qt_add_qml_module(${BIN_NAME}
 )
 
 qt_generate_wayland_protocol_client_sources(${BIN_NAME}
+    NO_INCLUDE_CORE_ONLY
     FILES
         ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-dde-shell-v1.xml
 )

--- a/examples/test_super_overlay_surface/CMakeLists.txt
+++ b/examples/test_super_overlay_surface/CMakeLists.txt
@@ -11,6 +11,7 @@ qt_add_executable(${BIN_NAME}
 )
 
 qt_generate_wayland_protocol_client_sources(${BIN_NAME}
+    NO_INCLUDE_CORE_ONLY
     FILES
         ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-dde-shell-v1.xml
 )

--- a/examples/test_window_overlapped/CMakeLists.txt
+++ b/examples/test_window_overlapped/CMakeLists.txt
@@ -11,6 +11,7 @@ qt_add_executable(${BIN_NAME}
 )
 
 qt_generate_wayland_protocol_client_sources(${BIN_NAME}
+    NO_INCLUDE_CORE_ONLY
     FILES
         ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-dde-shell-v1.xml
 )

--- a/examples/test_window_picker/CMakeLists.txt
+++ b/examples/test_window_picker/CMakeLists.txt
@@ -21,6 +21,7 @@ qt_add_qml_module(${BIN_NAME}
 )
 
 qt_generate_wayland_protocol_client_sources(${BIN_NAME}
+    NO_INCLUDE_CORE_ONLY
     FILES
         ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-dde-shell-v1.xml
 )

--- a/tests/test_window_picker/CMakeLists.txt
+++ b/tests/test_window_picker/CMakeLists.txt
@@ -21,6 +21,7 @@ qt_add_qml_module(${BIN_NAME}
 )
 
 qt_generate_wayland_protocol_client_sources(${BIN_NAME}
+    NO_INCLUDE_CORE_ONLY
     FILES
         ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-dde-shell-v1.xml
 )


### PR DESCRIPTION
Qt's client side wayland scanner includes only core header files by default, missing `wl_callback_interface`.

## Summary by Sourcery

Bug Fixes:
- Fix compilation failures in example and test targets by disabling core-only header inclusion when generating Wayland client sources for treeland-dde-shell-v1.