### PR TITLE
fix: Remove redundant 'delete' operations in `destroy_global`

### DIFF
--- a/src/modules/app-id-resolver/appidresolver.cpp
+++ b/src/modules/app-id-resolver/appidresolver.cpp
@@ -137,7 +137,6 @@ protected:
     void destroy_global() override
     {
         qCDebug(treelandAppIdResolver) << "AppIdResolverManager global destroyed";
-        delete q;
     }
 
     void destroy(Resource *resource) override

--- a/src/modules/dde-shell/ddeshellmanagerinterfacev1.cpp
+++ b/src/modules/dde-shell/ddeshellmanagerinterfacev1.cpp
@@ -35,7 +35,6 @@ public:
     DDEShellManagerInterfaceV1 *q;
 
 protected:
-    void destroy_global() override;
     void get_window_overlap_checker(Resource *resource, uint32_t id) override;
     void get_shell_surface(Resource *resource, uint32_t id, struct ::wl_resource *surface) override;
     void get_treeland_dde_active(Resource *resource, uint32_t id, struct ::wl_resource *seat) override;
@@ -89,11 +88,6 @@ DDEShellManagerInterfaceV1Private::DDEShellManagerInterfaceV1Private(DDEShellMan
 wl_global *DDEShellManagerInterfaceV1Private::global() const
 {
     return m_global;
-}
-
-void DDEShellManagerInterfaceV1Private::destroy_global()
-{
-    delete q;
 }
 
 void DDEShellManagerInterfaceV1Private::get_window_overlap_checker(Resource *resource,

--- a/src/modules/keystate/keystate.cpp
+++ b/src/modules/keystate/keystate.cpp
@@ -31,7 +31,6 @@ public:
     QMetaObject::Connection m_keyboardConnection{};
 
 protected:
-    void destroy_global() override;
     void destroy(Resource *resource) override;
     void fetchStates(Resource *resource) override;
 };
@@ -61,11 +60,6 @@ void KeyStateV5Private::setKeyboard(WInputDevice *keyboard)
     for (const auto &resource : resources) {
         fetchStates(resource);
     }
-}
-
-void KeyStateV5Private::destroy_global()
-{
-    delete q;
 }
 
 void KeyStateV5Private::destroy(Resource *resource)

--- a/src/modules/output-manager/outputmanagement.cpp
+++ b/src/modules/output-manager/outputmanagement.cpp
@@ -149,7 +149,6 @@ public:
     OutputManagerV1 *q;
 
 protected:
-    void destroy_global() override;
     void bind_resource(Resource *resource) override;
     void destroy(Resource *resource) override;
 
@@ -165,11 +164,6 @@ OutputManagerV1Private::OutputManagerV1Private(OutputManagerV1 *_q)
 wl_global *OutputManagerV1Private::global() const
 {
     return m_global;
-}
-
-void OutputManagerV1Private::destroy_global()
-{
-    delete q;
 }
 
 void OutputManagerV1Private::bind_resource(Resource *resource)

--- a/src/modules/prelaunch-splash/prelaunchsplash.cpp
+++ b/src/modules/prelaunch-splash/prelaunchsplash.cpp
@@ -81,7 +81,6 @@ protected:
     void destroy_global() override
     {
         qCDebug(prelaunchSplash) << "PrelaunchSplash v2 global destroyed";
-        delete q;
     }
 
     void destroy(Resource *resource) override

--- a/src/modules/shortcut/shortcutmanager.cpp
+++ b/src/modules/shortcut/shortcutmanager.cpp
@@ -100,7 +100,6 @@ public:
     WSocket* m_activeSessionSocket = nullptr;
 
 protected:
-    void destroy_global() override;
     void destroy_resource(Resource *resource) override;
     void destroy(Resource *resource) override;
     void acquire(Resource *resource) override;
@@ -217,11 +216,6 @@ void ShortcutManagerV2Private::sendInvalidCommit(WSocket *socket)
     wl_resource_post_error(resource->handle,
                            error_invalid_commit,
                            "Commit sent before last commit is processed.");
-}
-
-void ShortcutManagerV2Private::destroy_global()
-{
-    delete q;
 }
 
 void ShortcutManagerV2Private::destroy_resource(Resource *resource)

--- a/src/modules/virtual-output/virtualoutputmanagerinterfacev1.cpp
+++ b/src/modules/virtual-output/virtualoutputmanagerinterfacev1.cpp
@@ -95,7 +95,6 @@ wl_global *VirtualOutputManagerInterfaceV1Private::global() const
 void VirtualOutputManagerInterfaceV1Private::destroy_global()
 {
     m_resource.clear();
-    delete q;
 }
 
 void VirtualOutputManagerInterfaceV1Private::bind_resource(Resource *resource)

--- a/src/modules/wallpaper-color/wallpapercolorinterfacev1.cpp
+++ b/src/modules/wallpaper-color/wallpapercolorinterfacev1.cpp
@@ -60,7 +60,6 @@ void WallpaperColorInterfaceV1Private::destroy_resource(Resource *resource)
 
 void WallpaperColorInterfaceV1Private::destroy_global() {
     m_resource.clear();
-    delete q;
 }
 
 void WallpaperColorInterfaceV1Private::destroy(Resource *resource) {

--- a/src/modules/wallpaper/wallpapermanagerinterfacev1.cpp
+++ b/src/modules/wallpaper/wallpapermanagerinterfacev1.cpp
@@ -43,7 +43,6 @@ public:
 
     TreelandWallpaperManagerInterfaceV1 *q = nullptr;
 protected:
-    void destroy_global() override;
     void destroy(Resource *resource) override;
     void get_treeland_wallpaper(Resource *resource,
                                 uint32_t id,
@@ -60,11 +59,6 @@ TreelandWallpaperManagerInterfaceV1Private::TreelandWallpaperManagerInterfaceV1P
 wl_global *TreelandWallpaperManagerInterfaceV1Private::global() const
 {
     return m_global;
-}
-
-void TreelandWallpaperManagerInterfaceV1Private::destroy_global()
-{
-    delete q;
 }
 
 void TreelandWallpaperManagerInterfaceV1Private::destroy(Resource *resource)

--- a/src/modules/wallpaper/wallpapernotifierinterfacev1.cpp
+++ b/src/modules/wallpaper/wallpapernotifierinterfacev1.cpp
@@ -46,7 +46,6 @@ void TreelandWallpaperNotifierInterfaceV1Private::destroy_resource(Resource *res
 void TreelandWallpaperNotifierInterfaceV1Private::destroy_global()
 {
     m_resource.clear();
-    delete q;
 }
 
 void TreelandWallpaperNotifierInterfaceV1Private::destroy(Resource *resource)

--- a/src/modules/wallpaper/wallpapershellinterfacev1.cpp
+++ b/src/modules/wallpaper/wallpapershellinterfacev1.cpp
@@ -22,7 +22,6 @@ public:
     QList<QString> producedWallpapers;
 
 protected:
-    void destroy_global() override;
     void destroy(Resource *resource) override;
     void get_treeland_wallpaper_surface(Resource *resource,
                                         uint32_t id,
@@ -38,11 +37,6 @@ TreelandWallpaperShellInterfaceV1Private::TreelandWallpaperShellInterfaceV1Priva
 wl_global *TreelandWallpaperShellInterfaceV1Private::global() const
 {
     return m_global;
-}
-
-void TreelandWallpaperShellInterfaceV1Private::destroy_global()
-{
-    delete q;
 }
 
 void TreelandWallpaperShellInterfaceV1Private::destroy(Resource *resource)

--- a/src/modules/window-management/windowmanagementinterfacev1.cpp
+++ b/src/modules/window-management/windowmanagementinterfacev1.cpp
@@ -54,7 +54,6 @@ void WindowManagementInterfaceV1Private::destroy_resource(Resource *resource)
 
 void WindowManagementInterfaceV1Private::destroy_global() {
     m_resource.clear();
-    delete q;
 }
 
 void WindowManagementInterfaceV1Private::destroy(Resource *resource) {


### PR DESCRIPTION
WServer destroys all interfaces during its destruction phase; the lifecycle of classes inheriting from WServerInterface is tied to that of WServer.

Log: Remove redundant 'delete' operations in `destroy_global`

Influence: