### PR TITLE
fix: avoid set zero implicit size during splash transition

### DIFF
--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -493,16 +493,15 @@ void SurfaceWrapper::syncPrelaunchMappedState()
 
 void SurfaceWrapper::startPrelaunchSplashHideSequence()
 {
-    Q_ASSERT(m_surfaceItem);
-    QSizeF targetImplicitSize;
-    if (auto surf = surface()) {
-        const QSize surfaceSize = surf->size();
-        targetImplicitSize = QSizeF(surfaceSize.width(), surfaceSize.height());
-    }
+    auto surf = surface();
+    Q_ASSERT(surf != nullptr && m_surfaceItem != nullptr);
+    // A newly created QQuickItem may report implicitWidth/implicitHeight as 0
+    // before polish/layout. WSurface::size() is already stable after mapped.
+    QSizeF targetImplicitSize = surf->size();
     const bool hasValidTargetImplicitSize =
         targetImplicitSize.width() > 0 && targetImplicitSize.height() > 0;
     if (!hasValidTargetImplicitSize) {
-        qCWarning(treelandSurface) << "Invalid target implicit size, skip transition animation"
+        qCCritical(treelandSurface) << "Invalid target implicit size, skip transition animation"
                                    << "targetImplicit=" << targetImplicitSize;
     }
 
@@ -548,8 +547,9 @@ void SurfaceWrapper::startPrelaunchSplashHideSequence()
         ok = QMetaObject::invokeMethod(m_geometryAnimation, "start");
         Q_ASSERT(ok);
     } else {
-        completeSplashTransition(
-            QSizeF(m_surfaceItem->implicitWidth(), m_surfaceItem->implicitHeight()));
+        // WSurface size is available when mapped; implicit size of a newly created
+        // QQuickItem can still be 0 before polish/layout in following event loops.
+        completeSplashTransition(targetImplicitSize);
     }
 }
 


### PR DESCRIPTION
Log:
- During prelaunch->normal transition, m_surfaceItem has just been created and its implicitWidth/implicitHeight can still be 0 before Qt Quick polish/layout.
- In the no-geometry-animation path, completeSplashTransition() could therefore be called with QSizeF(m_surfaceItem->implicitWidth(), m_surfaceItem->implicitHeight()), which may become setImplicitSize(0, 0) once and produce incorrect transient geometry.

Why it happens:
- implicit size of a newly created QQuickItem is not guaranteed to be ready immediately.

Fix:
- Use mapped WSurface::size() as targetImplicitSize in startPrelaunchSplashHideSequence().
- Add a safety check in completeSplashTransition() to skip invalid implicit sizes instead of calling setImplicitSize(0, 0).

## Summary by Sourcery

Prevent splash transition from using invalid implicit sizes when hiding the prelaunch splash and completing the transition.

Bug Fixes:
- Use the mapped WSurface size as the target implicit size during the prelaunch splash hide sequence to avoid zero implicit sizes.
- Guard splash transition completion against non-positive implicit sizes and log critical errors instead of applying an invalid implicit size.