### PR TITLE
fix: add missing rendering flags to WSGRenderFootprintNode

### DIFF
--- a/waylib/src/server/qtquick/private/wrenderbuffernode.cpp
+++ b/waylib/src/server/qtquick/private/wrenderbuffernode.cpp
@@ -1118,7 +1118,7 @@ QRectF WRenderBufferNode::rect() const
 
 WRenderBufferNode::RenderingFlags WRenderBufferNode::flags() const
 {
-    return BoundedRectRendering;
+    return BoundedRectRendering | DepthAwareRendering;
 }
 
 void WRenderBufferNode::resize(const QSizeF &size)

--- a/waylib/src/server/qtquick/wsurfaceitem.cpp
+++ b/waylib/src/server/qtquick/wsurfaceitem.cpp
@@ -554,7 +554,7 @@ public:
 
     RenderingFlags flags() const override
     {
-        return QSGRenderNode::NoExternalRendering | QSGRenderNode::BoundedRectRendering;
+        return NoExternalRendering | BoundedRectRendering | DepthAwareRendering | OpaqueRendering;
     }
 
     QPointer<WSurfaceItemContent> m_owner;


### PR DESCRIPTION
Add DepthAwareRendering and OpaqueRendering flags to WSGRenderFootprintNode to prevent incorrect alpha channel handling. Without DepthAwareRendering, Qt forcibly treats all nodes as having alpha channels, causing nodes that should be opaque to render as semi- transparent. This particularly affects windows with XRGB8888 buffer format, which were incorrectly rendered as transparent.

While this appears to be a Qt rendering bug, WSGRenderFootprintNode should have these flags set correctly since it performs no actual rendering and should not produce side effects. The node acts as a footprint marker only and should be treated as opaque and depth-aware.

Technical details:
- Added DepthAwareRendering flag to enable proper depth handling
- Added OpaqueRendering flag to indicate no alpha channel
- This prevents Qt's renderer from treating the node as requiring alpha blending
- Debug method: Use QSG_RENDERER_DEBUG=render;noalpha environment variable to verify alpha node detection

Influence:
1. Test XRGB8888 format windows to verify they render as opaque instead of transparent
2. Verify windows with actual alpha channels (ARGB8888) still render correctly
3. Test depth ordering of overlapping windows to ensure proper layering
4. Use QSG_RENDERER_DEBUG=render to verify nodes are not incorrectly flagged as alpha
5. Test various window buffer formats (XRGB8888, ARGB8888, RGB565) for correct rendering
6. Verify no visual regression in transparent window rendering
7. Check performance impact on rendering pipeline with the additional flags

fix: 为 WSGRenderFootprintNode 添加缺失的渲染标志

为 WSGRenderFootprintNode 添加 DepthAwareRendering 和 OpaqueRendering 标 志以防止错误的 alpha 通道处理。缺少 DepthAwareRendering 会导致 Qt 强制将 所有节点视为具有 alpha 通道，使本应不透明的节点被渲染为半透明。这特别影
响使用 XRGB8888 缓冲区格式的窗口，这些窗口会被错误地渲染为透明。

虽然这似乎是 Qt 渲染器的 bug，但 WSGRenderFootprintNode 应该正确设置这 些标志，因为它本身不执行任何实际渲染，不应产生副作用。该节点仅作为占位标
记，应被视为不透明和深度感知的。

技术细节：
- 添加 DepthAwareRendering 标志以启用正确的深度处理
- 添加 OpaqueRendering 标志以指示无 alpha 通道
- 防止 Qt 渲染器将节点视为需要 alpha 混合
- 调试方法：使用 QSG_RENDERER_DEBUG=render;noalpha 环境变量验证 alpha 节 点检测

Influence:
1. 测试 XRGB8888 格式窗口，验证它们渲染为不透明而非透明
2. 验证具有实际 alpha 通道的窗口（ARGB8888）仍能正确渲染
3. 测试重叠窗口的深度排序，确保正确的层次关系
4. 使用 QSG_RENDERER_DEBUG=render 验证节点未被错误标记为 alpha
5. 测试各种窗口缓冲区格式（XRGB8888、ARGB8888、RGB565）的正确渲染
6. 验证透明窗口渲染无视觉回归
7. 检查额外标志对渲染管线的性能影响

## Summary by Sourcery

Bug Fixes:
- Fix incorrect semi-transparent rendering of windows, particularly with XRGB8888 buffers, by marking WSGRenderFootprintNode as opaque and depth-aware.