### PR TITLE
feat: improve splash screen active state handling

### DIFF
--- a/src/core/qml/TitleBar.qml
+++ b/src/core/qml/TitleBar.qml
@@ -65,7 +65,7 @@ Control {
     Rectangle {
         id: titlebar
         anchors.fill: parent
-        color: surface.shellSurface.isActivated ? "white" : "gray"
+        color: surface.isActivated ? "white" : "gray"
         layer.enabled: !root.noRadius
         layer.smooth: !root.noRadius
         opacity: !root.noRadius ? 0 : parent.opacity

--- a/src/core/shellhandler.h
+++ b/src/core/shellhandler.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #pragma once
@@ -11,6 +11,8 @@
 #include <QObject>
 #include <QPointer>
 #include <QSet>
+
+#include <utility>
 
 Q_MOC_INCLUDE("workspace/workspace.h")
 
@@ -115,14 +117,12 @@ private:
                                qlonglong splashThemeType);
 
     // --- helpers (internal) ---
-    SurfaceWrapper *matchOrCreateXdgWrapper(WAYLIB_SERVER_NAMESPACE::WXdgToplevelSurface *surface,
-                                            const QString &appId);
-    void initXdgWrapperCommon(WAYLIB_SERVER_NAMESPACE::WXdgToplevelSurface *surface,
-                              SurfaceWrapper *wrapper);
-    SurfaceWrapper *matchOrCreateXwaylandWrapper(WAYLIB_SERVER_NAMESPACE::WXWaylandSurface *surface,
-                                                 const QString &appId);
-    void initXwaylandWrapperCommon(WAYLIB_SERVER_NAMESPACE::WXWaylandSurface *surface,
-                                   SurfaceWrapper *wrapper);
+    // Creates or matches a wrapper from prelaunch splash, then initializes it
+    void ensureXdgWrapper(WAYLIB_SERVER_NAMESPACE::WXdgToplevelSurface *surface,
+                          const QString &appId);
+    // Creates or matches a wrapper from prelaunch splash, then initializes it
+    void ensureXwaylandWrapper(WAYLIB_SERVER_NAMESPACE::WXWaylandSurface *surface,
+                               const QString &appId);
     // Unified parent/container update for Xdg & XWayland toplevel wrappers.
     void updateWrapperContainer(SurfaceWrapper *wrapper,
                                 WAYLIB_SERVER_NAMESPACE::WSurface *parentSurface);

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -1,23 +1,23 @@
-// Copyright (C) 2024-2025 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "output.h"
 
-#include "outputconfig.hpp"
-#include "treelandconfig.hpp"
-#include "treelanduserconfig.hpp"
-#include "core/rootsurfacecontainer.h"
-#include "seat/helper.h"
-#include "surface/surfacewrapper.h"
-#include "workspace/workspace.h"
 #include "cmdline.h"
 #include "common/treelandlogging.h"
+#include "core/rootsurfacecontainer.h"
+#include "outputconfig.hpp"
+#include "seat/helper.h"
+#include "surface/surfacewrapper.h"
+#include "treelandconfig.hpp"
+#include "treelanduserconfig.hpp"
+#include "workspace/workspace.h"
 
 #include <wcursor.h>
 #include <winputpopupsurface.h>
 #include <wlayersurface.h>
-#include <woutputitem.h>
 #include <woutputhelper.h>
+#include <woutputitem.h>
 #include <woutputlayout.h>
 #include <woutputrenderwindow.h>
 #include <wquicktextureproxy.h>
@@ -236,8 +236,16 @@ void Output::placeSmartCascaded(SurfaceWrapper *surface)
 {
     auto wpModel = Helper::instance()->workspace()->modelFromId(surface->workspaceId());
     Q_ASSERT(wpModel);
-    auto latestActiveSurface = wpModel->activePenultimateWindow();
-    if (!latestActiveSurface || latestActiveSurface == surface) {
+    /*
+     The execution of Output::placeSmartCascaded and the surface obtaining focus occur almost
+     simultaneously after the window is mapped for the first time; the order is not currently
+     guaranteed.
+    */
+    auto latestActiveSurface = wpModel->latestActiveSurface();
+    if (latestActiveSurface == surface)
+        latestActiveSurface = wpModel->activePenultimateWindow();
+
+    if (!latestActiveSurface) {
         placeCentered(surface);
         return;
     }

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #pragma once

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 #pragma once
 
@@ -80,6 +80,7 @@ class SurfaceWrapper : public QQuickItem
     Q_PROPERTY(bool isWindowAnimationRunning READ isWindowAnimationRunning NOTIFY windowAnimationRunningChanged FINAL)
     Q_PROPERTY(bool coverEnabled READ coverEnabled NOTIFY coverEnabledChanged FINAL)
     Q_PROPERTY(bool acceptKeyboardFocus READ acceptKeyboardFocus NOTIFY acceptKeyboardFocusChanged FINAL)
+    Q_PROPERTY(bool isActivated READ isActivated NOTIFY isActivatedChanged FINAL)
 
 public:
     enum class Type
@@ -237,6 +238,7 @@ public:
     bool showOnWorkspace(int workspaceIndex) const;
 
     bool hasActiveCapability() const;
+    bool hasCapability(WToplevelSurface::Capability cap) const;
 
     bool skipSwitcher() const;
     bool skipDockPreView() const;
@@ -271,8 +273,10 @@ public:
 
     void markWrapperToRemoved();
 
-    bool acceptKeyboardFocus() const;
+    bool acceptKeyboardFocus() const; // set by treeland-dde-shell
     void setAcceptKeyboardFocus(bool accept);
+
+    bool isActivated() const;
 
 public Q_SLOTS:
     // for titlebar
@@ -334,6 +338,7 @@ Q_SIGNALS:
     void coverEnabledChanged();
     void aboutToBeInvalidated();
     void acceptKeyboardFocusChanged();
+    void isActivatedChanged();
     void surfaceItemCreated(); // Emitted once after surfaceItem is constructed
     void prelaunchSplashChanged();
     void typeChanged();
@@ -453,7 +458,7 @@ private:
     uint m_hideByLockScreen : 1;
     uint m_confirmHideByLockScreen : 1;
     uint m_blur : 1;
-    uint m_isActive : 1;
+    uint m_isActivated : 1;
     SurfaceRole m_surfaceRole = SurfaceRole::Normal;
     quint32 m_autoPlaceYOffset = 0;
     QPoint m_clientRequstPos;


### PR DESCRIPTION
1. Add support for active state control during splash screen phase
2. Delay splash screen destruction until surface is properly mapped
3. Introduce m_isActive flag to track activation state separately
4. Refactor active state update logic into dedicated method
5. Rename ActiveControlState::Mapped to MappedOrSplash for clarity

Log: Improved splash screen behavior with proper active state management

1. 在闪屏阶段添加活跃状态控制支持
2. 延迟闪屏销毁直到界面正确映射完成
3. 引入 m_isActive 标志单独跟踪激活状态
4. 重构活跃状态更新逻辑到专用方法
5. 重命名 ActiveControlState::Mapped 为 MappedOrSplash 以提高清晰度

## Summary by Sourcery

Improve window activation handling around prelaunch splash screens and initial mapping to ensure consistent active state and focus behavior.

New Features:
- Allow splash screen wrappers to participate in activation control and expose activation state to QML.
- Add capability querying on SurfaceWrapper so callers can treat splash and normal windows uniformly when checking activation and focus support.

Bug Fixes:
- Delay destruction of prelaunch splash screens until the real surface is mapped, avoiding premature removal during startup.
- Ensure windows converted from splash to normal surfaces correctly maintain or acquire activation and keyboard focus.
- Fix smart cascade placement to use the most recently active window when determining placement, even when activation races with initial mapping.

Enhancements:
- Unify XDG and XWayland wrapper creation and initialization, only setting up active watchers for newly created wrappers.
- Refine active-capability tracking to distinguish mapped or splash states and centralize active state propagation from wrappers to parent windows.
- Expose SurfaceWrapper activation as a property for use in UI components such as the title bar coloring logic.