### PR TITLE
feat: replace assert with runtime error handling for output commit

### DIFF
--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -380,8 +380,9 @@ void Output::enable()
             newState.set_scale(preferredScaleFactor(output()->size()));
         }
         newState.set_enabled(true);
-        bool ok = qwoutput->commit_state(newState);
-        Q_ASSERT(ok);
+        if (!qwoutput->commit_state(newState)) {
+            qCCritical(treelandCore, "commit failed on output %s", qwoutput->handle()->name);
+        }
     }
 }
 

--- a/waylib/examples/blur/main.cpp
+++ b/waylib/examples/blur/main.cpp
@@ -107,8 +107,9 @@ void Helper::initProtocols(WOutputRenderWindow *window, QQmlEngine *qmlEngine)
                         newState.set_mode(mode);
                 }
                 newState.set_enabled(true);
-                bool ok = qwoutput->commit_state(newState);
-                Q_ASSERT(ok);
+                if (!qwoutput->commit_state(newState)) {
+                    qCritical("commit failed on output %s", qwoutput->handle()->name);
+                }
             }
         }
     });

--- a/waylib/examples/outputcopy/main.cpp
+++ b/waylib/examples/outputcopy/main.cpp
@@ -171,8 +171,9 @@ void Helper::initProtocols(QQmlEngine *qmlEngine)
                         newState.set_mode(mode);
                 }
                 newState.set_enabled(true);
-                bool ok = qwoutput->commit_state(newState);
-                Q_ASSERT(ok);
+                if (!qwoutput->commit_state(newState)) {
+                    qCritical("commit failed on output %s", qwoutput->handle()->name);
+                }
             }
         }
     });

--- a/waylib/examples/outputviewport/main.cpp
+++ b/waylib/examples/outputviewport/main.cpp
@@ -108,8 +108,9 @@ void Helper::initProtocols(WOutputRenderWindow *window, QQmlEngine *qmlEngine)
                         newState.set_mode(mode);
                 }
                 newState.set_enabled(true);
-                bool ok = qwoutput->commit_state(newState);
-                Q_ASSERT(ok);
+                if (!qwoutput->commit_state(newState)) {
+                    qCritical("commit failed on output %s", qwoutput->handle()->name);
+                }
             }
         }
     });

--- a/waylib/examples/tinywl/helper.cpp
+++ b/waylib/examples/tinywl/helper.cpp
@@ -753,8 +753,9 @@ void Helper::enableOutput(WOutput *output)
                 newState.set_mode(mode);
         }
         newState.set_enabled(true);
-        bool ok = qwoutput->commit_state(newState);
-        Q_ASSERT(ok);
+        if (!qwoutput->commit_state(newState)) {
+            qCritical("commit failed on output %s", qwoutput->handle()->name);
+        }
     }
 }
 

--- a/waylib/src/server/qtquick/woutputhelper.cpp
+++ b/waylib/src/server/qtquick/woutputhelper.cpp
@@ -240,6 +240,9 @@ bool WOutputHelper::commit()
     }
 
     bool ok = d->qwoutput()->commit_state(&state);
+    if (!ok) {
+        qCritical("commit failed on output %s", d->qwoutput()->handle()->name);
+    }
     wlr_output_state_finish(&state);
     ExtraState committedExtraState = d->extraState;
 

--- a/waylib/tests/manual/live/main.cpp
+++ b/waylib/tests/manual/live/main.cpp
@@ -122,8 +122,9 @@ void Helper::initProtocols(WOutputRenderWindow *window, QQmlEngine *qmlEngine)
                         newState.set_mode(mode);
                 }
                 newState.set_enabled(true);
-                bool ok = qwoutput->commit_state(newState);
-                Q_ASSERT(ok);
+                if (!qwoutput->commit_state(newState)) {
+                    qCritical("commit failed on output %s", qwoutput->handle()->name);
+                }
             }
         }
     });


### PR DESCRIPTION
Replace Q_ASSERT checks on output->commit_state() with explicit runtime error logging. This avoids aborting the process when a commit fails and provides clearer diagnostics via critical logs.

Log:
Tasks:

Influence:
No functional change to core logic.

## Summary by Sourcery

Add runtime error logging for failed output state commits instead of asserting, across core helper code, output handling, examples, and tests.

Bug Fixes:
- Prevent hard process aborts on output commit failures by handling commit_state() errors at runtime with critical logs.

Enhancements:
- Standardize critical logging when output commit_state() calls fail throughout core helper logic, output enabling, and Waylib example helpers.