### PR TITLE
fix: skip redundant minimize requests

### DIFF
--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -1553,6 +1553,8 @@ void SurfaceWrapper::setRadius(qreal newRadius)
 
 void SurfaceWrapper::requestMinimize(bool onAnimation)
 {
+    if (m_surfaceState == State::Minimized)
+        return;
     setSurfaceState(State::Minimized);
     if (onAnimation)
         startMinimizeAnimation(iconGeometry(), CLOSE_ANIMATION);


### PR DESCRIPTION
1. Add early return guard in requestMinimize function
2. Check if surface is already in Minimized state before processing

## Summary by Sourcery

Bug Fixes:
- Prevent duplicate minimize requests by skipping state changes when the surface is already minimized.