### PR TITLE
fix: remove unused DDM headers in treeland.cpp

### DIFF
--- a/src/core/treeland.cpp
+++ b/src/core/treeland.cpp
@@ -3,7 +3,6 @@
 
 #include "treeland.h"
 
-#include "treelandconfig.hpp"
 #include "core/qmlengine.h"
 #include "greeter/usermodel.h"
 #include "interfaces/multitaskviewinterface.h"
@@ -17,17 +16,6 @@
 
 #if !defined(DISABLE_DDM) || defined(EXT_SESSION_LOCK_V1)
 #include "interfaces/lockscreeninterface.h"
-#endif
-
-#ifndef DISABLE_DDM
-#  include <Constants.h>
-#  include <Messages.h>
-#  include <SignalHandler.h>
-#  include <SocketWriter.h>
-using namespace DDM;
-
-#  include <DAccountsManager>
-#  include <DAccountsUser>
 #endif
 
 #include <wsocket.h>


### PR DESCRIPTION
Recent ddm refactor caused compilation failure due to removal of <SignalHandler.h>.
These headers are unused in treeland anyways :).

## Summary by Sourcery

Remove unused DDM-related headers from treeland.cpp to resolve compilation issues after recent refactors.

Bug Fixes:
- Fix compilation failure in treeland.cpp by removing references to removed DDM headers.

Enhancements:
- Clean up treeland.cpp includes by dropping unused DDM and configuration headers.