### PR TITLE
[codex] add QA docs and test harness examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+Treeland is a CMake-based C++/Qt Wayland compositor. Core code lives in
+`src/`, with major areas split into `core/`, `input/`, `output/`, `surface/`,
+`workspace/`, `modules/`, and `plugins/`. Wayland protocol definitions are in
+`protocols/`; runtime resources, D-Bus interfaces, dconfig files, shaders, icons, and
+systemd/session files are under `misc/`. Test clients and manual demos live in
+`examples/`, while automated protocol tests are in `tests/`. In-tree dependencies are
+kept in `waylib/` and `qwlroots/`; touch them only when the change is intentionally
+within those components.
+
+## Build, Test, and Development Commands
+
+- `cmake -B build -DWITH_SUBMODULE_WAYLIB=ON` configures with bundled `waylib` and
+  `qwlroots`.
+- `cmake -B build -DWITH_SUBMODULE_WAYLIB=OFF` configures against system-provided
+  Waylib.
+- `cmake --build build` builds Treeland and enabled subdirectories.
+- `ctest --test-dir build --output-on-failure` runs registered CTest tests.
+- `cmake -B build -DBUILD_TREELAND_EXAMPLES=ON` also builds example clients.
+- `dpkg-buildpackage -uc -us -nc -b` builds Debian packages after installing build
+  dependencies with `sudo apt build-dep .`.
+
+## Coding Style & Naming Conventions
+
+Use C++20 and C23 as configured in `CMakeLists.txt`. Follow `.editorconfig`: UTF-8,
+LF endings, final newline, spaces, and 4-space indentation except YAML uses 2 spaces
+and Makefiles use tabs. Format C/C++ changes with the repository `.clang-format`
+(Qt/WebKit-derived style, 100-column limit, right-aligned pointers, grouped includes).
+Prefer existing Qt naming patterns: classes in `UpperCamelCase`, functions and
+variables in `lowerCamelCase`, and CMake options in `UPPER_SNAKE_CASE`.
+
+## Testing Guidelines
+
+Add protocol or behavior tests under `tests/test_<area>/` with a local
+`CMakeLists.txt`, then register them from `tests/CMakeLists.txt`. Keep names
+descriptive, following existing patterns such as
+`test_protocol_shortcut` and `test_protocol_window-management`. Run `ctest` from the
+configured build tree before submitting changes; for UI or compositor behavior, add or
+update an `examples/test_*` client when it helps reproduce the scenario.
+
+## Commit & Pull Request Guidelines
+
+Recent history uses Conventional Commit-style subjects such as `fix: ...`,
+`feat: ...`, and `refactor: ...`; scope each commit to one logical change. Pull
+requests should describe behavior changes, list validation commands, and link related
+issues. Include screenshots or short recordings for visible UI, shell, wallpaper,
+lockscreen, or multitask-view changes. CI runs commit lint, cppcheck, and component
+builds for Treeland, Waylib, and qwlroots.
+
+## Security & Configuration Tips
+
+Do not commit local build trees, generated packages, or machine-specific session
+configuration. Treat files in `misc/dbus`, `misc/systemd`, `misc/dconfig`, and
+`protocols` as public integration contracts; document compatibility effects when
+changing them.

--- a/docs/quality-assurance.md
+++ b/docs/quality-assurance.md
@@ -1,0 +1,154 @@
+# Treeland 自动化测试与质量保证方案
+
+## 目标
+
+Treeland 是基于 wlroots、Waylib 和 QtQuick 的 Wayland compositor，质量风险主要集中在协议生命周期、窗口/输出状态机、Qt 对象所有权、系统集成和可视 UI 行为。测试体系应按层拆分，避免只依赖“能编译通过”。
+
+## PR 必跑门禁
+
+- `commitlint`：保持 `fix:`, `feat:`, `refactor:` 等提交格式。
+- `clang-format`：基于仓库 `.clang-format` 检查 C/C++ 格式。
+- `cppcheck`：覆盖常见 C/C++ 静态缺陷。
+- CMake 构建：至少覆盖 `WITH_SUBMODULE_WAYLIB=ON`。
+- CTest：运行 `tests/` 中注册的单元测试和协议测试。
+
+推荐命令：
+
+```bash
+cmake -B build -DWITH_SUBMODULE_WAYLIB=ON -DCMAKE_BUILD_TYPE=Debug
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+## 单元测试
+
+单元测试优先覆盖不依赖真实 compositor 会话的模块，例如：
+
+- `src/input/gestures.*`：手势方向、进度、触发/取消状态机。
+- `src/utils/propertymonitor.*`：Qt 属性变更监听。
+- `src/utils/cmdline.*`：命令行参数拆分与转义。
+- 可拆离的窗口状态、输出配置、快捷键解析逻辑。
+
+新增测试放在 `tests/unit/test_<module>/`，每个目录包含独立 `CMakeLists.txt`，并从 `tests/unit/CMakeLists.txt` 汇总。
+
+### 单元测试使用方法
+
+首次运行前先完成 CMake 配置和构建：
+
+```bash
+cmake -B build -DWITH_SUBMODULE_WAYLIB=ON -DCMAKE_BUILD_TYPE=Debug
+cmake --build build
+```
+
+运行所有单元测试：
+
+```bash
+ctest --test-dir build -R '^test_(gestures|propertymonitor)$' --output-on-failure
+```
+
+运行单个测试目标：
+
+```bash
+ctest --test-dir build -R test_gestures --output-on-failure
+ctest --test-dir build -R test_propertymonitor --output-on-failure
+```
+
+也可以直接执行构建产物，便于本地调试 Qt Test 输出：
+
+```bash
+./build/tests/unit/test_gestures/test_gestures
+./build/tests/unit/test_propertymonitor/test_propertymonitor
+```
+
+新增单元测试时，按现有目录结构创建 `tests/unit/test_<name>/main.cpp` 和
+`tests/unit/test_<name>/CMakeLists.txt`，再把子目录加入 `tests/unit/CMakeLists.txt`。
+
+## Wayland 协议测试
+
+继续扩展现有 `tests/test_protocol_*`。每个协议至少覆盖：
+
+- global bind / destroy 生命周期。
+- request 参数边界和非法请求处理。
+- event 顺序。
+- 多 client 并发。
+- client 提前退出时资源释放。
+- compositor 退出时无 UAF、double free 或悬挂回调。
+
+优先补充 `shortcut`、`personalization`、`window-management`、`capture`、`foreign-toplevel`、`dde-shell` 和 `app-id-resolver`。
+
+## Headless 集成测试
+
+建立轻量 compositor harness，在虚拟输出或 headless backend 中启动 Treeland，再启动测试 client。关键场景：
+
+- 窗口 map / unmap / close。
+- 焦点切换、最大化、全屏和 show desktop。
+- 输出增删、scale 和 transform 变化。
+- 锁屏路径：`DDM` 与 `EXT_SESSION_LOCK_V1`。
+- client 异常退出和协议资源清理。
+
+失败时保留 Treeland 日志、client 日志、截图和 core backtrace 作为 CI artifact。
+
+当前仓库提供了初始 harness：`tests/integration/headless`。默认 CTest 只执行
+`treeland --try-exec` 的 headless 环境 smoke test；真实 compositor 启动测试需要显式开启：
+
+```bash
+TREELAND_RUN_HEADLESS_COMPOSITOR=1 ctest --test-dir build -R test_headless_treeland --output-on-failure
+```
+
+后续可在这个 harness 中继续加入测试 client 启动、窗口 map/unmap、协议 round-trip 和失败日志归档。
+
+### Headless 集成测试使用方法
+
+默认运行 headless harness：
+
+```bash
+ctest --test-dir build -R test_headless_treeland --output-on-failure
+```
+
+默认模式只验证 `treeland --try-exec` 可以在 headless 环境中启动并正常退出，适合放入
+PR CI。测试会通过 CTest 自动传入 `TREELAND_TEST_BINARY=$<TARGET_FILE:treeland>`。
+
+开启真实 compositor smoke test：
+
+```bash
+TREELAND_RUN_HEADLESS_COMPOSITOR=1 ctest --test-dir build -R test_headless_treeland --output-on-failure
+```
+
+该模式会设置临时 `XDG_RUNTIME_DIR`、`WLR_BACKENDS=headless`、
+`WLR_RENDERER=pixman` 和独立 `WAYLAND_DISPLAY`，启动 Treeland 后等待 Wayland
+socket 创建，然后终止进程。若本机 wlroots/headless backend、渲染器或运行时权限不完整，
+该测试可能失败；这种模式更适合 nightly、专用 CI runner 或本地验证。
+
+直接调试时可手动指定二进制：
+
+```bash
+TREELAND_TEST_BINARY=./build/src/treeland ./build/tests/integration/headless/test_headless_treeland
+```
+
+## Qt/QML 与视觉回归
+
+对 lockscreen、multitask view、window picker、wallpaper 等 QML UI 做两类测试：
+
+- Qt Quick Test：组件能加载，required property 完整，signal/model 更新正确。
+- 截图 smoke：固定分辨率虚拟输出，检查关键区域非空、主要元素存在。避免早期使用严格像素对比。
+
+## Sanitizer 与压力测试
+
+每晚或手动 CI 跑 ASan/UBSan：
+
+```bash
+cmake -B build-asan -DADDRESS_SANITIZER=ON -DCMAKE_BUILD_TYPE=Debug
+cmake --build build-asan
+ctest --test-dir build-asan --output-on-failure
+```
+
+压力测试应循环创建/销毁 client、切换窗口焦点、模拟输出变化、切换壁纸、lock/unlock 和 capture 会话，用于暴露生命周期问题。
+
+## Packaging QA
+
+发行前验证 Debian/deepin/Arch 构建，并检查安装产物：
+
+- D-Bus service 与 systemd unit 可解析。
+- session 文件、dconfig schema、QML import 路径有效。
+- plugins 安装到 `TREELAND_PLUGINS_INSTALL_PATH`。
+- `misc/` 与 `protocols/` 变更包含兼容性说明。

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
+add_subdirectory(unit)
+add_subdirectory(integration)
 add_subdirectory(test_protocol_personalization)
 add_subdirectory(test_protocol_primary-output)
 add_subdirectory(test_protocol_shortcut)

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(headless)

--- a/tests/integration/headless/CMakeLists.txt
+++ b/tests/integration/headless/CMakeLists.txt
@@ -1,0 +1,20 @@
+find_package(Qt6 REQUIRED COMPONENTS Test)
+
+add_executable(test_headless_treeland
+    main.cpp
+)
+
+target_link_libraries(test_headless_treeland
+    PRIVATE
+        Qt::Test
+)
+
+add_test(
+    NAME test_headless_treeland
+    COMMAND test_headless_treeland
+)
+
+set_property(TEST test_headless_treeland PROPERTY TIMEOUT 20)
+set_property(TEST test_headless_treeland PROPERTY
+    ENVIRONMENT "TREELAND_TEST_BINARY=$<TARGET_FILE:treeland>"
+)

--- a/tests/integration/headless/main.cpp
+++ b/tests/integration/headless/main.cpp
@@ -1,0 +1,101 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFileInfo>
+#include <QProcess>
+#include <QProcessEnvironment>
+#include <QTemporaryDir>
+#include <QTest>
+
+class HeadlessTreelandTest : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void initTestCase()
+    {
+        m_treelandPath = qEnvironmentVariable("TREELAND_TEST_BINARY");
+        QVERIFY2(!m_treelandPath.isEmpty(),
+                 "TREELAND_TEST_BINARY must point to the treeland executable");
+
+        const QFileInfo binary(m_treelandPath);
+        QVERIFY2(binary.exists(),
+                 qPrintable(QStringLiteral("Missing binary: %1").arg(m_treelandPath)));
+        QVERIFY2(binary.isExecutable(),
+                 qPrintable(QStringLiteral("Binary is not executable: %1").arg(m_treelandPath)));
+    }
+
+    void tryExecStartsInHeadlessEnvironment()
+    {
+        QTemporaryDir runtimeDir;
+        QVERIFY(runtimeDir.isValid());
+
+        QProcess process;
+        process.setProcessEnvironment(headlessEnvironment(runtimeDir.path()));
+        process.start(m_treelandPath, { QStringLiteral("--try-exec") });
+
+        QVERIFY2(process.waitForStarted(5000), qPrintable(process.errorString()));
+        QVERIFY2(process.waitForFinished(10000), qPrintable(process.errorString()));
+
+        const QByteArray output = process.readAllStandardOutput() + process.readAllStandardError();
+        QCOMPARE(process.exitStatus(), QProcess::NormalExit);
+        QVERIFY2(process.exitCode() == 0, output.constData());
+    }
+
+    void compositorCreatesWaylandSocketWhenExplicitlyEnabled()
+    {
+        if (!qEnvironmentVariableIsSet("TREELAND_RUN_HEADLESS_COMPOSITOR")) {
+            QSKIP("Set TREELAND_RUN_HEADLESS_COMPOSITOR=1 to run the real compositor smoke test");
+        }
+
+        QTemporaryDir runtimeDir;
+        QVERIFY(runtimeDir.isValid());
+
+        const QString displayName =
+            QStringLiteral("treeland-headless-test-%1").arg(QCoreApplication::applicationPid());
+        const QString socketPath = QDir(runtimeDir.path()).filePath(displayName);
+
+        QProcess process;
+        process.setProcessEnvironment(headlessEnvironment(runtimeDir.path(), displayName));
+        process.start(m_treelandPath);
+
+        QVERIFY2(process.waitForStarted(5000), qPrintable(process.errorString()));
+
+        QTRY_VERIFY_WITH_TIMEOUT(QFileInfo::exists(socketPath), 10000);
+
+        process.terminate();
+        if (!process.waitForFinished(5000)) {
+            process.kill();
+            QVERIFY(process.waitForFinished(5000));
+        }
+
+        const QByteArray output = process.readAllStandardOutput() + process.readAllStandardError();
+        QVERIFY2(process.exitStatus() == QProcess::NormalExit
+                     || process.exitStatus() == QProcess::CrashExit,
+                 output.constData());
+    }
+
+private:
+    QProcessEnvironment headlessEnvironment(const QString &runtimeDir,
+                                            const QString &waylandDisplay = QString()) const
+    {
+        QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+        env.insert(QStringLiteral("XDG_RUNTIME_DIR"), runtimeDir);
+        env.insert(QStringLiteral("WLR_BACKENDS"), QStringLiteral("headless"));
+        env.insert(QStringLiteral("WLR_RENDERER"), QStringLiteral("pixman"));
+        env.insert(QStringLiteral("QT_LOGGING_RULES"), QStringLiteral("treeland.*=true"));
+        env.remove(QStringLiteral("DISPLAY"));
+
+        if (!waylandDisplay.isEmpty())
+            env.insert(QStringLiteral("WAYLAND_DISPLAY"), waylandDisplay);
+
+        return env;
+    }
+
+    QString m_treelandPath;
+};
+
+QTEST_MAIN(HeadlessTreelandTest)
+#include "main.moc"

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(test_gestures)
+add_subdirectory(test_propertymonitor)

--- a/tests/unit/test_gestures/CMakeLists.txt
+++ b/tests/unit/test_gestures/CMakeLists.txt
@@ -1,0 +1,27 @@
+find_package(Qt6 REQUIRED COMPONENTS Test)
+
+add_executable(test_gestures
+    main.cpp
+    ${PROJECT_SOURCE_DIR}/src/input/gestures.h
+    ${PROJECT_SOURCE_DIR}/src/input/gestures.cpp
+)
+
+target_include_directories(test_gestures
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/src
+)
+
+target_link_libraries(test_gestures
+    PRIVATE
+        Qt::Test
+)
+
+add_test(NAME test_gestures COMMAND test_gestures)
+
+set_property(TEST test_gestures PROPERTY
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+set_property(TEST test_gestures PROPERTY
+    TIMEOUT 3
+)

--- a/tests/unit/test_gestures/main.cpp
+++ b/tests/unit/test_gestures/main.cpp
@@ -1,0 +1,85 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "input/gestures.h"
+
+#include <QSignalSpy>
+#include <QTest>
+
+class GestureTest : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void swipeGestureReportsProgressFromMinimumDelta()
+    {
+        SwipeGesture gesture;
+        gesture.setDirection(SwipeGesture::Right);
+        gesture.setMinimumDelta(QPointF(10, 0));
+
+        QCOMPARE(gesture.deltaToProgress(QPointF(0, 0)), 0.0);
+        QCOMPARE(gesture.deltaToProgress(QPointF(5, 0)), 0.5);
+        QCOMPARE(gesture.deltaToProgress(QPointF(15, 0)), 1.0);
+        QVERIFY(!gesture.minimumDeltaReached(QPointF(9, 0)));
+        QVERIFY(gesture.minimumDeltaReached(QPointF(10, 0)));
+    }
+
+    void recognizerStartsAndTriggersMatchingSwipe()
+    {
+        GestureRecognizer recognizer;
+        auto *gesture = new SwipeGesture;
+        gesture->setMinimumFingerCount(3);
+        gesture->setMaximumFingerCount(3);
+        gesture->setDirection(SwipeGesture::Right);
+        gesture->setMinimumDelta(QPointF(10, 0));
+
+        QSignalSpy startedSpy(gesture, &SwipeGesture::started);
+        QSignalSpy progressSpy(gesture, &SwipeGesture::progress);
+        QSignalSpy triggeredSpy(gesture, &SwipeGesture::triggered);
+        QSignalSpy cancelledSpy(gesture, &SwipeGesture::cancelled);
+
+        recognizer.registerSwipeGesture(gesture);
+
+        QCOMPARE(recognizer.startSwipeGesture(2), 0);
+        QCOMPARE(startedSpy.count(), 0);
+
+        QCOMPARE(recognizer.startSwipeGesture(3), 1);
+        QCOMPARE(startedSpy.count(), 1);
+
+        recognizer.updateSwipeGesture(QPointF(5, 0));
+        QCOMPARE(progressSpy.count(), 1);
+        QCOMPARE(progressSpy.takeFirst().at(0).toReal(), 0.5);
+
+        recognizer.updateSwipeGesture(QPointF(5, 0));
+        recognizer.endSwipeGesture();
+
+        QCOMPARE(triggeredSpy.count(), 1);
+        QCOMPARE(cancelledSpy.count(), 0);
+        recognizer.unregisterSwipeGesture(gesture);
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    }
+
+    void recognizerCancelsSwipeBelowMinimumDelta()
+    {
+        GestureRecognizer recognizer;
+        auto *gesture = new SwipeGesture;
+        gesture->setDirection(SwipeGesture::Down);
+        gesture->setMinimumDelta(QPointF(0, 20));
+
+        QSignalSpy triggeredSpy(gesture, &SwipeGesture::triggered);
+        QSignalSpy cancelledSpy(gesture, &SwipeGesture::cancelled);
+
+        recognizer.registerSwipeGesture(gesture);
+        QCOMPARE(recognizer.startSwipeGesture(1), 1);
+        recognizer.updateSwipeGesture(QPointF(0, 10));
+        recognizer.endSwipeGesture();
+
+        QCOMPARE(triggeredSpy.count(), 0);
+        QCOMPARE(cancelledSpy.count(), 1);
+        recognizer.unregisterSwipeGesture(gesture);
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    }
+};
+
+QTEST_MAIN(GestureTest)
+#include "main.moc"

--- a/tests/unit/test_propertymonitor/CMakeLists.txt
+++ b/tests/unit/test_propertymonitor/CMakeLists.txt
@@ -1,0 +1,28 @@
+find_package(Qt6 REQUIRED COMPONENTS Qml Test)
+
+add_executable(test_propertymonitor
+    main.cpp
+    ${PROJECT_SOURCE_DIR}/src/utils/propertymonitor.h
+    ${PROJECT_SOURCE_DIR}/src/utils/propertymonitor.cpp
+)
+
+target_include_directories(test_propertymonitor
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/src
+)
+
+target_link_libraries(test_propertymonitor
+    PRIVATE
+        Qt::Qml
+        Qt::Test
+)
+
+add_test(NAME test_propertymonitor COMMAND test_propertymonitor)
+
+set_property(TEST test_propertymonitor PROPERTY
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+set_property(TEST test_propertymonitor PROPERTY
+    TIMEOUT 3
+)

--- a/tests/unit/test_propertymonitor/main.cpp
+++ b/tests/unit/test_propertymonitor/main.cpp
@@ -1,0 +1,120 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "utils/propertymonitor.h"
+
+#include <QSignalSpy>
+#include <QTest>
+
+class MonitorTarget : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(int value READ value WRITE setValue NOTIFY valueChanged)
+    Q_PROPERTY(QString title READ title WRITE setTitle NOTIFY titleChanged)
+
+public:
+    int value() const { return m_value; }
+
+    void setValue(int value)
+    {
+        if (m_value == value)
+            return;
+        m_value = value;
+        Q_EMIT valueChanged();
+    }
+
+    QString title() const { return m_title; }
+
+    void setTitle(const QString &title)
+    {
+        if (m_title == title)
+            return;
+        m_title = title;
+        Q_EMIT titleChanged();
+    }
+
+    int valueReceiverCount() const
+    {
+        return receivers(SIGNAL(valueChanged()));
+    }
+
+    int titleReceiverCount() const
+    {
+        return receivers(SIGNAL(titleChanged()));
+    }
+
+Q_SIGNALS:
+    void valueChanged();
+    void titleChanged();
+
+private:
+    int m_value = 0;
+    QString m_title;
+};
+
+class PropertyMonitorTest : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void emitsChangeSignalsWhenConfigurationChanges()
+    {
+        PropertyMonitor monitor;
+        MonitorTarget target;
+        QSignalSpy targetChangedSpy(&monitor, &PropertyMonitor::targetChanged);
+        QSignalSpy propertiesChangedSpy(&monitor, &PropertyMonitor::propertiesChanged);
+
+        monitor.setTarget(&target);
+        monitor.setProperties(QStringLiteral("value,title"));
+
+        QCOMPARE(monitor.target(), &target);
+        QCOMPARE(monitor.properties(), QStringLiteral("value,title"));
+        QCOMPARE(targetChangedSpy.count(), 1);
+        QCOMPARE(propertiesChangedSpy.count(), 1);
+
+        monitor.setTarget(&target);
+        monitor.setProperties(QStringLiteral("value,title"));
+
+        QCOMPARE(targetChangedSpy.count(), 1);
+        QCOMPARE(propertiesChangedSpy.count(), 1);
+    }
+
+    void connectsOnlyNamedNotifyPropertiesOnCurrentTarget()
+    {
+        PropertyMonitor monitor;
+        MonitorTarget firstTarget;
+        MonitorTarget secondTarget;
+
+        monitor.setTarget(&firstTarget);
+        monitor.setProperties(QStringLiteral("value, missing"));
+
+        QVERIFY(firstTarget.valueReceiverCount() > 0);
+        QCOMPARE(firstTarget.titleReceiverCount(), 0);
+
+        monitor.setTarget(&secondTarget);
+
+        QCOMPARE(firstTarget.valueReceiverCount(), 0);
+        QVERIFY(secondTarget.valueReceiverCount() > 0);
+        QCOMPARE(secondTarget.titleReceiverCount(), 0);
+    }
+
+    void reconnectsWhenPropertyListChanges()
+    {
+        PropertyMonitor monitor;
+        MonitorTarget target;
+
+        monitor.setTarget(&target);
+        monitor.setProperties(QStringLiteral("value"));
+
+        QVERIFY(target.valueReceiverCount() > 0);
+        QCOMPARE(target.titleReceiverCount(), 0);
+
+        monitor.setProperties(QStringLiteral("title"));
+
+        QCOMPARE(target.valueReceiverCount(), 0);
+        QVERIFY(target.titleReceiverCount() > 0);
+    }
+};
+
+QTEST_MAIN(PropertyMonitorTest)
+#include "main.moc"


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` contributor guidelines for repository layout, build/test commands, style, testing, and PR expectations.
- Add `docs/quality-assurance.md` with the proposed automated testing and QA strategy for Treeland.
- Add example Qt Test unit tests for gesture logic and property monitoring.
- Add an initial headless integration test harness for Treeland startup smoke testing.

## Validation

- `test_gestures`: 5 passed, 0 failed.
- `test_propertymonitor`: 5 passed, 0 failed.
- `test_headless_treeland` with `TREELAND_TEST_BINARY=/bin/true`: 3 passed, 0 failed, 1 skipped.
- Full top-level CMake configure was attempted but blocked locally by missing `wlroots-0.19`.

## Notes

- The real compositor smoke test is gated behind `TREELAND_RUN_HEADLESS_COMPOSITOR=1` so regular PR CI can keep the stable `--try-exec` smoke path.
