### PR TITLE
fix: resolve Qt 6.12 compilation errors

### DIFF
--- a/waylib/src/server/kernel/wcursor.cpp
+++ b/waylib/src/server/kernel/wcursor.cpp
@@ -1,6 +1,7 @@
-// Copyright (C) 2023 JiDe Zhang <zhangjide@deepin.org>.
+// Copyright (C) 2023 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+#include <QDebug>
 #define private public
 #include <QCursor>
 #undef private

--- a/waylib/src/server/platformplugin/qwlrootsintegration.cpp
+++ b/waylib/src/server/platformplugin/qwlrootsintegration.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 JiDe Zhang <zccrs@live.com>.
+// Copyright (C) 2023 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include <QObject>
@@ -64,10 +64,10 @@ WAYLIB_SERVER_BEGIN_NAMESPACE
 #define CALL_PROXY2(FunName, fallbackValue, ...) m_proxyIntegration ? m_proxyIntegration->FunName(__VA_ARGS__) : fallbackValue
 #define CALL_PROXY(FunName, ...) CALL_PROXY2(FunName, QPlatformIntegration::FunName(__VA_ARGS__), __VA_ARGS__)
 
-class Q_DECL_HIDDEN OffscreenSurface : public QPlatformOffscreenSurface
+class Q_DECL_HIDDEN PlatformOffscreenSurface : public QPlatformOffscreenSurface
 {
 public:
-    OffscreenSurface(QOffscreenSurface *surface)
+    PlatformOffscreenSurface(QOffscreenSurface *surface)
         : QPlatformOffscreenSurface(surface) {}
 
     bool isValid() const override {
@@ -504,7 +504,7 @@ QPlatformTheme *QWlrootsIntegration::createPlatformTheme(const QString &name) co
 QPlatformOffscreenSurface *QWlrootsIntegration::createPlatformOffscreenSurface(QOffscreenSurface *surface) const
 {
     if (QW::OffscreenSurface::check(surface))
-        return new OffscreenSurface(surface);
+        return new PlatformOffscreenSurface(surface);
 
     return CALL_PROXY(createPlatformOffscreenSurface, surface);
 }


### PR DESCRIPTION
1. Add explicit QDebug include before QCursor to prevent indirect include conflicts
2. Rename OffscreenSurface class to PlatformOffscreenSurface to avoid naming collision with Qt 6.12's new enum
3. Update all references to the renamed class in createPlatformOffscreenSurface method

The QDebug include is placed before QCursor's #define private public hack because in Qt 6.12, QDebug gets indirectly included through QCursor, causing compilation errors in standard C++ headers. The class rename resolves a naming conflict introduced by a new enum in Qt 6.12.

Influence:
1. Test cursor functionality across different Qt versions (6.11 and 6.12)
2. Verify offscreen surface creation and validation
3. Test platform integration initialization with both proxy and non- proxy configurations
4. Verify QDebug logging still works correctly throughout the codebase
5. Test platform theme creation with various theme names
6. Verify no regression in existing cursor and surface-related features

fix: 解决 Qt 6.12 环境编译错误

1. 在 QCursor 之前显式包含 QDebug 头文件，防止间接包含导致的冲突
2. 将 OffscreenSurface 类重命名为 PlatformOffscreenSurface，避免与 Qt 6.12 新增枚举的命名冲突
3. 更新 createPlatformOffscreenSurface 方法中对重命名类的所有引用

将 QDebug 包含放在 QCursor 的 #define private public 黑客技巧之前，是因 为在 Qt 6.12 中，QDebug 会通过 QCursor 间接包含，导致在标准 C++ 头文件中 出现编译错误。类重命名则解决了 Qt 6.12 中新增枚举引入的命名冲突问题。

Influence:
1. 测试不同 Qt 版本（6.11 和 6.12）下的光标功能
2. 验证离屏表面的创建和验证功能
3. 测试代理和非代理配置下的平台集成初始化
4. 验证代码库中 QDebug 日志功能仍正常工作
5. 测试各种主题名称的平台主题创建
6. 验证现有光标和表面相关功能无回归问题