### PR TITLE
fix(build): add missing headers for gcc 16 compatibility

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -133,6 +133,7 @@
 #include <linux/input.h>
 #include <pwd.h>
 #include <sys/ioctl.h>
+#include <unistd.h>
 #include <utility>
 #include <wayland-util.h>
 

--- a/src/xwayland.cpp
+++ b/src/xwayland.cpp
@@ -21,6 +21,7 @@
 #include <QTemporaryFile>
 #include <random>
 #include <sys/stat.h>
+#include <unistd.h>
 #include <X11/Xauth.h>
 
 int main(int argc, char *argv[])

--- a/waylib/examples/tinywl/helper.cpp
+++ b/waylib/examples/tinywl/helper.cpp
@@ -76,6 +76,8 @@
 #include <QQmlComponent>
 #include <QVariant>
 
+#include <unistd.h>
+
 #define WLR_FRACTIONAL_SCALE_V1_VERSION 1
 #define EXT_DATA_CONTROL_MANAGER_V1_VERSION 1
 

--- a/waylib/src/server/kernel/wserver.cpp
+++ b/waylib/src/server/kernel/wserver.cpp
@@ -30,6 +30,7 @@
 #include <QProcess>
 #include <QLocalServer>
 #include <QLocalSocket>
+#include <unistd.h>
 #include <private/qthread_p.h>
 #include <private/qguiapplication_p.h>
 #include <qpa/qplatformthemefactory_p.h>

--- a/waylib/src/server/kernel/wsocket.cpp
+++ b/waylib/src/server/kernel/wsocket.cpp
@@ -18,6 +18,7 @@
 #include <sys/types.h>
 #include <sys/un.h>
 #include <signal.h>
+#include <sys/syscall.h>
 #include <errno.h>
 
 struct wl_event_source;

--- a/waylib/src/server/protocols/wxwaylandsurface.cpp
+++ b/waylib/src/server/protocols/wxwaylandsurface.cpp
@@ -10,6 +10,9 @@
 #include <qwxwaylandsurface.h>
 #include <qwcompositor.h>
 
+#include <sys/syscall.h>
+#include <unistd.h>
+
 #define XCOORD_MAX 32767
 
 QW_USE_NAMESPACE


### PR DESCRIPTION
Fixes the Arch Linux build with gcc 16.1.1 which defaults to -std=gnu++20 (previously -std=gnu++17). glibc/system headers no longer transitively expose POSIX functions through other includes.

Add explicit includes for:

  src/xwayland.cpp:
    - <unistd.h> for gethostname() and execvp() src/seat/helper.cpp:
    - <unistd.h> for getuid() and readlink() waylib/src/server/kernel/wserver.cpp:
    - <unistd.h> for getpid() waylib/src/server/kernel/wsocket.cpp:
    - <sys/syscall.h> for SYS_pidfd_open and syscall() waylib/src/server/protocols/wxwaylandsurface.cpp:
    - <sys/syscall.h> for SYS_pidfd_open and syscall()
    - <unistd.h> for close() waylib/examples/tinywl/helper.cpp:
    - <unistd.h> for getuid()