### PR TITLE
chore: enable prelaunch splash by default

### DIFF
--- a/misc/dconfig/org.deepin.dde.treeland.json
+++ b/misc/dconfig/org.deepin.dde.treeland.json
@@ -14,7 +14,7 @@
             "visibility": "public"
         },
         "enablePrelaunchSplash": {
-            "value": false,
+            "value": true,
             "serial": 0,
             "flags": ["global"],
             "name": "Enable Prelaunch Splash",


### PR DESCRIPTION
Change the default value of enablePrelaunchSplash from false to true in treeland dconfig. This modification enables the prelaunch splash screen feature by default for all users, providing a better startup experience with visual feedback during system initialization.

将 treeland dconfig 中 enablePrelaunchSplash 的默认改为 true

## Summary by Sourcery

Enhancements:
- Update treeland dconfig to set enablePrelaunchSplash to true by default for all users.