### PR TITLE
fix: crash on session removal (logout) window active

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2266,8 +2266,8 @@ void Helper::removeSession(std::shared_ptr<Session> session)
 
     if (m_activeSession.lock() == session) {
         m_activeSession.reset();
-        m_activatedSurface = nullptr;
-        Q_EMIT activatedSurfaceChanged();
+        workspace()->clearActivedSurface();
+        setActivatedSurface(nullptr);
     }
 
     for (auto s : std::as_const(m_sessions)) {
@@ -2466,8 +2466,8 @@ void Helper::updateActiveUserSession(const QString &username, int id)
         // Update active session
         m_activeSession = session;
         // Clear activated surface
+        // TODO: Each Wayland socket's active surface needs to be cleaned up individually.
         setActivatedSurface(nullptr);
-        Q_EMIT activatedSurfaceChanged();
         // Emit signal and update socket enabled state
         if (previous && previous->socket)
             previous->socket->setEnabled(false);

--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -382,6 +382,13 @@ void Workspace::removeActivedSurface(SurfaceWrapper *surface)
     }
 }
 
+void Workspace::clearActivedSurface()
+{
+    for (auto wpModel : m_models->objects())
+        wpModel->clearActivedSurface();
+    m_showOnAllWorkspaceModel->clearActivedSurface();
+}
+
 void Workspace::setSwitcherEnabled(bool enabled)
 {
     m_switcherEnabled = enabled;

--- a/src/workspace/workspace.h
+++ b/src/workspace/workspace.h
@@ -80,6 +80,7 @@ public:
 
     void pushActivedSurface(SurfaceWrapper *surface);
     void removeActivedSurface(SurfaceWrapper *surface);
+    void clearActivedSurface();
     void setSwitcherEnabled(bool enabled);
 
     WorkspaceAnimationController *animationController() const;

--- a/src/workspace/workspacemodel.cpp
+++ b/src/workspace/workspacemodel.cpp
@@ -128,6 +128,11 @@ void WorkspaceModel::removeActivedSurface(SurfaceWrapper *surface)
     m_activedSurfaceHistory.remove(surface);
 }
 
+void WorkspaceModel::clearActivedSurface()
+{
+    m_activedSurfaceHistory.clear();
+}
+
 int WorkspaceModel::findActivedSurfaceHistoryIndex(SurfaceWrapper *surface) const
 {
     int index = 0;

--- a/src/workspace/workspacemodel.h
+++ b/src/workspace/workspacemodel.h
@@ -47,6 +47,7 @@ public:
     Q_INVOKABLE SurfaceWrapper *findNextActivedSurface() const;
     void pushActivedSurface(SurfaceWrapper *surface);
     void removeActivedSurface(SurfaceWrapper *surface);
+    void clearActivedSurface();
     int findActivedSurfaceHistoryIndex(SurfaceWrapper *surface) const;
 
 Q_SIGNALS:


### PR DESCRIPTION
when removing the active session, directly setting m_activatedSurface = nullptr did not clear the active surface history in WorkspaceModel, leading to use-after-free.

Fix by calling workspace()->clearActivedSurface() to clean up all workspace models (including show-on-all-workspace) before clearing the global activated surface.

Also added missing clearActivedSurface() implementation in WorkspaceModel and removed unnecessary activatedSurfaceChanged() signal.

Log: fixes logout crash.
PMS: BUG-347763
Influence: logout

## Summary by Sourcery

Prevent use-after-free on session removal by clearing workspace activated surface state before resetting the global activated surface.

Bug Fixes:
- Fix logout crash caused by stale activated surface history when the active session is removed.

Enhancements:
- Introduce Workspace::clearActivedSurface and WorkspaceModel::clearActivedSurface to reset activated surface history across all workspace models.
- Simplify activated surface change handling by removing the now-unnecessary activatedSurfaceChanged signal emissions.