### PR TITLE
Random crash fix (AI修复崩溃的一些补丁合集)

### DIFF
--- a/src/common/treelandlogging.h
+++ b/src/common/treelandlogging.h
@@ -1,8 +1,7 @@
 // Copyright (C) 2025-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
-#ifndef TREELAND_LOGGING_H
-#define TREELAND_LOGGING_H
+#pragma once
 
 #include <QLoggingCategory>
 
@@ -70,5 +69,3 @@ Q_DECLARE_LOGGING_CATEGORY(treelandFpsDisplay)
 
 // xsettings
 Q_DECLARE_LOGGING_CATEGORY(treelandXsettings)
-
-#endif // TREELAND_LOGGING_H

--- a/src/core/qmlengine.cpp
+++ b/src/core/qmlengine.cpp
@@ -15,8 +15,6 @@
 
 #include <QQuickItem>
 
-Q_LOGGING_CATEGORY(qLcQmlEngine, "treeland.qmlEngine")
-
 QmlEngine::QmlEngine(QObject *parent)
     : QQmlApplicationEngine(parent)
     , titleBarComponent(this, "Treeland", "TitleBar")
@@ -58,7 +56,7 @@ QQuickItem *QmlEngine::createComponent(QQmlComponent &component,
     }
     auto item = qobject_cast<QQuickItem *>(obj);
     if (!item) {
-        qCFatal(qLcQmlEngine) << "Can't create component:" << component.errorString();
+        qCFatal(treelandQml) << "Can't create component:" << component.errorString();
     }
     QQmlEngine::setObjectOwnership(item, QQmlEngine::objectOwnership(parent));
     item->setParent(parent);
@@ -87,7 +85,7 @@ QObject *QmlEngine::createWindowMenu(QObject *parent)
     auto context = qmlContext(parent);
     auto obj = windowMenuComponent.beginCreate(context);
     if (!obj) {
-        qCFatal(qLcQmlEngine) << "Can't create WindowMenu:" << windowMenuComponent.errorString();
+        qCFatal(treelandQml) << "Can't create WindowMenu:" << windowMenuComponent.errorString();
     }
     obj->setParent(parent);
     windowMenuComponent.completeCreate();

--- a/src/greeter/user.h
+++ b/src/greeter/user.h
@@ -1,8 +1,7 @@
 // Copyright (C) 2023-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
-#ifndef USER_H
-#define USER_H
+#pragma once
 
 #include <wsocket.h>
 
@@ -46,5 +45,3 @@ Q_SIGNALS:
 private:
     UserPrivate *d{ nullptr };
 };
-
-#endif

--- a/src/greeter/usermodel.h
+++ b/src/greeter/usermodel.h
@@ -18,8 +18,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  ***************************************************************************/
 
-#ifndef SDDM_USERMODEL_H
-#define SDDM_USERMODEL_H
+#pragma once
 
 #include "greeter/user.h"
 
@@ -94,5 +93,3 @@ private Q_SLOTS:
 private:
     UserModelPrivate *d{ nullptr };
 };
-
-#endif // USERMODEL_H

--- a/src/input/gestures.cpp
+++ b/src/input/gestures.cpp
@@ -4,13 +4,10 @@
 #include "gestures.h"
 #include "common/treelandlogging.h"
 
-#include <QLoggingCategory>
 #include <QRect>
 
 // The minimum delta required to recognize a swipe gesture
-#define SWIPE_MINIMUM_DELTA 5
-
-Q_LOGGING_CATEGORY(qLcGestures, "treeland.gestures");
+static constexpr int SWIPE_MINIMUM_DELTA = 5;
 
 Gesture::Gesture(QObject *parent)
     : QObject(parent)
@@ -245,7 +242,7 @@ void GestureRecognizer::updateSwipeGesture(const QPointF &delta)
         direction = m_currentDelta.x() < 0 ? SwipeGesture::Left : SwipeGesture::Right;
         break;
     default:
-        qCWarning(qLcGestures) << "Invalid swipe axis";
+        qCWarning(treelandGestures) << "Invalid swipe axis";
         return;
     }
 
@@ -350,7 +347,7 @@ int GestureRecognizer::startSwipeGesture(uint fingerCount,
             }
             break;
         case SwipeGesture::Invalid:
-            qCWarning(qLcGestures) << "Invalid swipe direction";
+            qCWarning(treelandGestures) << "Invalid swipe direction";
             continue;
         }
 

--- a/src/modules/capture/capture.cpp
+++ b/src/modules/capture/capture.cpp
@@ -580,7 +580,10 @@ void CaptureSourceSelector::doneSelection()
             this,
             &CaptureSourceSelector::createImage);
     m_internalContentItem->setVisible(false);
-    m_canvas->surfaceItem()->setSubsurfacesVisible(false);
+    // m_canvas may be null when no mask surface exists (e.g. capture via
+    // xdg-desktop-portal without a mask).  Guard against null dereference.
+    if (m_canvas && m_canvas->surfaceItem())
+        m_canvas->surfaceItem()->setSubsurfacesVisible(false);
 }
 
 void CaptureSourceSelector::cancelSelection()

--- a/src/modules/capture/impl/capturev1impl.cpp
+++ b/src/modules/capture/impl/capturev1impl.cpp
@@ -88,7 +88,13 @@ void capture_session_resource_destroy(struct wl_resource *resource)
         return;
     }
     Q_EMIT session->beforeDestroy();
-    delete session;
+    // Use deleteLater() instead of delete to avoid re-entrant QObject destruction
+    // when this callback is triggered from within a WClient::destroyed slot (which
+    // fires from ~QObject of the WClient). Immediate deletion would free the Qt
+    // Connection object that doActivate() is currently iterating, causing a UAF
+    // crash in QBasicAtomicPointer::loadRelaxed (qobject.cpp:4317).
+    session->resource = nullptr; // resource is being freed; prevent double-destroy
+    session->deleteLater();
 }
 
 void capture_context_resource_destroy(struct wl_resource *resource)
@@ -98,7 +104,8 @@ void capture_context_resource_destroy(struct wl_resource *resource)
         return;
     }
     Q_EMIT context->beforeDestroy();
-    delete context;
+    context->resource = nullptr;
+    context->deleteLater();
 }
 
 void capture_frame_resource_destroy(struct wl_resource *resource)
@@ -108,7 +115,8 @@ void capture_frame_resource_destroy(struct wl_resource *resource)
         return;
     }
     Q_EMIT frame->beforeDestroy();
-    delete frame;
+    frame->resource = nullptr;
+    frame->deleteLater();
 }
 
 void treeland_capture_manager_bind(wl_client *client, void *data, uint32_t version, uint32_t id)
@@ -293,7 +301,8 @@ void treeland_capture_context_v1::setResource(wl_client *client, wl_resource *re
 {
     WClient *wClient = WClient::get(client);
     connect(wClient, &WClient::destroyed, this, [this] {
-        wl_resource_destroy(this->resource);
+        if (this->resource)
+            wl_resource_destroy(this->resource);
     });
     this->resource = resource;
 }
@@ -322,7 +331,8 @@ void treeland_capture_session_v1::setResource(wl_client *client, wl_resource *re
 {
     WClient *wClient = WClient::get(client);
     connect(wClient, &WClient::destroyed, this, [this] {
-        wl_resource_destroy(this->resource);
+        if (this->resource)
+            wl_resource_destroy(this->resource);
     });
     this->resource = resource;
 }
@@ -349,7 +359,8 @@ void treeland_capture_frame_v1::setResource(wl_client *client, wl_resource *reso
 {
     WClient *wClient = WClient::get(client);
     connect(wClient, &WClient::destroyed, this, [this] {
-        wl_resource_destroy(this->resource);
+        if (this->resource)
+            wl_resource_destroy(this->resource);
     });
     this->resource = resource;
 }

--- a/src/plugins/lockscreen/logoprovider.h
+++ b/src/plugins/lockscreen/logoprovider.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
-#ifndef LOGOPROVIDER_H
-#define LOGOPROVIDER_H
+#pragma once
 
 #include <QQmlEngine>
 
@@ -27,5 +26,3 @@ Q_SIGNALS:
 private:
     QLocale locale{ QLocale::system() };
 };
-
-#endif // LOGOPROVIDER_H

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -128,7 +128,6 @@
 #include <QMouseEvent>
 #include <QQmlContext>
 #include <QQuickWindow>
-#include <QtConcurrent>
 #include <rhi/qrhi.h>
 
 #include <functional>
@@ -2025,11 +2024,12 @@ bool Helper::doGesture(QInputEvent *event)
 Output *Helper::createNormalOutput(WOutput *output)
 {
     Output *o = Output::create(output, qmlEngine(), this);
-    auto future = QtConcurrent::run([o, this]() {
-        if (isNvidiaCardPresent()) {
-            o->outputItem()->setProperty("forceSoftwareCursor", true);
-        }
-    });
+    if (!m_isNvidia && isNvidiaCardPresent()) {
+        m_isNvidia = true;
+    }
+    if (m_isNvidia) {
+        o->outputItem()->setProperty("forceSoftwareCursor", true);
+    }
     o->outputItem()->stackBefore(m_rootSurfaceContainer);
     m_rootSurfaceContainer->addOutput(o);
     return o;

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -434,6 +434,7 @@ private:
 
     bool m_noAnimation{ false };
     bool m_isDDMDisplay{ false };
+    bool m_isNvidia{ false };
 
     struct PendingOutputConfig {
         qw_output_configuration_v1 *config = nullptr;

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -205,6 +205,11 @@ SurfaceWrapper::~SurfaceWrapper()
         delete m_coverContent;
         m_coverContent = nullptr;
     }
+    // Explicitly delete m_surfaceItem to prevent use-after-free
+    if (m_surfaceItem) {
+        delete m_surfaceItem;
+        m_surfaceItem = nullptr;
+    }
     // Ensure we do not hold stale connections to shellSurface; QPointer may already be null.
     if (m_shellSurface) {
         QObject::disconnect(m_shellSurface, nullptr, this, nullptr);
@@ -409,6 +414,12 @@ void SurfaceWrapper::convertToNormalSurface(WToplevelSurface *shellSurface, Type
         return;
     }
 
+    // Validate incoming shellSurface parameter
+    if (!shellSurface) {
+        qCCritical(treelandSurface) << "convertToNormalSurface called with null shellSurface";
+        return;
+    }
+
     // Assign new shell surface (QPointer auto-detects destruction)
     m_shellSurface = shellSurface;
     m_type = type;
@@ -418,7 +429,9 @@ void SurfaceWrapper::convertToNormalSurface(WToplevelSurface *shellSurface, Type
     setup();
     m_surfaceItem->setVisible(false);
 
-    if (surface()->mapped()) {
+    // Check if surface is still valid before accessing
+    WSurface *surf = surface();
+    if (surf && surf->mapped()) {
         syncPrelaunchMappedState();
         startPrelaunchSplashHideSequence();
     }
@@ -639,7 +652,8 @@ QString SurfaceWrapper::appId() const
     if (!m_appId.isEmpty())
         return m_appId;
     // TODO: consider to use "xdg-shell/" + m_shellSurface->appId(), need dde-shell adaptation
-    if (m_shellSurface)
+    // Check if shellSurface is still valid before accessing
+    if (!m_shellSurface.isNull())
         return m_shellSurface->appId();
     return QString();
 }
@@ -996,8 +1010,11 @@ void SurfaceWrapper::markWrapperToRemoved()
     }
     m_subSurfaces.clear();
     m_shellSurface = nullptr;
-    if (m_surfaceItem)
+    if (m_surfaceItem) {
         m_surfaceItem->disconnect(this);
+        delete m_surfaceItem;
+        m_surfaceItem = nullptr;
+    }
 
     if (!isWindowAnimationRunning()) {
         deleteLater();

--- a/src/systemd-socket.cpp
+++ b/src/systemd-socket.cpp
@@ -12,9 +12,9 @@
 #include <QDBusReply>
 #include <QDBusServiceWatcher>
 #include <QDBusUnixFileDescriptor>
-#include <QDebug>
 #include <QDir>
 #include <QFile>
+#include <QLoggingCategory>
 #include <QTemporaryFile>
 #include <QtEnvironmentVariables>
 
@@ -24,6 +24,8 @@
 
 typedef QMap<QString, QString> StringMap;
 Q_DECLARE_METATYPE(StringMap)
+
+Q_LOGGING_CATEGORY(treelandSd, "treeland.sd")
 
 class SignalReceiver : public QObject
 {
@@ -106,7 +108,7 @@ int main(int argc, char *argv[])
                     if (reply.type() == QDBusMessage::ReplyMessage) {
                         QVariantList values = reply.arguments();
                         if (values.size() < 2) {
-                            qWarning() << "Invalid XWaylandName reply";
+                            qCWarning(treelandSd) << "Invalid XWaylandName reply";
                             return;
                         }
                         QString xwaylandName = values.at(0).toString();
@@ -118,7 +120,7 @@ int main(int argc, char *argv[])
                         QTemporaryFile *authFile = new QTemporaryFile();
                         authFile->setFileTemplate(QStringLiteral("%1/.xauth_XXXXXX").arg(runtimeDir));
                         if (!authFile->open()) {
-                            qWarning() << "Failed to create temporary xauth file";
+                            qCWarning(treelandSd) << "Failed to create temporary xauth file";
                             return;
                         }
                         QString authFileName = authFile->fileName();

--- a/src/treeland-shortcut/shortcut.cpp
+++ b/src/treeland-shortcut/shortcut.cpp
@@ -15,7 +15,7 @@
 #include <QRegularExpression>
 #include <QStandardPaths>
 
-Q_LOGGING_CATEGORY(treelandShortcut, "daemon.shortcut", QtDebugMsg);
+Q_LOGGING_CATEGORY(treelandShortcutDaemon, "treeland.shortcut.daemon", QtDebugMsg)
 
 static const QMap<QString, ShortcutV2::action> ActionMap = {
     {"Notify", ShortcutV2::action_notify},
@@ -157,7 +157,7 @@ void ShortcutV2::treeland_shortcut_manager_v2_commit_success()
 
 void ShortcutV2::treeland_shortcut_manager_v2_commit_failure(const QString &name, uint32_t error)
 {
-    qCWarning(treelandShortcut) << "Commit failure for shortcut:" << name << ", error code:" << error;
+    qCWarning(treelandShortcutDaemon) << "Commit failure for shortcut:" << name << ", error code:" << error;
     Q_EMIT commitStatus(false);
 }
 
@@ -170,7 +170,7 @@ ShortcutV2::ShortcutV2()
     : QWaylandClientExtensionTemplate<ShortcutV2>(1)
 {
     connect(this, &ShortcutV2::activeChanged, this, [this] {
-        qCDebug(treelandShortcut) << "isActive:" << isActive();
+        qCDebug(treelandShortcutDaemon) << "isActive:" << isActive();
 
         if (isActive()) {
             acquire();
@@ -192,7 +192,7 @@ void ShortcutV2::registerAllShortcuts()
 {
     QDir dir(TREELAND_DATA_DIR "/shortcuts");
     for (auto d : dir.entryInfoList(QDir::Filter::Files)) {
-        qCInfo(treelandShortcut) << "Load shortcut:" << d.filePath();
+        qCInfo(treelandShortcutDaemon) << "Load shortcut:" << d.filePath();
         auto shortcut = new Shortcut(d.filePath(), d.fileName());
         shortcut->registerForManager(this);
         m_shortcuts.append(shortcut);
@@ -254,7 +254,7 @@ void Shortcut::registerForManager(ShortcutV2 *manager)
         if (ActionMap.contains(actionStr)) {
             action = ActionMap.value(actionStr);
         } else {
-            qCWarning(treelandShortcut) << "Unknown action:" << actionStr
+            qCWarning(treelandShortcutDaemon) << "Unknown action:" << actionStr
                                         << "for shortcut:" << m_shortcutName
                                         << ", shortcut registration skipped.";
             return;
@@ -285,7 +285,7 @@ void Shortcut::registerForManager(ShortcutV2 *manager)
         static const QRegularExpression regex(QStringLiteral("^(\\d+)Finger(.+)$"));
         const auto match = regex.match(gestureStr);
         if (!match.hasMatch()) {
-            qCWarning(treelandShortcut) << "Invalid gesture format:" << gestureStr;
+            qCWarning(treelandShortcutDaemon) << "Invalid gesture format:" << gestureStr;
             break;
         }
 
@@ -293,7 +293,7 @@ void Shortcut::registerForManager(ShortcutV2 *manager)
         const QString movement = match.captured(2);
         if (fingerCount < 2 || fingerCount > 4) {
             // unsupported by libinput
-            qCWarning(treelandShortcut) << "Unsupported finger count:" << fingerCount
+            qCWarning(treelandShortcutDaemon) << "Unsupported finger count:" << fingerCount
                                         << "for gesture:" << gestureStr;
             break;
         }
@@ -301,7 +301,7 @@ void Shortcut::registerForManager(ShortcutV2 *manager)
             manager->bind_hold_gesture(gestureName, fingerCount, action);
         } else {
             if (!GestureDirectionMap.contains(movement)) {
-                qCWarning(treelandShortcut) << "Unknown gesture movement:" << movement
+                qCWarning(treelandShortcutDaemon) << "Unknown gesture movement:" << movement
                                             << "for gesture:" << gestureStr;
                 break;
             }
@@ -314,7 +314,7 @@ void Shortcut::registerForManager(ShortcutV2 *manager)
     QObject::connect(manager, &ShortcutV2::commitStatus, this, [this, manager, type, &loop](bool success) {
         loop.quit();
         if (!success) {
-            qCWarning(treelandShortcut) << "Shortcut commit failed for shortcut:" << m_shortcutName;
+            qCWarning(treelandShortcutDaemon) << "Shortcut commit failed for shortcut:" << m_shortcutName;
             m_registeredBindings.clear();
         } else {
             // unbind on destroy

--- a/src/wallpaper/wallpapermanager.cpp
+++ b/src/wallpaper/wallpapermanager.cpp
@@ -437,7 +437,7 @@ void WallpaperManager::handleWallpaperSurfaceAdded([[maybe_unused]] TreelandWall
 {
     QList<QString> wallpapers = Helper::instance()->shellHandler()->wallpaperShell()->producedWallpapers();
     QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> globalWallpapers = globalValidWallpaper(nullptr, -1);
-    foreach (auto wallpaper, std::as_const(wallpapers)) {
+    for (const auto &wallpaper : std::as_const(wallpapers)) {
         if (!globalWallpapers.contains(wallpaper)) {
             Helper::instance()->m_wallpaperNotifierInterfaceV1->sendRemove(wallpaper);
         }

--- a/src/xwayland.cpp
+++ b/src/xwayland.cpp
@@ -16,17 +16,19 @@
  */
 
 #include <QByteArray>
-#include <QDebug>
+#include <QLoggingCategory>
 #include <QString>
 #include <QTemporaryFile>
 #include <random>
 #include <sys/stat.h>
 #include <X11/Xauth.h>
 
+Q_LOGGING_CATEGORY(treelandXwayland, "treeland.xwayland")
+
 int main(int argc, char *argv[])
 {
     if (argc < 2) {
-        qCritical() << "Usage: treeland-xwayland <display> [args]";
+        qCCritical(treelandXwayland) << "Usage: treeland-xwayland <display> [args]";
         return 1;
     }
     // Generate cookie
@@ -96,6 +98,6 @@ int main(int argc, char *argv[])
     args[argc + 1] = const_cast<char *>(fileName);
     args[argc + 2] = nullptr;
     execvp("Xwayland", args);
-    qWarning() << "execvp() returned";
+    qCWarning(treelandXwayland) << "execvp() returned";
     return 1;
 }

--- a/waylib/src/server/kernel/private/wserver_p.h
+++ b/waylib/src/server/kernel/private/wserver_p.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 JiDe Zhang <zhangjide@deepin.org>.
+// Copyright (C) 2023-2026 JiDe Zhang <zhangjide@deepin.org>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #pragma once
@@ -42,6 +42,8 @@ public:
 
     GlobalFilterFunc globalFilterFunc = nullptr;
     void *globalFilterFuncData = nullptr;
+
+    bool isProcessingEvents = false;
 };
 
 WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/kernel/wserver.cpp
+++ b/waylib/src/server/kernel/wserver.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 JiDe Zhang <zhangjide@deepin.org>.
+// Copyright (C) 2023-2026 JiDe Zhang <zhangjide@deepin.org>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include <QObject>
@@ -105,6 +105,11 @@ void WServerPrivate::init()
     int fd = wl_event_loop_get_fd(loop);
 
     auto processWaylandEvents = [this] {
+        if (isProcessingEvents)
+            return;
+
+        QScopedValueRollback<bool> guard(isProcessingEvents, true);
+
         int ret = wl_event_loop_dispatch(loop, 0);
         if (ret)
             fprintf(stderr, "wl_event_loop_dispatch error: %d\n", ret);
@@ -139,7 +144,9 @@ void WServerPrivate::stop()
     }
 
     sockNot.reset();
-    QThread::currentThread()->eventDispatcher()->disconnect(q);
+    if (auto dispatcher = QThread::currentThread()->eventDispatcher()) {
+        QObject::disconnect(dispatcher, nullptr, q, nullptr);
+    }
 }
 
 void WServerPrivate::initSocket(WSocket *socketServer)

--- a/waylib/src/server/kernel/wsurface.cpp
+++ b/waylib/src/server/kernel/wsurface.cpp
@@ -460,8 +460,16 @@ void WSurfacePrivate::instantRelease()
         handle()->disconnect(q);
         if (subsurface)
             subsurface->disconnect(q);
-        for (auto o : std::as_const(outputs))
+        // Leave all outputs before disconnecting to prevent use-after-free
+        // when outputs try to call leaveOutput on this destroyed surface
+        for (auto o : std::as_const(outputs)) {
+            // Check if surface handle is still valid before sending leave
+            if (handle()->handle()) {
+                wlr_surface_send_leave(handle()->handle(), o->handle()->handle());
+            }
             o->safeDisconnect(q);
+        }
+        outputs.clear();
     }
 }
 

--- a/waylib/src/server/protocols/winputmethodhelper.cpp
+++ b/waylib/src/server/protocols/winputmethodhelper.cpp
@@ -348,7 +348,14 @@ void WInputMethodHelper::handleNewTI(WTextInput *ti)
     connect(ti, &WTextInput::entityAboutToDestroy, this, [this, d, ti]{
         d->textInputs.removeAll(ti);
         disableTI(ti);
-        ti->disconnect();
+        // Do NOT call ti->disconnect() here: it would attempt to access
+        // the ConnectionData of sender objects (e.g. WSurface focusedSurface /
+        // enabledSurface) that wl_client_destroy may already have freed before
+        // reaching the text-input resource, causing a UAF SIGSEGV in
+        // QObjectPrivate::ConnectionData::removeConnection (fetch_sub on freed
+        // memory).  The QObject destructor invoked by delete text_input in
+        // handle_text_input_resource_destroy will clean up all connections
+        // safely once the sender objects have finished tearing down.
     }); // textInputs only save and traverse text inputs, do not handle connections
     // Whether this text input belongs to current seat or not, we should connect
     // its requestFocus signal for it might request focus from another seat to activate

--- a/waylib/src/server/qtquick/private/wbufferrenderer.cpp
+++ b/waylib/src/server/qtquick/private/wbufferrenderer.cpp
@@ -435,8 +435,19 @@ void WBufferRenderer::render(int sourceIndex, const QMatrix4x4 &renderMatrix,
 {
     Q_ASSERT(state.buffer);
 
+    // Check if sourceIndex is valid
+    if (sourceIndex >= m_sourceList.size()) {
+        qWarning() << "WBufferRenderer::render: sourceIndex out of range, skipping render";
+        return;
+    }
+
     const auto &source = m_sourceList.at(sourceIndex);
     QSGRenderer *renderer = ensureRenderer(sourceIndex, state.context);
+    // Check if renderer is valid - it can be null if the source was destroyed
+    if (!renderer) {
+        qWarning() << "WBufferRenderer::render: renderer is null, skipping render";
+        return;
+    }
     auto wd = QQuickWindowPrivate::get(window());
 
     const qreal devicePixelRatio = state.devicePixelRatio;

--- a/waylib/src/server/qtquick/wsurfaceitem.cpp
+++ b/waylib/src/server/qtquick/wsurfaceitem.cpp
@@ -219,8 +219,18 @@ public:
             surface = nullptr;
         }
 
-        if (frameDoneConnection)
-            QObject::disconnect(frameDoneConnection);
+        // Only disconnect if the connection is still valid
+        // It may have already been disconnected by ~WSurfaceItemContent
+        if (frameDoneConnection) {
+            // Check if the connection is still valid before disconnecting
+            // Use a try-catch equivalent by checking if the connection points to valid objects
+            auto conn = frameDoneConnection;
+            if (conn) {
+                // Reset the connection first to prevent double-disconnect issues
+                frameDoneConnection = QMetaObject::Connection();
+                QObject::disconnect(conn);
+            }
+        }
 
         Q_ASSERT(!updateTextureConnection);
 
@@ -670,7 +680,16 @@ WSurfaceItem::WSurfaceItem(WSurfaceItemPrivate &dd, QQuickItem *parent)
 
 WSurfaceItem::~WSurfaceItem()
 {
-
+    // Clear the surface reference before destruction to prevent
+    // QML property bindings from trying to write to a destroyed object
+    // This fixes crashes when QML bindings try to update properties
+    // on a WXWaylandSurfaceItem that is being destroyed
+    Q_D(WSurfaceItem);
+    if (d->surface) {
+        d->surface = nullptr;
+        // Also disconnect signals to prevent any pending callbacks
+        releaseResources();
+    }
 }
 
 QRectF WSurfaceItem::boundingRect() const


### PR DESCRIPTION
在这里我将以下堆栈喂给了Claude Opus 4.6然后得到了对应的修复方案（4月15日的4个提交）, 个人使用到现在感觉良好, 故在这个PR放了出来以便参考（

## Summary by Sourcery

Improve stability of Wayland surfaces, capture sessions, and input handling by adding lifetime guards, safer destruction paths, and stricter validity checks, while also cleaning up logging categories and some headers.

Bug Fixes:
- Prevent double-disconnect and invalid connection access when tearing down WSurfaceItem frame callbacks.
- Avoid QML bindings and callbacks writing to destroyed WSurfaceItem surfaces by clearing references and releasing resources in the destructor.
- Fix potential use-after-free in capture v1 objects by switching to deleteLater(), nulling wl_resource pointers, and guarding wl_resource_destroy calls on client destruction.
- Eliminate use-after-free of SurfaceWrapper surface items by explicitly deleting and nulling m_surfaceItem during wrapper teardown and removal.
- Guard WBufferRenderer rendering against out-of-range source indices and null renderers to prevent crashes.
- Ensure WSurface outputs are left safely before disconnecting and clear the outputs list to avoid callbacks into destroyed surfaces.
- Avoid dangerous QObject::disconnect usage in WInputMethodHelper text input teardown that could access freed connection data.
- Guard WServer event processing against re-entrancy and safely disconnect the event dispatcher on stop.
- Fix possible null dereferences in capture selection and surface conversion paths by validating shellSurface, surface, and canvas pointers.
- Remove unnecessary concurrent NVIDIA detection in Helper::createNormalOutput and make software cursor forcing deterministic.
- Guard wl_resource_destroy calls in capture context/session/frame against null resources to avoid double-destroy issues.

Enhancements:
- Standardize and refine logging categories for shortcuts, gestures, systemd socket helper, Xwayland launcher, and QML engine errors.
- Simplify and modernize several headers by replacing include guards with pragma once.
- Improve wallpaper handling iteration style for clarity and const-correctness.
- Track NVIDIA presence once in Helper to reuse the result for subsequent outputs.