### PR TITLE
fix(seat): distinguish Focus from Activate in XWayland activation

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1943,7 +1943,7 @@ bool Helper::afterHandleEvent([[maybe_unused]] WSeat *seat,
 
             if (auto sh = surface->shellSurface();
                 sh && surface->surface() && surface->surface()->mapped()
-                && sh->hasCapability(WToplevelSurface::Capability::Focus)
+                && sh->hasCapability(WToplevelSurface::Capability::Activate)
                 && surface->hasActiveCapability()) {
                 surface->setActivate(true);
                 surface->stackToLast();
@@ -2111,11 +2111,8 @@ void Helper::setActivatedSurface(SurfaceWrapper *newActivateSurface)
         if (newActivateSurface->type() == SurfaceWrapper::Type::XWayland) {
             auto xwaylandSurface =
                 qobject_cast<WXWaylandSurface *>(newActivateSurface->shellSurface());
-            // override_redirect (bypass-manager) windows must not be restacked
-            // via wlr_xwayland_surface_restack, which asserts !override_redirect.
-            if (!xwaylandSurface->isBypassManager()) {
-                xwaylandSurface->restack(nullptr, WXWaylandSurface::XCB_STACK_MODE_ABOVE);
-            }
+            Q_ASSERT(!xwaylandSurface->isBypassManager());
+            xwaylandSurface->restack(nullptr, WXWaylandSurface::XCB_STACK_MODE_ABOVE);
         }
     }
 


### PR DESCRIPTION
Focus and Activate are closely related capabilities, but they are not interchangeable. This change updates the seat activation path to check Activate instead of Focus, so activation behavior matches capability semantics.

For XWayland bypass-manager (override_redirect) surfaces, Activate is not supported. The restack path now relies on that capability contract and enforces it with an assertion, preventing invalid activation/restack handling for bypass windows.

Behavior impact:

Activation decisions are based on Activate capability. Bypass-manager surfaces are excluded from activation/restack flow. Capability semantics stay consistent across seat logic and waylib XWayland surface implementation.

## Summary by Sourcery

Align seat activation logic with surface activation capability semantics and enforce correct handling of XWayland bypass-manager windows during restacking.

Bug Fixes:
- Use the Activate capability instead of Focus when deciding whether to activate and restack a surface after event handling.
- Prevent invalid restacking of XWayland bypass-manager (override_redirect) windows by asserting they are not restacked through the activation path.