### PR TITLE
fix: lower classed QML element waylib being non-addressable in QML

### DIFF
--- a/src/core/qml/Decoration.qml
+++ b/src/core/qml/Decoration.qml
@@ -32,21 +32,21 @@ Item {
         Cursor.shape: {
             switch(edges) {
             case Qt.TopEdge:
-                return waylib.CursorShape.TopSide
+                return CursorShape.TopSide
             case Qt.RightEdge:
-                return waylib.CursorShape.RightSide
+                return CursorShape.RightSide
             case Qt.BottomEdge:
-                return waylib.CursorShape.BottomSide
+                return CursorShape.BottomSide
             case Qt.LeftEdge:
-                return waylib.CursorShape.LeftSide
+                return CursorShape.LeftSide
             case Qt.TopEdge | Qt.LeftEdge:
-                return waylib.CursorShape.TopLeftCorner
+                return CursorShape.TopLeftCorner
             case Qt.TopEdge | Qt.RightEdge:
-                return waylib.CursorShape.TopRightCorner
+                return CursorShape.TopRightCorner
             case Qt.BottomEdge | Qt.LeftEdge:
-                return waylib.CursorShape.BottomLeftCorner
+                return CursorShape.BottomLeftCorner
             case Qt.BottomEdge | Qt.RightEdge:
-                return waylib.CursorShape.BottomRightCorner
+                return CursorShape.BottomRightCorner
             }
 
             return Qt.ArrowCursor;

--- a/waylib/examples/tinywl/Decoration.qml
+++ b/waylib/examples/tinywl/Decoration.qml
@@ -30,21 +30,21 @@ Item {
         Cursor.shape: {
             switch(edges) {
             case Qt.TopEdge:
-                return waylib.CursorShape.TopSide
+                return CursorShape.TopSide
             case Qt.RightEdge:
-                return waylib.CursorShape.RightSide
+                return CursorShape.RightSide
             case Qt.BottomEdge:
-                return waylib.CursorShape.BottomSide
+                return CursorShape.BottomSide
             case Qt.LeftEdge:
-                return waylib.CursorShape.LeftSide
+                return CursorShape.LeftSide
             case Qt.TopEdge | Qt.LeftEdge:
-                return waylib.CursorShape.TopLeftCorner
+                return CursorShape.TopLeftCorner
             case Qt.TopEdge | Qt.RightEdge:
-                return waylib.CursorShape.TopRightCorner
+                return CursorShape.TopRightCorner
             case Qt.BottomEdge | Qt.LeftEdge:
-                return waylib.CursorShape.BottomLeftCorner
+                return CursorShape.BottomLeftCorner
             case Qt.BottomEdge | Qt.RightEdge:
-                return waylib.CursorShape.BottomRightCorner
+                return CursorShape.BottomRightCorner
             }
 
             return Qt.ArrowCursor;

--- a/waylib/src/server/kernel/wglobal.h
+++ b/waylib/src/server/kernel/wglobal.h
@@ -188,7 +188,7 @@ protected:
 
 class WAYLIB_SERVER_EXPORT WGlobal {
     Q_GADGET
-    QML_NAMED_ELEMENT(waylib)
+    QML_VALUE_TYPE(wglobal)
     QML_UNCREATABLE("Use for enums")
 
 public:
@@ -248,6 +248,13 @@ public:
 
     static bool isInvalidCursor(const QCursor &c);
     static bool isClientResourceCursor(const QCursor &c);
+};
+
+struct Q_DECL_HIDDEN WCursorShapeQMLProxy {
+    Q_GADGET
+    QML_NAMED_ELEMENT(CursorShape)
+    QML_FOREIGN_NAMESPACE(WAYLIB_SERVER_NAMESPACE::WGlobal)
+    QML_UNCREATABLE("Use for enums")
 };
 
 WAYLIB_SERVER_END_NAMESPACE


### PR DESCRIPTION
Types declared with Q_GADGET are considered value types in QML and requires a lowercase name. (see:
https://doc.qt.io/qt-6/qtqml-cppintegration-definetypes.html#registering-value-types)

However for it to be addressable in QML, the type name has to be uppercase.

Using QML_FOREIGN_NAMESPACE is the preferred way to proxy enum in value types, according to Qt documentation. (see:
https://doc.qt.io/qt-6/qtqml-cppintegration-definetypes.html#value-types-with-enumerations)

## Summary by Sourcery

Fix QML exposure of Waylib cursor enums by registering WGlobal as a value type and introducing a QML enum proxy, and update QML usages to reference the new type name.

Bug Fixes:
- Make Waylib cursor shape enums addressable from QML by registering WGlobal as a value type instead of a lowercase element and exposing the enum through a QML_FOREIGN_NAMESPACE proxy.

Enhancements:
- Update QML decoration components to reference the new Waylib cursor shape type name for edge-resize cursors.