### PR TITLE
fix: buffer assignment error with clang build

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,7 +29,6 @@ int main(int argc, char *argv[])
     QGuiApplication::setQuitOnLastWindowClosed(false);
 
     QGuiApplication app(argc, argv);
-    qRegisterMetaType<QW_NAMESPACE::qw_buffer*>("qw_buffer*");
 
     app.setOrganizationName("deepin");
     app.setApplicationName("treeland");

--- a/src/modules/prelaunch-splash/prelaunchsplash.h
+++ b/src/modules/prelaunch-splash/prelaunchsplash.h
@@ -5,12 +5,12 @@
 
 #include <wayland-server-core.h>
 #include <wserver.h>
-
 #include <qwbuffer.h>
+#include <memory>
 
 #include <QObject>
 
-#include <memory>
+Q_MOC_INCLUDE(<qwbuffer.h>)
 
 WAYLIB_SERVER_USE_NAMESPACE
 QW_USE_NAMESPACE
@@ -23,7 +23,6 @@ QW_BEGIN_NAMESPACE
 class qw_display;
 class qw_buffer;
 QW_END_NAMESPACE
-Q_DECLARE_OPAQUE_POINTER(QW_NAMESPACE::qw_buffer *)
 
 class PrelaunchSplashPrivate;
 struct wl_global;
@@ -52,3 +51,5 @@ protected: // WServerInterface
 private:
     std::unique_ptr<PrelaunchSplashPrivate> d;
 };
+
+Q_DECLARE_OPAQUE_POINTER(QW_NAMESPACE::qw_buffer*)

--- a/waylib/src/server/qtquick/wbufferitem.h
+++ b/waylib/src/server/qtquick/wbufferitem.h
@@ -6,14 +6,12 @@
 #include <wglobal.h>
 #include <wtextureproviderprovider.h>
 #include <qwglobal.h>
+#include <qwbuffer.h>
+
+Q_MOC_INCLUDE(<qwbuffer.h>)
 
 #include <QQuickItem>
 #include <QVariant>
-
-QW_BEGIN_NAMESPACE
-class qw_buffer;
-QW_END_NAMESPACE
-Q_DECLARE_OPAQUE_POINTER(QW_NAMESPACE::qw_buffer*)
 
 QT_BEGIN_NAMESPACE
 class QSGTextureProvider;
@@ -60,3 +58,4 @@ private:
 WAYLIB_SERVER_END_NAMESPACE
 
 Q_DECLARE_METATYPE(WAYLIB_SERVER_NAMESPACE::WBufferItem*)
+Q_DECLARE_OPAQUE_POINTER(QW_NAMESPACE::qw_buffer*)


### PR DESCRIPTION
fix: qw_buffer metatype handling for Clang builds
Clang is stricter about incomplete types and rejects assigning
qw_buffer to a Q_PROPERTY of type qw_buffer* in QML, causing:

  Unable to assign qw_buffer to qw_buffer*

Ensure proper metatype and opaque pointer declarations, and
make qw_buffer visible to MOC via Q_MOC_INCLUDE.

This restores correct type handling in the Qt meta-object system.

Issue: Fixes https://github.com/linuxdeepin/treeland/issues/737
Log: fixes incorrect icon rendering when opening PrelaunchSplash.
Influence: Launching the application for the first time

## Summary by Sourcery

Adjust buffer property exposure for WBufferItem to resolve QML buffer assignment issues with clang builds.

Bug Fixes:
- Allow WBufferItem buffer to be passed through QML bindings without type errors by exposing it as QObject* and casting internally.
- Prevent runtime errors and incorrect icon rendering when opening PrelaunchSplash caused by failed qw_buffer* assignments in QML.

Enhancements:
- Simplify type registration by removing the qw_buffer* meta-type registration from application startup.