### PR TITLE
fix: prevent deadlock during Wayland client destruction

### DIFF
--- a/waylib/src/server/kernel/private/wserver_p.h
+++ b/waylib/src/server/kernel/private/wserver_p.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 JiDe Zhang <zhangjide@deepin.org>.
+// Copyright (C) 2023-2026 JiDe Zhang <zhangjide@deepin.org>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #pragma once
@@ -42,6 +42,9 @@ public:
 
     GlobalFilterFunc globalFilterFunc = nullptr;
     void *globalFilterFuncData = nullptr;
+
+    bool isProcessingEvents = false;
+    void safeFlushClients();
 };
 
 WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/kernel/wserver.cpp
+++ b/waylib/src/server/kernel/wserver.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 JiDe Zhang <zhangjide@deepin.org>.
+// Copyright (C) 2023-2026 JiDe Zhang <zhangjide@deepin.org>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include <QObject>
@@ -26,6 +26,7 @@
 #include <QSocketNotifier>
 #include <QMutex>
 #include <QDebug>
+#include <QScopedValueRollback>
 #include <QProcess>
 #include <QLocalServer>
 #include <QLocalSocket>
@@ -104,18 +105,26 @@ void WServerPrivate::init()
     loop = wl_display_get_event_loop(display->handle());
     int fd = wl_event_loop_get_fd(loop);
 
-    auto processWaylandEvents = [this] {
+    sockNot.reset(new QSocketNotifier(fd, QSocketNotifier::Read));
+    QObject::connect(sockNot.get(), &QSocketNotifier::activated, q, [this] {
+        if (isProcessingEvents)
+            return;
+
+        QScopedValueRollback<bool> guard(isProcessingEvents, true);
+
         int ret = wl_event_loop_dispatch(loop, 0);
         if (ret)
             fprintf(stderr, "wl_event_loop_dispatch error: %d\n", ret);
-        wl_display_flush_clients(display->handle());
-    };
+    });
 
-    sockNot.reset(new QSocketNotifier(fd, QSocketNotifier::Read));
-    QObject::connect(sockNot.get(), &QSocketNotifier::activated, q, processWaylandEvents);
-
+    // Match upstream wl_display_run order: flush before dispatch.
     QAbstractEventDispatcher *dispatcher = QThread::currentThread()->eventDispatcher();
-    QObject::connect(dispatcher, &QAbstractEventDispatcher::aboutToBlock, q, processWaylandEvents);
+    QObject::connect(dispatcher, &QAbstractEventDispatcher::aboutToBlock, q, [this] {
+        if (isProcessingEvents)
+            return;
+
+        safeFlushClients();
+    });
 
     for (auto socket : std::as_const(sockets))
         initSocket(socket);
@@ -127,6 +136,12 @@ void WServerPrivate::stop()
 {
     W_Q(WServer);
 
+    // Disconnect event handlers BEFORE destroying clients to prevent
+    // callbacks from firing during client destruction.
+    sockNot.reset();
+    if (auto *dispatcher = QThread::currentThread()->eventDispatcher())
+        QObject::disconnect(dispatcher, nullptr, q, nullptr);
+
     if (display)
         wl_display_destroy_clients(*display);
 
@@ -137,9 +152,22 @@ void WServerPrivate::stop()
         (*i)->destroy(q);
         delete *i;
     }
+}
 
-    sockNot.reset();
-    QThread::currentThread()->eventDispatcher()->disconnect(q);
+// Replace wl_display_flush_clients: its wl_list_for_each_safe loop deadlocks
+// when destroy-signal cascades make the pre-saved next node self-linked.
+void WServerPrivate::safeFlushClients()
+{
+    struct wl_list *head = wl_display_get_client_list(display->handle());
+    struct wl_list *node = head->next;
+    while (node != head) {
+        // Self-linked node: already destroyed, stop to avoid infinite loop.
+        if (node->next == node)
+            break;
+        struct wl_list *next = node->next;
+        wl_client_flush(wl_client_from_link(node));
+        node = next;
+    }
 }
 
 void WServerPrivate::initSocket(WSocket *socketServer)


### PR DESCRIPTION
wl_display_flush_clients uses wl_list_for_each_safe to iterate the
client list. The _safe variant pre-saves the next pointer so that
removing the *current* node is safe. However, when wl_client_destroy
is called on the current client, its destroy_signal may cascade and
destroy the pre-saved *next* client as well. The destroyed next client
undergoes wl_list_remove + wl_list_init, making its link self-referencing
(prev = next = self). On the next loop iteration, client == next and
the termination condition (&client->link != head) is always true,
causing an infinite loop with 100% CPU.

Fix:
- Replace wl_display_flush_clients with safeFlushClients() that detects
  self-linked nodes (node->next == node) and stops traversal. Unlike
  wl_display_flush_clients, safeFlushClients uses wl_client_flush (pure
  sendmsg I/O) instead of wl_connection_flush + wl_client_destroy, so
  it cannot trigger cascading client destruction during traversal.
- Separate dispatch and flush into different callbacks: activated does
  only wl_event_loop_dispatch, aboutToBlock does only safeFlushClients.
  This matches the upstream wl_display_run order (flush before dispatch).
- Add isProcessingEvents reentrant guard to prevent aboutToBlock from
  re-entering during dispatch.
- In stop(), disconnect event handlers before destroying clients to
  prevent callbacks from firing during teardown.



## Summary by Sourcery

Prevent re-entrant Wayland event processing during client destruction to avoid deadlocks or crashes.

Bug Fixes:
- Guard Wayland event processing with a re-entrancy flag and early returns to avoid corrupted client state during wl_client destruction.
- Add checks for display and its handle before and after dispatching Wayland events to prevent access to invalid display handles.
- Ensure event dispatcher disconnection during server stop only occurs when a dispatcher exists, avoiding potential null access or invalid connections.

Enhancements:
- Refine server shutdown cleanup logic for Wayland clients and event dispatcher connections.

## Summary by Sourcery

Prevent Wayland server deadlock during client destruction by adjusting event processing and client flushing behavior.

Bug Fixes:
- Avoid infinite loops in Wayland client flushing by replacing wl_display_flush_clients with a traversal that stops on self-linked list nodes and only flushes clients.
- Prevent re-entrant processing of Wayland events by guarding dispatch and flush callbacks with an isProcessingEvents flag.
- Stop callbacks from firing during server teardown by disconnecting event handlers before destroying Wayland clients.

Enhancements:
- Separate Wayland event dispatch and client flush into distinct callbacks, aligning their order with upstream wl_display_run behavior.