### PR TITLE
feat: add other user login support

### DIFF
--- a/misc/dconfig/org.deepin.dde.treeland.json
+++ b/misc/dconfig/org.deepin.dde.treeland.json
@@ -45,6 +45,17 @@
             "description[zh_CN]": "在 Treeland 启动以及新键盘连接时启用数字键盘",
             "permissions": "readwrite",
             "visibility": "public"
+        },
+        "showOtherUserOption": {
+            "value": false,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Show Other User Option",
+            "name[zh_CN]": "显示其他用户选项",
+            "description": "Show the 'Other...' entry in the login user list to allow logging in as an unlisted (e.g. LDAP/NSS) user",
+            "description[zh_CN]": "在登录用户列表中显示 Other... 选项，允许以未列出的用户（如 LDAP/NSS 用户）登录",
+            "permissions": "readwrite",
+            "visibility": "public"
         }
     }
 }

--- a/src/greeter/user.cpp
+++ b/src/greeter/user.cpp
@@ -59,6 +59,19 @@ User::User(AccountsUserPtr ptr)
     d->updateUserData();
 }
 
+User::User(const QString &userName, uid_t uid, gid_t gid,
+           const QString &homeDir, const QString &fullName)
+    : d(new UserPrivate{})
+{
+    d->userName = userName;
+    d->uid = uid;
+    d->gid = gid;
+    d->homeDir = homeDir;
+    d->fullName = fullName;
+    d->identity = AccountTypes::Default;
+    d->noPasswdLogin = false;
+}
+
 User::~User()
 {
     delete d;

--- a/src/greeter/user.h
+++ b/src/greeter/user.h
@@ -19,6 +19,8 @@ class User : public QObject
     Q_OBJECT
 public:
     explicit User(AccountsUserPtr ptr);
+    explicit User(const QString &userName, uid_t uid, gid_t gid,
+                  const QString &homeDir, const QString &fullName = {});
     ~User() override;
 
     [[nodiscard]] bool noPasswdLogin() const noexcept;

--- a/src/greeter/usermodel.cpp
+++ b/src/greeter/usermodel.cpp
@@ -38,6 +38,7 @@
 #include <QTranslator>
 
 #include <memory>
+#include <algorithm>
 #include <pwd.h>
 
 using namespace DDM;
@@ -354,4 +355,46 @@ void UserModel::onUserDeleted(quint64 uid)
     endResetModel();
 
     Q_EMIT countChanged();
+}
+
+bool UserModel::tryAddNssUser(const QString &userName)
+{
+    if (userName.isEmpty()) {
+        return false;
+    }
+
+    // Already in model?
+    bool found = std::any_of(d->users.cbegin(), d->users.cend(),
+                             [&userName](const UserPtr &u) { return u->userName() == userName; });
+    if (found) {
+        qCInfo(treelandGreeter) << "NSS user already in model:" << userName;
+        return true;
+    }
+
+    // TODO: getpwnam is synchronous and may block on slow NSS/LDAP backends;
+    // consider moving to an async worker thread in a future iteration.
+    struct passwd *pw = ::getpwnam(userName.toLocal8Bit().constData());
+    if (!pw) {
+        qCInfo(treelandGreeter) << "NSS user not found:" << userName;
+        return false;
+    }
+
+    // pw_gecos is comma-separated ("Full Name,Room,Work,Home,Other"); use only the first field.
+    QString fullName = QString::fromLocal8Bit(pw->pw_gecos).section(QLatin1Char(','), 0, 0);
+
+    qCInfo(treelandGreeter) << "Adding NSS/LDAP user to model:" << userName;
+    beginResetModel();
+    d->users.emplace_back(std::make_unique<User>(
+        userName,
+        static_cast<uid_t>(pw->pw_uid),
+        static_cast<gid_t>(pw->pw_gid),
+        QString::fromLocal8Bit(pw->pw_dir),
+        fullName));
+    std::sort(d->users.begin(), d->users.end(), [](const UserPtr &u1, const UserPtr &u2) {
+        return u1->userName() < u2->userName();
+    });
+    endResetModel();
+
+    Q_EMIT countChanged();
+    return true;
 }

--- a/src/greeter/usermodel.h
+++ b/src/greeter/usermodel.h
@@ -80,6 +80,7 @@ public:
     void updateUserLoginState(const QString &username, bool loggedIn);
     void clearUserLoginState();
     [[nodiscard]] bool containsAllUsers() const;
+    [[nodiscard]] Q_INVOKABLE bool tryAddNssUser(const QString &userName);
 
 Q_SIGNALS:
     void currentUserNameChanged();

--- a/src/plugins/lockscreen/qml/ControlAction.qml
+++ b/src/plugins/lockscreen/qml/ControlAction.qml
@@ -16,7 +16,9 @@ RowLayout {
     property int buttonSize: 30
     property bool powerVisible: powerList.visible
 
-    /**************/
+    signal otherUserRequested()
+
+    /***************/
     /* Components */
     /**************/
 
@@ -50,7 +52,7 @@ RowLayout {
     ControlActionItem {
         id: userItem
         Layout.alignment: Qt.AlignHCenter
-        visible: userList.count > 1
+        visible: userList.count > 1 || Helper.globalConfig.showOtherUserOption
         iconName: "login_user"
 
         UserList {
@@ -58,6 +60,7 @@ RowLayout {
             x: (userItem.width - userList.width) / 2 - 10
             y: -userList.height - 10
             onClosed: userItem.expand = false
+            onOtherUserRequested: bottomGroup.otherUserRequested()
         }
 
         onClicked: {

--- a/src/plugins/lockscreen/qml/LockView.qml
+++ b/src/plugins/lockscreen/qml/LockView.qml
@@ -149,6 +149,13 @@ FocusScope {
     /*****************************/
 
     Connections {
+        target: controlAction
+        function onOtherUserRequested() {
+            userInput.startOtherUserMode()
+        }
+    }
+
+    Connections {
         target: GreeterProxy
         function onLockChanged(isLocked) {
             if (isLocked) {

--- a/src/plugins/lockscreen/qml/UserInput.qml
+++ b/src/plugins/lockscreen/qml/UserInput.qml
@@ -13,6 +13,8 @@ Item {
     height: 300
 
     property string normalHint: qsTr("Please enter password")
+    property bool enteringOtherUser: false
+    property bool showUserNotFoundError: false
 
     /**************/
     /* Components */
@@ -70,6 +72,13 @@ Item {
                 source: avatar
                 maskSource: maskSource
                 invert: false
+                visible: !loginGroup.enteringOtherUser
+            }
+            D.DciIcon {
+                anchors.centerIn: parent
+                name: "login_user"
+                sourceSize { width: 96; height: 96 }
+                visible: loginGroup.enteringOtherUser
             }
             Rectangle {
                 radius: 20
@@ -131,10 +140,11 @@ Item {
             width: loginGroup.width
             height: 30
             anchors.horizontalCenter: parent.horizontalCenter
-            echoMode: showPasswordBtn.hiddenPWD ? TextInput.Password : TextInput.Normal
+            echoMode: loginGroup.enteringOtherUser ? TextInput.Normal
+                      : (showPasswordBtn.hiddenPWD ? TextInput.Password : TextInput.Normal)
             rightPadding: capsIndicator.visible ? 24 + capsIndicator.width : 24
             maximumLength: 510
-            placeholderText: qsTr("Password")
+            placeholderText: loginGroup.enteringOtherUser ? qsTr("Username") : qsTr("Password")
             placeholderTextColor: Qt.rgba(1.0, 1.0, 1.0, 0.6)
             color: palette.windowText
             font: D.DTK.fontManager.t8
@@ -143,7 +153,10 @@ Item {
                     capsIndicatorVisible = !capsIndicatorVisible
                     event.accepted = true
                 } else if (event.key === Qt.Key_Return) {
-                    userLogin()
+                    if (loginGroup.enteringOtherUser)
+                        confirmOtherUser()
+                    else
+                        userLogin()
                     event.accepted = true
                 }
             }
@@ -157,7 +170,7 @@ Item {
 
                 D.ActionButton {
                     id: capsIndicator
-                    visible: passwordField.capsIndicatorVisible
+                    visible: passwordField.capsIndicatorVisible && !loginGroup.enteringOtherUser
                     palette.windowText: undefined
                     icon {
                         name: "login_capslock"
@@ -172,6 +185,7 @@ Item {
                 D.ActionButton {
                     id: showPasswordBtn
                     property bool hiddenPWD: true
+                    visible: !loginGroup.enteringOtherUser
                     icon {
                         name: hiddenPWD ? "login_display_password" : "login_hidden_password"
                         height: 10
@@ -223,7 +237,7 @@ Item {
             radius: parent.height / 2
         }
 
-        onClicked: userLogin()
+        onClicked: loginGroup.enteringOtherUser ? confirmOtherUser() : userLogin()
     }
 
     RowLayout {
@@ -287,6 +301,7 @@ Item {
 
     Text {
         id: hintText
+        visible: !loginGroup.enteringOtherUser || loginGroup.showUserNotFoundError
         font: D.DTK.fontManager.t8
         color: Qt.rgba(1.0, 1.0, 1.0, 0.7)
         anchors {
@@ -301,11 +316,35 @@ Item {
     /*****************************/
 
     function updateUser() {
+        loginGroup.enteringOtherUser = false
+        loginGroup.showUserNotFoundError = false
         let currentUser = UserModel.get(UserModel.currentUserName)
         username.text = currentUser.realName.length === 0 ? currentUser.name : currentUser.realName
         passwordField.text = ''
         avatar.fallbackSource = currentUser.icon
         hintText.text = normalHint
+    }
+
+    function startOtherUserMode() {
+        loginGroup.enteringOtherUser = true
+        loginGroup.showUserNotFoundError = false
+        username.text = qsTr("Enter username")
+        passwordField.text = ""
+        passwordField.forceActiveFocus()
+    }
+
+    function confirmOtherUser() {
+        let name = passwordField.text.trim()
+        if (name.length === 0) return
+        if (UserModel.tryAddNssUser(name)) {
+            UserModel.currentUserName = name
+            // updateUser() fires via currentUserNameChanged, resets enteringOtherUser
+        } else {
+            loginGroup.showUserNotFoundError = true
+            hintText.text = qsTr("User not found.")
+            passwordField.selectAll()
+            passwordField.forceActiveFocus()
+        }
     }
 
     function userLogin() {

--- a/src/plugins/lockscreen/qml/UserList.qml
+++ b/src/plugins/lockscreen/qml/UserList.qml
@@ -16,6 +16,8 @@ D.Popup {
     property var useScrollBar: listv.contentHeight > maxListHeight
     property var lastCheckedIndex: -1
 
+    signal otherUserRequested()
+
     focus: true
     padding: 6
     modal: true
@@ -201,6 +203,53 @@ D.Popup {
             onClicked: selectCurrentUser(model.name, index)
 
             checked: UserModel.currentUserName === model.name
+        }
+
+        footer: D.CheckDelegate {
+            id: otherUserItem
+            height: Helper.globalConfig.showOtherUserOption ? 44 : 0
+            width: 220
+            padding: 4
+            focus: true
+            indicator: null
+            visible: Helper.globalConfig.showOtherUserOption
+
+            contentItem: RowLayout {
+                Control {
+                    Layout.preferredHeight: 36
+                    Layout.preferredWidth: 36
+                    Layout.alignment: Qt.AlignVCenter
+                    background: Item {
+                        D.DciIcon {
+                            anchors.fill: parent
+                            name: "login_user"
+                            sourceSize { width: 36; height: 36 }
+                        }
+                    }
+                }
+
+                Column {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 36
+                    Layout.alignment: Qt.AlignVCenter
+                    Text {
+                        text: qsTr("Other…")
+                        color: otherUserItem.ListView.isCurrentItem ? "white" : "black"
+                        font: D.DTK.fontManager.t8
+                    }
+                }
+            }
+
+            background: Rectangle {
+                anchors.fill: parent
+                radius: 6
+                color: otherUserItem.hovered ? Qt.rgba(0.2, 0.2, 0.2, 0.12) : "transparent"
+            }
+
+            onClicked: {
+                users.close()
+                users.otherUserRequested()
+            }
         }
     }
 }


### PR DESCRIPTION
1. Add new User constructor accepting raw user data fields
2. Implement UserModel::tryAddNssUser to lookup and add NSS/LDAP users
3. Add Other option in user list popup on lock screen
4. Implement username input mode with user lookup functionality
5. Handle user not found error display in UI

Influence:
1. Test clicking Other option in user list to enter username mode
2. Verify text field switches from password to username input
3. Test entering valid NSS/LDAP username and confirm user is added
4. Test entering invalid username to verify error message displays
5. Verify login flow works after successfully adding NSS user
6. Test that caps lock and password visibility buttons are hidden in username mode
7. Test that existing users in model cannot be added again
8. Verify user list is properly sorted after adding new user
9. Test switching between normal user and other user modes
10. Verify escape/cancel behavior returns to normal state