### PR TITLE
fix: clean up all treeland originated warnings on treeland startup

### DIFF
--- a/misc/systemd/treeland.service.in
+++ b/misc/systemd/treeland.service.in
@@ -9,6 +9,9 @@ After=seatd.service
 
 [Service]
 User=dde
+RuntimeDirectory=treeland
+RuntimeDirectoryMode=0700
+Environment="XDG_RUNTIME_DIR=%t/treeland"
 Environment=LIBSEAT_BACKEND=seatd
 Environment=DSG_APP_ID=org.deepin.dde.treeland
 Environment=ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer

--- a/src/core/qml/Decoration.qml
+++ b/src/core/qml/Decoration.qml
@@ -32,21 +32,21 @@ Item {
         Cursor.shape: {
             switch(edges) {
             case Qt.TopEdge:
-                return Waylib.CursorShape.TopSide
+                return waylib.CursorShape.TopSide
             case Qt.RightEdge:
-                return Waylib.CursorShape.RightSide
+                return waylib.CursorShape.RightSide
             case Qt.BottomEdge:
-                return Waylib.CursorShape.BottomSide
+                return waylib.CursorShape.BottomSide
             case Qt.LeftEdge:
-                return Waylib.CursorShape.LeftSide
+                return waylib.CursorShape.LeftSide
             case Qt.TopEdge | Qt.LeftEdge:
-                return Waylib.CursorShape.TopLeftCorner
+                return waylib.CursorShape.TopLeftCorner
             case Qt.TopEdge | Qt.RightEdge:
-                return Waylib.CursorShape.TopRightCorner
+                return waylib.CursorShape.TopRightCorner
             case Qt.BottomEdge | Qt.LeftEdge:
-                return Waylib.CursorShape.BottomLeftCorner
+                return waylib.CursorShape.BottomLeftCorner
             case Qt.BottomEdge | Qt.RightEdge:
-                return Waylib.CursorShape.BottomRightCorner
+                return waylib.CursorShape.BottomRightCorner
             }
 
             return Qt.ArrowCursor;

--- a/src/plugins/lockscreen/qml/SessionList.qml
+++ b/src/plugins/lockscreen/qml/SessionList.qml
@@ -77,7 +77,8 @@ Popup {
                     Layout.leftMargin: 5
                     Image {
                         anchors.fill: parent
-                        source: name
+                        // TODO: Provide icon for session
+                        // source: name
                         fillMode: Image.PreserveAspectFit
                     }
                 }

--- a/src/surface/surfacecontainer.cpp
+++ b/src/surface/surfacecontainer.cpp
@@ -162,7 +162,12 @@ QList<SurfaceContainer *> SurfaceContainer::subContainers() const
 
 void SurfaceContainer::setQmlEngine(QQmlEngine *engine)
 {
-    engine->setContextForObject(this, engine->rootContext());
+    const auto *context = engine->contextForObject(this);
+    if (context) {
+        Q_ASSERT(context == engine->rootContext());
+    } else {
+        engine->setContextForObject(this, engine->rootContext());
+    }
 
     const auto subContainers = this->subContainers();
     for (auto sub : subContainers) {

--- a/waylib/examples/tinywl/Decoration.qml
+++ b/waylib/examples/tinywl/Decoration.qml
@@ -30,21 +30,21 @@ Item {
         Cursor.shape: {
             switch(edges) {
             case Qt.TopEdge:
-                return Waylib.CursorShape.TopSide
+                return waylib.CursorShape.TopSide
             case Qt.RightEdge:
-                return Waylib.CursorShape.RightSide
+                return waylib.CursorShape.RightSide
             case Qt.BottomEdge:
-                return Waylib.CursorShape.BottomSide
+                return waylib.CursorShape.BottomSide
             case Qt.LeftEdge:
-                return Waylib.CursorShape.LeftSide
+                return waylib.CursorShape.LeftSide
             case Qt.TopEdge | Qt.LeftEdge:
-                return Waylib.CursorShape.TopLeftCorner
+                return waylib.CursorShape.TopLeftCorner
             case Qt.TopEdge | Qt.RightEdge:
-                return Waylib.CursorShape.TopRightCorner
+                return waylib.CursorShape.TopRightCorner
             case Qt.BottomEdge | Qt.LeftEdge:
-                return Waylib.CursorShape.BottomLeftCorner
+                return waylib.CursorShape.BottomLeftCorner
             case Qt.BottomEdge | Qt.RightEdge:
-                return Waylib.CursorShape.BottomRightCorner
+                return waylib.CursorShape.BottomRightCorner
             }
 
             return Qt.ArrowCursor;

--- a/waylib/src/server/kernel/wglobal.h
+++ b/waylib/src/server/kernel/wglobal.h
@@ -188,7 +188,7 @@ protected:
 
 class WAYLIB_SERVER_EXPORT WGlobal {
     Q_GADGET
-    QML_NAMED_ELEMENT(Waylib)
+    QML_NAMED_ELEMENT(waylib)
     QML_UNCREATABLE("Use for enums")
 
 public:

--- a/waylib/src/server/platformplugin/qwlrootsintegration.cpp
+++ b/waylib/src/server/platformplugin/qwlrootsintegration.cpp
@@ -350,7 +350,7 @@ public:
         m_format.setMajorVersion(3);
 
         if (auto c = qobject_cast<QW::OpenGLContext*>(m_context)) {
-            auto eglConfig = q_configFromGLFormat(c->eglDisplay(), m_format, false, EGL_WINDOW_BIT);
+            auto eglConfig = q_configFromGLFormat(c->eglDisplay(), m_format, false, EGL_PBUFFER_BIT);
             if (eglConfig)
                 m_format = q_glFormatFromConfig(c->eglDisplay(), eglConfig, m_format);
             Q_ASSERT(m_format.renderableType() == QSurfaceFormat::OpenGLES);


### PR DESCRIPTION
Fixed Warnings:
- `QQmlEngine::setContextForObject(): Object already has a QQmlContext` By checking if context is already set first in `SurfaceContainer::setQmlEngine`

- `qrc:/qt/qml/LockScreen/qml/SessionList.qml:78:21: QML QQuickImage:` `Cannot open: qrc:/qt/qml/LockScreen/qml/Treeland` By commenting out the Image src in `SessionList.qml`. We currently don't have an appropriate icon for sessions.

- `Invalid QML element name "Waylib";` `value type names should begin with a lowercase letter` By renaming the QML element `Waylib` to `waylib`, to comply with QML naming convention.

- `QStandardPaths: XDG_RUNTIME_DIR not set,` `defaulting to '/tmp/runtime-dde'` By setting runtime directory to `/run/treeland` in systemd service file.

- `Cannot find EGLConfig, returning null config` By relaxing constraints for `q_configFromGLFormat` in `qwlrootsintegration.cpp` from `EGL_WINDOW_BIT` to `EGL_PBUFFER_BIT`. Window buffers are generally not avaliable for compositors.

## Summary by Sourcery

Resolve various startup warnings in Treeland by adjusting QML naming, context handling, lock screen resources, and OpenGL configuration.

Bug Fixes:
- Prevent duplicate QQmlContext assignment in SurfaceContainer to eliminate QQmlEngine context warnings.
- Disable the unresolved session icon source in the lock screen session list to avoid QML image loading warnings.
- Rename the exported QML element from Waylib to waylib and update usages to satisfy QML naming rules and remove invalid element warnings.
- Relax EGL configuration selection in the wlroots integration to use PBUFFER configs, avoiding failures to find a valid EGLConfig.