### PR TITLE
fix: prevent activated surface use-after-free on logout

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2266,8 +2266,7 @@ void Helper::removeSession(std::shared_ptr<Session> session)
 
     if (m_activeSession.lock() == session) {
         m_activeSession.reset();
-        m_activatedSurface = nullptr;
-        Q_EMIT activatedSurfaceChanged();
+        setActivatedSurface(nullptr);
     }
 
     for (auto s : std::as_const(m_sessions)) {
@@ -2467,7 +2466,6 @@ void Helper::updateActiveUserSession(const QString &username, int id)
         m_activeSession = session;
         // Clear activated surface
         setActivatedSurface(nullptr);
-        Q_EMIT activatedSurfaceChanged();
         // Emit signal and update socket enabled state
         if (previous && previous->socket)
             previous->socket->setEnabled(false);

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -422,7 +422,7 @@ private:
     QPointer<QQuickItem> m_taskSwitch;
     QList<qw_idle_inhibitor_v1 *> m_idleInhibitors;
 
-    SurfaceWrapper *m_activatedSurface = nullptr;
+    QPointer<SurfaceWrapper> m_activatedSurface = nullptr;
     LockScreen *m_lockScreen = nullptr;
     float m_animationSpeed = 1.0;
     OutputMode m_mode = OutputMode::Extension;


### PR DESCRIPTION
Ensure the activated surface is safely cleared when logging out or switching sessions by using QPointer and unifying the reset path through setActivatedSurface(nullptr).

Log: prevent activated surface use-after-free on logout
PMS: BUG-347763
Influence: logout

## Summary by Sourcery

Bug Fixes:
- Avoid potential use-after-free of the activated surface by making it a QPointer and always clearing it via setActivatedSurface(nullptr).