### PR TITLE
refactor: Make `interfaceName()` public in WServerInterface implement…

### DIFF
--- a/src/modules/app-id-resolver/appidresolver.h
+++ b/src/modules/app-id-resolver/appidresolver.h
@@ -27,6 +27,7 @@ public:
     // Callback is invoked asynchronously on the Wayland (main) thread; empty string if resolver
     // disconnects
     bool resolvePidfd(int pidfd, std::function<void(const QString &)> callback);
+    QByteArrayView interfaceName() const override;
 
 Q_SIGNALS:
     void availableChanged();
@@ -35,7 +36,6 @@ protected: // WServerInterface overrides
     void create(WAYLIB_SERVER_NAMESPACE::WServer *server) override;
     void destroy(WAYLIB_SERVER_NAMESPACE::WServer *server) override;
     wl_global *global() const override;
-    QByteArrayView interfaceName() const override;
 
 private:
     std::unique_ptr<AppIdResolverManagerPrivate> d;

--- a/src/modules/dde-shell/ddeshellmanagerinterfacev1.h
+++ b/src/modules/dde-shell/ddeshellmanagerinterfacev1.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #pragma once
@@ -29,6 +29,7 @@ public:
 
     void checkRegionalConflict(const QRegion &region);
 
+    QByteArrayView interfaceName() const override;
 Q_SIGNALS:
     void surfaceCreated(DDEShellSurfaceInterface *interface);
     void activeCreated(DDEActiveInterface *interface);
@@ -44,7 +45,6 @@ protected:
     void create(WServer *server) override;
     void destroy(WServer *server) override;
     wl_global *global() const override;
-    QByteArrayView interfaceName() const override;
 
 private:
     std::unique_ptr<DDEShellManagerInterfaceV1Private> d;

--- a/src/modules/prelaunch-splash/prelaunchsplash.h
+++ b/src/modules/prelaunch-splash/prelaunchsplash.h
@@ -25,6 +25,7 @@ public:
     explicit PrelaunchSplash(QObject *parent = nullptr);
     ~PrelaunchSplash() override;
 
+    QByteArrayView interfaceName() const override;
 Q_SIGNALS:
     void splashRequested(const QString &appId,
                          const QString &instanceId,
@@ -35,7 +36,6 @@ protected: // WServerInterface
     void create(WAYLIB_SERVER_NAMESPACE::WServer *server) override;
     void destroy(WAYLIB_SERVER_NAMESPACE::WServer *server) override;
     wl_global *global() const override;
-    QByteArrayView interfaceName() const override;
 
 private:
     std::unique_ptr<PrelaunchSplashPrivate> d;

--- a/src/modules/virtual-output/virtualoutputmanagerinterfacev1.h
+++ b/src/modules/virtual-output/virtualoutputmanagerinterfacev1.h
@@ -20,7 +20,10 @@ public:
     explicit VirtualOutputManagerInterfaceV1(QObject *parent = nullptr);
     ~VirtualOutputManagerInterfaceV1() override;
 
+    QByteArrayView interfaceName() const override;
+
     static constexpr int InterfaceVersion = 1;
+
 Q_SIGNALS:
     void requestCreateVirtualOutput(VirtualOutputInterfaceV1 *interface);
     void destroyVirtualOutput(VirtualOutputInterfaceV1 *interface);
@@ -29,7 +32,6 @@ protected:
     void create(WServer *server) override;
     void destroy(WServer *server) override;
     wl_global *global() const override;
-    QByteArrayView interfaceName() const override;
 
 private:
     friend class VirtualOutputManagerInterfaceV1Private;

--- a/src/modules/wallpaper-color/wallpapercolorinterfacev1.h
+++ b/src/modules/wallpaper-color/wallpapercolorinterfacev1.h
@@ -20,6 +20,8 @@ public:
     explicit WallpaperColorInterfaceV1(QObject *parent = nullptr);
     ~WallpaperColorInterfaceV1() override;
 
+    QByteArrayView interfaceName() const override;
+
     static constexpr int InterfaceVersion = 1;
     Q_INVOKABLE void updateWallpaperColor(const QString &output, bool isDarkType);
 
@@ -27,7 +29,6 @@ protected:
     void create(WServer *server) override;
     void destroy(WServer *server) override;
     wl_global *global() const override;
-    QByteArrayView interfaceName() const override;
 
 private:
     std::unique_ptr<WallpaperColorInterfaceV1Private> d;

--- a/src/modules/wallpaper/wallpapermanagerinterfacev1.h
+++ b/src/modules/wallpaper/wallpapermanagerinterfacev1.h
@@ -22,6 +22,8 @@ public:
     explicit TreelandWallpaperManagerInterfaceV1(QObject *parent = nullptr);
     ~TreelandWallpaperManagerInterfaceV1() override;
 
+    QByteArrayView interfaceName() const override;
+
     static constexpr int InterfaceVersion = 1;
 
 Q_SIGNALS:
@@ -31,7 +33,6 @@ protected:
     void create(WServer *server) override;
     void destroy(WServer *server) override;
     wl_global *global() const override;
-    QByteArrayView interfaceName() const override;
 
 private:
     std::unique_ptr<TreelandWallpaperManagerInterfaceV1Private> d;

--- a/src/modules/wallpaper/wallpapernotifierinterfacev1.h
+++ b/src/modules/wallpaper/wallpapernotifierinterfacev1.h
@@ -23,6 +23,8 @@ public:
     explicit TreelandWallpaperNotifierInterfaceV1(QObject *parent = nullptr);
     ~TreelandWallpaperNotifierInterfaceV1() override;
 
+    QByteArrayView interfaceName() const override;
+
     static constexpr int InterfaceVersion = 1;
 
     void sendAdd(TreelandWallpaperInterfaceV1::WallpaperType type, const QString &fileSource);
@@ -35,7 +37,6 @@ protected:
     void create(WServer *server) override;
     void destroy(WServer *server) override;
     wl_global *global() const override;
-    QByteArrayView interfaceName() const override;
 
 private:
     std::unique_ptr<TreelandWallpaperNotifierInterfaceV1Private> d;

--- a/src/modules/wallpaper/wallpapershellinterfacev1.h
+++ b/src/modules/wallpaper/wallpapershellinterfacev1.h
@@ -22,6 +22,8 @@ public:
     explicit TreelandWallpaperShellInterfaceV1(QObject *parent = nullptr);
     ~TreelandWallpaperShellInterfaceV1() override;
 
+    QByteArrayView interfaceName() const override;
+
     static constexpr int InterfaceVersion = 1;
     QList<QString> producedWallpapers() const;
 
@@ -32,7 +34,6 @@ protected:
     void create(WServer *server) override;
     void destroy(WServer *server) override;
     wl_global *global() const override;
-    QByteArrayView interfaceName() const override;
 
 private:
     std::unique_ptr<TreelandWallpaperShellInterfaceV1Private> d;

--- a/src/modules/window-management/windowmanagementinterfacev1.h
+++ b/src/modules/window-management/windowmanagementinterfacev1.h
@@ -29,6 +29,8 @@ public:
     explicit WindowManagementInterfaceV1(QObject *parent = nullptr);
     ~WindowManagementInterfaceV1() override;
 
+    QByteArrayView interfaceName() const override;
+
     static constexpr int InterfaceVersion = 1;
     DesktopState desktopState();
     void setDesktopState(DesktopState state);
@@ -41,7 +43,6 @@ protected:
     void create(WServer *server) override;
     void destroy(WServer *server) override;
     wl_global *global() const override;
-    QByteArrayView interfaceName() const override;
 
 private:
     std::unique_ptr<WindowManagementInterfaceV1Private> d;

--- a/waylib/src/server/kernel/wbackend.h
+++ b/waylib/src/server/kernel/wbackend.h
@@ -41,6 +41,8 @@ public:
     void activateSession();
     void deactivateSession();
 
+    QByteArrayView interfaceName() const override;
+
 Q_SIGNALS:
     void outputAdded(WOutput *output);
     void outputRemoved(WOutput *output);
@@ -54,7 +56,6 @@ protected:
     void create(WServer *server) override;
     void destroy(WServer *server) override;
     wl_global *global() const override;
-    QByteArrayView interfaceName() const override;
 };
 
 WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/kernel/wseat.h
+++ b/waylib/src/server/kernel/wseat.h
@@ -108,6 +108,8 @@ public:
 
     QList<WInputDevice*> deviceList() const;
 
+    QByteArrayView interfaceName() const override;
+
 Q_SIGNALS:
     void keyboardChanged();
     void keyboardFocusSurfaceChanged();
@@ -129,7 +131,6 @@ protected:
     void create(WServer *server) override;
     void destroy(WServer *server) override;
     wl_global *global() const override;
-    QByteArrayView interfaceName() const override;
 
     // for event filter
     bool filterEventBeforeDisposeStage(QWindow *targetWindow, QInputEvent *event);


### PR DESCRIPTION
…ations

Move `interfaceName()` from protected to public section across multiple WServerInterface-derived classes to align with its intended usage as a public-facing identifier.

This also keeps the declaration order consistent with other virtual overrides and improves API clarity.

Log: Expose `interfaceName()` as public in interface implementations

Influence: No functional change; improves interface consistency and usability

## Summary by Sourcery

Enhancements:
- Make interfaceName() publicly accessible in all WServerInterface-derived modules (virtual output, wallpaper, window management, backend, seat, app-id resolver, DDE shell, prelaunch splash) for consistent public identification of interfaces.