### PR TITLE
WIP: Virtualinput pointer and keyboard 

### DIFF
--- a/misc/dconfig/org.deepin.dde.treeland.user.json
+++ b/misc/dconfig/org.deepin.dde.treeland.user.json
@@ -443,6 +443,17 @@
             "permissions": "readonly",
             "visibility": "private"
         },
+        "inputAccelProfile": {
+            "value": 2,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Libinput Accel Profile",
+            "name[zh_CN]": "Libinput 加速曲线",
+            "description": "Pointer acceleration profile, enum value of libinput_config_accel_profile",
+            "description[zh_CN]": "指针加速曲线，对应 libinput_config_accel_profile 枚举值",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
         "wallpaperConfig": {
             "value": "",
             "serial": 0,

--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -23,6 +23,7 @@
 
 #include <winputmethodhelper.h>
 #include <winputpopupsurface.h>
+#include <wvirtualinputhelper.h>
 #include <wlayershell.h>
 #include <wlayersurface.h>
 #include <woutputrenderwindow.h>
@@ -336,6 +337,8 @@ void ShellHandler::removeXWayland(WXWayland *xwayland)
 void ShellHandler::initInputMethodHelper(WServer *server, WSeat *seat)
 {
     Q_ASSERT_X(!m_inputMethodHelper, Q_FUNC_INFO, "Only init once!");
+    Q_ASSERT_X(!m_virtualInputHelper, Q_FUNC_INFO, "Only init once!");
+    m_virtualInputHelper = new WVirtualInputHelper(server, seat);
     m_inputMethodHelper = new WInputMethodHelper(server, seat);
 
     connect(m_inputMethodHelper,

--- a/src/core/shellhandler.h
+++ b/src/core/shellhandler.h
@@ -46,6 +46,7 @@ class WInputMethodHelper;
 class WInputPopupSurface;
 class WSeat;
 class WSurface;
+class WVirtualInputHelper;
 class WXWaylandSurface;
 WAYLIB_SERVER_END_NAMESPACE
 
@@ -161,6 +162,7 @@ private:
     WAYLIB_SERVER_NAMESPACE::WLayerShell *m_layerShell = nullptr;
     TreelandWallpaperShellInterfaceV1 *m_wallpaperShell = nullptr;
     WAYLIB_SERVER_NAMESPACE::WInputMethodHelper *m_inputMethodHelper = nullptr;
+    WAYLIB_SERVER_NAMESPACE::WVirtualInputHelper *m_virtualInputHelper = nullptr;
     QList<WAYLIB_SERVER_NAMESPACE::WXWayland *> m_xwaylands;
     ForeignToplevelV1 *m_treelandForeignToplevel = nullptr;
 

--- a/src/input/inputdevice.cpp
+++ b/src/input/inputdevice.cpp
@@ -1,8 +1,10 @@
 // Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+#include "helper.h"
 #include "inputdevice.h"
 #include "common/treelandlogging.h"
+#include "treelanduserconfig.hpp"
 
 #include <winputdevice.h>
 
@@ -12,6 +14,7 @@
 #include <QInputDevice>
 #include <QLoggingCategory>
 #include <QPointer>
+
 
 QW_USE_NAMESPACE
 
@@ -351,24 +354,38 @@ InputDevice *InputDevice::instance()
     return m_instance;
 }
 
-bool InputDevice::initTouchPad(WInputDevice *device)
+void InputDevice::initDevice(WInputDevice *device)
 {
     if (!device) {
         qCCritical(treelandInput) << "Cannot initialize touchpad for null device";
-        return false;
+        return;
     }
 
-    if (!device->qtDevice()) {
+    if (!device->qtDevice() || !device->handle()->is_libinput()) {
         qCCritical(treelandInput) << "Cannot initialize touchpad: device has no qtDevice";
-        return false;
+        return;
     }
 
-    if (device->handle()->is_libinput()
-        && device->qtDevice()->type() == QInputDevice::DeviceType::TouchPad) {
+    auto deviceType = device->qtDevice()->type();
+    if (deviceType == QInputDevice::DeviceType::TouchPad) {
         configTapEnabled(libinput_device_handle(device->handle()), LIBINPUT_CONFIG_TAP_ENABLED);
-        return true;
     }
-    return false;
+
+    if (deviceType == QInputDevice::DeviceType::TouchPad
+        || deviceType == QInputDevice::DeviceType::Mouse) {
+        return;
+    }
+
+    auto config = Helper::instance()->config();
+    auto applyAccelProfile = [device, config]() {
+        configAccelProfile(libinput_device_handle(device->handle()),
+                           static_cast<libinput_config_accel_profile>(config->inputAccelProfile()));
+    };
+
+    connect(config, &TreelandUserConfig::inputAccelProfileChanged, device, applyAccelProfile);
+    connect(config, &TreelandUserConfig::configInitializeSucceed, device, applyAccelProfile);
+
+    applyAccelProfile();
 }
 
 [[maybe_unused]] SwipeGesture* InputDevice::registerTouchpadSwipe(const SwipeFeedBack &feed_back)

--- a/src/input/inputdevice.h
+++ b/src/input/inputdevice.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #pragma once
@@ -9,7 +9,9 @@
 
 #include <wglobal.h>
 
+#include <QHash>
 #include <QInputDevice>
+#include <QVector>
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 class WInputDevice;
@@ -40,7 +42,7 @@ public:
     InputDevice(const InputDevice &) = delete;
     InputDevice &operator=(const InputDevice &) = delete;
 
-    bool initTouchPad(WInputDevice *device);
+    void initDevice(WInputDevice *device);
 
     SwipeGesture* registerTouchpadSwipe(const SwipeFeedBack &feed_back);
     HoldGesture* registerTouchpadHold(const HoldFeedBack &feed);
@@ -62,5 +64,6 @@ private:
 
     static InputDevice *m_instance;
     std::unique_ptr<GestureRecognizer> m_touchpadRecognizer;
+    QHash<WInputDevice *, QVector<QMetaObject::Connection>> m_deviceConnections;
     uint m_touchpadFingerCount = 0;
 };

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1441,7 +1441,7 @@ void Helper::init(Treeland::Treeland *treeland)
     connect(m_seatManager, &SeatsManager::deviceAdded, this, [this](WInputDevice *device) {
         m_seatManager->assignDevice(device, m_renderWindow,
                                    m_rootSurfaceContainer->outputLayout(), m_seat);
-        InputDevice::instance()->initTouchPad(device);
+        InputDevice::instance()->initDevice(device);
     });
 
     // Setup drag request handling for all seats

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -112,6 +112,7 @@
 #include <qwrenderer.h>
 #include <qwscreencopyv1.h>
 #include <qwsession.h>
+#include <qwsinglepixelbufferv1.h>
 #include <qwsubcompositor.h>
 #include <qwviewporter.h>
 #include <qwxwayland.h>
@@ -1476,6 +1477,7 @@ void Helper::init(Treeland::Treeland *treeland)
     // free follow display
     m_compositor = qw_compositor::create(*m_server->handle(), 6, *m_renderer);
     qw_subcompositor::create(*m_server->handle());
+    qw_single_pixel_buffer_manager_v1::create(m_server->handle()->handle());
     qw_screencopy_manager_v1::create(*m_server->handle());
     qw_ext_image_copy_capture_manager_v1::create(*m_server->handle(), 1);
     qw_ext_output_image_capture_source_manager_v1::create(*m_server->handle(), 1);

--- a/waylib/examples/tinywl/helper.cpp
+++ b/waylib/examples/tinywl/helper.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 JiDe Zhang <zhangjide@deepin.org>.
+// Copyright (C) 2024-2026 JiDe Zhang <zhangjide@deepin.org>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "helper.h"
@@ -28,6 +28,7 @@
 #include <woutputrenderwindow.h>
 #include <wqmlcreator.h>
 #include <winputmethodhelper.h>
+#include <wvirtualinputhelper.h>
 #include <WForeignToplevel>
 #include <WXdgOutput>
 #include <wxwaylandsurface.h>
@@ -414,6 +415,7 @@ void Helper::init()
         });
     });
 
+    m_virtualInputHelper = new WVirtualInputHelper(m_server, m_seat);
     m_inputMethodHelper = new WInputMethodHelper(m_server, m_seat);
 
     connect(m_inputMethodHelper, &WInputMethodHelper::inputPopupSurfaceV2Added, this, [this](WInputPopupSurface *inputPopup) {

--- a/waylib/examples/tinywl/helper.h
+++ b/waylib/examples/tinywl/helper.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #pragma once
@@ -34,6 +34,7 @@ class WOutputLayer;
 class WOutput;
 class WXWayland;
 class WInputMethodHelper;
+class WVirtualInputHelper;
 class WXdgDecorationManager;
 class WSocket;
 class WSurface;
@@ -161,6 +162,7 @@ private:
     qw_compositor *m_compositor = nullptr;
     WXWayland *m_xwayland = nullptr;
     WInputMethodHelper *m_inputMethodHelper = nullptr;
+    WVirtualInputHelper *m_virtualInputHelper = nullptr;
     WXdgDecorationManager *m_xdgDecorationManager = nullptr;
     WForeignToplevel *m_foreignToplevel = nullptr;
     WExtForeignToplevelListV1 *m_extForeignToplevelListV1 = nullptr;

--- a/waylib/src/server/CMakeLists.txt
+++ b/waylib/src/server/CMakeLists.txt
@@ -167,12 +167,14 @@ set(SOURCES
     protocols/wxdgdecorationmanager.cpp
     protocols/wlayershell.cpp
     protocols/winputmethodhelper.cpp
+    protocols/wvirtualinputhelper.cpp
     protocols/winputpopupsurface.cpp
     protocols/private/winputmethodv2.cpp
     protocols/private/wtextinputv1.cpp
     protocols/private/wtextinputv2.cpp
     protocols/private/wtextinputv3.cpp
     protocols/private/wvirtualkeyboardv1.cpp
+    protocols/private/wvirtualpointerv1.cpp
     protocols/ext_foreign_toplevel_image_capture_source.c #TODO: Remove after wlroots 0.20
     protocols/wcursorshapemanagerv1.cpp
     protocols/woutputmanagerv1.cpp
@@ -263,6 +265,8 @@ set(HEADERS
     protocols/WXdgOutput
     protocols/WInputMethodHelper
     protocols/winputmethodhelper.h
+    protocols/WVirtualInputHelper
+    protocols/wvirtualinputhelper.h
     protocols/winputpopupsurface.h
     protocols/WInputPopupSurface
     protocols/wcursorshapemanagerv1.h

--- a/waylib/src/server/protocols/WVirtualInputHelper
+++ b/waylib/src/server/protocols/WVirtualInputHelper
@@ -1,0 +1,1 @@
+#include "wvirtualinputhelper.h"

--- a/waylib/src/server/protocols/private/wvirtualpointerv1.cpp
+++ b/waylib/src/server/protocols/private/wvirtualpointerv1.cpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "wvirtualpointerv1_p.h"
+#include "private/wglobal_p.h"
+
+#include <qwdisplay.h>
+#include <qwvirtualpointerv1.h>
+
+QW_USE_NAMESPACE
+WAYLIB_SERVER_BEGIN_NAMESPACE
+
+class Q_DECL_HIDDEN WVirtualPointerManagerV1Private : public WObjectPrivate
+{
+    W_DECLARE_PUBLIC(WVirtualPointerManagerV1)
+
+public:
+    explicit WVirtualPointerManagerV1Private(WVirtualPointerManagerV1 *qq)
+        : WObjectPrivate(qq)
+    {
+    }
+};
+
+WVirtualPointerManagerV1::WVirtualPointerManagerV1([[maybe_unused]] QObject *parent)
+    : WObject(*new WVirtualPointerManagerV1Private(this))
+{
+}
+
+QByteArrayView WVirtualPointerManagerV1::interfaceName() const
+{
+    return "zwlr_virtual_pointer_manager_v1";
+}
+
+void WVirtualPointerManagerV1::create(WServer *server)
+{
+    auto manager = qw_virtual_pointer_manager_v1::create(*server->handle());
+    Q_ASSERT(manager);
+    m_handle = manager;
+    connect(manager, &qw_virtual_pointer_manager_v1::notify_new_virtual_pointer,
+            this, &WVirtualPointerManagerV1::newVirtualPointer);
+}
+
+wl_global *WVirtualPointerManagerV1::global() const
+{
+    return nativeInterface<qw_virtual_pointer_manager_v1>()->handle()->global;
+}
+
+WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/protocols/private/wvirtualpointerv1_p.h
+++ b/waylib/src/server/protocols/private/wvirtualpointerv1_p.h
@@ -1,0 +1,34 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <wglobal.h>
+#include <wserver.h>
+
+#include <qwglobal.h>
+
+struct wlr_virtual_pointer_v1_new_pointer_event;
+
+WAYLIB_SERVER_BEGIN_NAMESPACE
+
+class WVirtualPointerManagerV1Private;
+class WAYLIB_SERVER_EXPORT WVirtualPointerManagerV1 : public QObject, public WObject, public WServerInterface
+{
+    Q_OBJECT
+    W_DECLARE_PRIVATE(WVirtualPointerManagerV1)
+
+public:
+    explicit WVirtualPointerManagerV1(QObject *parent = nullptr);
+
+    QByteArrayView interfaceName() const override;
+
+Q_SIGNALS:
+    void newVirtualPointer(wlr_virtual_pointer_v1_new_pointer_event *event);
+
+private:
+    void create(WServer *server) override;
+    wl_global *global() const override;
+};
+
+WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/protocols/winputmethodhelper.cpp
+++ b/waylib/src/server/protocols/winputmethodhelper.cpp
@@ -7,17 +7,16 @@
 #include "wtextinputv2_p.h"
 #include "wtextinput_p.h"
 #include "winputmethodv2_p.h"
-#include "wvirtualkeyboardv1_p.h"
 #include "winputpopupsurface.h"
 #include "wseat.h"
 #include "wsurface.h"
 #include "private/wglobal_p.h"
 
 #include <qwcompositor.h>
+#include <qwinputdevice.h>
 #include <qwinputmethodv2.h>
 #include <qwtextinputv3.h>
 #include <qwvirtualkeyboardv1.h>
-#include <qwinputdevice.h>
 #include <qwseat.h>
 #include <qwbox.h>
 
@@ -29,18 +28,16 @@ WAYLIB_SERVER_BEGIN_NAMESPACE
 Q_LOGGING_CATEGORY(qLcInputMethod, "waylib.server.im", QtInfoMsg)
 
 struct Q_DECL_HIDDEN GrabHandlerArg {
-    const WInputMethodHelper *const helper;
     qw_input_method_keyboard_grab_v2 *grab;
 };
 
 void handleKey(struct wlr_seat_keyboard_grab *grab, uint32_t time_msec, uint32_t key, uint32_t state)
 {
     auto arg = reinterpret_cast<GrabHandlerArg*>(grab->data);
-    for (auto vk: arg->helper->virtualKeyboards()) {
-        if (wlr_keyboard_from_input_device(vk->handle()->handle()) == grab->seat->keyboard_state.keyboard) {
-            grab->seat->keyboard_state.default_grab->interface->key(grab, time_msec, key, state);
-            return;
-        }
+    if (grab->seat->keyboard_state.keyboard
+        && wlr_input_device_get_virtual_keyboard(&grab->seat->keyboard_state.keyboard->base)) {
+        grab->seat->keyboard_state.default_grab->interface->key(grab, time_msec, key, state);
+        return;
     }
     arg->grab->send_key(time_msec, Qt::Key(key), state);
 }
@@ -48,11 +45,10 @@ void handleKey(struct wlr_seat_keyboard_grab *grab, uint32_t time_msec, uint32_t
 void handleModifiers(struct wlr_seat_keyboard_grab *grab, const struct wlr_keyboard_modifiers *modifiers)
 {
     auto arg = reinterpret_cast<GrabHandlerArg*>(grab->data);
-    for (auto vk: arg->helper->virtualKeyboards()) {
-        if (wlr_keyboard_from_input_device(vk->handle()->handle()) == grab->seat->keyboard_state.keyboard) {
-            grab->seat->keyboard_state.default_grab->interface->modifiers(grab, modifiers);
-            return;
-        }
+    if (grab->seat->keyboard_state.keyboard
+        && wlr_input_device_get_virtual_keyboard(&grab->seat->keyboard_state.keyboard->base)) {
+        grab->seat->keyboard_state.default_grab->interface->modifiers(grab, modifiers);
+        return;
     }
     arg->grab->send_modifiers(const_cast<struct wlr_keyboard_modifiers *>(modifiers));
 }
@@ -69,13 +65,12 @@ public:
         , textInputManagerV1(server->attach<WTextInputManagerV1>())
         , textInputManagerV2(server->attach<WTextInputManagerV2>())
         , textInputManagerV3(server->attach<WTextInputManagerV3>())
-        , virtualKeyboardManagerV1(server->attach<WVirtualKeyboardManagerV1>())
         , enabledTextInput(nullptr)
         , activeInputMethod(nullptr)
         , activeKeyboardGrab(nullptr)
         , keyboardGrab{}
         , grabInterface{}
-        , handlerArg({.helper = qq, .grab = nullptr})
+        , handlerArg({.grab = nullptr})
     {
         Q_ASSERT(server);
         Q_ASSERT(seat);
@@ -91,7 +86,6 @@ public:
     const QPointer<WTextInputManagerV1> textInputManagerV1;
     const QPointer<WTextInputManagerV2> textInputManagerV2;
     const QPointer<WTextInputManagerV3> textInputManagerV3;
-    const QPointer<WVirtualKeyboardManagerV1> virtualKeyboardManagerV1;
     WTextInput *enabledTextInput { nullptr };
     WInputMethodV2 *activeInputMethod { nullptr };
     qw_input_method_keyboard_grab_v2 *activeKeyboardGrab {nullptr};
@@ -101,7 +95,6 @@ public:
     GrabHandlerArg handlerArg;
 
     QList<WTextInput *> textInputs;
-    QList<WInputDevice *> virtualKeyboards;
     QList<WInputPopupSurface *> popupSurfaces;
 };
 
@@ -113,7 +106,6 @@ WInputMethodHelper::WInputMethodHelper(WServer *server, WSeat *seat)
     d->seat->safeConnect(&WSeat::keyboardFocusSurfaceChanged, this, &WInputMethodHelper::resendKeyboardFocus);
     connect(d->inputMethodManagerV2, &WInputMethodManagerV2::newInputMethod, this, &WInputMethodHelper::handleNewIMV2);
     connect(d->textInputManagerV3, &WTextInputManagerV3::newTextInput, this, &WInputMethodHelper::handleNewTI);
-    connect(d->virtualKeyboardManagerV1, &WVirtualKeyboardManagerV1::newVirtualKeyboard, this, &WInputMethodHelper::handleNewVKV1);
     connect(d->textInputManagerV1, &WTextInputManagerV1::newTextInput, this, &WInputMethodHelper::handleNewTI);
     connect(d->textInputManagerV2, &WTextInputManagerV2::newTextInput, this, &WInputMethodHelper::handleNewTI);
 }
@@ -126,7 +118,6 @@ WInputMethodHelper::~WInputMethodHelper()
     if (d->textInputManagerV1) d->textInputManagerV1->disconnect(this);
     if (d->textInputManagerV2) d->textInputManagerV2->disconnect(this);
     if (d->textInputManagerV3) d->textInputManagerV3->disconnect(this);
-    if (d->virtualKeyboardManagerV1) d->virtualKeyboardManagerV1->disconnect(this);
 }
 
 WTextInput *WInputMethodHelper::focusedTextInput() const
@@ -183,12 +174,6 @@ qw_input_method_keyboard_grab_v2 *WInputMethodHelper::activeKeyboardGrab() const
     return d->activeKeyboardGrab;
 }
 
-const QList<WInputDevice *> &WInputMethodHelper::virtualKeyboards() const
-{
-    W_DC(WInputMethodHelper);
-    return d->virtualKeyboards;
-}
-
 void WInputMethodHelper::handleNewIMV2(qw_input_method_v2 *imv2)
 {
     W_D(WInputMethodHelper);
@@ -223,7 +208,7 @@ void WInputMethodHelper::handleNewKGV2(qw_input_method_keyboard_grab_v2 *kgv2)
     };
     auto setKeyboard = [](qw_input_method_keyboard_grab_v2 *kgv2, WInputDevice *keyboard) {
         if (keyboard) {
-            auto *virtualKeyboard = wlr_input_device_get_virtual_keyboard(*keyboard->handle());
+            auto *virtualKeyboard = wlr_input_device_get_virtual_keyboard(keyboard->handle()->handle());
             // refer to:
             // https://github.com/swaywm/sway/blob/master/sway/input/keyboard.c#L391
             if (virtualKeyboard
@@ -231,7 +216,7 @@ void WInputMethodHelper::handleNewKGV2(qw_input_method_keyboard_grab_v2 *kgv2)
                     == wl_resource_get_client(kgv2->handle()->resource)) {
                 return;
             }
-            kgv2->set_keyboard(wlr_keyboard_from_input_device(*keyboard->handle()));
+            kgv2->set_keyboard(wlr_keyboard_from_input_device(keyboard->handle()->handle()));
         } else {
             kgv2->set_keyboard(nullptr);
         }
@@ -279,19 +264,6 @@ void WInputMethodHelper::handleNewIPSV2(qw_input_popup_surface_v2 *ipsv2)
     if (ti && ti->focusedSurface()) {
         createPopupSurface(ti->focusedSurface(), ti->cursorRect(), ipsv2);
     }
-}
-
-void WInputMethodHelper::handleNewVKV1(wlr_virtual_keyboard_v1 *vkv1)
-{
-    W_D(WInputMethodHelper);
-    WInputDevice *keyboard = new WInputDevice(qw_input_device::from(&vkv1->keyboard.base));
-    d->virtualKeyboards.append(keyboard);
-    d->seat->attachInputDevice(keyboard);
-    keyboard->safeConnect(&qw_input_device::before_destroy, this, [d, keyboard] () {
-        if (d->seat) d->seat->detachInputDevice(keyboard);
-        d->virtualKeyboards.removeOne(keyboard);
-        keyboard->safeDeleteLater();
-    });
 }
 
 void WInputMethodHelper::resendKeyboardFocus()

--- a/waylib/src/server/protocols/winputmethodhelper.h
+++ b/waylib/src/server/protocols/winputmethodhelper.h
@@ -15,15 +15,12 @@ QW_BEGIN_NAMESPACE
 class qw_input_method_v2;
 class qw_input_method_keyboard_grab_v2;
 class qw_input_popup_surface_v2;
-class qw_virtual_keyboard_v1;
 QW_END_NAMESPACE
 struct wlr_seat_keyboard_grab;
-struct wlr_virtual_keyboard_v1;
 struct wlr_keyboard_modifiers;
 WAYLIB_SERVER_BEGIN_NAMESPACE
 class WServer;
 class WSeat;
-class WInputDevice;
 class WInputMethodV2;
 class WInputMethodHelperPrivate;
 class WInputPopupSurface;
@@ -42,12 +39,10 @@ Q_SIGNALS:
     void inputPopupSurfaceV2Removed(WInputPopupSurface *popupSurface);
 
 private:
-    const QList<WInputDevice *> &virtualKeyboards() const;
     void handleNewTI(WTextInput *ti);
     void handleNewIMV2(QW_NAMESPACE::qw_input_method_v2 *imv2);
     void handleNewKGV2(QW_NAMESPACE::qw_input_method_keyboard_grab_v2 *kgv2);
     void handleNewIPSV2(QW_NAMESPACE::qw_input_popup_surface_v2 *ipsv2);
-    void handleNewVKV1(wlr_virtual_keyboard_v1 *vkv1);
     void updateAllPopupSurfaces(QRect cursorRect);
     void updatePopupSurface(WInputPopupSurface *popup, QRect cursorRect);
     void notifyLeave();

--- a/waylib/src/server/protocols/wvirtualinputhelper.cpp
+++ b/waylib/src/server/protocols/wvirtualinputhelper.cpp
@@ -1,0 +1,159 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "wvirtualinputhelper.h"
+
+#include "private/wglobal_p.h"
+#include "private/wvirtualkeyboardv1_p.h"
+#include "private/wvirtualpointerv1_p.h"
+#include "wcursor.h"
+#include "winputdevice.h"
+#include "woutput.h"
+#include "wseat.h"
+#include "wserver.h"
+
+#include <qwcursor.h>
+#include <qwinputdevice.h>
+#include <qwoutput.h>
+#include <qwvirtualkeyboardv1.h>
+#include <qwvirtualpointerv1.h>
+
+QW_USE_NAMESPACE
+WAYLIB_SERVER_BEGIN_NAMESPACE
+
+class Q_DECL_HIDDEN WVirtualInputHelperPrivate : public WObjectPrivate
+{
+    W_DECLARE_PUBLIC(WVirtualInputHelper)
+
+public:
+    explicit WVirtualInputHelperPrivate(WServer *s, WSeat *st, WVirtualInputHelper *qq)
+        : WObjectPrivate(qq)
+        , server(s)
+        , seat(st)
+        , virtualKeyboardManagerV1(server->attach<WVirtualKeyboardManagerV1>())
+        , virtualPointerManagerV1(server->attach<WVirtualPointerManagerV1>())
+    {
+        Q_ASSERT(server);
+        Q_ASSERT(seat);
+        Q_ASSERT(virtualKeyboardManagerV1);
+        Q_ASSERT(virtualPointerManagerV1);
+    }
+
+    const QPointer<WServer> server;
+    const QPointer<WSeat> seat;
+    const QPointer<WVirtualKeyboardManagerV1> virtualKeyboardManagerV1;
+    const QPointer<WVirtualPointerManagerV1> virtualPointerManagerV1;
+    QList<WInputDevice *> virtualKeyboards;
+    QList<WInputDevice *> virtualPointers;
+};
+
+WVirtualInputHelper::WVirtualInputHelper(WServer *server, WSeat *seat)
+    : QObject(server)
+    , WObject(*new WVirtualInputHelperPrivate(server, seat, this))
+{
+    W_D(WVirtualInputHelper);
+    connect(d->virtualKeyboardManagerV1, &WVirtualKeyboardManagerV1::newVirtualKeyboard,
+            this, &WVirtualInputHelper::handleNewVKV1);
+    connect(d->virtualPointerManagerV1, &WVirtualPointerManagerV1::newVirtualPointer,
+            this, &WVirtualInputHelper::handleNewVPV1);
+}
+
+WVirtualInputHelper::~WVirtualInputHelper()
+{
+    W_D(WVirtualInputHelper);
+    if (d->virtualKeyboardManagerV1)
+        d->virtualKeyboardManagerV1->disconnect(this);
+    if (d->virtualPointerManagerV1)
+        d->virtualPointerManagerV1->disconnect(this);
+}
+
+bool WVirtualInputHelper::shouldAcceptSeat(::wlr_seat *suggestedSeat) const
+{
+    W_DC(WVirtualInputHelper);
+    return !suggestedSeat || (d->seat && d->seat->nativeHandle() == suggestedSeat);
+}
+
+WInputDevice *WVirtualInputHelper::ensureDevice(qw_input_device *handle) const
+{
+    if (!handle)
+        return nullptr;
+
+    if (auto *device = WInputDevice::fromHandle(handle))
+        return device;
+
+    return new WInputDevice(handle);
+}
+
+void WVirtualInputHelper::attachDevice(WInputDevice *device)
+{
+    W_D(WVirtualInputHelper);
+    if (!device || !d->seat || device->seat() == d->seat)
+        return;
+
+    if (device->seat())
+        return;
+
+    d->seat->attachInputDevice(device);
+}
+
+void WVirtualInputHelper::detachDevice(WInputDevice *device)
+{
+    W_D(WVirtualInputHelper);
+    if (!device || !d->seat || device->seat() == d->seat)
+        return;
+
+    if (device->seat())
+        return;
+
+    d->seat->detachInputDevice(device);
+}
+
+void WVirtualInputHelper::maybeMapToOutput(WInputDevice *device, ::wlr_output *output) const
+{
+    W_DC(WVirtualInputHelper);
+    if (!device || !output || !d->seat || !d->seat->cursor())
+        return;
+
+    if (!WOutput::fromHandle(qw_output::from(output)))
+        return;
+
+    d->seat->cursor()->handle()->map_input_to_output(device->handle()->handle(), output);
+}
+
+void WVirtualInputHelper::handleNewVKV1(::wlr_virtual_keyboard_v1 *virtualKeyboard)
+{
+    W_D(WVirtualInputHelper);
+    auto *device = ensureDevice(qw_input_device::from(&virtualKeyboard->keyboard.base));
+    if (!device || device->seat() || d->virtualKeyboards.contains(device))
+        return;
+
+    d->virtualKeyboards.append(device);
+    attachDevice(device);
+    device->safeConnect(&qw_input_device::before_destroy, this, [this, d, device] {
+        detachDevice(device);
+        d->virtualKeyboards.removeOne(device);
+        device->safeDeleteLater();
+    });
+}
+
+void WVirtualInputHelper::handleNewVPV1(::wlr_virtual_pointer_v1_new_pointer_event *event)
+{
+    W_D(WVirtualInputHelper);
+    if (!event || !shouldAcceptSeat(event->suggested_seat))
+        return;
+
+    auto *device = ensureDevice(qw_input_device::from(&event->new_pointer->pointer.base));
+    if (!device || device->seat() || d->virtualPointers.contains(device))
+        return;
+
+    d->virtualPointers.append(device);
+    attachDevice(device);
+    maybeMapToOutput(device, event->suggested_output);
+    device->safeConnect(&qw_input_device::before_destroy, this, [this, d, device] {
+        detachDevice(device);
+        d->virtualPointers.removeOne(device);
+        device->safeDeleteLater();
+    });
+}
+
+WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/protocols/wvirtualinputhelper.h
+++ b/waylib/src/server/protocols/wvirtualinputhelper.h
@@ -1,0 +1,44 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include "wglobal.h"
+
+#include <QObject>
+
+QW_BEGIN_NAMESPACE
+class qw_input_device;
+QW_END_NAMESPACE
+
+struct wlr_output;
+struct wlr_seat;
+struct wlr_virtual_keyboard_v1;
+struct wlr_virtual_pointer_v1_new_pointer_event;
+
+WAYLIB_SERVER_BEGIN_NAMESPACE
+
+class WInputDevice;
+class WSeat;
+class WServer;
+class WVirtualInputHelperPrivate;
+class WAYLIB_SERVER_EXPORT WVirtualInputHelper : public QObject, public WObject
+{
+    Q_OBJECT
+    W_DECLARE_PRIVATE(WVirtualInputHelper)
+
+public:
+    explicit WVirtualInputHelper(WServer *server, WSeat *seat);
+    ~WVirtualInputHelper() override;
+
+private:
+    void handleNewVKV1(::wlr_virtual_keyboard_v1 *virtualKeyboard);
+    void handleNewVPV1(::wlr_virtual_pointer_v1_new_pointer_event *event);
+    bool shouldAcceptSeat(::wlr_seat *suggestedSeat) const;
+    WInputDevice *ensureDevice(QW_NAMESPACE::qw_input_device *handle) const;
+    void attachDevice(WInputDevice *device);
+    void detachDevice(WInputDevice *device);
+    void maybeMapToOutput(WInputDevice *device, ::wlr_output *output) const;
+};
+
+WAYLIB_SERVER_END_NAMESPACE


### PR DESCRIPTION
- add single-pixel-buffer-v1 protocol support
- add WVirtualInputHelper for virtual keyboard and pointer

These protocols are required for running the wl-find-cursor client,
which is used in automated testing to simulate input events.

## Summary by Sourcery

Add support for virtual input devices and single-pixel buffer protocol, and integrate centralized input device initialization and configuration management.

New Features:
- Introduce WVirtualInputHelper to manage virtual keyboard and pointer devices and attach them to the compositor seat.
- Add support for the zwlr_virtual_pointer_manager_v1 protocol via WVirtualPointerManagerV1 and its private implementation.
- Enable the single-pixel-buffer-v1 Wayland protocol on the compositor.

Enhancements:
- Refactor input device initialization into generic init/deinit hooks with per-device configuration wiring, including pointer acceleration profile updates driven by user config.
- Simplify WInputMethodHelper by removing direct virtual keyboard management and relying on core virtual input handling.
- Wire virtual input helper usage into the main shell handler and tinywl example so virtual input is available across environments.

Build:
- Register new virtual input helper and virtual pointer protocol sources and headers in the server build configuration.