### PR TITLE
fix: decoration assert crash when proxy decoration is not created

### DIFF
--- a/src/surface/surfaceproxy.cpp
+++ b/src/surface/surfaceproxy.cpp
@@ -97,7 +97,7 @@ void SurfaceProxy::setSurface(SurfaceWrapper *newSurface)
         m_sourceConnections << connect(m_sourceSurface,
                                        &SurfaceWrapper::noTitleBarChanged,
                                        this,
-                                       &SurfaceProxy::updateProxySurfaceTitleBarAndDecoration);
+                                       &SurfaceProxy::updateNoTitleBar);
         m_sourceConnections << connect(m_sourceSurface,
                                        &SurfaceWrapper::radiusChanged,
                                        this,
@@ -105,11 +105,11 @@ void SurfaceProxy::setSurface(SurfaceWrapper *newSurface)
         m_sourceConnections << connect(m_sourceSurface,
                                        &SurfaceWrapper::noDecorationChanged,
                                        this,
-                                       &SurfaceProxy::updateProxySurfaceTitleBarAndDecoration);
+                                       &SurfaceProxy::updateNoDecoration);
         m_sourceConnections << connect(m_sourceSurface,
                                        &SurfaceWrapper::noCornerRadiusChanged,
                                        this,
-                                       &SurfaceProxy::updateProxySurfaceTitleBarAndDecoration);
+                                       &SurfaceProxy::updateNoCornerRadius);
 
         m_sourceConnections << connect(m_proxySurface,
                                        &SurfaceWrapper::widthChanged,
@@ -122,7 +122,7 @@ void SurfaceProxy::setSurface(SurfaceWrapper *newSurface)
 
         updateImplicitSize();
         updateProxySurfaceScale();
-        updateProxySurfaceTitleBarAndDecoration();
+        updateShape();
     } else {
         if (m_shadow) {
             m_shadow->deleteLater();
@@ -161,17 +161,26 @@ void SurfaceProxy::updateProxySurfaceScale()
     }
 }
 
-void SurfaceProxy::updateProxySurfaceTitleBarAndDecoration()
+void SurfaceProxy::updateShape()
 {
-    if (m_fullProxy) {
-        m_proxySurface->setNoTitleBar(m_sourceSurface->noTitleBar());
-        m_proxySurface->setNoDecoration(m_sourceSurface->noDecoration());
-        m_proxySurface->setNoCornerRadius(m_sourceSurface->noCornerRadius());
-    } else {
-        m_proxySurface->setNoTitleBar(m_sourceSurface->noTitleBar());
-        m_proxySurface->setNoDecoration(true);
-        m_proxySurface->setNoCornerRadius(false);
-    }
+    updateNoTitleBar();
+    updateNoDecoration();
+    updateNoCornerRadius();
+}
+
+void SurfaceProxy::updateNoTitleBar()
+{
+    m_proxySurface->setNoTitleBar(m_sourceSurface->noTitleBar());
+}
+
+void SurfaceProxy::updateNoDecoration()
+{
+    m_proxySurface->setNoDecoration(m_fullProxy ? m_sourceSurface->noDecoration() : false);
+}
+
+void SurfaceProxy::updateNoCornerRadius()
+{
+    m_proxySurface->setNoCornerRadius(m_fullProxy ? m_sourceSurface->noCornerRadius() : false);
 }
 
 void SurfaceProxy::updateImplicitSize()
@@ -285,7 +294,7 @@ void SurfaceProxy::setFullProxy(bool newFullProxy)
             m_shadow->stackBefore(m_proxySurface);
             QQuickItemPrivate::get(m_shadow)->culled = true;
         }
-        updateProxySurfaceTitleBarAndDecoration();
+        updateShape();
     }
 
     Q_EMIT fullProxyChanged();

--- a/src/surface/surfaceproxy.h
+++ b/src/surface/surfaceproxy.h
@@ -46,7 +46,10 @@ Q_SIGNALS:
 private:
     void geometryChange(const QRectF &newGeo, const QRectF &oldGeo) override;
     void updateProxySurfaceScale();
-    void updateProxySurfaceTitleBarAndDecoration();
+    void updateShape();
+    void updateNoTitleBar();
+    void updateNoDecoration();
+    void updateNoCornerRadius();
     void updateImplicitSize();
     void onSourceRadiusChanged();
 

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -888,19 +888,18 @@ void SurfaceWrapper::setNoDecoration(bool newNoDecoration)
     if (m_wrapperAboutToRemove)
         return;
 
-    setNoCornerRadius(newNoDecoration);
     if (m_noDecoration == newNoDecoration)
         return;
 
     m_noDecoration = newNoDecoration;
+    setNoCornerRadius(newNoDecoration);
 
-    if (m_type == Type::SplashScreen) {
+    if (m_type == Type::SplashScreen && !m_isProxy) {
         Q_EMIT noDecorationChanged();
         return;
     }
 
     updateDecoration();
-    Q_EMIT noDecorationChanged();
 }
 
 void SurfaceWrapper::updateDecoration()
@@ -928,6 +927,7 @@ void SurfaceWrapper::updateDecoration()
     }
 
     updateBoundingRect();
+    Q_EMIT noDecorationChanged();
 }
 
 void SurfaceWrapper::updateTitleBar()


### PR DESCRIPTION
SurfaceProxy previously updated title bar, decoration and corner radius via a shared slot while the proxy decoration might not have been created yet. This could result in invalid state propagation and trigger decoration-related assertions.

Refactor the update logic by:
- separating noTitleBar / noDecoration / noCornerRadius updates
- introducing updateShape() for controlled initialization
- avoiding decoration updates before proxy decoration exists

Additionally, adjust SurfaceWrapper::setNoDecoration() to ensure corner radius state is updated in a consistent order and prevent unnecessary decoration updates for proxy and splash surfaces.

See #689

## Summary by Sourcery

Refine surface proxy and wrapper decoration handling to prevent invalid state propagation and decoration-related crashes.

Bug Fixes:
- Prevent decoration assertions by avoiding proxy decoration updates before the proxy surface is fully initialized.
- Ensure corner radius state is updated in a consistent order when toggling decorations, avoiding redundant updates for proxy and splash surfaces.
- Emit decoration change signals only after decorations are fully updated to keep observers in sync.

Enhancements:
- Refactor SurfaceProxy decoration logic into separate shape update functions for title bar, decoration, and corner radius, improving control over initialization and updates.