### PR TITLE
fix(build): workaround qt_add_shaders bug with '@' in build path

### DIFF
--- a/cmake/DefineTarget.cmake
+++ b/cmake/DefineTarget.cmake
@@ -58,3 +58,34 @@ function(impl_treeland)
     )
 endfunction()
 
+# Workaround for qt_add_shaders bug: paths containing '@' are incorrectly
+# split by Qt6ShaderToolsMacros.cmake (it uses '@' as a replacement separator).
+function(treeland_add_shaders target resourcename)
+    cmake_parse_arguments(arg "BATCHABLE;PRECOMPILE" "PREFIX;BASE" "FILES" ${ARGN})
+
+    set(qsb_outputs "")
+    foreach(shader_file IN LISTS arg_FILES)
+        get_filename_component(shader_name "${shader_file}" NAME)
+        set(qsb_file "${CMAKE_CURRENT_BINARY_DIR}/.qsb/${shader_name}.qsb")
+        list(APPEND qsb_outputs "${qsb_file}")
+
+        add_custom_command(
+            OUTPUT "${qsb_file}"
+            COMMAND Qt6::qsb --qt6 $<$<BOOL:${arg_BATCHABLE}>:--batchable> "${shader_file}" -o "${qsb_file}"
+            DEPENDS "${shader_file}" Qt6::qsb
+            COMMENT "Compiling shader ${shader_name}"
+            VERBATIM
+        )
+        set_source_files_properties("${qsb_file}" PROPERTIES GENERATED TRUE)
+    endforeach()
+
+    add_custom_target(${resourcename}_gen DEPENDS ${qsb_outputs})
+    add_dependencies(${target} ${resourcename}_gen)
+
+    qt_add_resources(${target} "${resourcename}"
+        PREFIX "${arg_PREFIX}"
+        BASE "${arg_BASE}"
+        FILES ${qsb_outputs}
+    )
+endfunction()
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -259,9 +259,8 @@ target_compile_definitions(libtreeland
     WLR_USE_UNSTABLE
 )
 
-qt_add_shaders(libtreeland "treeland_shaders_ng"
+treeland_add_shaders(libtreeland "treeland_shaders_ng"
     BATCHABLE
-    PRECOMPILE
     PREFIX
         "/shaders"
     BASE


### PR DESCRIPTION
Replace qt_add_shaders with treeland_add_shaders using add_custom_command to invoke Qt6::qsb directly, avoiding the '@' splitting bug in Qt6ShaderToolsMacros.cmake.

替换 qt_add_shaders 为自定义的 treeland_add_shaders，通过 add_custom_command 直接调用 Qt6::qsb，绕过 Qt6ShaderToolsMacros.cmake 中 '@' 字符被错误拆分的 bug。

Log: 修复构建路径含 '@' 时着色器编译失败的问题
Issue: Fixes #845
Influence: 构建目录路径包含 '@' 字符（如 /tmp/u@123）时不再编译失败。

## Summary by Sourcery

Work around a Qt shader compilation bug by replacing direct use of qt_add_shaders with a custom helper that invokes qsb explicitly and packages the generated shader binaries as resources.

Bug Fixes:
- Prevent shader compilation failures when the build directory path contains the '@' character by avoiding the buggy qt_add_shaders macro.

Enhancements:
- Introduce a treeland_add_shaders CMake helper function to generate shader binaries via Qt6::qsb and register them as resources in the build.