### PR TITLE
fix: clean up warnings on treeland startup

### DIFF
--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -149,7 +149,7 @@ Output::Output(WOutputItem *output, QObject *parent)
     // TODO: Investigate better ways to track the panel specific persistent settings.
     // The connector name of the panel may change.
     QString outputName = output->output()->name();
-    m_config = OutputConfig::createByName("org.deepin.dde.treeland.outputs",
+    m_config = OutputConfig::createByName("org.deepin.dde.treeland.output",
                                     "org.deepin.dde.treeland",
                                     "/" + outputName, this);
 }

--- a/src/plugins/lockscreen/qml/ControlAction.qml
+++ b/src/plugins/lockscreen/qml/ControlAction.qml
@@ -107,10 +107,12 @@ RowLayout {
         id: actionItem
         property bool expand: false
         property string iconName
+        property alias hovered: button.hovered
         signal clicked()
         implicitWidth: bottomGroup.buttonSize + 6
         implicitHeight: bottomGroup.buttonSize + 6
         D.RoundButton {
+            id: button
             icon {
                 width: 16
                 height: 16

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1994,7 +1994,7 @@ void Helper::onSessionNew(const QString &sessionId, const QDBusObjectPath &sessi
     const auto path = sessionPath.path();
     qCDebug(treelandCore) << "Session new, sessionId:" << sessionId << ", sessionPath:" << path;
     QDBusConnection::systemBus().connect("org.freedesktop.login1", path, "org.freedesktop.login1.Session", "Lock", this, SLOT(onSessionLock()));
-    QDBusConnection::systemBus().connect("org.freedesktop.login1", path, "org.freedesktop.login1.Session", "Unlock", this, SLOT(onSessionUnLock()));
+    QDBusConnection::systemBus().connect("org.freedesktop.login1", path, "org.freedesktop.login1.Session", "Unlock", this, SLOT(onSessionUnlock()));
 }
 
 void Helper::onSessionLock()
@@ -2300,8 +2300,9 @@ std::shared_ptr<Session> Helper::ensureSession(int id, QString username)
                 if (!session->noTitlebarAtom) {
                     qCWarning(treelandInput) << "Failed to intern atom:" << _DEEPIN_NO_TITLEBAR;
                 }
-                session->settingManager = new SettingManager(session->xwayland->xcbConnection(),
-                                                             session->xwayland);
+                session->settingManager = new SettingManager(session->xwayland->xcbConnection());
+                // TODO: proper destruction of QThread. relying on the QObject tree is crashy.
+                // We are moving session management out of Helper anyways, will fix later.
                 session->settingManagerThread = new QThread(session->xwayland);
 
                 session->settingManager->moveToThread(session->settingManagerThread);

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -289,6 +289,8 @@ private Q_SLOTS:
     void deleteTaskSwitch();
     void onPrepareForSleep(bool sleep);
     void onSessionNew(const QString &sessionId, const QDBusObjectPath &objectPath);
+    void onSessionLock();
+    void onSessionUnlock();
 
 private:
     void onOutputAdded(WOutput *output);
@@ -312,8 +314,6 @@ private:
     void onSurfaceWrapperAboutToRemove(SurfaceWrapper *wrapper);
     void handleRequestDrag([[maybe_unused]] WSurface *surface);
     void handleLockScreen(LockScreenInterface *lockScreen);
-    void onSessionLock();
-    void onSessionUnlock();
     void handleNewForeignToplevelCaptureRequest(wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request *request);
     void onExtSessionLock(WSessionLock *lock);
 

--- a/waylib/src/server/protocols/wxdgsurface.h
+++ b/waylib/src/server/protocols/wxdgsurface.h
@@ -11,6 +11,7 @@ class WAYLIB_SERVER_EXPORT WXdgSurface : public WToplevelSurface
 {
     Q_OBJECT
     QML_NAMED_ELEMENT(WaylandXdgSurface)
+    QML_UNCREATABLE("Cannot create WaylandXdgSurface from QML")
 
 protected:
     explicit WXdgSurface(WToplevelSurfacePrivate &d, QObject *parent = nullptr);

--- a/waylib/src/server/qtquick/wquickoutputlayout.h
+++ b/waylib/src/server/qtquick/wquickoutputlayout.h
@@ -19,6 +19,7 @@ class WAYLIB_SERVER_EXPORT WQuickOutputLayout : public WOutputLayout
     Q_OBJECT
     W_DECLARE_PRIVATE(WQuickOutputLayout)
     QML_NAMED_ELEMENT(OutputLayout)
+    QML_UNCREATABLE("Cannot create OutputLayout from QML")
     Q_PROPERTY(QList<WOutputItem*> outputs READ outputs NOTIFY outputsChanged)
 
 public:


### PR DESCRIPTION
Fixes:
- marked `WaylandXdgSurface` and `OutputLayout` as `QML_UNCREATABLE`
- fixed non-existent `hovered` property in ControlActionItem in `ControlAction.qml`
- fixed incorrect slot definition `onSessionLock` and `onSessionUnlock` in `Helper`
- fixed inconsistent dconfig naming for `OutputConfig`.

## Summary by Sourcery

Clean up session handling, configuration naming, QML properties, and QML type creatability to resolve startup warnings and minor runtime issues.

Bug Fixes:
- Correct the DBus Unlock signal slot name to use the existing onSessionUnlock handler.
- Expose a valid hovered property on ControlActionItem by aliasing the internal button state.
- Fix the dconfig group name used when creating OutputConfig instances for outputs.

Enhancements:
- Mark WaylandXdgSurface and OutputLayout QML types as uncreatable to prevent misuse from QML.
- Adjust Helper session setting manager construction and add notes about QThread destruction for future cleanup.