### PR TITLE
fix: lockscreen not shown after switch back from tty

### DIFF
--- a/src/greeter/greeterproxy.cpp
+++ b/src/greeter/greeterproxy.cpp
@@ -134,6 +134,14 @@ void GreeterProxy::setShowShutdownView(bool show) {
     }
 }
 
+void GreeterProxy::setShowAnimation(bool show)
+{
+    if (m_showAnimation != show) {
+        m_showAnimation = show;
+        Q_EMIT showAnimationChanged(show);
+    }
+}
+
 void GreeterProxy::setLock(bool isLocked)
 {
     if (isLocked && !m_isLocked) {

--- a/src/greeter/greeterproxy.h
+++ b/src/greeter/greeterproxy.h
@@ -136,6 +136,15 @@ public:
      */
     void setShowShutdownView(bool show);
 
+    /**
+     * @brief Set whether to show animation
+     *
+     * Use in C++ only
+     *
+     * @param show true to show animation, false to disable animation
+     */
+    void setShowAnimation(bool show);
+
     ////////////////////
     // Public methods //
     ////////////////////

--- a/src/plugins/lockscreen/qml/LockView.qml
+++ b/src/plugins/lockscreen/qml/LockView.qml
@@ -151,27 +151,35 @@ FocusScope {
     Connections {
         target: GreeterProxy
         function onLockChanged(isLocked) {
-            if (isLocked) {
-                root.forceActiveFocus()
-                root.visible = true
-                root.state = LoginAnimation.Show
-                leftAnimation.item.start({x: root.x - quickAction.width, y: quickAction.y}, {x: quickAction.x, y: quickAction.y})
-                logoAnimation.item.start({x: root.x - logo.width, y: logo.y}, {x: logo.x, y: logo.y})
-                rightAnimation.item.start({x: root.width + userInput.width, y: userInput.y}, {x: userInput.x, y: userInput.y})
-                bottomAnimation.item.start({x: controlAction.x, y: controlAction.y + controlAction.height}, {x: controlAction.x, y: controlAction.y})
-            } else {
-                root.state = LoginAnimation.Hide
-                leftAnimation.item.start({x: quickAction.x, y: quickAction.y}, {x: root.x - quickAction.width, y: quickAction.y})
-                logoAnimation.item.start({x: logo.x, y: logo.y}, {x: root.x - logo.width, y: logo.y})
-                rightAnimation.item.start({x: userInput.x, y: userInput.y}, {x: root.width + userInput.width, y: userInput.y})
-                bottomAnimation.item.start({x: controlAction.x, y: controlAction.y}, {x: controlAction.x, y: controlAction.y + controlAction.height})
-            }
+            root.applyLockState(isLocked)
         }
     }
 
     onAnimationPlayFinished: {
         if (!GreeterProxy.isLocked) {
             root.visible = false
+        }
+    }
+
+    Component.onCompleted: {
+        root.applyLockState(true)
+    }
+
+    function applyLockState(isLocked) {
+        if (isLocked) {
+            root.forceActiveFocus()
+            root.visible = true
+            root.state = LoginAnimation.Show
+            leftAnimation.item.start({x: root.x - quickAction.width, y: quickAction.y}, {x: quickAction.x, y: quickAction.y})
+            logoAnimation.item.start({x: root.x - logo.width, y: logo.y}, {x: logo.x, y: logo.y})
+            rightAnimation.item.start({x: root.width + userInput.width, y: userInput.y}, {x: userInput.x, y: userInput.y})
+            bottomAnimation.item.start({x: controlAction.x, y: controlAction.y + controlAction.height}, {x: controlAction.x, y: controlAction.y})
+        } else {
+            root.state = LoginAnimation.Hide
+            leftAnimation.item.start({x: quickAction.x, y: quickAction.y}, {x: root.x - quickAction.width, y: quickAction.y})
+            logoAnimation.item.start({x: logo.x, y: logo.y}, {x: root.x - logo.width, y: logo.y})
+            rightAnimation.item.start({x: userInput.x, y: userInput.y}, {x: root.width + userInput.width, y: userInput.y})
+            bottomAnimation.item.start({x: controlAction.x, y: controlAction.y}, {x: controlAction.x, y: controlAction.y + controlAction.height})
         }
     }
 


### PR DESCRIPTION
The LockView.qml (in fact the whole lockscreen component in Greeter.qml) is re-created after switch back from tty, as the output is exactly being removed and re-added once. So that we cannot use property listener for displaying lockscreen as usual.

This will work as intended.