### PR TITLE
Fix SSD fallback and refine decoration handling logic

### DIFF
--- a/src/modules/personalization/personalizationmanager.cpp
+++ b/src/modules/personalization/personalizationmanager.cpp
@@ -501,6 +501,8 @@ Personalization::Personalization(WToplevelSurface *target,
     , m_target(target)
     , m_manager(manager)
 {
+    // Some clients never bind the PersonalizationV1 protocol, so no window context is created
+    // and these properties stay at their default-initialized fallback values.
     connect(target, &WToplevelSurface::aboutToBeInvalidated, this, [this] {
         disconnect(m_connection);
     });

--- a/src/modules/personalization/personalizationmanager.h
+++ b/src/modules/personalization/personalizationmanager.h
@@ -74,11 +74,11 @@ Q_SIGNALS:
 private:
     WWrapPointer<WToplevelSurface> m_target;
     PersonalizationV1 *m_manager;
-    int32_t m_backgroundType;
-    int32_t m_cornerRadius;
-    Shadow m_shadow;
-    Border m_border;
-    personalization_window_context_v1::WindowStates m_states;
+    int32_t m_backgroundType = Personalization::BackgroundType::Normal;
+    int32_t m_cornerRadius = 0;
+    Shadow m_shadow {};
+    Border m_border {};
+    personalization_window_context_v1::WindowStates m_states {};
 
     QMetaObject::Connection m_connection;
 };

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1065,12 +1065,11 @@ void Helper::onSurfaceWrapperAdded(SurfaceWrapper *wrapper)
                 if (!isLaunchpad(layer)) {
                     wrapper->setNoDecoration(false);
                 }
-                return;
-            }
-
-            wrapper->setNoTitleBar(false);
-            wrapper->setNoDecoration(m_xdgDecorationManager->modeBySurface(wrapper->surface())
+            } else {
+                wrapper->setNoTitleBar(false);
+                wrapper->setNoDecoration(m_xdgDecorationManager->modeBySurface(wrapper->surface())
                                      != WXdgDecorationManager::Server);
+            }
         };
 
         if (isXdgToplevel) {

--- a/waylib/src/server/protocols/wxdgdecorationmanager.cpp
+++ b/waylib/src/server/protocols/wxdgdecorationmanager.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 rewine <luhongxu@deepin.org>.
+// Copyright (C) 2023-2026 rewine <luhongxu@deepin.org>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wxdgdecorationmanager.h"
@@ -78,7 +78,6 @@ void WXdgDecorationManagerPrivate::updateDecorationMode(qw_xdg_toplevel_decorati
             break;
         default:
             Q_UNREACHABLE();
-            break;
     }
     if (mode == WXdgDecorationManager::None) {
         mode = preferredMode;
@@ -93,12 +92,9 @@ void WXdgDecorationManagerPrivate::updateDecorationMode(qw_xdg_toplevel_decorati
                 break;
             default:
                 Q_UNREACHABLE();
-                break;
         }
-        decorations.insert(surface, preferredMode);
-    } else {
-        decorations.insert(surface, mode);
     }
+    decorations.insert(surface, mode);
 
     Q_EMIT q->surfaceModeChanged(surface, mode);
 }


### PR DESCRIPTION
This pull request includes several improvements and fixes related to window decoration handling, property initialization, and code maintenance across the personalization and decoration manager modules. The main focus is on ensuring default values are correctly set, improving logic for window decoration, and cleaning up unreachable code.

### Window Decoration Handling

* Fixed the logic in `Helper::onSurfaceWrapperAdded` to ensure that both `setNoTitleBar` and `setNoDecoration` are properly set for surfaces that are not launchpads, removing an unnecessary early return and streamlining the decision flow.
* Simplified and corrected the insertion of decoration modes in `WXdgDecorationManagerPrivate::updateDecorationMode` by always inserting the final `mode` value, and removed redundant code and unreachable `break` statements. [[1]](diffhunk://#diff-52e4e6bdf562d0a8553336c135a62da57857f6f748905664be1ef1b5a8351058L81) [[2]](diffhunk://#diff-52e4e6bdf562d0a8553336c135a62da57857f6f748905664be1ef1b5a8351058L96-R97)

### Property Initialization and Documentation

* Set default initial values for `Personalization` class properties such as `m_backgroundType`, `m_cornerRadius`, `m_shadow`, `m_border`, and `m_states` to ensure predictable behavior when the protocol is not bound.
* Added a clarifying comment in the `Personalization` constructor to explain why some properties may remain at their default values if the protocol is not bound by clients.

### Code Maintenance

* Updated the copyright year range in `wxdgdecorationmanager.cpp` to reflect ongoing development through 2026.

## Summary by Sourcery

Refine window decoration handling and establish safe default personalization values.

Bug Fixes:
- Correct window decoration and title bar flags for non-launchpad xdg toplevel surfaces based on the decoration manager mode.
- Ensure server-side decoration mode mappings are consistently stored without unreachable branches.

Enhancements:
- Default-initialize personalization background, corner radius, shadow, border, and window state properties to predictable fallback values when the protocol is unbound.
- Clarify personalization behavior with an inline comment explaining default fallback usage.
- Update copyright metadata for the XDG decoration manager implementation through 2026.