### PR TITLE
fix: personalization resource destroy callbacks had inverted null check

### DIFF
--- a/src/modules/personalization/impl/appearance_impl.cpp
+++ b/src/modules/personalization/impl/appearance_impl.cpp
@@ -98,9 +98,15 @@ personalization_appearance_context_v1::personalization_appearance_context_v1(
         this,
         [](struct wl_resource *resource) {
             auto *p = personalization_appearance_context_v1::fromResource(resource);
+            if (!p)
+                return;
             Q_EMIT p->beforeDestroy();
+            wl_resource_set_user_data(resource, nullptr);
             delete p;
-            wl_list_remove(wl_resource_get_link(resource));
+            // wl_list_remove is already called by the wayland core
+            // (remove_and_destroy_resource) before this callback runs;
+            // calling it again would double-remove the link and corrupt
+            // the list, causing the heap use-after-free seen in valgrind.
         });
 
     wl_list_insert(&manager->resources, wl_resource_get_link(resource));

--- a/src/modules/personalization/impl/font_impl.cpp
+++ b/src/modules/personalization/impl/font_impl.cpp
@@ -73,9 +73,15 @@ personalization_font_context_v1::personalization_font_context_v1(
                                    [](struct wl_resource *resource) {
                                        auto *p =
                                            personalization_font_context_v1::fromResource(resource);
+                                       if (!p)
+                                           return;
                                        Q_EMIT p->beforeDestroy();
+                                       wl_resource_set_user_data(resource, nullptr);
                                        delete p;
-                                       wl_list_remove(wl_resource_get_link(resource));
+                                       // wl_list_remove is already called by the wayland core
+                                       // (remove_and_destroy_resource) before this callback runs;
+                                       // calling it again would double-remove the link and corrupt
+                                       // the list, causing the heap use-after-free seen in valgrind.
                                    });
 
     wl_list_insert(&manager->resources, wl_resource_get_link(resource));

--- a/src/modules/personalization/impl/personalization_manager_impl.cpp
+++ b/src/modules/personalization/impl/personalization_manager_impl.cpp
@@ -90,7 +90,7 @@ personalization_window_context_v1::~personalization_window_context_v1()
 
 static void personalization_window_context_resource_destroy(struct wl_resource *resource)
 {
-    if (resource)
+    if (!resource)
         return;
 
     auto window_context = personalization_window_context_v1::from_resource(resource);
@@ -98,8 +98,8 @@ static void personalization_window_context_resource_destroy(struct wl_resource *
         return;
     }
 
+    wl_resource_set_user_data(resource, nullptr);
     delete window_context;
-    wl_list_remove(wl_resource_get_link(resource));
 }
 
 namespace Personalization {
@@ -222,7 +222,7 @@ personalization_wallpaper_context_v1::~personalization_wallpaper_context_v1()
 
 static void personalization_wallpaper_context_resource_destroy(struct wl_resource *resource)
 {
-    if (resource)
+    if (!resource)
         return;
 
     auto wallpaper_context = personalization_wallpaper_context_v1::from_resource(resource);
@@ -230,8 +230,8 @@ static void personalization_wallpaper_context_resource_destroy(struct wl_resourc
         return;
     }
 
+    wl_resource_set_user_data(resource, nullptr);
     delete wallpaper_context;
-    wl_list_remove(wl_resource_get_link(resource));
 }
 
 void set_cursor_theme([[maybe_unused]] struct wl_client *client, struct wl_resource *resource, const char *name)
@@ -312,7 +312,7 @@ personalization_cursor_context_v1::~personalization_cursor_context_v1()
 
 static void personalization_cursor_context_resource_destroy(struct wl_resource *resource)
 {
-    if (resource)
+    if (!resource)
         return;
 
     auto cursor_context = personalization_cursor_context_v1::from_resource(resource);
@@ -320,8 +320,8 @@ static void personalization_cursor_context_resource_destroy(struct wl_resource *
         return;
     }
 
+    wl_resource_set_user_data(resource, nullptr);
     delete cursor_context;
-    wl_list_remove(wl_resource_get_link(resource));
 }
 
 void create_personalization_window_context_listener(struct wl_client *client,
@@ -360,16 +360,13 @@ treeland_personalization_manager_v1 *treeland_personalization_manager_v1::from_r
 
 static void treeland_personalization_manager_resource_destroy(struct wl_resource *resource)
 {
-    if (resource)
+    if (!resource)
         return;
 
-    auto manager = treeland_personalization_manager_v1::from_resource(resource);
-    if (!manager) {
-        return;
-    }
-
-    delete manager;
-    wl_list_remove(wl_resource_get_link(resource));
+    // The manager object is shared by all bound manager resources and is owned
+    // by treeland_personalization_manager_v1::create()/display lifetime.
+    // Destroying a single wl_resource must not delete the shared manager.
+    wl_resource_set_user_data(resource, nullptr);
 }
 
 void create_personalization_window_context_listener(struct wl_client *client,


### PR DESCRIPTION
All 4 wl_resource destroy callbacks in personalization_manager_impl.cpp had an inverted null check introduced by commit 56c8376:

```
    if (resource)   // always true in a destroy callback
        return;     // function returns immediately, doing nothing

    wl_list_remove(...)  // never reached
    delete context;      // never reached
```

This meant wl_list_remove was never called, leaving freed wl_resource objects as dangling links in manager->resources. When a Wayland client disconnects, wl_client_destroy frees the resource memory while stale links remain in the list. Subsequent wl_list_insert/wl_list_remove operations on the same list then write to freed memory, corrupting the heap and causing crashes.

Fix by inverting the check to if (!resource).

## Summary by Sourcery

Bug Fixes:
- Correct wl_resource destroy callbacks for personalization window, wallpaper, cursor, and manager contexts so their cleanup logic runs as intended when resources are destroyed.