### PR TITLE
fix(WSurfaceItem): add subsurfaces.clear() after deleteLater

### DIFF
--- a/waylib/src/server/qtquick/wsurfaceitem.cpp
+++ b/waylib/src/server/qtquick/wsurfaceitem.cpp
@@ -986,6 +986,7 @@ void WSurfaceItem::releaseResources()
     } else {
         for (auto item : std::as_const(d->subsurfaces))
             item->deleteLater();
+        d->subsurfaces.clear();
     }
 
     if (auto content = d->getItemContent())


### PR DESCRIPTION
Prevent dangling pointers after deleteLater() in releaseResources(), avoiding UAF in subsequent subsurface iterations.

Log: add subsurface.clear after deleteLater

## Summary by Sourcery

Bug Fixes:
- Avoid dangling subsurface pointers by clearing the subsurfaces container after calling deleteLater on its items.

#704 