### PR TITLE
chore: refactor treeland screensaver to persistent daemon

### DIFF
--- a/debian/treeland.install
+++ b/debian/treeland.install
@@ -5,7 +5,6 @@ usr/lib/systemd/system/*
 usr/libexec/*
 usr/share/*/translations/*
 usr/share/dbus-1/system.d/*
-usr/share/dbus-1/services/org.freedesktop.ScreenSaver.service
 usr/lib/*/lib*.so.*
 usr/lib/*/treeland/plugins/lib*.so
 

--- a/misc/systemd/CMakeLists.txt
+++ b/misc/systemd/CMakeLists.txt
@@ -21,11 +21,13 @@ configure_file("dde-session-pre.target.wants/treeland-xwayland.service.in" "dde-
 configure_file("dde-session-pre.target.wants/treeland-shortcut.service.in" "dde-session-pre.target.wants/treeland-shortcut.service" IMMEDIATE @ONLY)
 configure_file("dde-session-pre.target.wants/treeland.service.in" "dde-session-pre.target.wants/treeland.service" IMMEDIATE @ONLY)
 configure_file("treeland-session-helper.service.in" "treeland-session-helper.service" IMMEDIATE @ONLY)
+configure_file("treeland-screensaver.service.in" "treeland-screensaver.service" IMMEDIATE @ONLY)
 configure_file("treeland.service.in" "treeland.service" IMMEDIATE @ONLY)
 
 install(FILES ${SERVICES} DESTINATION ${SYSTEMD_USER_UNIT_DIR})
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/treeland.service DESTINATION ${SYSTEMD_SYSTEM_UNIT_DIR})
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/treeland-session-helper.service DESTINATION ${SYSTEMD_USER_UNIT_DIR})
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/treeland-screensaver.service DESTINATION ${SYSTEMD_USER_UNIT_DIR})
 
 install(DIRECTORY DESTINATION ${SYSTEMD_USER_UNIT_DIR}/dde-session-pre.target.wants/)
 install(DIRECTORY DESTINATION ${SYSTEMD_USER_UNIT_DIR}/dde-session-shutdown.target.wants/)
@@ -48,3 +50,4 @@ install_symlink(treeland-shortcut.service dde-session-pre.target.wants)
 install_symlink(treeland.service dde-session-pre.target.wants)
 install_symlink(treeland-session-shutdown.service dde-session-shutdown.target.wants)
 install_symlink(treeland-session-helper.service treeland.service.wants)
+install_symlink(treeland-screensaver.service treeland.service.wants)

--- a/misc/systemd/treeland-screensaver.service.in
+++ b/misc/systemd/treeland-screensaver.service.in
@@ -1,0 +1,18 @@
+[Unit]
+Description=Treeland ScreenSaver D-Bus Service
+CollectMode=inactive-or-failed
+
+PartOf=dde-session-pre.target
+Before=dde-session-pre.target
+
+Requisite=treeland-sd.service
+After=treeland-sd.service
+
+[Service]
+ExecCondition=/bin/sh -c 'test "$XDG_SESSION_DESKTOP" = "Treeland" || exit 2'
+Type=dbus
+BusName=org.freedesktop.ScreenSaver
+ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/treeland-screensaver
+Slice=session.slice
+Restart=on-failure
+RestartSec=1s

--- a/src/treeland-screensaver/CMakeLists.txt
+++ b/src/treeland-screensaver/CMakeLists.txt
@@ -18,8 +18,6 @@ add_custom_command(
     COMMENT "Generating treeland-screensaver-v1.c"
 )
 
-configure_file("org.freedesktop.ScreenSaver.service.in" "org.freedesktop.ScreenSaver.service" IMMEDIATE @ONLY)
-
 qt_add_executable(treeland-screensaver
     screensaver.cpp
     ${TREELAND_SCREENSAVER_HEADER}
@@ -34,4 +32,3 @@ target_link_libraries(treeland-screensaver
 
 install(TARGETS treeland-screensaver RUNTIME DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}")
 install(FILES org.freedesktop.ScreenSaver.xml DESTINATION "${CMAKE_INSTALL_DATADIR}/dbus-1/interfaces")
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.freedesktop.ScreenSaver.service DESTINATION "${CMAKE_INSTALL_DATADIR}/dbus-1/services")

--- a/src/treeland-screensaver/org.freedesktop.ScreenSaver.service.in
+++ b/src/treeland-screensaver/org.freedesktop.ScreenSaver.service.in
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=org.freedesktop.ScreenSaver
-Exec=@CMAKE_INSTALL_FULL_LIBEXECDIR@/treeland-screensaver

--- a/src/treeland-screensaver/screensaver.cpp
+++ b/src/treeland-screensaver/screensaver.cpp
@@ -4,8 +4,9 @@
 /**
  * org.freedesktop.ScreenSaver implementation using treeland_screensaver protocol
  * 
+ * This service runs as a persistent daemon under Treeland session.
  * For each Inhibit request a wayland connection is created, which will be terminated
- * upon UnInhibit. The app will exit when there are no more active inhibits.
+ * upon UnInhibit.
  */
 
 #include <QCoreApplication>
@@ -95,8 +96,6 @@ public Q_SLOTS:
             if (inhibits[caller].isEmpty())
                 inhibits.remove(caller);
         }
-        if (inhibits.isEmpty())
-            QCoreApplication::quit();
     }
 };
 
@@ -109,8 +108,6 @@ public Q_SLOTS:
         for (auto it = inhibits[caller].cbegin(); it != inhibits[caller].cend(); ++it) \
             uninhibit(it.value());                                                     \
         inhibits.remove(caller);                                                       \
-        if (inhibits.isEmpty())                                                        \
-            QCoreApplication::quit();                                                  \
     }
 
 static void onServiceUnregistered(const QString &service) {


### PR DESCRIPTION
Removed the D-Bus service file for org.freedesktop.ScreenSaver and converted treeland-screensaver from a transient service to a persistent daemon under treeland.service. The screensaver service now runs continuously in Treeland sessions instead of exiting when there are no active inhibits. Added systemd service configuration with proper dependencies and session detection. The D-Bus service will be handled by dde-session-daemon in X11 environments.

Influence:
1. Verify treeland-screensaver starts automatically with treeland session
2. Test screensaver inhibit/uninhibit functionality in Treeland
3. Ensure service persists after all inhibits are removed
4. Confirm D-Bus service availability in Treeland sessions
5. Verify X11 sessions continue to use dde-session-daemon for screensaver
6. Test systemd service dependencies and startup order

chore: 重构 treeland 屏保为常驻进程

移除了 org.freedesktop.ScreenSaver 的 D-Bus 服务文件，将 treeland- screensaver 从临时服务转换为 treeland.service 下的常驻守护进程。屏保服务 现在在 Treeland 会话中持续运行，而不是在没有活动抑制时退出。添加了带有正
确依赖关系和会话检测的 systemd 服务配置。X11 环境下的 D-Bus 服务将继续由
dde-session-daemon 处理。

Influence:
1. 验证 treeland-screensaver 是否随 treeland 会话自动启动
2. 在 Treeland 中测试屏保抑制/取消抑制功能
3. 确保服务在所有抑制移除后仍然保持运行
4. 确认 D-Bus 服务在 Treeland 会话中可用
5. 验证 X11 会话继续使用 dde-session-daemon 处理屏保
6. 测试 systemd 服务依赖关系和启动顺序

## Summary by Sourcery

Refactor treeland-screensaver to run as a persistent daemon in Treeland sessions instead of exiting when no inhibits are active, and wire it into the systemd-based session services.

Enhancements:
- Keep the treeland-screensaver process running after all inhibits are removed rather than quitting when none remain.
- Integrate treeland-screensaver as a dedicated user systemd service that is started and wanted by treeland.service, with appropriate unit configuration.

Build:
- Generate and install a treeland-screensaver systemd user unit and add it to the existing systemd CMake configuration, including symlinks from treeland.service.wants.

Chores:
- Remove the D-Bus org.freedesktop.ScreenSaver.service file now that the screensaver is managed as a persistent daemon instead of a transient D-Bus-activated service.