### PR TITLE
fix: fix corner radius clipping when no compositor decoration

### DIFF
--- a/src/core/qml/SurfaceContent.qml
+++ b/src/core/qml/SurfaceContent.qml
@@ -52,7 +52,10 @@ Item {
 
             if (!root.wrapper)
                 return false;
-            return cornerRadius > 0 && !root.wrapper.noCornerRadius && root.wrapper.visibleDecoration;
+            return (cornerRadius > 0) &&
+                    !root.wrapper.noCornerRadius &&
+                    root.wrapper.decoration &&
+                    root.wrapper.visibleDecoration;
         }
 
         sourceComponent: Shape {


### PR DESCRIPTION
Fix corner radius clipping logic to check for compositor decoration existence before applying rounded corners. Previously, the code would attempt to clip corners even when no compositor decoration was present, which could cause visual artifacts.

修复圆角裁剪逻辑，在应用圆角前检查合成器装饰器是否存在。