### PR TITLE
fix: crash caused by treeland capture

### DIFF
--- a/examples/test_capture/main.cpp
+++ b/examples/test_capture/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 #include "capture.h"
 
@@ -89,7 +89,7 @@ int main(int argc, char *argv[])
     QObject::connect(&engine,
                      &QQmlApplicationEngine::objectCreated,
                      manager,
-                     [&app, manager, captureWithMask](QObject *object, const QUrl &) {
+                     [manager, captureWithMask](QObject *object, const QUrl &) {
                          if (auto canvasWindow = qobject_cast<QQuickWindow *>(object)) {
                              auto waylandWindow = static_cast<QtWaylandClient::QWaylandWindow *>(
                                  canvasWindow->handle());

--- a/examples/test_window_appearance/main.cpp
+++ b/examples/test_window_appearance/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Dingyuan Zhang <lxz@mkacg.com>.
+// Copyright (C) 2023-2026 Dingyuan Zhang <lxz@mkacg.com>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "personalization_manager.h"
@@ -29,11 +29,11 @@ public:
         group1Layout->addWidget(button1);
         group1Layout->addWidget(button2);
         mainLayout->addLayout(group1Layout);
-        connect(button1, &QPushButton::clicked, this, [this, button1] {
+        connect(button1, &QPushButton::clicked, this, [this] {
             context->set_window_theme_type(
                 TREELAND_PERSONALIZATION_APPEARANCE_CONTEXT_V1_THEME_TYPE_LIGHT);
         });
-        connect(button2, &QPushButton::clicked, this, [this, button1] {
+        connect(button2, &QPushButton::clicked, this, [this] {
             context->set_window_theme_type(
                 TREELAND_PERSONALIZATION_APPEARANCE_CONTEXT_V1_THEME_TYPE_DARK);
         });

--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -586,7 +586,7 @@ void RootSurfaceContainer::setupSurfaceRequestHandlers(SurfaceWrapper *surface)
     bool isXwayland = surface->type() == SurfaceWrapper::Type::XWayland;
 
     if (isXdgToplevel || isXwayland) {
-        connect(surface, &SurfaceWrapper::requestMinimize, this, [this, surface]() {
+        connect(surface, &SurfaceWrapper::requestMinimize, this, [surface]() {
             auto *helper = Helper::instance();
             if (!helper)
                 return;

--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -320,7 +320,7 @@ void ShellHandler::init(WServer *server, WSeat *seat)
 
     m_wallpaperShell = server->attach<TreelandWallpaperShellInterfaceV1>(m_wallpaperShell);
     if (Helper::instance()->isDDMDisplay()) {
-        m_wallpaperShell->setFilter([this](WClient *client) { return Helper::instance()->sessionManager()->isDDEUserClient(client); });
+        m_wallpaperShell->setFilter([](WClient *client) { return Helper::instance()->sessionManager()->isDDEUserClient(client); });
     }
 
     m_inputMethodHelper = new WInputMethodHelper(server, seat);

--- a/src/core/windowconfigstore.cpp
+++ b/src/core/windowconfigstore.cpp
@@ -98,7 +98,7 @@ void WindowConfigStore::withSplashConfigFor(const QString &appId,
         config,
         &AppConfig::configInitializeSucceed,
         ctx,
-        [this, appId, callback, skipCallback, configGuard](DTK_CORE_NAMESPACE::DConfig *) {
+        [appId, callback, skipCallback, configGuard](DTK_CORE_NAMESPACE::DConfig *) {
             if (!configGuard) {
                 qCWarning(treelandCore)
                     << "WindowConfigStore: configInitializeSucceed but config deleted for" << appId;

--- a/src/modules/capture/capture.cpp
+++ b/src/modules/capture/capture.cpp
@@ -816,8 +816,6 @@ void CaptureSourceSelector::componentComplete()
         m_canvasContainer->addSurface(m_captureManager->maskSurfaceWrapper());
         m_canvas->setX(0);
         m_canvas->setY(0);
-        m_captureManager->maskSurfaceWrapper()->setWorkspaceId(
-            Workspace::ShowOnAllWorkspaceId); // TODO: use a more reasonable id
     }
     QQuickItem::componentComplete();
 }
@@ -1208,7 +1206,6 @@ void CaptureSourceSelector::releaseMaskSurface()
             auto node = q.dequeue();
             if (node) {
                 m_canvasContainer->removeSurface(node);
-                node->setWorkspaceId(-1);
                 m_savedContainer->addSurface(node);
                 for (const auto &child : std::as_const(node->subSurfaces())) {
                     q.enqueue(child);

--- a/src/modules/personalization/personalizationmanagerinterfacev1.cpp
+++ b/src/modules/personalization/personalizationmanagerinterfacev1.cpp
@@ -1056,31 +1056,31 @@ void PersonalizationManagerInterfaceV1::onCursorContextCreated(PersonalizationCu
 
 void PersonalizationManagerInterfaceV1::onAppearanceContextCreated(PersonalizationAppearanceContextV1 *context)
 {
-    connect(context, &PersonalizationAppearanceContextV1::roundCornerRadiusChanged, this, [this](int32_t radius) {
+    connect(context, &PersonalizationAppearanceContextV1::roundCornerRadiusChanged, this, [](int32_t radius) {
         Helper::instance()->config()->setWindowRadius(radius);
         for (auto *c : s_appearanceContexts) {
             c->sendRoundCornerRadius(radius);
         }
     });
-    connect(context, &PersonalizationAppearanceContextV1::iconThemeChanged, this, [this](const QString &theme) {
+    connect(context, &PersonalizationAppearanceContextV1::iconThemeChanged, this, [](const QString &theme) {
         Helper::instance()->config()->setIconThemeName(theme);
         for (auto *c : s_appearanceContexts) {
             c->sendIconTheme(theme);
         }
     });
-    connect(context, &PersonalizationAppearanceContextV1::activeColorChanged, this, [this](const QString &color) {
+    connect(context, &PersonalizationAppearanceContextV1::activeColorChanged, this, [](const QString &color) {
         Helper::instance()->config()->setActiveColor(color);
         for (auto *c : s_appearanceContexts) {
             c->sendActiveColor(color);
         }
     });
-    connect(context, &PersonalizationAppearanceContextV1::windowOpacityChanged, this, [this](uint32_t opacity) {
+    connect(context, &PersonalizationAppearanceContextV1::windowOpacityChanged, this, [](uint32_t opacity) {
         Helper::instance()->config()->setWindowOpacity(opacity);
         for (auto *c : s_appearanceContexts) {
             c->sendWindowOpacity(opacity);
         }
     });
-    connect(context, &PersonalizationAppearanceContextV1::windowThemeTypeChanged, this, [this](uint32_t type) {
+    connect(context, &PersonalizationAppearanceContextV1::windowThemeTypeChanged, this, [](uint32_t type) {
         const auto dconfigType = protocolWindowThemeTypeToDConfig(type);
         if (dconfigType.has_value()) {
             Helper::instance()->config()->setWindowThemeType(*dconfigType);
@@ -1089,7 +1089,7 @@ void PersonalizationManagerInterfaceV1::onAppearanceContextCreated(Personalizati
             c->sendWindowThemeType(type);
         }
     });
-    connect(context, &PersonalizationAppearanceContextV1::titlebarHeightChanged, this, [this](uint32_t height) {
+    connect(context, &PersonalizationAppearanceContextV1::titlebarHeightChanged, this, [](uint32_t height) {
         Helper::instance()->config()->setWindowTitlebarHeight(height);
         for (auto *c : s_appearanceContexts) {
             c->sendWindowTitlebarHeight(height);

--- a/src/modules/virtual-output/virtualoutputmanagerinterfacev1.cpp
+++ b/src/modules/virtual-output/virtualoutputmanagerinterfacev1.cpp
@@ -116,7 +116,7 @@ void VirtualOutputManagerInterfaceV1Private::create_virtual_output(Resource *res
     s_virtualOutputs.append(virtualOutput);
     QObject::connect(virtualOutput, &VirtualOutputInterfaceV1::beforeDestroy,
                      q, &VirtualOutputManagerInterfaceV1::destroyVirtualOutput);
-    QObject::connect(virtualOutput, &QObject::destroyed, [virtualOutput, this]() {
+    QObject::connect(virtualOutput, &QObject::destroyed, [virtualOutput]() {
         s_virtualOutputs.removeOne(virtualOutput);
     });
 

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1197,10 +1197,12 @@ void Helper::onSurfaceWrapperAboutToRemove(SurfaceWrapper *wrapper)
         m_extForeignToplevelListV1->removeSurface(wrapper->shellSurface());
     }
     // Ensure the wrapper is removed from active history early to avoid cascading on half-invalid entries
-    if (wrapper) {
+    if (wrapper && wrapper->workspaceId() != -1) {
         auto ws = workspace();
-        if (ws)
+        if (ws) {
+            Q_ASSERT(ws == wrapper->container());
             ws->removeActivedSurface(wrapper);
+        }
     }
 }
 

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2839,7 +2839,7 @@ void Helper::handleRequestDragForSeat(WSeat *seat, WSurface *)
             DDEActiveInterface::sendDrop(seat);
     });
 
-    QObject::connect(qw_drag::from(drag), &qw_drag::before_destroy, this, [this, seat, drag] {
+    QObject::connect(qw_drag::from(drag), &qw_drag::before_destroy, this, [seat, drag] {
         drag->data = NULL;
         seat->setAlwaysUpdateHoverTarget(false);
     });

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -121,7 +121,6 @@ class SurfaceContainer;
 class SurfaceWrapper;
 class TreelandConfig;
 class TreelandUserConfig;
-class treeland_window_picker_v1;
 class UserModel;
 class VirtualOutputManagerInterfaceV1;
 class WallpaperColorInterfaceV1;


### PR DESCRIPTION
+ 修复一些编译警告
+ Treeland capture有一个特殊的surface container，里面的surface应不属于workspace，workspace id应保持-1，在调用workspace相关的函数之前，应该判断该surface是不是在workspace里面。

## Summary by Sourcery

Fix Treeland capture workspace handling and clean up unused lambda captures to address warnings.

Bug Fixes:
- Avoid removing surfaces without a valid workspace from the active history to prevent crashes when Treeland capture uses a special surface container.

Enhancements:
- Remove unnecessary captures of the enclosing object in various lambdas to reduce compiler warnings and tighten signal/slot connections.
- Stop overriding the workspace ID for capture mask surfaces so they remain outside regular workspaces as intended.
- Remove an unused forward declaration from the seat helper header.