### PR TITLE
chore: adapt config refactor from ddm

### DIFF
--- a/src/greeter/usermodel.cpp
+++ b/src/greeter/usermodel.cpp
@@ -21,7 +21,7 @@
 
 #include "common/treelandlogging.h"
 
-#include <Configuration.h>
+#include <Config.h>
 
 #include <DDBusInterface>
 
@@ -109,7 +109,7 @@ UserModel::UserModel(QObject *parent)
     });
 
     // find out index of the last user
-    auto lastUserName = stateConfig.Last.User.get();
+    auto lastUserName = lastUser();
 
     for (const auto &user : d->users) {
         if (user->userName() == lastUserName) {
@@ -153,7 +153,7 @@ int UserModel::lastIndex() const
 
 QString UserModel::lastUser()
 {
-    return stateConfig.Last.User.get();
+    return stateConfig.get<QString>("Last", "User");
 }
 
 int UserModel::rowCount(const QModelIndex &parent) const


### PR DESCRIPTION
DDM simplified its configuration system for simplicity and better maintainence, adapt this change.

Related with https://github.com/linuxdeepin/ddm/pull/77

## Summary by Sourcery

Adapt greeter session and user models to the new shared configuration API and keys.

Enhancements:
- Switch greeter components from the old Configuration header and field accessors to the new Config API.
- Read X11/Wayland session directories and last session/user values via the new generic configuration getters and reuse them across model initialization and file watching.