### PR TITLE
feat: rename qtwaylandscanner Resource object name

### DIFF
--- a/src/modules/tools/qtwaylandscanner.cpp
+++ b/src/modules/tools/qtwaylandscanner.cpp
@@ -1030,8 +1030,8 @@ bool Scanner::process()
                     printf("\n");
                     printf("    {\n");
                     printf("        Q_UNUSED(client);\n");
-                    printf("        Resource *r = Resource::fromResource(resource);\n");
-                    printf("        if (Q_UNLIKELY(!r->%s_object)) {\n", interfaceNameStripped);
+                    printf("        Resource *qResource = Resource::fromResource(resource);\n");
+                    printf("        if (Q_UNLIKELY(!qResource->%s_object)) {\n", interfaceNameStripped);
                     for (const WaylandArgument &a : e.arguments) {
                         if (a.type == QByteArrayLiteral("fd"))
                             printf("        close(%s);\n", a.name.constData());
@@ -1040,11 +1040,11 @@ bool Scanner::process()
                         printf("            wl_resource_destroy(resource);\n");
                     printf("            return;\n");
                     printf("        }\n");
-                    printf("        static_cast<%s *>(r->%s_object)->%s(\n",
+                    printf("        static_cast<%s *>(qResource->%s_object)->%s(\n",
                            interfaceName,
                            interfaceNameStripped,
                            e.name.constData());
-                    printf("            r");
+                    printf("            qResource");
                     for (const WaylandArgument &a : e.arguments) {
                         printf(",\n");
                         QByteArray cType = waylandToCType(a.type, a.interface);


### PR DESCRIPTION
The naming of the variable `r` in the line
`Resource *r = Resource::fromResource(resource);` is too generic; it is highly prone to conflicting with parameter names defined in the protocol, which can lead to errors in the code generated by the scanner.

Log: rename qtwaylandscanner Resource object name
Tasks:

Influence:
1. Verify whether the scanner generates an error when generating code for a protocol containing a parameter named 'r'.

## Summary by Sourcery

Enhancements:
- Clarify the qtwaylandscanner-generated Resource variable name to prevent naming collisions with protocol parameters.