### PR TITLE
fix(xwayland): prevent use-after-free in xauth file path construction

### DIFF
--- a/src/xwayland.cpp
+++ b/src/xwayland.cpp
@@ -40,7 +40,8 @@ int main(int argc, char *argv[])
 
     // Create xauth file
     char *display = argv[1]; // display is passed as the first argument
-    const char *fileName = qPrintable(QStringLiteral("/tmp/.xauth_%1").arg(display));
+    QByteArray authFilePath = QByteArray("/tmp/.xauth_").append(display);
+    const char *fileName = authFilePath.constData();
     const int oldumask = umask(077);
     FILE * const authFp = fopen(fileName, "wb");
     if (!authFp)


### PR DESCRIPTION
Extend QString lifetime and use QByteArray to avoid dangling pointer in fopen. 

Issue: Fixes #727
Influence: restart ddm.service treeland.service

## Summary by Sourcery

Bug Fixes:
- Fix a potential use-after-free in XWayland xauth file path construction by ensuring the filename buffer remains valid during fopen().

## Summary by Sourcery

Bug Fixes:
- Ensure the xauth file path buffer remains valid for fopen() by storing it in a QByteArray instead of a temporary QString.