### PR TITLE
fix: 'wallpaper changed' events could not be sent or received

### DIFF
--- a/examples/test_set_wallpaper/main.cpp
+++ b/examples/test_set_wallpaper/main.cpp
@@ -155,9 +155,6 @@ int main(int argc, char *argv[])
                 qApp->exit(EXIT_FAILURE);
                 return;
             }
-            delete wallpaper;
-            delete wallpaperManager;
-            qApp->exit(EXIT_SUCCESS);
         }
     });
     wallpaperManager->instantiate();

--- a/src/modules/wallpaper/wallpapermanagerinterfacev1.cpp
+++ b/src/modules/wallpaper/wallpapermanagerinterfacev1.cpp
@@ -141,7 +141,6 @@ public:
     wl_resource *refSurfaceResource = nullptr;
 
 protected:
-    void bind_resource(Resource *resource) override;
     void destroy_resource(Resource *resource) override;
     void destroy(Resource *resource) override;
     void set_image_source(Resource *resource, const QString &fileSource, uint32_t nativeRole) override;
@@ -160,11 +159,6 @@ TreelandWallpaperInterfaceV1Private::TreelandWallpaperInterfaceV1Private(Treelan
     , resource(_resource)
     , refSurfaceResource(refsurface)
 {
-}
-
-void TreelandWallpaperInterfaceV1Private::bind_resource([[maybe_unused]] Resource *resource)
-{
-    Q_EMIT q->binded();
 }
 
 void TreelandWallpaperInterfaceV1Private::destroy_resource([[maybe_unused]] Resource *resource)

--- a/src/modules/wallpaper/wallpapermanagerinterfacev1.h
+++ b/src/modules/wallpaper/wallpapermanagerinterfacev1.h
@@ -79,7 +79,6 @@ Q_SIGNALS:
     void videoSourceChanged(int workspaceIndex,
                             const QString &fileSource,
                             WallpaperRoles roles);
-    void binded();
 
 private:
     explicit TreelandWallpaperInterfaceV1(struct wl_resource *output,

--- a/src/wallpaper/wallpapermanager.cpp
+++ b/src/wallpaper/wallpapermanager.cpp
@@ -359,24 +359,21 @@ TreelandWallpaperInterfaceV1::WallpaperType WallpaperManager::getWallpaperType(c
 
 void WallpaperManager::onWallpaperAdded(TreelandWallpaperInterfaceV1 *interface)
 {
-    connect(interface,
-        &TreelandWallpaperInterfaceV1::binded,
-        this, [this, interface]{
-            Workspace *workspace = Helper::instance()->workspace();
-            Q_ASSERT(workspace);
-            for (int i = 0; i < m_wallpaperConfig.size(); ++i) {
-                if (m_wallpaperConfig[i].outputName == getOutputId(interface->wOutput()->nativeHandle())) {
-                    WallpaperOutputConfig outputConfig = m_wallpaperConfig[i];
-                    interface->sendChanged(TreelandWallpaperInterfaceV1::Lockscreen, outputConfig.lockScreenWallpapertype, outputConfig.lockscreenWallpaper);
-                    for (WallpaperWorkspaceConfig workspaceConfig : std::as_const(outputConfig.workspaces)) {
-                        if (workspaceConfig.workspaceId == workspace->currentIndex()) {
-                            interface->sendChanged(TreelandWallpaperInterfaceV1::Desktop, workspaceConfig.desktopWallpapertype, workspaceConfig.desktopWallpaper);
-                        }
-                    }
+    Workspace *workspace = Helper::instance()->workspace();
+    Q_ASSERT(workspace);
+    for (int i = 0; i < m_wallpaperConfig.size(); ++i) {
+        if (m_wallpaperConfig[i].outputName == getOutputId(interface->wOutput()->nativeHandle())) {
+            WallpaperOutputConfig outputConfig = m_wallpaperConfig[i];
+            interface->sendChanged(TreelandWallpaperInterfaceV1::Lockscreen, outputConfig.lockScreenWallpapertype, outputConfig.lockscreenWallpaper);
+            for (WallpaperWorkspaceConfig workspaceConfig : std::as_const(outputConfig.workspaces)) {
+                if (workspaceConfig.workspaceId == workspace->currentIndex()) {
+                    interface->sendChanged(TreelandWallpaperInterfaceV1::Desktop, workspaceConfig.desktopWallpapertype, workspaceConfig.desktopWallpaper);
                     break;
                 }
             }
-        }, Qt::SingleShotConnection);
+            break;
+        }
+    }
     connect(interface,
             &TreelandWallpaperInterfaceV1::imageSourceChanged,
             this,


### PR DESCRIPTION
1, modified to immediately send the "wallpaper changed" event upon the creation of TreelandWallpaperInterfaceV1.
2, Removed the logic for destroying the interface after setting the wallpaper in `test_set_wallpaper`, to prevent the client from failing to receive events.

Log: 'wallpaper changed' events could not be sent or received

Influence:

## Summary by Sourcery

Ensure wallpaper change events are delivered immediately when a wallpaper interface is created and keep the test client alive to receive those events.

Bug Fixes:
- Send initial lockscreen and desktop wallpaper state as soon as a TreelandWallpaperInterfaceV1 is added instead of waiting for a bind callback that was never emitted.
- Prevent the test_set_wallpaper client from destroying the wallpaper interfaces and exiting immediately after setting the wallpaper so events can be received.

Enhancements:
- Simplify wallpaper interface lifecycle by removing the unused binded signal and associated callback logic.