### PR TITLE
chore: disable restrictive systemd security options

### DIFF
--- a/misc/systemd/dde-session-pre.target.wants/treeland.service.in
+++ b/misc/systemd/dde-session-pre.target.wants/treeland.service.in
@@ -35,8 +35,15 @@ RestartSec=1s
 NoNewPrivileges=true
 OOMScoreAdjust=-300
 Nice=-15
-MemoryDenyWriteExecute=true
-PrivateIPC=true
-ProtectSystem=full
+# Enable MemoryDenyWriteExecute will cause Treeland crash in certain
+# condition (observed on arm64 virtual machine). The coredump indicate
+# that it happened in libgallium.so, which is involved by
+# qwoutput->commit_state() call inside Output::enable().
+#
+# MemoryDenyWriteExecute=true
+# Failed to set up mount namespacing: /dev/mqueue: Operation not permitted
+# PrivateIPC=true
+# [xwayland/sockets.c:100] /tmp/.X11-unix not owned by root or us
+# ProtectSystem=full
 ProtectProc=invisible
 RestrictSUIDSGID=true


### PR DESCRIPTION
Disabled several restrictive systemd security options in Treeland service to resolve stability issues:
1. Commented out MemoryDenyWriteExecute=true due to crashes observed on arm64 VMs in libgallium.so during output enabling
2. Commented out PrivateIPC=true due to mount namespace setup failures with /dev/mqueue permission errors
3. Commented out ProtectSystem=full due to X11 socket ownership issues with /tmp/.X11-unix

These changes are necessary to maintain system stability while investigating the root causes of these security feature conflicts.

禁用了 Treeland 服务中的几个限制性 systemd 安全选项以解决稳定性问题：
1. 注释掉 MemoryDenyWriteExecute=true，因为在 arm64 虚拟机上观察到在输出 启用期间 libgallium.so 中发生崩溃
2. 注释掉 PrivateIPC=true，因为 /dev/mqueue 权限错误导致挂载命名空间设置 失败
3. 注释掉 ProtectSystem=full，因为 /tmp/.X11-unix 的 X11 套接字所有权 问题

## Summary by Sourcery

Enhancements:
- Disable several restrictive systemd security options in the Treeland systemd service unit to improve runtime stability while underlying compatibility issues are investigated.