### PR TITLE
refactor: privatize generated protocol implementations

### DIFF
--- a/src/modules/app-id-resolver/CMakeLists.txt
+++ b/src/modules/app-id-resolver/CMakeLists.txt
@@ -11,7 +11,7 @@ impl_treeland(
     SOURCE
         appidresolver.h
         appidresolver.cpp
-    ${CMAKE_BINARY_DIR}/src/modules/app-id-resolver/wayland-treeland-app-id-resolver-v1-server-protocol.c
+        ${CMAKE_BINARY_DIR}/src/modules/app-id-resolver/wayland-treeland-app-id-resolver-v1-server-protocol.c
     INCLUDE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     LINK

--- a/src/modules/app-id-resolver/appidresolver.cpp
+++ b/src/modules/app-id-resolver/appidresolver.cpp
@@ -3,186 +3,201 @@
 
 #include "appidresolver.h"
 
+#include "qwayland-server-treeland-app-id-resolver-v1.h"
+
 #include <wserver.h>
 
 #include <qwdisplay.h>
 
+#include <QHash>
 #include <QLoggingCategory>
 
 #include <fcntl.h>
 #include <unistd.h>
-#include <errno.h>
-#include <string.h>
 #include <utility>
 
 Q_LOGGING_CATEGORY(treelandAppIdResolver, "treeland.appid.resolver", QtInfoMsg)
 
-AppIdResolver::AppIdResolver(AppIdResolverManager *manager,
-                             wl_client *client,
-                             int version,
-                             uint32_t id)
-    : QObject(manager)
-    , m_manager(manager)
+#define TREELAND_APP_ID_RESOLVER_MANAGER_V1_VERSION 1
+
+WAYLIB_SERVER_USE_NAMESPACE
+
+class AppIdResolver
+    : public QObject
+    , public QtWaylandServer::treeland_app_id_resolver_v1
 {
-    init(client, id, version);
-}
-
-AppIdResolver::~AppIdResolver() = default;
-
-void AppIdResolver::destroy(Resource *resource)
-{
-    wl_resource_destroy(resource->handle);
-}
-
-void AppIdResolver::destroy_resource(Resource *resource)
-{
-    Q_UNUSED(resource);
-    m_alive = false;
-    Q_EMIT disconnected();
-}
-
-void AppIdResolver::respond(Resource *resource,
-                            uint32_t request_id,
-                            const QString &app_id,
-                            const QString &sandboxEngineName)
-{
-    Q_UNUSED(resource);
-    Q_UNUSED(sandboxEngineName);
-    Q_EMIT resolved(request_id, app_id);
-}
-
-uint32_t AppIdResolver::requestResolve(int pidfd)
-{
-    if (!m_alive || pidfd < 0)
-        return 0;
-    int dupfd = fcntl(pidfd, F_DUPFD_CLOEXEC, 0);
-    if (dupfd < 0)
-        return 0;
-    uint32_t id = m_nextRequestId++;
-    send_identify_request(id, dupfd);
-    return id;
-}
-
-// ---------------- Manager -----------------
-
-AppIdResolverManager::AppIdResolverManager(QObject *parent)
-    : QObject(parent)
-{
-}
-
-void AppIdResolverManager::createGlobal(wl_display *display)
-{
-    if (m_display)
-        return;
-    m_display = display;
-    init(m_display, 1);
-    // QtWaylandServer base class sets up global internally; we cannot get wl_global* directly.
-    qCDebug(treelandAppIdResolver) << "AppIdResolverManager global created";
-}
-
-void AppIdResolverManager::removeGlobal()
-{
-    if (!m_display)
-        return;
-    globalRemove();
-    m_display = nullptr;
-    qCDebug(treelandAppIdResolver) << "AppIdResolverManager global removed";
-}
-
-void AppIdResolverManager::destroy(Resource *resource)
-{
-    wl_resource_destroy(resource->handle);
-}
-
-void AppIdResolverManager::get_resolver(Resource *resource,
-                                                                            uint32_t id)
-{
-    qCDebug(treelandAppIdResolver) << "get_resolver called (client id):" << id;
-    if (m_resolver) {
-        wl_resource_post_error(resource->handle,
-                               WL_DISPLAY_ERROR_INVALID_OBJECT,
-                               "resolver already exists");
-        return;
+public:
+    AppIdResolver(QObject *parent, wl_client *client, int version, uint32_t id)
+        : QObject(parent)
+        , QtWaylandServer::treeland_app_id_resolver_v1(client, id, version)
+    {
     }
-    m_resolver = new AppIdResolver(this, resource->client(), resource->version(), id);
-    connect(m_resolver, &AppIdResolver::resolved, this, &AppIdResolverManager::handleResolved);
-    connect(m_resolver, &AppIdResolver::disconnected, this, &AppIdResolverManager::resolverGone);
-    Q_EMIT availableChanged();
-    qCDebug(treelandAppIdResolver) << "Resolver bound";
-}
 
-void AppIdResolverManager::resolverGone()
-{
-    if (!m_resolver)
-        return;
-    // All pending requests (signalOnly and callback) return empty appId on resolver loss
-    // Copy out pending callbacks and ids to avoid iterator invalidation or reentrancy issues
-    auto callbacks = m_callbacks.values();
-    // Clear internal state before emitting callbacks to avoid reentrancy issues
-    m_callbacks.clear();
-    // Emit results for previously pending callbacks
-    for (auto &cb : std::as_const(callbacks)) {
-        if (cb)
-            cb(QString());
+    uint32_t requestResolve(int pidfd)
+    {
+        if (!m_alive || pidfd < 0)
+            return 0;
+        int dupfd = fcntl(pidfd, F_DUPFD_CLOEXEC, 0);
+        if (dupfd < 0)
+            return 0;
+        uint32_t id = m_nextRequestId++;
+        send_identify_request(id, dupfd);
+        return id;
     }
-    // Prevent any late signal emissions during queued deletion
-    QObject::disconnect(m_resolver, nullptr, this, nullptr);
-    m_resolver->deleteLater();
-    m_resolver = nullptr;
-    Q_EMIT availableChanged();
-}
 
-void AppIdResolverManager::handleResolved(uint32_t id, const QString &appId)
+    std::function<void(uint32_t, const QString &)> onResolved;
+    std::function<void()> onDisconnected;
+
+protected:
+    void destroy(Resource *resource) override
+    {
+        wl_resource_destroy(resource->handle);
+    }
+
+    void destroy_resource([[maybe_unused]] Resource *resource) override
+    {
+        m_alive = false;
+        if (onDisconnected)
+            onDisconnected();
+    }
+
+    void respond([[maybe_unused]] Resource *resource,
+                 uint32_t request_id,
+                 const QString &app_id,
+                 [[maybe_unused]] const QString &sandboxEngineName) override
+    {
+        if (onResolved)
+            onResolved(request_id, app_id);
+    }
+
+private:
+    bool m_alive = true;
+    uint32_t m_nextRequestId = 1;
+};
+
+class AppIdResolverManagerPrivate : public QtWaylandServer::treeland_app_id_resolver_manager_v1
 {
-    auto it = m_callbacks.find(id);
-    if (it != m_callbacks.end()) {
+public:
+    explicit AppIdResolverManagerPrivate(AppIdResolverManager *q)
+        : q(q)
+    {
+    }
+
+    bool resolvePidfd(int pidfd, std::function<void(const QString &)> callback)
+    {
+        if (!m_resolver)
+            return false;
+        uint32_t id = m_resolver->requestResolve(pidfd);
+        if (id == 0)
+            return false;
+        m_callbacks.insert(id, std::move(callback));
+        return true;
+    }
+
+    wl_global *globalHandle() const
+    {
+        return m_global;
+    }
+
+private:
+    AppIdResolverManager *q = nullptr;
+    AppIdResolver *m_resolver = nullptr;
+    QHash<uint32_t, std::function<void(const QString &)>> m_callbacks;
+
+    void resolverGone()
+    {
+        if (!m_resolver)
+            return;
+        // All pending requests return empty appId when resolver disappears.
+        auto callbacks = m_callbacks.values();
+        m_callbacks.clear();
+        for (auto &cb : std::as_const(callbacks)) {
+            if (cb)
+                cb(QString());
+        }
+        QObject::disconnect(m_resolver, nullptr, q, nullptr);
+        m_resolver->deleteLater();
+        m_resolver = nullptr;
+        Q_EMIT q->availableChanged();
+    }
+
+    void handleResolved(uint32_t id, const QString &appId)
+    {
+        auto it = m_callbacks.find(id);
+        if (it == m_callbacks.end())
+            return;
+
         auto cb = it.value();
         m_callbacks.erase(it);
         if (cb)
             cb(appId);
-        return;
     }
+
+protected:
+    void destroy_global() override
+    {
+        qCDebug(treelandAppIdResolver) << "AppIdResolverManager global destroyed";
+        delete q;
+    }
+
+    void destroy(Resource *resource) override
+    {
+        wl_resource_destroy(resource->handle);
+    }
+
+    void get_resolver(Resource *resource, uint32_t id) override
+    {
+        qCDebug(treelandAppIdResolver) << "get_resolver called (client id):" << id;
+        if (m_resolver) {
+            wl_resource_post_error(resource->handle,
+                                   WL_DISPLAY_ERROR_INVALID_OBJECT,
+                                   "resolver already exists");
+            return;
+        }
+
+        m_resolver = new AppIdResolver(q, resource->client(), resource->version(), id);
+        m_resolver->onResolved = [this](uint32_t requestId, const QString &appId) {
+            handleResolved(requestId, appId);
+        };
+        m_resolver->onDisconnected = [this]() {
+            resolverGone();
+        };
+        Q_EMIT q->availableChanged();
+        qCDebug(treelandAppIdResolver) << "Resolver bound";
+    }
+};
+
+AppIdResolverManager::AppIdResolverManager(QObject *parent)
+    : QObject(parent)
+    , d(new AppIdResolverManagerPrivate(this))
+{
 }
+
+AppIdResolverManager::~AppIdResolverManager() = default;
 
 bool AppIdResolverManager::resolvePidfd(int pidfd, std::function<void(const QString &)> callback)
 {
-    if (!m_resolver)
-        return false;
-    uint32_t id = m_resolver->requestResolve(pidfd);
-    if (id == 0)
-        return false;
-    m_callbacks.insert(id, std::move(callback));
-    return true;
+    return d->resolvePidfd(pidfd, std::move(callback));
 }
-
-void AppIdResolverManager::destroy_global()
-{
-    delete this;
-}
-
-// ---------------- WServerInterface -----------------
 
 void AppIdResolverManager::create(WServer *server)
 {
-    if (!server || m_display)
-        return;
-    createGlobal(*server->handle());
+    d->init(*server->handle(), TREELAND_APP_ID_RESOLVER_MANAGER_V1_VERSION);
+    qCDebug(treelandAppIdResolver) << "AppIdResolverManager global created";
 }
 
-void AppIdResolverManager::destroy(WServer *server)
+void AppIdResolverManager::destroy([[maybe_unused]] WServer *server)
 {
-    Q_UNUSED(server);
-    removeGlobal();
+    d->globalRemove();
+    qCDebug(treelandAppIdResolver) << "AppIdResolverManager global removal scheduled";
 }
 
 wl_global *AppIdResolverManager::global() const
 {
-    // QtWayland private base does not expose the wl_global. Returning nullptr is acceptable;
-    // other modules in tree also sometimes return handle->global. We can't here.
-    return nullptr;
+    return d->globalHandle();
 }
 
 QByteArrayView AppIdResolverManager::interfaceName() const
 {
-    return "treeland_app_id_resolver_manager_v1";
+    return QtWaylandServer::treeland_app_id_resolver_manager_v1::interfaceName();
 }

--- a/src/modules/app-id-resolver/appidresolver.h
+++ b/src/modules/app-id-resolver/appidresolver.h
@@ -3,90 +3,40 @@
 
 #pragma once
 
-#include "qwayland-server-treeland-app-id-resolver-v1.h"
-
 #include <wayland-server-core.h>
 #include <wglobal.h>
 #include <wserver.h>
 
-#include <QHash>
 #include <QObject>
-#include <QPointer>
 
 #include <functional>
+#include <memory>
 
-WAYLIB_SERVER_USE_NAMESPACE
-
-class AppIdResolverManager;
-
-class AppIdResolver
-    : public QObject
-    , public QtWaylandServer::treeland_app_id_resolver_v1
-{
-    Q_OBJECT
-public:
-    AppIdResolver(AppIdResolverManager *manager, wl_client *client, int version, uint32_t id);
-    ~AppIdResolver() override;
-
-    uint32_t requestResolve(int pidfd); // returns request id or 0
-
-Q_SIGNALS:
-    void resolved(uint32_t requestId, const QString &appId);
-    void disconnected();
-
-protected:
-    void destroy(Resource *resource) override;
-    void destroy_resource(Resource *resource) override;
-    void respond(Resource *resource,
-                 uint32_t request_id,
-                 const QString &app_id,
-                 const QString &sandboxEngineName) override;
-
-private:
-    AppIdResolverManager *m_manager;
-    bool m_alive = true;
-    uint32_t m_nextRequestId = 1;
-};
+class AppIdResolverManagerPrivate;
 
 class AppIdResolverManager
     : public QObject
-    , public QtWaylandServer::treeland_app_id_resolver_manager_v1
     , public WAYLIB_SERVER_NAMESPACE::WServerInterface
 {
     Q_OBJECT
 public:
     explicit AppIdResolverManager(QObject *parent = nullptr);
-    ~AppIdResolverManager() override = default;
-
-    // WServer attach-style lifecycle
-    void createGlobal(wl_display *display); // kept for internal use
-    void removeGlobal();
+    ~AppIdResolverManager() override;
 
     // Callback-based API: returns true if request started, false if no resolver or dup fd failed
-    // Callback is invoked asynchronously on the Wayland (main) thread; empty string if resolver disconnects
+    // Callback is invoked asynchronously on the Wayland (main) thread; empty string if resolver
+    // disconnects
     bool resolvePidfd(int pidfd, std::function<void(const QString &)> callback);
 
 Q_SIGNALS:
     void availableChanged();
 
-protected: // protocol generated virtuals
-    void destroy_global() override;
-    void destroy(Resource *resource) override;
-    void get_resolver(Resource *resource, uint32_t id) override;
-
 protected: // WServerInterface overrides
     void create(WAYLIB_SERVER_NAMESPACE::WServer *server) override;
     void destroy(WAYLIB_SERVER_NAMESPACE::WServer *server) override;
-    wl_global *global() const override; // might be nullptr (QtWayland hides it)
+    wl_global *global() const override;
     QByteArrayView interfaceName() const override;
 
 private:
-    wl_display *m_display = nullptr;
-    AppIdResolver *m_resolver = nullptr;
-    // request id -> callback
-    QHash<uint32_t, std::function<void(const QString &)>> m_callbacks;
-    wl_global *m_global = nullptr; // best-effort cache (not exposed by QtWayland API directly)
-
-    void resolverGone();
-    void handleResolved(uint32_t id, const QString &appId);
+    std::unique_ptr<AppIdResolverManagerPrivate> d;
 };

--- a/src/modules/prelaunch-splash/CMakeLists.txt
+++ b/src/modules/prelaunch-splash/CMakeLists.txt
@@ -11,7 +11,7 @@ impl_treeland(
     SOURCE
         prelaunchsplash.h
         prelaunchsplash.cpp
-    ${CMAKE_BINARY_DIR}/src/modules/prelaunch-splash/wayland-treeland-prelaunch-splash-v2-server-protocol.c
+        ${CMAKE_BINARY_DIR}/src/modules/prelaunch-splash/wayland-treeland-prelaunch-splash-v2-server-protocol.c
     INCLUDE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     LINK

--- a/src/modules/prelaunch-splash/prelaunchsplash.cpp
+++ b/src/modules/prelaunch-splash/prelaunchsplash.cpp
@@ -11,9 +11,6 @@
 
 #include <QByteArray>
 #include <QLoggingCategory>
-#include <QMetaType>
-
-#include <memory>
 
 WAYLIB_SERVER_USE_NAMESPACE
 QW_USE_NAMESPACE
@@ -83,6 +80,7 @@ public:
 protected:
     void destroy_global() override
     {
+        qCDebug(prelaunchSplash) << "PrelaunchSplash v2 global destroyed";
         delete q;
     }
 
@@ -131,17 +129,14 @@ PrelaunchSplash::~PrelaunchSplash() = default;
 
 void PrelaunchSplash::create(WAYLIB_SERVER_NAMESPACE::WServer *server)
 {
-    if (d->isGlobal())
-        return;
     d->init(*server->handle(), TREELAND_PRELAUNCH_SPLASH_MANAGER_V2_VERSION);
     qCDebug(prelaunchSplash) << "PrelaunchSplash v2 global created";
 }
 
-void PrelaunchSplash::destroy(WAYLIB_SERVER_NAMESPACE::WServer *server)
+void PrelaunchSplash::destroy([[maybe_unused]] WAYLIB_SERVER_NAMESPACE::WServer *server)
 {
-    Q_UNUSED(server);
     d->globalRemove();
-    qCDebug(prelaunchSplash) << "PrelaunchSplash v2 global removed";
+    qCDebug(prelaunchSplash) << "PrelaunchSplash v2 global removal scheduled";
 }
 
 wl_global *PrelaunchSplash::global() const
@@ -153,5 +148,3 @@ QByteArrayView PrelaunchSplash::interfaceName() const
 {
     return QtWaylandServer::treeland_prelaunch_splash_manager_v2::interfaceName();
 }
-
-// End of file

--- a/src/modules/prelaunch-splash/prelaunchsplash.h
+++ b/src/modules/prelaunch-splash/prelaunchsplash.h
@@ -5,27 +5,16 @@
 
 #include <wayland-server-core.h>
 #include <wserver.h>
+
 #include <qwbuffer.h>
-#include <memory>
 
 #include <QObject>
 
+#include <memory>
+
 Q_MOC_INCLUDE(<qwbuffer.h>)
 
-WAYLIB_SERVER_USE_NAMESPACE
-QW_USE_NAMESPACE
-
-namespace WAYLIB_SERVER_NAMESPACE {
-class WServer;
-}
-
-QW_BEGIN_NAMESPACE
-class qw_display;
-class qw_buffer;
-QW_END_NAMESPACE
-
 class PrelaunchSplashPrivate;
-struct wl_global;
 
 class PrelaunchSplash
     : public QObject
@@ -52,4 +41,4 @@ private:
     std::unique_ptr<PrelaunchSplashPrivate> d;
 };
 
-Q_DECLARE_OPAQUE_POINTER(QW_NAMESPACE::qw_buffer*)
+Q_DECLARE_OPAQUE_POINTER(QW_NAMESPACE::qw_buffer *)


### PR DESCRIPTION
Move treeland app-id-resolver and prelaunch-splash protocol handling behind private QtWaylandServer-based implementation classes, and align lifecycle code with generated protocol semantics.

Log: refactor generated protocol implementations for treeland modules. Tasks:
1. Hide QtWaylandServer protocol classes behind private implementations.
2. Use version macros, direct create/destroy lifecycle, and [[maybe_unused]].

Influence:
1. Verify behavior for treeland-app-id-resolver-v1.
2. Verify behavior for treeland-prelaunch-splash-manager-v2.