### PR TITLE
fix: disconnect socket signals when shell surface is removed

### DIFF
--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -995,6 +995,12 @@ void SurfaceWrapper::markWrapperToRemoved()
         subS->m_parentSurface = nullptr;
     }
     m_subSurfaces.clear();
+    if (auto client = m_shellSurface->waylandClient()) {
+        disconnect(client->socket(),
+                   &WSocket::enabledChanged,
+                   this,
+                   &SurfaceWrapper::onSocketEnabledChanged);
+    }
     m_shellSurface = nullptr;
     if (m_surfaceItem)
         m_surfaceItem->disconnect(this);


### PR DESCRIPTION
SurfaceWrapper may outlive its associated shell surface during teardown. In RootSurfaceContainer::destroyForSurface(), SurfaceWrapper::markWrapperToRemoved() clears m_shellSurface while the wrapper object can still remain alive (e.g. during closing animations).

Log: Prevent potential use-after-free / null dereference in
     onSocketEnabledChanged

Influence:
1. Fix possible crash when surfaces are destroyed while socket state changes are propagated.

## Summary by Sourcery

Bug Fixes:
- Prevent a potential crash by early-returning in onSocketEnabledChanged when the associated shell surface has already been cleared.