### PR TITLE
chore: remove obsolete dconfig usage in personalization

### DIFF
--- a/src/modules/personalization/personalizationmanager.cpp
+++ b/src/modules/personalization/personalizationmanager.cpp
@@ -73,7 +73,6 @@ QString PersonalizationV1::readWallpaperSettings(const QString &group,
 
 PersonalizationV1::PersonalizationV1(QObject *parent)
     : QObject(parent)
-    , m_dconfig(DConfig::create("org.deepin.treeland", "org.deepin.treeland", QString()))
 {
     if (PERSONALIZATION_MANAGER) {
         qFatal("There are multiple instances of QuickPersonalizationManager");
@@ -420,12 +419,12 @@ void PersonalizationV1::setCursorSize(const QSize &size)
 
 int32_t PersonalizationV1::windowRadius() const
 {
-    return m_dconfig->value("windowRadius", 18).toInt();
+    return Helper::instance()->config()->windowRadius();
 }
 
 QString PersonalizationV1::iconTheme() const
 {
-    return m_dconfig->value("iconThemeName", 18).toString();
+    return Helper::instance()->config()->iconThemeName();
 }
 
 QString PersonalizationV1::background(const QString &output, int workspaceId)

--- a/src/modules/personalization/personalizationmanager.h
+++ b/src/modules/personalization/personalizationmanager.h
@@ -11,8 +11,6 @@
 #include <wxdgsurface.h>
 #include <WWrapPointer>
 
-#include <DConfig>
-
 #include <QObject>
 #include <QQmlEngine>
 #include <QQuickItem>
@@ -157,8 +155,8 @@ private:
     uid_t m_userId = 0;
     QString m_cacheDirectory;
     QString m_settingFile;
+    // TODO： use Dconfig
     QString m_iniMetaData;
-    QScopedPointer<DTK_CORE_NAMESPACE::DConfig> m_dconfig;
     treeland_personalization_manager_v1 *m_manager = nullptr;
     QList<personalization_window_context_v1 *> m_windowContexts;
     std::vector<personalization_appearance_context_v1 *> m_appearanceContexts;


### PR DESCRIPTION
Remove outdated DConfig member variable and usage in PersonalizationV1 class. The DConfig functionality has been moved to Helper class in previous refactoring, but some residual code was left behind. This cleanup ensures consistent configuration access through the centralized Helper instance.

The changes include:
1. Remove m_dconfig member variable declaration from header file
2. Remove m_dconfig initialization in constructor
3. Replace direct DConfig calls with Helper::instance()->config() methods
4. Update windowRadius() and iconTheme() methods to use Helper class

Log: Removed obsolete DConfig usage in personalization module

Influence:
1. Verify window radius settings are correctly retrieved from Helper
2. Test icon theme configuration functionality
3. Ensure personalization settings work as expected without DConfig
4. Confirm no regression in appearance customization features

chore: 移除个性化模块中过时的 DConfig 使用

删除 PersonalizationV1 类中过时的 DConfig 成员变量和使用。在之前的重构
中，DConfig 功能已移至 Helper 类，但遗留了一些残余代码。此次清理确保通过
集中化的 Helper 实例进行一致的配置访问。

变更包括：
1. 从头文件中移除 m_dconfig 成员变量声明
2. 移除构造函数中的 m_dconfig 初始化
3. 将直接 DConfig 调用替换为 Helper::instance()->config() 方法
4. 更新 windowRadius() 和 iconTheme() 方法以使用 Helper 类

Log: 移除个性化模块中过时的 DConfig 使用

Influence:
1. 验证窗口圆角设置是否正确从 Helper 获取
2. 测试图标主题配置功能
3. 确保在没有 DConfig 的情况下个性化设置正常工作
4. 确认外观定制功能没有回归

## Summary by Sourcery

Clean up personalization configuration access to rely on the centralized Helper config instead of a local DConfig instance.

Enhancements:
- Route window radius and icon theme lookups through Helper::instance()->config() for consistent configuration access.
- Remove the obsolete DConfig dependency and member from PersonalizationV1, simplifying the personalization manager internals.

Chores:
- Add a TODO comment to clarify future DConfig-related work around INI metadata handling in the personalization module.