### PR TITLE
fix: prevent crash during Wayland client destruction

### DIFF
--- a/waylib/src/server/kernel/wsocket.cpp
+++ b/waylib/src/server/kernel/wsocket.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 JiDe Zhang <zhangjide@deepin.org>.
+// Copyright (C) 2023-2026 JiDe Zhang <zhangjide@deepin.org>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wsocket.h"
@@ -174,20 +174,25 @@ struct Q_DECL_HIDDEN WlClientDestroyListener {
         : client(client)
     {
         destroy.notify = handle_destroy;
+        destroy_late.notify = handle_destroy_late;
     }
 
     ~WlClientDestroyListener();
 
     static WlClientDestroyListener *get(const wl_client *client);
+    static WlClientDestroyListener *get_late(const wl_client *client);
     static void handle_destroy(struct wl_listener *listener, void *);
+    static void handle_destroy_late(struct wl_listener *listener, void *);
 
     wl_listener destroy;
+    wl_listener destroy_late;
     QPointer<WClient> client;
 };
 
 WlClientDestroyListener::~WlClientDestroyListener()
 {
     wl_list_remove(&destroy.link);
+    wl_list_remove(&destroy_late.link);
 }
 
 WlClientDestroyListener *WlClientDestroyListener::get(const wl_client *client)
@@ -199,6 +204,18 @@ WlClientDestroyListener *WlClientDestroyListener::get(const wl_client *client)
     }
 
     WlClientDestroyListener *tmp = wl_container_of(listener, tmp, destroy);
+    return tmp;
+}
+
+WlClientDestroyListener *WlClientDestroyListener::get_late(const wl_client *client)
+{
+    wl_listener *listener = wl_client_get_destroy_listener(const_cast<wl_client*>(client),
+                                                           WlClientDestroyListener::handle_destroy_late);
+    if (!listener) {
+        return nullptr;
+    }
+
+    WlClientDestroyListener *tmp = wl_container_of(listener, tmp, destroy_late);
     return tmp;
 }
 
@@ -259,6 +276,7 @@ public:
     {
         auto listener = new WlClientDestroyListener(qq);
         wl_client_add_destroy_listener(handle, &listener->destroy);
+        wl_client_add_destroy_late_listener(handle, &listener->destroy_late);
     }
 
     ~WClientPrivate() {
@@ -267,6 +285,8 @@ public:
 
         if (handle) {
             auto listener = WlClientDestroyListener::get(handle);
+            if (!listener)
+                listener = WlClientDestroyListener::get_late(handle);
             Q_ASSERT(listener);
             delete listener;
         }
@@ -286,11 +306,22 @@ void WlClientDestroyListener::handle_destroy(wl_listener *listener, void *data)
     WlClientDestroyListener *self = wl_container_of(listener, self, destroy);
     if (self->client && self->client->handle()) {
         Q_ASSERT(reinterpret_cast<wl_client*>(data) == self->client->handle());
-        self->client->d_func()->handle = nullptr;
-        auto socket = self->client->socket();
+        auto client = self->client.data();
+        auto socket = client->socket();
         Q_ASSERT(socket);
-        bool ok = socket->removeClient(self->client);
-        Q_ASSERT(ok);
+        // Remove from list without emitting Qt signals to avoid event loop reentrancy.
+        // WClient deletion is still deferred to handle_destroy_late until resources are destroyed.
+        WSocketPrivate *socketPrivate = WSocketPrivate::get(socket);
+        socketPrivate->clients.removeOne(client);
+        client->d_func()->handle = nullptr;
+    }
+}
+
+void WlClientDestroyListener::handle_destroy_late(wl_listener *listener, [[maybe_unused]] void *data)
+{
+    WlClientDestroyListener *self = wl_container_of(listener, self, destroy_late);
+    if (self->client) {
+        delete self->client.data();
     }
 
     delete self;

--- a/waylib/src/server/protocols/private/wtextinputv1.cpp
+++ b/waylib/src/server/protocols/private/wtextinputv1.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Yixue Wang <wangyixue@deepin.org>.
+// Copyright (C) 2023-2026 Yixue Wang <wangyixue@deepin.org>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wtextinputv1_p.h"
@@ -400,9 +400,7 @@ void text_input_manager_get_text_input(wl_client *client, wl_resource *resource,
         return;
     }
     d->resource = text_input_resource;
-    QObject::connect(text_input->waylandClient(), &WClient::destroyed, text_input, [text_input] {
-        wl_resource_destroy(text_input->d_func()->resource);
-    });
+    // wl_client_destroy handles resource destruction via wl_map_for_each.
     wl_resource_set_implementation(text_input_resource, &text_input_v1_impl, text_input, text_input_resource_destroy);
     manager->d_func()->textInputs.append(text_input);
     QObject::connect(text_input, &WTextInputV1::entityAboutToDestroy, manager, [manager, text_input]{
@@ -425,14 +423,11 @@ static void text_input_manager_bind(wl_client *wl_client, void *data, uint32_t v
 {
     WTextInputManagerV1 *manager = reinterpret_cast<WTextInputManagerV1 *>(data);
     wl_resource *resource = wl_resource_create(wl_client, &zwp_text_input_manager_v1_interface, version, id);
-    WClient *wClient = WClient::get(wl_client);
-    QObject::connect(wClient, &WClient::destroyed, manager, [resource]{
-        wl_resource_destroy(resource);
-    });
     if (!resource) {
         wl_client_post_no_memory(wl_client);
         return;
     }
+    // wl_client_destroy handles resource destruction via wl_map_for_each.
     wl_resource_set_implementation(resource, &text_input_manager_v1_impl, manager, nullptr);
 }
 

--- a/waylib/src/server/protocols/private/wtextinputv2.cpp
+++ b/waylib/src/server/protocols/private/wtextinputv2.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Yixue Wang <wangyixue@deepin.org>.
+// Copyright (C) 2024-2026 Yixue Wang <wangyixue@deepin.org>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wtextinputv2_p.h"
@@ -127,10 +127,7 @@ void text_input_manager_bind(wl_client *client,
         wl_client_post_no_memory(client);
         return;
     }
-    WClient *wClient = WClient::get(client);
-    QObject::connect(wClient, &WClient::destroyed, manager, [resource]{
-        wl_resource_destroy(resource);
-    });
+    // wl_client_destroy handles resource destruction via wl_map_for_each.
     wl_resource_set_implementation(resource, &manager_impl, manager, nullptr);
 }
 
@@ -182,9 +179,7 @@ void handle_manager_get_text_input(wl_client *client,
     Q_ASSERT(wSeat);
     text_input->d_func()->client = wClient;
     text_input->d_func()->seat = wSeat;
-    QObject::connect(wClient, &WClient::destroyed, text_input, [text_input_resource] {
-        wl_resource_destroy(text_input_resource);
-    });
+    // wl_client_destroy handles resource destruction via wl_map_for_each.
     wl_resource_set_implementation(text_input_resource, &text_input_impl, text_input, handle_text_input_resource_destroy);
     manager->d_func()->textInputs.append(text_input);
     QObject::connect(text_input, &WTextInput::entityAboutToDestroy, manager, [manager, text_input]{


### PR DESCRIPTION
Root Cause:
When wl_client_destroy() is called, it first emits destroy_signal, then iterates all resources via wl_map_for_each() to destroy them. The original code deleted WClient in the destroy_signal handler, which triggered WClient::destroyed signal. Business code connected to this signal called wl_resource_destroy(), modifying the wl_map while it was being iterated, causing use-after-free crash.

Call chain that caused crash:
  wl_client_destroy()
    → destroy_signal
      → delete WClient
        → WClient::destroyed
          → wl_resource_destroy()  ← modifies wl_map
    → wl_map_for_each()  ← iterates corrupted wl_map → crash!

Fix:
1. Add destroy_late_signal listener to delay WClient deletion until after all resources are destroyed by wl_map_for_each().
2. Remove dangerous signal connections that called wl_resource_destroy() in WClient::destroyed handlers (wtextinputv1/v2).
3. Directly manipulate socket's client list without emitting Qt signals to avoid event loop reentrancy during Wayland callbacks.

After fix:
  wl_client_destroy()
    → destroy_signal: only clear handle pointer
    → wl_map_for_each(): safely destroy all resources
    → destroy_late_signal: delete WClient
      → WClient::destroyed (no wl_resource_destroy calls)

## Summary by Sourcery

Delay WClient destruction to align with Wayland's two-phase client destroy sequence and prevent use-after-free crashes when wl_client_destroy iterates and frees resources.

Bug Fixes:
- Prevent crashes caused by wl_resource_destroy being invoked during Wayland client destroy_signal handling, which previously corrupted wl_map iteration.

Enhancements:
- Introduce a separate late destroy listener for Wayland clients so WClient objects are deleted only after all Wayland resources have been cleaned up.
- Stop emitting Qt signals when removing clients from WSocket and instead manipulate the internal client list directly to avoid event loop reentrancy issues.
- Simplify text-input protocol resource lifetime management by relying on wl_client_destroy to clean up Wayland resources instead of WClient::destroyed handlers.