### PR TITLE
fix: use globalRemove to implement WServerInterface::destroy

### DIFF
--- a/src/modules/app-id-resolver/appidresolver.cpp
+++ b/src/modules/app-id-resolver/appidresolver.cpp
@@ -155,6 +155,11 @@ bool AppIdResolverManager::resolvePidfd(int pidfd, std::function<void(const QStr
     return true;
 }
 
+void AppIdResolverManager::destroy_global()
+{
+    delete this;
+}
+
 // ---------------- WServerInterface -----------------
 
 void AppIdResolverManager::create(WServer *server)

--- a/src/modules/app-id-resolver/appidresolver.h
+++ b/src/modules/app-id-resolver/appidresolver.h
@@ -70,6 +70,7 @@ Q_SIGNALS:
     void availableChanged();
 
 protected: // protocol generated virtuals
+    void destroy_global() override;
     void destroy(Resource *resource) override;
     void get_resolver(Resource *resource, uint32_t id) override;
 

--- a/src/modules/dde-shell/ddeshellmanagerinterfacev1.cpp
+++ b/src/modules/dde-shell/ddeshellmanagerinterfacev1.cpp
@@ -35,6 +35,7 @@ public:
     DDEShellManagerInterfaceV1 *q;
 
 protected:
+    void destroy_global() override;
     void get_window_overlap_checker(Resource *resource, uint32_t id) override;
     void get_shell_surface(Resource *resource, uint32_t id, struct ::wl_resource *surface) override;
     void get_treeland_dde_active(Resource *resource, uint32_t id, struct ::wl_resource *seat) override;
@@ -88,6 +89,11 @@ DDEShellManagerInterfaceV1Private::DDEShellManagerInterfaceV1Private(DDEShellMan
 wl_global *DDEShellManagerInterfaceV1Private::global() const
 {
     return m_global;
+}
+
+void DDEShellManagerInterfaceV1Private::destroy_global()
+{
+    delete q;
 }
 
 void DDEShellManagerInterfaceV1Private::get_window_overlap_checker(Resource *resource,
@@ -244,7 +250,7 @@ void DDEShellManagerInterfaceV1::create(WServer *server)
 
 void DDEShellManagerInterfaceV1::destroy([[maybe_unused]] WServer *server)
 {
-    d = nullptr;
+    d->globalRemove();
 }
 
 wl_global *DDEShellManagerInterfaceV1::global() const

--- a/src/modules/keystate/keystate.cpp
+++ b/src/modules/keystate/keystate.cpp
@@ -31,6 +31,7 @@ public:
     QMetaObject::Connection m_keyboardConnection{};
 
 protected:
+    void destroy_global() override;
     void destroy(Resource *resource) override;
     void fetchStates(Resource *resource) override;
 };
@@ -60,6 +61,11 @@ void KeyStateV5Private::setKeyboard(WInputDevice *keyboard)
     for (const auto &resource : resources) {
         fetchStates(resource);
     }
+}
+
+void KeyStateV5Private::destroy_global()
+{
+    delete q;
 }
 
 void KeyStateV5Private::destroy(Resource *resource)
@@ -155,6 +161,7 @@ void KeyStateV5::create(WServer *server)
 
 void KeyStateV5::destroy([[maybe_unused]] WServer *server)
 {
+    d->globalRemove();
 }
 
 wl_global *KeyStateV5::global() const

--- a/src/modules/output-manager/outputmanagement.cpp
+++ b/src/modules/output-manager/outputmanagement.cpp
@@ -149,6 +149,7 @@ public:
     OutputManagerV1 *q;
 
 protected:
+    void destroy_global() override;
     void bind_resource(Resource *resource) override;
     void destroy(Resource *resource) override;
 
@@ -164,6 +165,11 @@ OutputManagerV1Private::OutputManagerV1Private(OutputManagerV1 *_q)
 wl_global *OutputManagerV1Private::global() const
 {
     return m_global;
+}
+
+void OutputManagerV1Private::destroy_global()
+{
+    delete q;
 }
 
 void OutputManagerV1Private::bind_resource(Resource *resource)
@@ -236,7 +242,10 @@ void OutputManagerV1::create(WServer *server)
     d->init(server->handle()->handle(), TREELAND_OUTPUT_MANAGER_V1_VERSION);
 }
 
-void OutputManagerV1::destroy([[maybe_unused]] WServer *server) { }
+void OutputManagerV1::destroy([[maybe_unused]] WServer *server)
+{
+    d->globalRemove();
+}
 
 wl_global *OutputManagerV1::global() const
 {

--- a/src/modules/prelaunch-splash/prelaunchsplash.cpp
+++ b/src/modules/prelaunch-splash/prelaunchsplash.cpp
@@ -81,6 +81,11 @@ public:
     }
 
 protected:
+    void destroy_global() override
+    {
+        delete q;
+    }
+
     void destroy(Resource *resource) override
     {
         wl_resource_destroy(resource->handle);
@@ -135,8 +140,6 @@ void PrelaunchSplash::create(WAYLIB_SERVER_NAMESPACE::WServer *server)
 void PrelaunchSplash::destroy(WAYLIB_SERVER_NAMESPACE::WServer *server)
 {
     Q_UNUSED(server);
-    if (!d->isGlobal())
-        return;
     d->globalRemove();
     qCDebug(prelaunchSplash) << "PrelaunchSplash v2 global removed";
 }

--- a/src/modules/shortcut/shortcutmanager.cpp
+++ b/src/modules/shortcut/shortcutmanager.cpp
@@ -100,6 +100,7 @@ public:
     WSocket* m_activeSessionSocket = nullptr;
 
 protected:
+    void destroy_global() override;
     void destroy_resource(Resource *resource) override;
     void destroy(Resource *resource) override;
     void acquire(Resource *resource) override;
@@ -216,6 +217,11 @@ void ShortcutManagerV2Private::sendInvalidCommit(WSocket *socket)
     wl_resource_post_error(resource->handle,
                            error_invalid_commit,
                            "Commit sent before last commit is processed.");
+}
+
+void ShortcutManagerV2Private::destroy_global()
+{
+    delete q;
 }
 
 void ShortcutManagerV2Private::destroy_resource(Resource *resource)
@@ -390,6 +396,7 @@ void ShortcutManagerV2::create(WServer *server)
 void ShortcutManagerV2::destroy(WServer *server)
 {
     Q_UNUSED(server);
+    d->globalRemove();
     Q_EMIT before_destroy();
 }
 

--- a/src/modules/virtual-output/virtualoutputmanagerinterfacev1.cpp
+++ b/src/modules/virtual-output/virtualoutputmanagerinterfacev1.cpp
@@ -194,7 +194,7 @@ void VirtualOutputManagerInterfaceV1::create(WServer *server)
 }
 
 void VirtualOutputManagerInterfaceV1::destroy([[maybe_unused]] WServer *server) {
-    d = nullptr;
+    d->globalRemove();
 }
 
 wl_global *VirtualOutputManagerInterfaceV1::global() const

--- a/src/modules/wallpaper-color/wallpapercolorinterfacev1.cpp
+++ b/src/modules/wallpaper-color/wallpapercolorinterfacev1.cpp
@@ -103,7 +103,7 @@ void WallpaperColorInterfaceV1::create(WServer *server)
 }
 
 void WallpaperColorInterfaceV1::destroy([[maybe_unused]] WServer *server) {
-    d = nullptr;
+    d->globalRemove();
 }
 
 wl_global *WallpaperColorInterfaceV1::global() const

--- a/src/modules/wallpaper/wallpapermanagerinterfacev1.cpp
+++ b/src/modules/wallpaper/wallpapermanagerinterfacev1.cpp
@@ -117,7 +117,7 @@ void TreelandWallpaperManagerInterfaceV1::create(WServer *server)
 
 void TreelandWallpaperManagerInterfaceV1::destroy([[maybe_unused]] WServer *server)
 {
-    d = nullptr;
+    d->globalRemove();
 }
 
 wl_global *TreelandWallpaperManagerInterfaceV1::global() const

--- a/src/modules/wallpaper/wallpapernotifierinterfacev1.cpp
+++ b/src/modules/wallpaper/wallpapernotifierinterfacev1.cpp
@@ -83,7 +83,7 @@ void TreelandWallpaperNotifierInterfaceV1::create(WServer *server)
 
 void TreelandWallpaperNotifierInterfaceV1::destroy([[maybe_unused]] WServer *server)
 {
-    d = nullptr;
+    d->globalRemove();
 }
 
 wl_global *TreelandWallpaperNotifierInterfaceV1::global() const

--- a/src/modules/wallpaper/wallpapershellinterfacev1.cpp
+++ b/src/modules/wallpaper/wallpapershellinterfacev1.cpp
@@ -101,7 +101,7 @@ void TreelandWallpaperShellInterfaceV1::create(WServer *server)
 
 void TreelandWallpaperShellInterfaceV1::destroy([[maybe_unused]] WServer *server)
 {
-    d = nullptr;
+    d->globalRemove();
 }
 
 wl_global *TreelandWallpaperShellInterfaceV1::global() const

--- a/src/modules/window-management/windowmanagementinterfacev1.cpp
+++ b/src/modules/window-management/windowmanagementinterfacev1.cpp
@@ -116,7 +116,7 @@ void WindowManagementInterfaceV1::create(WServer *server)
 }
 
 void WindowManagementInterfaceV1::destroy([[maybe_unused]] WServer *server) {
-    d = nullptr;
+    d->globalRemove();
 }
 
 wl_global *WindowManagementInterfaceV1::global() const


### PR DESCRIPTION
Destruct the protocol class in `destroy_global`.

Log: use globalRemove to implement WServerInterface::destroy

Influence:

## Summary by Sourcery

Align server interface destruction with Wayland global lifecycle for various protocol managers.

Bug Fixes:
- Ensure WServerInterface::destroy properly removes associated Wayland globals instead of leaving dangling pointers or no-ops.

Enhancements:
- Implement destroy_global hooks in multiple protocol manager private classes to delete their public wrappers when the Wayland global is destroyed.
- Standardize use of globalRemove() in destroy methods across output, shell, keystate, shortcut, app-id resolver, prelaunch splash, wallpaper, virtual output, and window management interfaces to centralize global teardown behavior.