### PR TITLE
refactor: Remove manual resource tracking in interface implementations

### DIFF
--- a/src/modules/app-id-resolver/appidresolver.cpp
+++ b/src/modules/app-id-resolver/appidresolver.cpp
@@ -78,8 +78,9 @@ private:
 class AppIdResolverManagerPrivate : public QtWaylandServer::treeland_app_id_resolver_manager_v1
 {
 public:
-    explicit AppIdResolverManagerPrivate(AppIdResolverManager *q)
-        : q(q)
+    explicit AppIdResolverManagerPrivate(AppIdResolverManager *_q)
+        : QtWaylandServer::treeland_app_id_resolver_manager_v1()
+        , q(_q)
     {
     }
 

--- a/src/modules/dde-shell/ddeshellmanagerinterfacev1.cpp
+++ b/src/modules/dde-shell/ddeshellmanagerinterfacev1.cpp
@@ -81,7 +81,8 @@ void DDEShellManagerInterfaceV1Private::set_xwindow_position_relative(Resource *
 }
 
 DDEShellManagerInterfaceV1Private::DDEShellManagerInterfaceV1Private(DDEShellManagerInterfaceV1 *_q)
-    : q(_q)
+    : QtWaylandServer::treeland_dde_shell_manager_v1()
+    , q(_q)
 {
 }
 

--- a/src/modules/keystate/keystate.cpp
+++ b/src/modules/keystate/keystate.cpp
@@ -122,7 +122,8 @@ void KeyStateV5Private::fetchStates(Resource *resource)
 }
 
 KeyStateV5Private::KeyStateV5Private(WSeat *seat, KeyStateV5 *_q)
-    : q(_q)
+    : QtWaylandServer::org_kde_kwin_keystate()
+    , q(_q)
     , m_seat(seat)
 {
     assert(seat);

--- a/src/modules/output-manager/outputmanagement.cpp
+++ b/src/modules/output-manager/outputmanagement.cpp
@@ -157,7 +157,8 @@ protected:
 };
 
 OutputManagerV1Private::OutputManagerV1Private(OutputManagerV1 *_q)
-    : q(_q)
+    : QtWaylandServer::treeland_output_manager_v1()
+    , q(_q)
 {
 }
 

--- a/src/modules/prelaunch-splash/prelaunchsplash.cpp
+++ b/src/modules/prelaunch-splash/prelaunchsplash.cpp
@@ -67,8 +67,9 @@ private:
 class PrelaunchSplashPrivate : public QtWaylandServer::treeland_prelaunch_splash_manager_v2
 {
 public:
-    explicit PrelaunchSplashPrivate(PrelaunchSplash *q)
-        : q(q)
+    explicit PrelaunchSplashPrivate(PrelaunchSplash *_q)
+        : QtWaylandServer::treeland_prelaunch_splash_manager_v2()
+        , q(_q)
     {
     }
 

--- a/src/modules/virtual-output/virtualoutputmanagerinterfacev1.cpp
+++ b/src/modules/virtual-output/virtualoutputmanagerinterfacev1.cpp
@@ -45,11 +45,11 @@ VirtualOutputInterfaceV1Private::VirtualOutputInterfaceV1Private(VirtualOutputIn
                                                                  const QString &_name,
                                                                  wl_array *_outputs,
                                                                  wl_resource *resource)
-    : q(_q)
+    : QtWaylandServer::treeland_virtual_output_v1(resource)
+    , q(_q)
     , name(_name)
 {
     wlarrayToStringList(_outputs, outputList);
-    init(resource);
 }
 
 void VirtualOutputInterfaceV1Private::destroy_resource([[maybe_unused]] Resource *resource)
@@ -70,11 +70,7 @@ public:
     wl_global *global() const;
 
     VirtualOutputManagerInterfaceV1 *q;
-    QList<Resource *> m_resource;
 protected:
-    void destroy_global() override;
-    void bind_resource(Resource *resource) override;
-    void destroy_resource(Resource *resource) override;
     // TODO(YaoBing Xiao): treeland-virtual-output-manager-v1 is missing the 'destroy' request.
     // void destroy(Resource *resource) override;
     void create_virtual_output(Resource *resource, uint32_t id, const QString &name, wl_array *outputs) override;
@@ -83,28 +79,14 @@ protected:
 };
 
 VirtualOutputManagerInterfaceV1Private::VirtualOutputManagerInterfaceV1Private(VirtualOutputManagerInterfaceV1 *_q)
-    : q(_q)
+    : QtWaylandServer::treeland_virtual_output_manager_v1()
+    , q(_q)
 {
 }
 
 wl_global *VirtualOutputManagerInterfaceV1Private::global() const
 {
     return m_global;
-}
-
-void VirtualOutputManagerInterfaceV1Private::destroy_global()
-{
-    m_resource.clear();
-}
-
-void VirtualOutputManagerInterfaceV1Private::bind_resource(Resource *resource)
-{
-    m_resource.append(resource);
-}
-
-void VirtualOutputManagerInterfaceV1Private::destroy_resource(Resource *resource)
-{
-    m_resource.removeOne(resource);
 }
 
 // void VirtualOutputManagerInterfaceV1Private::destroy(Resource *resource)

--- a/src/modules/wallpaper-color/wallpapercolorinterfacev1.cpp
+++ b/src/modules/wallpaper-color/wallpapercolorinterfacev1.cpp
@@ -26,19 +26,17 @@ public:
     WallpaperColorInterfaceV1 *q;
     QMap<wl_resource *, QList<QString>> watch_lists;
     QMap<QString, bool> color_map;
-    QList<Resource *> m_resource;
 
 protected:
-    void bind_resource(Resource *resource) override;
     void destroy_resource(Resource *resource) override;
-    void destroy_global() override;
     void destroy(Resource *resource) override;
     void watch(Resource *resource, const QString &output) override;
     void unwatch(Resource *resource, const QString &output) override;
 };
 
 WallpaperColorInterfaceV1Private::WallpaperColorInterfaceV1Private(WallpaperColorInterfaceV1 *_q)
-    : q(_q)
+    : QtWaylandServer::treeland_wallpaper_color_manager_v1()
+    , q(_q)
 {
 }
 
@@ -47,19 +45,9 @@ wl_global *WallpaperColorInterfaceV1Private::global() const
     return m_global;
 }
 
-void WallpaperColorInterfaceV1Private::bind_resource(Resource *resource)
-{
-    m_resource.append(resource);
-}
-
 void WallpaperColorInterfaceV1Private::destroy_resource(Resource *resource)
 {
-    m_resource.removeOne(resource);
     watch_lists.remove(resource->handle);
-}
-
-void WallpaperColorInterfaceV1Private::destroy_global() {
-    m_resource.clear();
 }
 
 void WallpaperColorInterfaceV1Private::destroy(Resource *resource) {

--- a/src/modules/wallpaper/wallpapermanagerinterfacev1.cpp
+++ b/src/modules/wallpaper/wallpapermanagerinterfacev1.cpp
@@ -52,7 +52,8 @@ protected:
 };
 
 TreelandWallpaperManagerInterfaceV1Private::TreelandWallpaperManagerInterfaceV1Private(TreelandWallpaperManagerInterfaceV1 *_q)
-    : q(_q)
+    : QtWaylandServer::treeland_wallpaper_manager_v1()
+    , q(_q)
 {
 }
 

--- a/src/modules/wallpaper/wallpapernotifierinterfacev1.cpp
+++ b/src/modules/wallpaper/wallpapernotifierinterfacev1.cpp
@@ -11,19 +11,17 @@ class TreelandWallpaperNotifierInterfaceV1Private : public QtWaylandServer::tree
 public:
     TreelandWallpaperNotifierInterfaceV1Private(TreelandWallpaperNotifierInterfaceV1 *_q);
     wl_global *global() const;
-    QList<Resource *> m_resource;
 
     TreelandWallpaperNotifierInterfaceV1 *q = nullptr;
 
 protected:
     void bind_resource(Resource *resource) override;
-    void destroy_resource(Resource *resource) override;
-    void destroy_global() override;
     void destroy(Resource *resource) override;
 };
 
 TreelandWallpaperNotifierInterfaceV1Private::TreelandWallpaperNotifierInterfaceV1Private(TreelandWallpaperNotifierInterfaceV1 *_q)
-    : q(_q)
+    : QtWaylandServer::treeland_wallpaper_notifier_v1()
+    , q(_q)
 {
 }
 
@@ -34,18 +32,7 @@ wl_global *TreelandWallpaperNotifierInterfaceV1Private::global() const
 
 void TreelandWallpaperNotifierInterfaceV1Private::bind_resource(Resource *resource)
 {
-    m_resource.append(resource);
-    Q_EMIT q->binded();
-}
-
-void TreelandWallpaperNotifierInterfaceV1Private::destroy_resource(Resource *resource)
-{
-    m_resource.removeOne(resource);
-}
-
-void TreelandWallpaperNotifierInterfaceV1Private::destroy_global()
-{
-    m_resource.clear();
+    Q_EMIT q->bound(resource->handle);
 }
 
 void TreelandWallpaperNotifierInterfaceV1Private::destroy(Resource *resource)
@@ -61,14 +48,14 @@ TreelandWallpaperNotifierInterfaceV1::TreelandWallpaperNotifierInterfaceV1(QObje
 
 void TreelandWallpaperNotifierInterfaceV1::sendAdd(TreelandWallpaperInterfaceV1::WallpaperType type, const QString &fileSource)
 {
-    for (auto resource : d->m_resource) {
+    for (const auto &resource : d->resourceMap()) {
         d->send_add(resource->handle, type, fileSource);
     }
 }
 
 void TreelandWallpaperNotifierInterfaceV1::sendRemove(const QString &fileSource)
 {
-    for (auto resource : d->m_resource) {
+    for (const auto &resource : d->resourceMap()) {
         d->send_remove(resource->handle, fileSource);
     }
 }
@@ -93,4 +80,9 @@ wl_global *TreelandWallpaperNotifierInterfaceV1::global() const
 QByteArrayView TreelandWallpaperNotifierInterfaceV1::interfaceName() const
 {
     return d->interfaceName();
+}
+
+void TreelandWallpaperNotifierInterfaceV1::sendAddForResource(wl_resource *resource, TreelandWallpaperInterfaceV1::WallpaperType type, const QString &fileSource)
+{
+    d->send_add(resource, type, fileSource);
 }

--- a/src/modules/wallpaper/wallpapernotifierinterfacev1.h
+++ b/src/modules/wallpaper/wallpapernotifierinterfacev1.h
@@ -27,11 +27,12 @@ public:
 
     static constexpr int InterfaceVersion = 1;
 
+    void sendAddForResource(wl_resource *resource, TreelandWallpaperInterfaceV1::WallpaperType type, const QString &fileSource);
     void sendAdd(TreelandWallpaperInterfaceV1::WallpaperType type, const QString &fileSource);
     void sendRemove(const QString &fileSource);
 
 Q_SIGNALS:
-    void binded();
+    void bound(wl_resource *resource);
 
 protected:
     void create(WServer *server) override;

--- a/src/modules/wallpaper/wallpapershellinterfacev1.cpp
+++ b/src/modules/wallpaper/wallpapershellinterfacev1.cpp
@@ -30,7 +30,8 @@ protected:
 };
 
 TreelandWallpaperShellInterfaceV1Private::TreelandWallpaperShellInterfaceV1Private(TreelandWallpaperShellInterfaceV1 *_q)
-    : q(_q)
+    : QtWaylandServer::treeland_wallpaper_shell_v1()
+    , q(_q)
 {
 }
 

--- a/src/modules/window-management/windowmanagementinterfacev1.cpp
+++ b/src/modules/window-management/windowmanagementinterfacev1.cpp
@@ -20,19 +20,17 @@ public:
     wl_global *global() const;
 
     WindowManagementInterfaceV1 *q;
-    QList<Resource *> m_resource;
 
     uint32_t state = 0; // desktop_state 0: normal, 1: show, 2: preview;
 protected:
     void bind_resource(Resource *resource) override;
-    void destroy_resource(Resource *resource) override;
-    void destroy_global() override;
     void destroy(Resource *resource) override;
     void set_desktop(Resource *resource, uint32_t state) override;
 };
 
 WindowManagementInterfaceV1Private::WindowManagementInterfaceV1Private(WindowManagementInterfaceV1 *_q)
-    : q(_q)
+    : QtWaylandServer::treeland_window_management_v1()
+    , q(_q)
 {
 }
 
@@ -43,17 +41,7 @@ wl_global *WindowManagementInterfaceV1Private::global() const
 
 void WindowManagementInterfaceV1Private::bind_resource(Resource *resource)
 {
-    m_resource.append(resource);
     send_show_desktop(resource->handle, state);
-}
-
-void WindowManagementInterfaceV1Private::destroy_resource(Resource *resource)
-{
-    m_resource.removeOne(resource);
-}
-
-void WindowManagementInterfaceV1Private::destroy_global() {
-    m_resource.clear();
 }
 
 void WindowManagementInterfaceV1Private::destroy(Resource *resource) {
@@ -100,7 +88,7 @@ void WindowManagementInterfaceV1::setDesktopState(DesktopState state)
     }
 
     d->state = s;
-    for (auto resource : d->m_resource) {
+    for (const auto &resource : d->resourceMap()) {
         d->send_show_desktop(resource->handle, s);
     }
 

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1556,9 +1556,9 @@ void Helper::init(Treeland::Treeland *treeland)
         m_wallpaperNotifierInterfaceV1->setFilter([this](WClient *client) { return m_sessionManager->isDDEUserClient(client); });
     }
     connect(m_wallpaperNotifierInterfaceV1,
-            &TreelandWallpaperNotifierInterfaceV1::binded,
+            &TreelandWallpaperNotifierInterfaceV1::bound,
             m_wallpaperManager,
-            &WallpaperManager::onWallpaperNotifierbinded);
+            &WallpaperManager::onWallpaperNotifierBound);
 
     m_wallpaperManagerInterfaceV1 = m_server->attach<TreelandWallpaperManagerInterfaceV1>();
     connect(m_wallpaperManagerInterfaceV1,

--- a/src/wallpaper/wallpapermanager.cpp
+++ b/src/wallpaper/wallpapermanager.cpp
@@ -423,13 +423,13 @@ void WallpaperManager::onVideoChanged(int workspaceIndex, const QString &fileSou
     }
 }
 
-void WallpaperManager::onWallpaperNotifierbinded()
+void WallpaperManager::onWallpaperNotifierBound(wl_resource *resource)
 {
     QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> globalWallpapers = globalValidWallpaper(nullptr, -1);
     QMapIterator<QString, TreelandWallpaperInterfaceV1::WallpaperType> i(globalWallpapers);
     while (i.hasNext()) {
         i.next();
-        Helper::instance()->m_wallpaperNotifierInterfaceV1->sendAdd(static_cast<TreelandWallpaperInterfaceV1::WallpaperType>(i.value()), i.key());
+        Helper::instance()->m_wallpaperNotifierInterfaceV1->sendAddForResource(resource, static_cast<TreelandWallpaperInterfaceV1::WallpaperType>(i.value()), i.key());
     }
 }
 

--- a/src/wallpaper/wallpapermanager.h
+++ b/src/wallpaper/wallpapermanager.h
@@ -55,7 +55,7 @@ public Q_SLOTS:
     void onVideoChanged(int workspaceIndex,
                         const QString &fileSource,
                         TreelandWallpaperInterfaceV1::WallpaperRoles roles);
-    void onWallpaperNotifierbinded();
+    void onWallpaperNotifierBound(wl_resource *resource);
     void handleWallpaperSurfaceAdded(TreelandWallpaperSurfaceInterfaceV1 *interface);
 
 private:


### PR DESCRIPTION
Drop the custom `m_resource` list and related lifecycle handlers (`bind_resource`, `destroy_resource`, `destroy_global`) across multiple interface implementations.

All resource management is now delegated to the underlying QtWaylandServer infrastructure via `resourceMap()`, eliminating redundant bookkeeping and reducing the risk of inconsistencies.

Additionally, clean up resource usage by removing duplicated storage and relying on the base class accessors where appropriate.

Log: Remove redundant resource tracking and use `resourceMap()`

Influence: No functional change; simplifies code and improves consistency

## Summary by Sourcery

Simplify multiple Wayland interface implementations by delegating resource management to QtWaylandServer base classes instead of maintaining manual resource lists.

Enhancements:
- Remove custom resource tracking lists and lifecycle handlers in various Wayland interface private classes in favor of using the inherited resourceMap() and base class initialization.
- Adjust constructors of several interface manager/private classes to explicitly initialize their QtWaylandServer base types, improving consistency with the Wayland protocol wrappers.
- Update wallpaper notifier and manager interactions to use per-resource notifications and a signal carrying wl_resource*, ensuring newly bound clients receive existing wallpaper state without relying on local resource lists.