### PR TITLE
refactor: use const iterators for QVector in signal connector

### DIFF
--- a/qwlroots/src/util/qwsignalconnector.h
+++ b/qwlroots/src/util/qwsignalconnector.h
@@ -117,8 +117,8 @@ public:
     }
     void disconnect(wl_signal *signal) {
         auto tmpList = listenerList;
-        auto begin = tmpList.begin();
-        while (begin != tmpList.end()) {
+        auto begin = tmpList.constBegin();
+        while (begin != tmpList.constEnd()) {
             qw_signal_listener *l = *begin;
             ++begin;
 
@@ -129,8 +129,8 @@ public:
     void invalidate() {
         QVector<qw_signal_listener*> tmpList;
         tmpList.swap(listenerList);
-        auto begin = tmpList.begin();
-        while (begin != tmpList.end()) {
+        auto begin = tmpList.constBegin();
+        while (begin != tmpList.constEnd()) {
             qw_signal_listener *l = *begin;
             wl_list_remove(&l->l.link);
             ++begin;


### PR DESCRIPTION
The `invalidate` method in `QwSignalConnector` iterates through a temporary `QVector` of `qw_signal_listener*` pointers. Previously, it used non-const iterators (`begin()` and `end()`). This change updates the iteration to use `constBegin()` and `constEnd()`. This is a best practice when the loop only reads from the container and does not modify its structure (e.g., adding or removing elements from `tmpList`). The elements pointed to by the iterators (`qw_signal_listener*`) are still modified (specifically, their `wl_list_remove` operation), but the `QVector` itself remains unchanged during the iteration. This refactoring improves code clarity and expresses the intent that the vector's contents are not being structurally altered during traversal.

Influence:
1. Verify that `QwSignalConnector` instances can still be invalidated correctly.
2. Ensure that signals connected via `QwSignalConnector` are properly disconnected when the connector is invalidated.
3. Check for any memory leaks or crashes related to signal listener management.

refactor: 在信号连接器中为 QVector 使用 const 迭代器

`QwSignalConnector` 的 `invalidate` 方法会遍历一个临时的 `QVector`， 其中存储着 `qw_signal_listener*` 指针。此前，它使用了非 const 迭
代器 (`begin()` 和 `end()`)。此更改将迭代更新为使用 `constBegin()` 和 `constEnd()`。当循环只从容器读取数据，而不修改其结构（例如，不
向 `tmpList` 添加或删除元素）时，这是一种最佳实践。迭代器指向的元素
(`qw_signal_listener*`) 仍然会被修改（特别是它们的 `wl_list_remove` 操 作），但在迭代过程中 `QVector` 本身不会被结构性改变。此重构提高了代码清
晰度，并表达了在遍历过程中不会对向量内容进行结构性更改的意图。

Influence:
1. 验证 `QwSignalConnector` 实例是否仍能正确失效。
2. 确保通过 `QwSignalConnector` 连接的信号在连接器失效时能正确断开。
3. 检查是否存在与信号监听器管理相关的内存泄漏或崩溃。

## Summary by Sourcery

Enhancements:
- Adopt constBegin/constEnd iteration over the temporary QVector of qw_signal_listener* in QwSignalConnector::invalidate to clarify that the vector structure remains unchanged while listeners are removed from their lists.