### PR TITLE
feat: refactor treeland-screensaver-v1 protocol implementation

### DIFF
--- a/src/modules/screensaver/CMakeLists.txt
+++ b/src/modules/screensaver/CMakeLists.txt
@@ -1,6 +1,9 @@
 find_package(TreelandProtocols 0.5.3 REQUIRED)
 
-ws_generate_local(server ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-screensaver-v1.xml treeland-screensaver-v1-protocol)
+local_qtwayland_server_protocol_treeland(libtreeland
+    PROTOCOL ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-screensaver-v1.xml
+    BASENAME treeland-screensaver-v1
+)
 
 impl_treeland(
     NAME
@@ -8,7 +11,7 @@ impl_treeland(
     SOURCE
         ${CMAKE_SOURCE_DIR}/src/modules/screensaver/screensaverinterfacev1.h
         ${CMAKE_SOURCE_DIR}/src/modules/screensaver/screensaverinterfacev1.cpp
-        ${WAYLAND_PROTOCOLS_OUTPUTDIR}/treeland-screensaver-v1-protocol.c
+        ${CMAKE_BINARY_DIR}/src/modules/screensaver/wayland-treeland-screensaver-v1-server-protocol.c
     INCLUDE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
 )

--- a/src/modules/screensaver/screensaverinterfacev1.cpp
+++ b/src/modules/screensaver/screensaverinterfacev1.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "screensaverinterfacev1.h"
-#include "treeland-screensaver-v1-protocol.h"
+#include "qwayland-server-treeland-screensaver-v1.h"
 #include "helper.h"
 
 #include <wayland-server.h>
@@ -12,64 +12,93 @@
 
 #include <QDebug>
 
-// request implementation
+class ScreensaverInterfaceV1Private : public QtWaylandServer::treeland_screensaver_v1
+{
+public:
+    explicit ScreensaverInterfaceV1Private(ScreensaverInterfaceV1 *_q);
+    wl_global *global() const;
 
-static void inhibit([[maybe_unused]] struct wl_client *client, struct wl_resource *resource, const char *appName, const char *reason) {
-    auto screensaver = static_cast<ScreensaverInterfaceV1 *>(wl_resource_get_user_data(resource));
-    screensaver->inhibit(resource, appName, reason);
-}
-
-static void uninhibit([[maybe_unused]] struct wl_client *client, struct wl_resource *resource) {
-    auto screensaver = static_cast<ScreensaverInterfaceV1 *>(wl_resource_get_user_data(resource));
-    screensaver->uninhibit(resource);
-}
-
-static const struct treeland_screensaver_v1_interface treeland_screensaver_impl {
-    .inhibit = inhibit,
-    .uninhibit = uninhibit,
+    ScreensaverInterfaceV1 *q = nullptr;
+    QHash<wl_resource*, std::tuple<QString, QString>> inhibits;
+protected:
+    void inhibit(Resource *resource, const QString &application_name, const QString &reason_for_inhibit) override;
+    void uninhibit(Resource *resource) override;
+    void destroy(Resource *resource) override;
 };
 
-// wayland object binding
-
-static void handleResourceDestroy(struct wl_resource *resource) {
-    auto screensaver = static_cast<ScreensaverInterfaceV1 *>(wl_resource_get_user_data(resource));
-    screensaver->uninhibit(resource);
+ScreensaverInterfaceV1Private::ScreensaverInterfaceV1Private(ScreensaverInterfaceV1 *_q)
+    : QtWaylandServer::treeland_screensaver_v1()
+    , q(_q)
+{
 }
 
-static void handleBindingGlobal(struct wl_client *client, void *data, uint32_t version, uint32_t id) {
-    auto screensaver = static_cast<ScreensaverInterfaceV1 *>(data);
-    auto *resource = wl_resource_create(client, &treeland_screensaver_v1_interface, version, id);
-    wl_resource_set_implementation(resource, &treeland_screensaver_impl, screensaver, handleResourceDestroy);
+wl_global *ScreensaverInterfaceV1Private::global() const
+{
+    return m_global;
 }
 
-// ScreensaverInterfaceV1
-
-QByteArrayView ScreensaverInterfaceV1::interfaceName() const {
-    static const QByteArray arr(treeland_screensaver_v1_interface.name);
-    return QByteArrayView(arr);
+void ScreensaverInterfaceV1Private::destroy(Resource *resource)
+{
+    uninhibit(resource);
+    wl_resource_destroy(resource->handle);
 }
 
-void ScreensaverInterfaceV1::inhibit(wl_resource *res, const char *appName, const char *reason) {
-    if (m_inhibits.contains(res))
-        return wl_resource_post_error(res, TREELAND_SCREENSAVER_V1_ERROR_ALREADY_INHIBITED,
-                                      "Trying to inhibit with an existing inhibit active");
-    m_inhibits.insert(res, std::make_tuple(QByteArray(appName), QByteArray(reason)));
+void ScreensaverInterfaceV1Private::inhibit(Resource *resource, const QString &application_name, const QString &reason_for_inhibit)
+{
+    wl_resource *res = resource->handle;
+    if (inhibits.contains(res)) {
+        wl_resource_post_error(res, TREELAND_SCREENSAVER_V1_ERROR_ALREADY_INHIBITED,
+                               "Trying to inhibit with an existing inhibit active");
+        return;
+    }
+
+    inhibits.insert(res, std::make_tuple(application_name, reason_for_inhibit));
     Helper::instance()->updateIdleInhibitor();
 }
 
-void ScreensaverInterfaceV1::uninhibit(wl_resource *res) {
-    if (!m_inhibits.contains(res))
-        return wl_resource_post_error(res, TREELAND_SCREENSAVER_V1_ERROR_NOT_YET_INHIBITED,
-                                      "Trying to uninhibit but no active inhibit existed");
-    m_inhibits.remove(res);
+void ScreensaverInterfaceV1Private::uninhibit(Resource *resource)
+{
+    wl_resource *res = resource->handle;
+    if (!inhibits.contains(res)) {
+        wl_resource_post_error(res, TREELAND_SCREENSAVER_V1_ERROR_NOT_YET_INHIBITED,
+                               "Trying to uninhibit but no active inhibit existed");
+        return;
+    }
+
+    inhibits.remove(res);
     Helper::instance()->updateIdleInhibitor();
 }
 
-void ScreensaverInterfaceV1::create(WServer *server) {
-    m_global = wl_global_create(server->handle()->handle(), &treeland_screensaver_v1_interface,
-                                treeland_screensaver_v1_interface.version, this, handleBindingGlobal);
+ScreensaverInterfaceV1::ScreensaverInterfaceV1(QObject *parent)
+    : QObject(parent)
+    , WServerInterface()
+    , d(new ScreensaverInterfaceV1Private(this))
+{
 }
 
-void ScreensaverInterfaceV1::destroy([[maybe_unused]] WServer *server) {
-    wl_global_destroy(m_global);
+ScreensaverInterfaceV1::~ScreensaverInterfaceV1() = default;
+
+QByteArrayView ScreensaverInterfaceV1::interfaceName() const
+{
+    return d->interfaceName();
+}
+
+bool ScreensaverInterfaceV1::isInhibited() const
+{
+    return !d->inhibits.isEmpty();
+}
+
+void ScreensaverInterfaceV1::create(WServer *server)
+{
+    d->init(server->handle()->handle(), InterfaceVersion);
+}
+
+void ScreensaverInterfaceV1::destroy([[maybe_unused]] WServer *server)
+{
+    d->globalRemove();
+}
+
+wl_global *ScreensaverInterfaceV1::global() const
+{
+    return d->global();
 }

--- a/src/modules/screensaver/screensaverinterfacev1.h
+++ b/src/modules/screensaver/screensaverinterfacev1.h
@@ -1,21 +1,28 @@
-// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2025-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wserver.h"
 
-/**
- * Simple idle inhibit protocol.
- */
-class ScreensaverInterfaceV1 : public Waylib::Server::WServerInterface {
-    struct wl_global *m_global { nullptr };
-    QHash<wl_resource*, std::tuple<QByteArray, QByteArray>> m_inhibits;
+WAYLIB_SERVER_USE_NAMESPACE
+
+class ScreensaverInterfaceV1Private;
+class ScreensaverInterfaceV1 : public QObject , public WServerInterface
+{
+    Q_OBJECT
 public:
+    explicit ScreensaverInterfaceV1(QObject *parent = nullptr);
+    ~ScreensaverInterfaceV1() override;
+
     QByteArrayView interfaceName() const override;
-    void inhibit(wl_resource *res, const char *appName, const char *reason);
-    void uninhibit(wl_resource *res);
-    inline bool isInhibited() const { return !m_inhibits.isEmpty(); }
+    bool isInhibited() const;
+
+    static constexpr int InterfaceVersion = 1;
+
 protected:
-    void create(WAYLIB_SERVER_NAMESPACE::WServer *server) override;
-    void destroy(WAYLIB_SERVER_NAMESPACE::WServer *server) override;
-    inline wl_global *global() const override { return m_global; }
+    void create(WServer *server) override;
+    void destroy(WServer *server) override;
+    wl_global *global() const override;
+
+private:
+    std::unique_ptr<ScreensaverInterfaceV1Private> d;
 };


### PR DESCRIPTION
implemented on top of QtWaylandServer generated protocol classes.

Log: refactor treeland-screensaver-v1 protocol implementation. Tasks:

Influence:
1. Verify behavior for treeland-screensaver-v1.

## Summary by Sourcery

Refactor the treeland-screensaver-v1 protocol handling to use QtWaylandServer-generated server-side classes and a QObject-based interface implementation.

Enhancements:
- Introduce a private QtWaylandServer::treeland_screensaver_v1-based helper to manage screensaver inhibit resources and lifecycle.
- Update ScreensaverInterfaceV1 to be a QObject and WServerInterface hybrid with encapsulated state and helper-driven protocol logic.
- Expose an isInhibited query based on the underlying resource map instead of manual hash management.

Build:
- Switch CMake screensaver module to generate and link QtWayland server-side protocol sources via local_qtwayland_server_protocol_treeland instead of the previous ws_generate_local workflow.