### PR TITLE
fix: Gradia-like capture causes treeland crashed

### DIFF
--- a/src/modules/capture/capture.cpp
+++ b/src/modules/capture/capture.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "capture.h"
@@ -580,7 +580,10 @@ void CaptureSourceSelector::doneSelection()
             this,
             &CaptureSourceSelector::createImage);
     m_internalContentItem->setVisible(false);
-    m_canvas->surfaceItem()->setSubsurfacesVisible(false);
+    // m_canvas may be null when no mask surface exists (e.g. capture via
+    // xdg-desktop-portal without a mask).  Guard against null dereference.
+    if (m_canvas && m_canvas->surfaceItem())
+        m_canvas->surfaceItem()->setSubsurfacesVisible(false);
 }
 
 void CaptureSourceSelector::cancelSelection()


### PR DESCRIPTION
When using Gradia (or any screenshot tool via xdg-desktop-portal) to capture, there is no mask surface. `m_canvas` is only set in `componentComplete()` when `captureManager()->maskShellSurface()` and `captureManager()->maskSurfaceWrapper()` both exist. Without a mask, `m_canvas` remains `nullptr`. When the capture `finishSelect` signal fires, `doneSelection()` unconditionally dereferences `m_canvas->surfaceItem()`, causing a null pointer crash (`this=0x0`).

__Fix__: Added a null guard before accessing `m_canvas->surfaceItem()`:

```cpp
if (m_canvas && m_canvas->surfaceItem())
    m_canvas->surfaceItem()->setSubsurfacesVisible(false);
```