### PR TITLE
feat: add dconfig option to allow setting Numlock state on startup

### DIFF
--- a/misc/dconfig/org.deepin.dde.treeland.json
+++ b/misc/dconfig/org.deepin.dde.treeland.json
@@ -34,6 +34,17 @@
             "description[zh_CN]": "在未匹配到窗口时销毁预启动闪屏的超时时长",
             "permissions": "readwrite",
             "visibility": "public"
+        },
+        "numlock": {
+            "value": false,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Numlock",
+            "name[zh_CN]": "数字键盘",
+            "description": "Enable Numlock on Treeland startup & new keyboard connection",
+            "description[zh_CN]": "在 Treeland 启动以及新键盘连接时启用数字键盘",
+            "permissions": "readwrite",
+            "visibility": "public"
         }
     }
 }

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -357,6 +357,7 @@ private:
     std::shared_ptr<Session> ensureSession(int id, QString username);
     void updateActiveUserSession(const QString &username, int id);
     bool isXWaylandClient(WClient *client);
+    void configureNumlock();
 
     static Helper *m_instance;
     TreelandUserConfig *m_config = nullptr;


### PR DESCRIPTION
This feature is also present in SDDM.
We implement it in Treeland, since it is effectively the "greeter".

This is added per request from DDE devs.

Changes:
- added option "numlock" in TreelandConfig (org.deepin.dde.treeland) defaults to `false`.
- Set every keyboard's Numlock state on `inputAdded` if that option is set to `true`.

## Summary by Sourcery

Add configuration support to control Num Lock state on startup and apply it to keyboards when inputs are initialized.

New Features:
- Introduce a Treeland configuration option to enable or disable Num Lock at startup.
- Automatically set the Num Lock state for keyboards when new input devices are added if the configuration option is enabled.