### PR TITLE
fix: fix multiple crashes caused by thread affinity

### DIFF
--- a/src/modules/capture/capture.cpp
+++ b/src/modules/capture/capture.cpp
@@ -236,9 +236,6 @@ void CaptureContextV1::handleSourceDestroyed()
 void CaptureContextV1::handleSessionStart()
 {
     m_currentFrameData.acked = true;
-    moveToThread(QQuickWindowPrivate::get(outputRenderWindow())->context->thread());
-    captureSource()->moveToThread(
-        QQuickWindowPrivate::get(outputRenderWindow())->context->thread());
     auto conn = connect(outputRenderWindow(),
                         &WOutputRenderWindow::renderEnd,
                         this,

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -422,7 +422,9 @@ void SurfaceWrapper::convertToNormalSurface(WToplevelSurface *shellSurface, Type
     setup();
     m_surfaceItem->setVisible(false);
 
-    if (surface()->mapped()) {
+    // Check if surface is still valid before accessing
+    WSurface *surf = surface();
+    if (surf && surf->mapped()) {
         syncPrelaunchMappedState();
         startPrelaunchSplashHideSequence();
     }

--- a/waylib/src/server/kernel/wsocket.cpp
+++ b/waylib/src/server/kernel/wsocket.cpp
@@ -146,6 +146,7 @@ public:
     void restore();
 
     void addClient(WClient *client);
+    void doRemoveClient(WClient *client);
 
     W_DECLARE_PUBLIC(WSocket)
 
@@ -499,10 +500,11 @@ void WSocket::close()
     }
 
     if (!d->clients.isEmpty()) {
-        for (auto client : std::as_const(d->clients))
-            removeClient(client);
+        QList<WClient*> clientsToClose;
+        std::swap(clientsToClose, d->clients);
+        for (auto client : std::as_const(clientsToClose))
+            d->doRemoveClient(client);
 
-        d->clients.clear();
         Q_EMIT clientsChanged();
     }
 }
@@ -771,6 +773,23 @@ WClient *WSocket::addClient(wl_client *client, bool isWlClientOwned)
     return wclient;
 }
 
+void WSocketPrivate::doRemoveClient(WClient *client)
+{
+    W_Q(WSocket);
+
+    Q_EMIT q->aboutToBeDestroyedClient(client);
+
+    auto handle = client->handle();
+    if (handle && client->d_func()->isWlClientOwned) {
+        // Set handle to nullptr to prevent handle_destroy from calling removeClient again
+        client->d_func()->handle = nullptr;
+        delete client;
+        wl_client_destroy(handle);
+    } else {
+        delete client;
+    }
+}
+
 bool WSocket::removeClient(wl_client *client)
 {
     if (auto c = WClient::get(client))
@@ -782,20 +801,11 @@ bool WSocket::removeClient(WClient *client)
 {
     W_D(WSocket);
 
-    bool ok = d->clients.removeOne(client);
-    if (!ok)
+    if (!d->clients.removeOne(client))
         return false;
 
-    Q_EMIT aboutToBeDestroyedClient(client);
+    d->doRemoveClient(client);
 
-    auto handle = client->handle();
-    if (handle && client->d_func()->isWlClientOwned) {
-        // Set handle to nullptr to prevent handle_destroy from calling removeClient again
-        client->d_func()->handle = nullptr;
-        wl_client_destroy(handle);
-    }
-
-    delete client;
     Q_EMIT clientsChanged();
 
     return true;

--- a/waylib/src/server/kernel/wsocket.h
+++ b/waylib/src/server/kernel/wsocket.h
@@ -51,6 +51,7 @@ public Q_SLOTS:
 
 private:
     friend class WSocket;
+    friend class WSocketPrivate;
     friend struct WlClientDestroyListener;
     explicit WClient(wl_client *client, WSocket *socket, bool isWlClientOwned = true);
     ~WClient() = default;

--- a/waylib/src/server/qtquick/wtextureproviderprovider.cpp
+++ b/waylib/src/server/qtquick/wtextureproviderprovider.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wtextureproviderprovider.h"
@@ -6,7 +6,6 @@
 #include "private/wglobal_p.h"
 
 #include <rhi/qrhi.h>
-#include <private/qquickwindow_p.h>
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 Q_LOGGING_CATEGORY(qLcTextureProvider, "waylib.server.texture.provider")
@@ -42,9 +41,9 @@ QFuture<QImage> WTextureCapturer::grabToImage()
 {
     W_D(WTextureCapturer);
     auto future = d->imgPromise.future();
-    moveToThread(QQuickWindowPrivate::get(d->renderWindow)->context->thread());
+
     if (d->renderWindow->inRendering()) {
-        connect(d->renderWindow, &WOutputRenderWindow::renderEnd, this, &WTextureCapturer::doGrabToImage, Qt::AutoConnection);
+        connect(d->renderWindow, &WOutputRenderWindow::renderEnd, this, &WTextureCapturer::doGrabToImage, Qt::SingleShotConnection);
     } else {
         // FIXME What if a new render process start before this job is executed?
         QMetaObject::invokeMethod(this, &WTextureCapturer::doGrabToImage, Qt::AutoConnection);
@@ -55,8 +54,10 @@ QFuture<QImage> WTextureCapturer::grabToImage()
 void WTextureCapturer::doGrabToImage()
 {
     W_D(WTextureCapturer);
-    if (d->imgPromise.isCanceled())
-        return;
+    disconnect(d->renderWindow,
+               &WOutputRenderWindow::renderEnd,
+               this,
+               &WTextureCapturer::doGrabToImage);
     d->imgPromise.start();
     WSGTextureProvider *textureProvider = d->provider->wTextureProvider();
     if (textureProvider && textureProvider->texture() && textureProvider->texture()->rhiTexture()) {

--- a/waylib/src/server/utils/wextimagecapturesourcev1impl.cpp
+++ b/waylib/src/server/utils/wextimagecapturesourcev1impl.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2025-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wextimagecapturesourcev1impl.h"
@@ -16,7 +16,7 @@
 #include <qwcompositor.h>
 
 #include <QLoggingCategory>
-#include <private/qquickwindow_p.h>
+
 #include <memory>
 
 Q_LOGGING_CATEGORY(qLcImageCapture, "waylib.server.imagecapture")
@@ -122,17 +122,7 @@ WExtImageCaptureSourceV1Impl::WExtImageCaptureSourceV1Impl(WSurfaceItemContent *
     , m_renderEndConnection()
 {
     Q_ASSERT(m_surfaceContent);
-    
-    // Get texture provider and render window for thread setup
-    auto textureProvider = m_surfaceContent->wTextureProvider();
-    if (textureProvider) {
-        auto renderWindow = textureProvider->window();
-        if (renderWindow) {
-            // Move to render thread
-            moveToThread(QQuickWindowPrivate::get(renderWindow)->context->thread());
-        }
-    }
-    
+
     // Initialize wlr_ext_image_capture_source_v1
     wlr_ext_image_capture_source_v1_init(handle(), impl());
     


### PR DESCRIPTION
and use-after-free issues

Remove moveToThread() calls that cause V4 GC
ScarceResourceData corruption (prev=0xFFFFFFFF SIGSEGV), fix iterator invalidation in WSocket::close(),
add client_list integrity validation before
wl_client_create, and prevent UAF in
WInputMethodHelper::handleNewTI.

移除moveToThread调用避免V4 GC
ScarceResourceData链损坏(prev=0xFFFFFFFF导致SIGSEGV)，
修复WSocket::close()迭代器失效问题，
添加wl_client_create前client_list完整性校验，
防止WInputMethodHelper中的UAF崩溃。

Log: 修复多个崩溃：moveToThread导致的GC链损坏、迭代器失效、UAF等
PMS: BUG-344213
Influence: 修复moveToThread导致的SIGSEGV、迭代器失效、UAF等崩溃，提升稳定性。

## Summary by Sourcery

Strengthen thread-affinity and lifecycle handling around rendering, capture, and Wayland client management to eliminate crashes and improve stability.

Bug Fixes:
- Remove unsafe moveToThread usage in rendering and capture paths to prevent V4 GC ScarceResourceData corruption and related SIGSEGVs.
- Fix WSocket client shutdown by avoiding iterator invalidation, removing destroy listeners safely, and emitting clientsChanged with a consistent client list.
- Validate wl_display client_list integrity before wl_client_create in both WSocket and the security context manager to avoid crashes on corrupted lists.
- Prevent use-after-free in SurfaceWrapper by explicitly deleting and nulling surface items and guarding access to shellSurface and surface objects.
- Avoid use-after-free in WInputMethodHelper text input teardown by no longer force-disconnecting the text input during entityAboutToDestroy handling.

Enhancements:
- Improve robustness of render-end driven image capture by using direct connections, requesting frames when needed, and cleaning up connections after one-shot readback.