### PR TITLE
fix(treeland-user): Remove systemd security restrictions to fix servi…

### DIFF
--- a/misc/systemd/dde-session-pre.target.wants/treeland.service.in
+++ b/misc/systemd/dde-session-pre.target.wants/treeland.service.in
@@ -31,12 +31,3 @@ ExecStop=-/usr/bin/systemctl --user unset-environment XDG_SESSION_DESKTOP
 Slice=session.slice
 Restart=on-failure
 RestartSec=1s
-
-NoNewPrivileges=true
-OOMScoreAdjust=-300
-Nice=-15
-MemoryDenyWriteExecute=true
-PrivateIPC=true
-ProtectSystem=full
-ProtectProc=invisible
-RestrictSUIDSGID=true


### PR DESCRIPTION
```
Jan 28 11:10:58 honor-laptop (treeland)[811]: treeland.service: PrivateIPC=yes is configured, but IPC namespace setup failed, ignoring: Operation not permitted
Jan 28 11:10:58 honor-laptop (treeland)[811]: treeland.service: Failed to set up mount namespacing: /dev/mqueue: Operation not permitted
Jan 28 11:10:58 honor-laptop (treeland)[811]: treeland.service: Failed at step NAMESPACE spawning /usr/bin/treeland: Operation not permitted
Jan 28 11:10:58 honor-laptop systemd[703]: treeland.service: Main process exited, code=exited, status=226/NAMESPACE
Jan 28 11:10:58 honor-laptop systemd[703]: treeland.service: Failed with result 'exit-code'.
```

> PrivateIPC: This option is only available for system services, or for services running in per-user instances of the service manager in which case PrivateUsers= is implicitly enabled (requires unprivileged user namespaces support to be enabled in the kernel via the "kernel.unprivileged_userns_clone=" sysctl).

Security controls for the treeland-user service have been temporarily removed. They will be added back after further confirmation of the options.
 