### PR TITLE
fix: treeland-protocols broken changes

### DIFF
--- a/src/modules/foreign-toplevel/impl/foreign_toplevel_manager_impl.cpp
+++ b/src/modules/foreign-toplevel/impl/foreign_toplevel_manager_impl.cpp
@@ -70,6 +70,9 @@ static void treeland_dock_preview_context_handle_destroy(struct wl_client *clien
                                                          struct wl_resource *resource);
 
 static const struct treeland_foreign_toplevel_handle_v1_interface treeland_toplevel_handle_impl = {
+    .destroy = treeland_foreign_toplevel_handle_destroy,
+    .set_fullscreen = treeland_foreign_toplevel_handle_set_fullscreen,
+    .unset_fullscreen = treeland_foreign_toplevel_handle_unset_fullscreen,
     .set_maximized = treeland_foreign_toplevel_handle_set_maximized,
     .unset_maximized = treeland_foreign_toplevel_handle_unset_maximized,
     .set_minimized = treeland_foreign_toplevel_handle_set_minimized,
@@ -77,17 +80,14 @@ static const struct treeland_foreign_toplevel_handle_v1_interface treeland_tople
     .activate = treeland_foreign_toplevel_handle_activate,
     .close = treeland_foreign_toplevel_handle_close,
     .set_rectangle = treeland_foreign_toplevel_handle_set_rectangle,
-    .destroy = treeland_foreign_toplevel_handle_destroy,
-    .set_fullscreen = treeland_foreign_toplevel_handle_set_fullscreen,
-    .unset_fullscreen = treeland_foreign_toplevel_handle_unset_fullscreen,
 };
 
 static const struct treeland_dock_preview_context_v1_interface
     treeland_dock_preview_context_impl = {
+        .destroy = treeland_dock_preview_context_handle_destroy,
         .show = treeland_dock_preview_context_handle_show,
         .show_tooltip = treeland_dock_preview_context_handle_show_tooltip,
         .close = treeland_dock_preview_context_handle_close,
-        .destroy = treeland_dock_preview_context_handle_destroy,
     };
 
 static struct treeland_foreign_toplevel_handle_v1 *toplevel_handle_from_resource(
@@ -739,11 +739,18 @@ treeland_foreign_toplevel_handle_v1 *treeland_foreign_toplevel_handle_v1::create
     return toplevel;
 }
 
+static void treeland_foreign_toplevel_manager_handle_destroy([[maybe_unused]] struct wl_client *client,
+                                                             struct wl_resource *resource)
+{
+    wl_resource_destroy(resource);
+}
+
 static const struct treeland_foreign_toplevel_manager_v1_interface
     treeland_foreign_toplevel_manager_impl = {
-        .stop = treeland_foreign_toplevel_manager_handle_stop,
+        .destroy = treeland_foreign_toplevel_manager_handle_destroy,
         .get_dock_preview_context =
-            treeland_foreign_toplevel_manager_handle_get_dock_preview_context,
+        treeland_foreign_toplevel_manager_handle_get_dock_preview_context,
+        .stop = treeland_foreign_toplevel_manager_handle_stop,
     };
 
 struct treeland_foreign_toplevel_manager_v1 *foreign_toplevel_manager_from_resource(

--- a/src/modules/personalization/impl/appearance_impl.cpp
+++ b/src/modules/personalization/impl/appearance_impl.cpp
@@ -12,6 +12,10 @@
 
 static const struct treeland_personalization_appearance_context_v1_interface
     personalization_appearance_context_impl = {
+        .destroy =
+        []([[maybe_unused]] struct wl_client *client, struct wl_resource *resource) {
+            wl_resource_destroy(resource);
+        },
         .set_round_corner_radius = dispatch_member_function<
             &personalization_appearance_context_v1::setRoundCornerRadius>(),
         .get_round_corner_radius =
@@ -51,10 +55,6 @@ static const struct treeland_personalization_appearance_context_v1_interface
             []([[maybe_unused]] struct wl_client *client, struct wl_resource *resource) {
                 Q_EMIT personalization_appearance_context_v1::fromResource(resource)
                     ->requestWindowTitlebarHeight();
-            },
-        .destroy =
-            []([[maybe_unused]] struct wl_client *client, struct wl_resource *resource) {
-                wl_resource_destroy(resource);
             }
     };
 

--- a/src/modules/personalization/impl/font_impl.cpp
+++ b/src/modules/personalization/impl/font_impl.cpp
@@ -7,6 +7,10 @@
 
 static const struct treeland_personalization_font_context_v1_interface
     personalization_font_context_impl = {
+        .destroy =
+        []([[maybe_unused]] struct wl_client *client, struct wl_resource *resource) {
+            wl_resource_destroy(resource);
+        },
         .set_font_size =
             []([[maybe_unused]] struct wl_client *client,
                struct wl_resource *resource,
@@ -38,10 +42,6 @@ static const struct treeland_personalization_font_context_v1_interface
         .get_monospace_font =
             []([[maybe_unused]] struct wl_client *client, struct wl_resource *resource) {
                 Q_EMIT personalization_font_context_v1::fromResource(resource)->requestMonoFont();
-            },
-        .destroy =
-            []([[maybe_unused]] struct wl_client *client, struct wl_resource *resource) {
-                wl_resource_destroy(resource);
             }
     };
 

--- a/src/modules/personalization/impl/personalization_manager_impl.cpp
+++ b/src/modules/personalization/impl/personalization_manager_impl.cpp
@@ -65,12 +65,12 @@ static void on_destroy([[maybe_unused]] struct wl_client *client, struct wl_reso
 
 static const struct treeland_personalization_window_context_v1_interface
     personalization_window_context_impl = {
+        .destroy = Personalization::WindowContext::on_destroy,
+        .set_titlebar = Personalization::WindowContext::set_titlebar,
         .set_blend_mode = Personalization::WindowContext::set_background_type,
         .set_round_corner_radius = Personalization::WindowContext::set_round_corner_radius,
         .set_shadow = Personalization::WindowContext::set_shadow,
         .set_border = Personalization::WindowContext::set_border,
-        .set_titlebar = Personalization::WindowContext::set_titlebar,
-        .destroy = Personalization::WindowContext::on_destroy,
     };
 
 personalization_window_context_v1 *personalization_window_context_v1::from_resource(
@@ -195,6 +195,7 @@ static void personalization_wallpaper_context_destroy([[maybe_unused]] struct wl
 
 static const struct treeland_personalization_wallpaper_context_v1_interface
     personalization_wallpaper_context_impl = {
+        .destroy = personalization_wallpaper_context_destroy,
         .set_fd = set_fd,
         .set_identifier = set_identifier,
         .set_output = set_output,
@@ -202,7 +203,6 @@ static const struct treeland_personalization_wallpaper_context_v1_interface
         .set_isdark = set_isdark,
         .commit = wallpaper_commit,
         .get_metadata = get_metadata,
-        .destroy = personalization_wallpaper_context_destroy,
     };
 
 personalization_wallpaper_context_v1 *personalization_wallpaper_context_v1::from_resource(
@@ -287,12 +287,12 @@ static void personalization_cursor_context_destroy([[maybe_unused]] struct wl_cl
 
 static const struct treeland_personalization_cursor_context_v1_interface
     personalization_cursor_context_impl = {
+        .destroy = personalization_cursor_context_destroy,
         .set_theme = set_cursor_theme,
         .get_theme = get_cursor_theme,
         .set_size = set_cursor_size,
         .get_size = get_cursor_size,
         .commit = cursor_commit,
-        .destroy = personalization_cursor_context_destroy,
     };
 
 personalization_cursor_context_v1 *personalization_cursor_context_v1::from_resource(

--- a/src/modules/screensaver/screensaverinterfacev1.cpp
+++ b/src/modules/screensaver/screensaverinterfacev1.cpp
@@ -24,9 +24,16 @@ static void uninhibit([[maybe_unused]] struct wl_client *client, struct wl_resou
     screensaver->uninhibit(resource);
 }
 
+static void destroy([[maybe_unused]] struct wl_client *client,
+                    struct wl_resource *resource)
+{
+    wl_resource_destroy(resource);
+}
+
 static const struct treeland_screensaver_v1_interface treeland_screensaver_impl {
-    .inhibit = inhibit,
+    .destroy = destroy,
     .uninhibit = uninhibit,
+    .inhibit = inhibit,
 };
 
 // wayland object binding

--- a/src/modules/virtual-output/virtualoutputmanagerinterfacev1.cpp
+++ b/src/modules/virtual-output/virtualoutputmanagerinterfacev1.cpp
@@ -75,8 +75,7 @@ protected:
     void destroy_global() override;
     void bind_resource(Resource *resource) override;
     void destroy_resource(Resource *resource) override;
-    // TODO(YaoBing Xiao): treeland-virtual-output-manager-v1 is missing the 'destroy' request.
-    // void destroy(Resource *resource) override;
+    void destroy(Resource *resource) override;
     void create_virtual_output(Resource *resource, uint32_t id, const QString &name, wl_array *outputs) override;
     void get_virtual_output_list(Resource *resource) override;
     void get_virtual_output(Resource *resource, const QString &name, uint32_t id) override;
@@ -107,10 +106,10 @@ void VirtualOutputManagerInterfaceV1Private::destroy_resource(Resource *resource
     m_resource.removeOne(resource);
 }
 
-// void VirtualOutputManagerInterfaceV1Private::destroy(Resource *resource)
-// {
-//     wl_resource_destroy(resource->handle);
-// }
+void VirtualOutputManagerInterfaceV1Private::destroy(Resource *resource)
+{
+    wl_resource_destroy(resource->handle);
+}
 
 void VirtualOutputManagerInterfaceV1Private::create_virtual_output(Resource *resource,
                                                                    uint32_t id,


### PR DESCRIPTION
fixed Treeland compilation errors following
the protocol changes.

Log: fix treeland-protocols broken changes

Influence:



link commit: https://github.com/linuxdeepin/treeland-protocols/pull/49