### PR TITLE
fix: fullscreen window size reduced by titlebar height

### DIFF
--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -1328,9 +1328,30 @@ void SurfaceWrapper::onAnimationReady()
 {
     Q_ASSERT(m_pendingState != m_surfaceState);
     Q_ASSERT(m_pendingGeometry.isValid());
+    auto setPadding = [&](const QMarginsF& padding){
+        m_surfaceItem->setTopPadding(padding.top());
+        m_surfaceItem->setLeftPadding(padding.left());
+        m_surfaceItem->setRightPadding(padding.right());
+        m_surfaceItem->setBottomPadding(padding.bottom());
+    };
+
+    if (m_surfaceItem) {
+        if (m_pendingState == State::Fullscreen) {
+            m_recoverPadding = QMarginsF(m_surfaceItem->leftPadding(),
+                                         m_surfaceItem->topPadding(),
+                                         m_surfaceItem->rightPadding(),
+                                         m_surfaceItem->bottomPadding());
+            setPadding({0, 0, 0, 0});
+        } else if (m_surfaceState == State::Fullscreen) {
+            setPadding(m_recoverPadding);
+        }
+    }
 
     if (!resize(m_pendingGeometry.size())) {
         // abort change state if resize failed
+        if(m_surfaceItem && m_pendingState == State::Fullscreen) {
+            setPadding(m_recoverPadding);
+        }
         m_geometryAnimation->disconnect(this);
         m_geometryAnimation->deleteLater();
         m_geometryAnimation = nullptr;

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -461,6 +461,7 @@ private:
     SurfaceRole m_surfaceRole = SurfaceRole::Normal;
     quint32 m_autoPlaceYOffset = 0;
     QPoint m_clientRequstPos;
+    QMarginsF m_recoverPadding;
 
     bool m_socketEnabled{ false };
     bool m_windowAnimationEnabled{ true };


### PR DESCRIPTION
Temporarily set the target state before resize() so that
  updateTitleBar() updates topPadding correctly (zero for fullscreen).
  Restore the original state afterwards so doSetSurfaceState() can
  properly track the state transition (e.g. issuing setFullScreen(false)
  when exiting fullscreen).

  在全屏状态切换时，resize()先于updateTitleBar()执行，导致
  resizeSurface()使用了带有标题栏高度的topPadding计算configure
  尺寸，客户端收到的全屏尺寸比实际小了标题栏高度。修复方案是在
  resize前临时设置目标状态以更新padding，随后恢复原始状态。

Log: 修复全屏窗口尺寸被标题栏高度缩减的bug
PMS: BUG-359605
Issue: Fixes #744
Influence: 全屏窗口现在能正确覆盖整个屏幕，退出全屏时客户端也能正确收到状态变更。

## Summary by Sourcery

Bug Fixes:
- Fix fullscreen windows being resized smaller than the screen by the titlebar height during state transitions.