### PR TITLE
fix: position input method popups on initial text input focus [Fcitx5 on Wayland]

### DIFF
--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -877,6 +877,9 @@ void ShellHandler::onInputPopupSurfaceV2Added(WInputPopupSurface *surface)
     auto parentWrapper = m_rootSurfaceContainer->getSurface(parent);
     parentWrapper->addSubSurface(wrapper);
     m_popupContainer->addSurface(wrapper);
+    // m_popupContainer is a simple SurfaceContainer, so input popups need the
+    // same explicit initialization marker as xdg popups for their first layout.
+    wrapper->setHasInitializeContainer(true);
     wrapper->setOwnsOutput(parentWrapper->ownsOutput());
     Q_ASSERT(wrapper->parentItem());
     Q_EMIT surfaceWrapperAdded(wrapper);
@@ -886,6 +889,7 @@ void ShellHandler::onInputPopupSurfaceV2Removed(WInputPopupSurface *surface)
 {
     auto wrapper = m_rootSurfaceContainer->getSurface(surface->surface());
     Q_EMIT surfaceWrapperAboutToRemove(wrapper);
+    wrapper->setHasInitializeContainer(false);
     m_rootSurfaceContainer->destroyForSurface(wrapper);
 }
 

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -737,8 +737,12 @@ QPointF Output::calculateBasePosition(SurfaceWrapper *surface, const QPointF &dP
         return QPointF();
     }
 
+    const qreal titlebarOffset = parent->titlebarGeometry().isNull()
+        ? 0.0
+        : parent->titlebarGeometry().height();
+
     return QPointF(parent->x() + parent->surfaceItem()->x() + dPos.x(),
-                   parent->y() + parent->surfaceItem()->y() + dPos.y());
+                   parent->y() + parent->surfaceItem()->y() + dPos.y() + titlebarOffset);
 }
 
 void Output::adjustToOutputBounds(QPointF &pos, const QRectF &normalGeo, const QRectF &outputRect) const

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -850,7 +850,13 @@ void Output::clearPopupCache(SurfaceWrapper *surface)
 void Output::arrangePopupSurface(SurfaceWrapper *surface)
 {
     SurfaceWrapper *parentSurfaceWrapper = surface->parentSurface();
-    Q_ASSERT(parentSurfaceWrapper);
+    if (!parentSurfaceWrapper) {
+        //  When an input popup is still alive while its parent text-input client is being torn down, 
+        //  arrangePopupSurface() can run in a transient state where parentSurface is temporarily unavailable.
+        qCWarning(treelandSurface) << "[popup] skip arrangePopupSurface: missing parent surface"
+                                << "surface=" << surface;
+        return;
+    }
 
     QRectF normalGeo = surface->normalGeometry();
     if (normalGeo.isEmpty()) {
@@ -860,15 +866,17 @@ void Output::arrangePopupSurface(SurfaceWrapper *surface)
     WOutputItem *targetOutput = nullptr;
     // TODO： Consider determining the targetOutput based on the upper left corner or overlapping area
     if (surface->type() == SurfaceWrapper::Type::XdgPopup) {
-        targetOutput = Helper::instance()->getOutputAtCursor()->outputItem();
+        auto *outputAtCursor = Helper::instance()->getOutputAtCursor();
+        targetOutput = outputAtCursor ? outputAtCursor->outputItem() : nullptr;
     } else if (surface->type() == SurfaceWrapper::Type::InputPopup) {
-        targetOutput = parentSurfaceWrapper->ownsOutput()->outputItem();
+        auto *parentOutput = parentSurfaceWrapper->ownsOutput();
+        targetOutput = parentOutput ? parentOutput->outputItem() : nullptr;
     }
 
     if (!targetOutput) {
-        qCWarning(treelandSurface) << "[popup] skip arrangePopupSurface: missing target output"
-                   << "surface=" << surface
-                   << "parentSurface=" << parentSurfaceWrapper;
+        qCInfo(treelandSurface) << "[popup] skip arrangePopupSurface: missing target output"
+                                << "surface=" << surface
+                                << "parentSurface=" << parentSurfaceWrapper;
         return;
     }
 

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -15,6 +15,7 @@
 
 #include <wcursor.h>
 #include <winputpopupsurface.h>
+#include <winputpopupsurfaceitem.h>
 #include <wlayersurface.h>
 #include <woutputhelper.h>
 #include <woutputitem.h>
@@ -450,6 +451,12 @@ void Output::addSurface(SurfaceWrapper *surface)
                 // Reposition should ignore positionAutomatic
                 arrangePopupSurface(surface);
             });
+        } else if (surface->type() == SurfaceWrapper::Type::InputPopup) {
+            auto inputPopupSurfaceItem = qobject_cast<WInputPopupSurfaceItem *>(surface->surfaceItem());
+            connect(inputPopupSurfaceItem, &WInputPopupSurfaceItem::referenceRectChanged, this, [surface, this] {
+                // Reposition should ignore positionAutomatic
+                arrangePopupSurface(surface);
+            });
         }
     }
 }
@@ -850,12 +857,25 @@ void Output::arrangePopupSurface(SurfaceWrapper *surface)
         return;
     }
 
-    WOutputItem* targetOutput = Helper::instance()->getOutputAtCursor()->outputItem();
-    bool isSubMenu = (parentSurfaceWrapper->type() == SurfaceWrapper::Type::XdgPopup);
+    WOutputItem *targetOutput = nullptr;
+    // TODO： Consider determining the targetOutput based on the upper left corner or overlapping area
+    if (surface->type() == SurfaceWrapper::Type::XdgPopup) {
+        targetOutput = Helper::instance()->getOutputAtCursor()->outputItem();
+    } else if (surface->type() == SurfaceWrapper::Type::InputPopup) {
+        targetOutput = parentSurfaceWrapper->ownsOutput()->outputItem();
+    }
+
+    if (!targetOutput) {
+        qCWarning(treelandSurface) << "[popup] skip arrangePopupSurface: missing target output"
+                   << "surface=" << surface
+                   << "parentSurface=" << parentSurfaceWrapper;
+        return;
+    }
 
     if (parentSurfaceWrapper->type() == SurfaceWrapper::Type::Layer) {
         handleLayerShellPopup(surface, normalGeo);
     } else {
+        bool isSubMenu = (parentSurfaceWrapper->type() == SurfaceWrapper::Type::XdgPopup);
         handleRegularPopup(surface, normalGeo, isSubMenu, targetOutput);
     }
 }

--- a/waylib/src/server/protocols/private/wtextinput_p.h
+++ b/waylib/src/server/protocols/private/wtextinput_p.h
@@ -59,9 +59,9 @@ enum ContentPurpose {
 Q_ENUM_NS(ContentPurpose)
 
 enum Feature {
-    F_SurroundingText,
-    F_ContentType,
-    F_CursorRect
+    F_SurroundingText = 1 << 0,
+    F_ContentType = 1 << 1,
+    F_CursorRect = 1 << 2
 };
 Q_FLAG_NS(Feature)
 Q_DECLARE_FLAGS(Features, Feature)


### PR DESCRIPTION
该PR修复了Electron应用在原生Wayland下运行时(例如玲珑版MoeKoe Music或者VSCode), 'A'或者'万'提示框以及输入框直接飘到屏幕左上角的BUG, 希望大佬们能对我的PR进行改进, 感谢🌹

Ensure input-method popup surfaces are laid out from the first frame by marking input popups initialized in the popup container, tracking cursor rectangle changes for relayout, and using a safe fallback position before clients provide a cursor rectangle.

Also align internal text-input feature flags with wlroots bitmasks and send the initial text-input rectangle event even when it is empty, so Fcitx5 can show status popups such as 'A'/'万' on first focus.