### PR TITLE
fix: capturev1 resource destroy callbacks: use deleteLater() to avoid UAF

### DIFF
--- a/src/modules/capture/impl/capturev1impl.cpp
+++ b/src/modules/capture/impl/capturev1impl.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "capturev1impl.h"
@@ -88,7 +88,13 @@ void capture_session_resource_destroy(struct wl_resource *resource)
         return;
     }
     Q_EMIT session->beforeDestroy();
-    delete session;
+    // Use deleteLater() instead of delete to avoid re-entrant QObject destruction
+    // when this callback is triggered from within a WClient::destroyed slot (which
+    // fires from ~QObject of the WClient). Immediate deletion would free the Qt
+    // Connection object that doActivate() is currently iterating, causing a UAF
+    // crash in QBasicAtomicPointer::loadRelaxed (qobject.cpp:4317).
+    session->resource = nullptr; // resource is being freed; prevent double-destroy
+    session->deleteLater();
 }
 
 void capture_context_resource_destroy(struct wl_resource *resource)
@@ -98,7 +104,8 @@ void capture_context_resource_destroy(struct wl_resource *resource)
         return;
     }
     Q_EMIT context->beforeDestroy();
-    delete context;
+    context->resource = nullptr;
+    context->deleteLater();
 }
 
 void capture_frame_resource_destroy(struct wl_resource *resource)
@@ -108,7 +115,8 @@ void capture_frame_resource_destroy(struct wl_resource *resource)
         return;
     }
     Q_EMIT frame->beforeDestroy();
-    delete frame;
+    frame->resource = nullptr;
+    frame->deleteLater();
 }
 
 void treeland_capture_manager_bind(wl_client *client, void *data, uint32_t version, uint32_t id)
@@ -293,7 +301,8 @@ void treeland_capture_context_v1::setResource(wl_client *client, wl_resource *re
 {
     WClient *wClient = WClient::get(client);
     connect(wClient, &WClient::destroyed, this, [this] {
-        wl_resource_destroy(this->resource);
+        if (this->resource)
+            wl_resource_destroy(this->resource);
     });
     this->resource = resource;
 }
@@ -322,7 +331,8 @@ void treeland_capture_session_v1::setResource(wl_client *client, wl_resource *re
 {
     WClient *wClient = WClient::get(client);
     connect(wClient, &WClient::destroyed, this, [this] {
-        wl_resource_destroy(this->resource);
+        if (this->resource)
+            wl_resource_destroy(this->resource);
     });
     this->resource = resource;
 }
@@ -349,7 +359,8 @@ void treeland_capture_frame_v1::setResource(wl_client *client, wl_resource *reso
 {
     WClient *wClient = WClient::get(client);
     connect(wClient, &WClient::destroyed, this, [this] {
-        wl_resource_destroy(this->resource);
+        if (this->resource)
+            wl_resource_destroy(this->resource);
     });
     this->resource = resource;
 }


### PR DESCRIPTION
When WClient::destroyed fires (from ~QObject of a WClient being deleted), the connected slots in `treeland_capture_{context,session,frame}_v1::setResource` call wl_resource_destroy(this->resource). This triggers the wl_resource destructor callback (capture_{context,session,frame}_resource_destroy) which immediately calls 'delete this' — deleting the Qt receiver QObject while Qt's doActivate() is still iterating its WClient::destroyed connection list.

The immediate deletion calls ~QObject() → removeConnection() → c->deref(), which can free the Connection object c that doActivate() currently holds as a raw pointer. On the next loop iteration, c->nextConnectionList.loadRelaxed() reads freed memory, resulting in a UAF crash at QBasicAtomicPointer::loadRelaxed (qobject.cpp:4317):

```
  doActivate → list->first.loadRelaxed() → c->receiver OK
    → c->receiverThreadData → td (non-null but freed) → td->threadId SIGSEGV
```

Fix: replace 'delete session/context/frame' with deleteLater() and null out the resource pointer first. This defers the QObject destruction to the next event loop iteration, after doActivate() has finished iterating connections. Also add null guards in the WClient::destroyed slots since resource is now set to nullptr by the callbacks.

## Summary by Sourcery

Defer destruction of capture v1 context/session/frame objects on Wayland resource teardown to avoid use-after-free when WClient is destroyed.

Bug Fixes:
- Prevent a use-after-free crash by replacing immediate deletion of capture context/session/frame objects with deferred QObject deletion on Wayland resource destroy callbacks.

Enhancements:
- Null out capture context/session/frame resource pointers before scheduling deferred deletion and guard WClient::destroyed handlers against null resources to avoid double-destroy.