### PR TITLE
fix: check if surface is about to be removed

### DIFF
--- a/src/surface/surfacecontainer.cpp
+++ b/src/surface/surfacecontainer.cpp
@@ -221,6 +221,10 @@ void SurfaceContainer::geometryChange(const QRectF &newGeo, const QRectF &oldGeo
 
 bool SurfaceContainer::doAddSurface(SurfaceWrapper *surface, bool setContainer)
 {
+	// Check if surface is about to be removed to avoid accessing invalid state
+    if (surface->isWrapperAboutToRemove())
+        return false;
+
     if (m_model->hasSurface(surface))
         return false;
 

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -195,6 +195,9 @@ public:
     bool isAnimationRunning() const;
     bool isWindowAnimationRunning() const;
 
+	// Check if wrapper is about to be removed
+    bool isWrapperAboutToRemove() const { return m_wrapperAboutToRemove; }
+
     qreal radius() const;
     void setRadius(qreal newRadius);
 


### PR DESCRIPTION
当你先打开Xwayland运行的QQ,微信(两者先都不按下登录键)预备, 接着以飞快的手速同时按下微信和QQ的登录键,随后再立刻按开Xwayland运行的有道云笔记时。伴随着QQ/微信的窗口消失再出现其应用对应的主界面,和有道云笔记也同时出现主界面时,treeland一定崩溃。该提交用于修复Xwayland窗口因为用户飞快的操作手速,而同时进行出现/消失时引起invalid state

## Summary by Sourcery

Bug Fixes:
- Guard against adding a surface whose wrapper is about to be removed, preventing crashes caused by rapid Xwayland window creation and destruction.