### PR TITLE
fix: fix build errors with GCC 16.1.1 and Qt 6.11.1 on Arch Linux

### DIFF
--- a/.github/workflows/qwlroots-archlinux-build.yml
+++ b/.github/workflows/qwlroots-archlinux-build.yml
@@ -25,13 +25,14 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pacman -Syu --noconfirm qt6-base cmake pkgconfig wlroots0.19 pixman wayland-protocols wlr-protocols
-          pacman -Syu --noconfirm clang ninja base-devel git
+          pacman -S --noconfirm qt6-base cmake pkgconfig wlroots0.19 pixman wayland-protocols wlr-protocols
+          pacman -S --noconfirm clang ninja base-devel git
 
       - name: Configure and build qwlroots
         working-directory: qwlroots
         run: |
           echo "Working directory:" $PWD
+          rm -rf build
           cmake --preset ci
           cmake --build --preset ci
 
@@ -52,7 +53,7 @@ jobs:
           cd /tmp/qwlroots-install
 
           # Install zip if not available
-          pacman -Syu --noconfirm zip
+          pacman -S --noconfirm zip
 
           # Create package info
           echo "Creating package info..."

--- a/.github/workflows/treeland-archlinux-build.yml
+++ b/.github/workflows/treeland-archlinux-build.yml
@@ -23,40 +23,40 @@ jobs:
 
       - name: Install base dependencies
         run: |
-          pacman -Syu --noconfirm --noprogressbar base-devel git cmake ninja pkgconfig clang make
-          pacman -Syu --noconfirm --noprogressbar fakeroot meson sudo
+          pacman -S --noconfirm --noprogressbar base-devel git cmake ninja pkgconfig clang make
+          pacman -S --noconfirm --noprogressbar fakeroot meson sudo
 
       - name: Install Qt6 dependencies
         run: |
           # Qt6 dependencies matching qwlroots and waylib builds
-          pacman -Syu --noconfirm --noprogressbar qt6-base qt6-declarative qt6-wayland qt6-tools
+          pacman -S --noconfirm --noprogressbar qt6-base qt6-declarative qt6-wayland qt6-tools
 
       - name: Install graphics and wayland dependencies
         run: |
           # Core graphics and wayland dependencies (matching qwlroots and waylib builds)
-          pacman -Syu --noconfirm --noprogressbar pixman vulkan-headers wayland wayland-protocols wlr-protocols
-          pacman -Syu --noconfirm --noprogressbar wlroots0.19 libinput pam systemd-libs jemalloc gcc-libs glibc
+          pacman -S --noconfirm --noprogressbar pixman vulkan-headers wayland wayland-protocols wlr-protocols
+          pacman -S --noconfirm --noprogressbar wlroots0.19 libinput pam systemd-libs jemalloc gcc-libs glibc
 
       - name: Install additional waylib/qwlroots dependencies
         run: |
           # Additional dependencies from waylib and qwlroots build configs
-          pacman -Syu --noconfirm --noprogressbar libdrm xcb-util-errors libxdmcp
+          pacman -S --noconfirm --noprogressbar libdrm xcb-util-errors libxdmcp
 
       - name: Install DTK dependencies
         run: |
           # Try to install DTK from available packages
           # If not available, the build will proceed without them (may fail)
-          pacman -Syu --noconfirm --noprogressbar dtk6core dtk6declarative dtk6systemsettings
+          pacman -S --noconfirm --noprogressbar dtk6core dtk6declarative dtk6systemsettings
 
       - name: Install DDM dependencies
         run: |
           # Try to install DDM from available packages
-          pacman -Syu --noconfirm --noprogressbar ddm
+          pacman -S --noconfirm --noprogressbar ddm
 
       - name: Install MPV dependencies
         run: |
           # Try to install MPV from available packages
-          pacman -Syu --noconfirm --noprogressbar mpv
+          pacman -S --noconfirm --noprogressbar mpv
 
       - name: Build and Install treeland-protocols
         run: |
@@ -78,6 +78,7 @@ jobs:
         run: |
           echo "Working directory:" $PWD
           echo "Configuring treeland with merged waylib and qwlroots code..."
+          rm -rf build
           cmake --preset ci
           cmake --build --preset ci
           echo "✅ treeland built successfully with merged waylib and qwlroots code!"
@@ -98,7 +99,7 @@ jobs:
           cd /tmp/treeland-install
 
           # Install zip if not available
-          pacman -Syu --noconfirm zip
+          pacman -S --noconfirm zip
 
           # Create package info
           echo "Creating package info..."
@@ -126,6 +127,7 @@ jobs:
           ls -la /tmp/treeland-archlinux-*.zip
 
       - name: Upload treeland ArchLinux build artifacts
+        if: ${{ !env.ACT }}
         uses: actions/upload-artifact@v4
         with:
           name: treeland-archlinux-build

--- a/.github/workflows/waylib-archlinux-build.yml
+++ b/.github/workflows/waylib-archlinux-build.yml
@@ -25,9 +25,9 @@ jobs:
           pacman --noconfirm --noprogressbar -Syu
       - name: Install dependencies
         run: |
-          pacman -Syu --noconfirm --noprogressbar base-devel qt6-base qt6-declarative cmake pkgconfig pixman vulkan-headers wlroots0.19 wayland-protocols wlr-protocols git
-          pacman -Syu --noconfirm --noprogressbar clang ninja make
-          pacman -Syu --noconfirm --noprogressbar fakeroot meson sudo
+          pacman -S --noconfirm --noprogressbar base-devel qt6-base qt6-declarative cmake pkgconfig pixman vulkan-headers wlroots0.19 wayland-protocols wlr-protocols git
+          pacman -S --noconfirm --noprogressbar clang ninja make
+          pacman -S --noconfirm --noprogressbar fakeroot meson sudo
 
       - uses: actions/checkout@v4
 
@@ -42,6 +42,7 @@ jobs:
         working-directory: waylib
         run: |
           echo "Working directory:" $PWD
+          rm -rf build
           cmake --preset ci -DWITH_SUBMODULE_QWLROOTS=ON
           cmake --build --preset ci
 
@@ -62,7 +63,7 @@ jobs:
           cd /tmp/waylib-install
 
           # Install zip if not available
-          pacman -Syu --noconfirm zip
+          pacman -S --noconfirm zip
 
           # Create package info
           echo "Creating package info..."

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -32,7 +32,7 @@
             "generator": "Ninja",
             "binaryDir": "${sourceDir}/build",
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror -Wno-stringop-overflow",
+                "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror -Wno-stringop-overflow -Wno-sfinae-incomplete",
                 "CMAKE_C_FLAGS": "-Wall -Wextra -Werror -Wno-stringop-overflow"
             }
         },

--- a/qwlroots/CMakePresets.json
+++ b/qwlroots/CMakePresets.json
@@ -9,7 +9,7 @@
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror",
+        "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror -Wno-sfinae-incomplete",
         "CMAKE_C_FLAGS": "-Wall -Wextra -Werror"
       }
     }

--- a/qwlroots/src/qwglobal.h
+++ b/qwlroots/src/qwglobal.h
@@ -120,11 +120,14 @@ public:
     typedef Derive DeriveType;
 
     qw_class_box() {
+        QT_WARNING_PUSH
+        QT_WARNING_DISABLE_GCC("-Wmaybe-uninitialized")
         if constexpr (requires { static_cast<DeriveType*>(this)->init(); }) {
             static_cast<DeriveType*>(this)->init();
         } else {
             Q_ASSERT_X(false, "qw_class_box", "No default constructor.");
         }
+        QT_WARNING_POP
     }
 
     ~qw_class_box() {

--- a/qwlroots/src/util/qwsignalconnector.h
+++ b/qwlroots/src/util/qwsignalconnector.h
@@ -7,6 +7,7 @@
 #include <QVector>
 
 #include <wayland-server-core.h>
+#include <functional>
 
 QW_BEGIN_NAMESPACE
 
@@ -25,7 +26,10 @@ class qw_signal_connector
             SlotFun1 slot1;
             SlotFun2 slot2;
         };
-        void *data;
+        void *data = nullptr;
+        // Non-empty only for member-function-pointer connects.
+        // Receives (wl signal data, user extra data); both may be null.
+        std::function<void(void *, void *)> mfp_fn;
     };
 
 public:
@@ -77,37 +81,76 @@ public:
     }
     template <typename T>
     inline qw_signal_listener *connect(wl_signal *signal, T *object, void (*slot)(T*)) {
-        return connect(signal, object, reinterpret_cast<SlotFun0>(*(void**)(&slot)));
+        return connect(signal, object, reinterpret_cast<SlotFun0>(slot));
     }
     template <typename T>
     inline qw_signal_listener *connect(wl_signal *signal, T *object, void (*slot)(T*))
         requires ( !std::is_same_v<void,T> ) {
-        return connect(signal, object, reinterpret_cast<SlotFun0>(*(void**)(&slot)));
+        return connect(signal, object, reinterpret_cast<SlotFun0>(slot));
     }
     template <typename T, typename T1>
     inline qw_signal_listener *connect_t(wl_signal *signal, T *object, void (*slot)(T*, T1*))
         requires ( !std::is_same_v<void,T> ) {
-        return connect(signal, object, reinterpret_cast<SlotFun1>(*(void**)(&slot)));
+        return connect(signal, object, reinterpret_cast<SlotFun1>(slot));
     }
     template <typename T, typename T1, typename T2, typename T3>
     inline qw_signal_listener *connect(wl_signal *signal, T *object, void (*slot)(T*, T1*, T2*), T3 *data)
         requires ( !std::is_same_v<void,T> ) {
-        return connect(signal, object, reinterpret_cast<SlotFun2>(*(void**)(&slot)), data);
+        return connect(signal, object, reinterpret_cast<SlotFun2>(slot), data);
     }
+    // Member-function-pointer overloads.
+    //
+    // Member function pointers cannot be converted to regular function pointers:
+    // an MFP may carry a this-pointer adjustment and, for virtual functions,
+    // dispatches through the vtable rather than holding a direct function address.
+    // They are therefore semantically incompatible with free function pointers,
+    // and any cast between the two types is undefined behavior.
+    //
+    // Instead we capture the object pointer and MFP in a std::function lambda.
+    // The lambda is stored in qw_signal_listener::mfp_fn and invoked by the
+    // shared callMfp notify callback.  No type-punning involved.
     template <typename T, typename TSlot>
     inline qw_signal_listener *connect(wl_signal *signal, T *object, void (TSlot::*slot)())
         requires ( std::is_base_of_v<TSlot,T> ) {
-        return connect(signal, object, reinterpret_cast<SlotFun0>(*(void**)(&slot)));
+        auto *typed_obj = static_cast<TSlot *>(object);
+        qw_signal_listener *l = new qw_signal_listener;
+        listenerList.push_back(l);
+        l->signal = signal;
+        l->l.notify = callMfp;
+        l->mfp_fn = [typed_obj, slot](void *, void *) {
+            (typed_obj->*slot)();
+        };
+        wl_signal_add(signal, &l->l);
+        return l;
     }
     template <typename T, typename T1, typename TSlot>
     inline qw_signal_listener *connect(wl_signal *signal, T *object, void (TSlot::*slot)(T1*))
         requires ( std::is_base_of_v<TSlot,T> ) {
-        return connect(signal, object, reinterpret_cast<SlotFun1>(*(void**)(&slot)));
+        auto *typed_obj = static_cast<TSlot *>(object);
+        qw_signal_listener *l = new qw_signal_listener;
+        listenerList.push_back(l);
+        l->signal = signal;
+        l->l.notify = callMfp;
+        l->mfp_fn = [typed_obj, slot](void *sigdata, void *) {
+            (typed_obj->*slot)(static_cast<T1 *>(sigdata));
+        };
+        wl_signal_add(signal, &l->l);
+        return l;
     }
     template <typename T, typename T1, typename T2, typename T3, typename TSlot>
     inline qw_signal_listener *connect(wl_signal *signal, T *object, void (TSlot::*slot)(T1*, T2*), T3 *data)
         requires ( std::is_base_of_v<TSlot,T> ) {
-        return connect(signal, object, reinterpret_cast<SlotFun2>(*(void**)(&slot)), data);
+        auto *typed_obj = static_cast<TSlot *>(object);
+        qw_signal_listener *l = new qw_signal_listener;
+        listenerList.push_back(l);
+        l->signal = signal;
+        l->l.notify = callMfp;
+        l->data = static_cast<void *>(data);
+        l->mfp_fn = [typed_obj, slot](void *sigdata, void *extra) {
+            (typed_obj->*slot)(static_cast<T1 *>(sigdata), static_cast<T2 *>(extra));
+        };
+        wl_signal_add(signal, &l->l);
+        return l;
     }
     void disconnect(qw_signal_listener *l) {
         Q_ASSERT(listenerList.contains(l));
@@ -152,6 +195,11 @@ private:
     static void callSlot2(wl_listener *wl_listener, void *data) {
         qw_signal_listener *listener = wl_container_of(wl_listener, listener, l);
         listener->slot2(listener->object, data, listener->data);
+    }
+
+    static void callMfp(wl_listener *wl_listener, void *data) {
+        qw_signal_listener *listener = wl_container_of(wl_listener, listener, l);
+        listener->mfp_fn(data, listener->data);
     }
 
     QVector<qw_signal_listener*> listenerList;

--- a/waylib/CMakePresets.json
+++ b/waylib/CMakePresets.json
@@ -9,7 +9,7 @@
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror -Wno-stringop-overflow",
+        "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror -Wno-stringop-overflow -Wno-sfinae-incomplete",
         "CMAKE_C_FLAGS": "-Wall -Wextra -Werror -Wno-stringop-overflow"
       }
     }

--- a/waylib/src/server/kernel/wsocket.cpp
+++ b/waylib/src/server/kernel/wsocket.cpp
@@ -15,10 +15,11 @@
 #include <sys/stat.h>
 #include <sys/file.h>
 #include <sys/socket.h>
+#include <sys/syscall.h>
 #include <sys/types.h>
 #include <sys/un.h>
 #include <signal.h>
-#include <sys/syscall.h>
+#include <unistd.h>
 #include <errno.h>
 
 struct wl_event_source;


### PR DESCRIPTION
- Add missing <unistd.h> includes for getpid/getuid/execvp/gethostname/close: src/xwayland.cpp, waylib/src/server/kernel/wserver.cpp, waylib/src/server/protocols/wxwaylandsurface.cpp, waylib/examples/tinywl/helper.cpp
- Add missing <sys/syscall.h>/<unistd.h> for SYS_pidfd_open/syscall(): waylib/src/server/kernel/wsocket.cpp, waylib/src/server/protocols/wxwaylandsurface.cpp
- Suppress GCC 16 false-positive -Wsfinae-incomplete in MOC-generated code (waylibserver and libtreeland targets, CXX-only via generator expression)
- Suppress GCC 16 false-positive -Wmaybe-uninitialized in qw_class_box constructor template (qwlroots/src/qwglobal.h)
- Remove deprecated QPlatformIntegration::RasterGLSurface (Qt 6.11): waylib/src/server/platformplugin/qwlrootsintegration.cpp
- Replace removed DDM::DaemonMessages::LoginSucceeded (not in ddm 0.3.4): greeterproxy.cpp - remove the case as UserLoggedIn already handles login
- Add .destroy = nullptr to Wayland interface structs missing the field (added since-v2 destructor in protocol XMLs): virtual_output_manager_impl.cpp, screensaverinterfacev1.cpp, ddminterfacev1.cpp, personalization_manager_impl.cpp
- workflow: add rm -rf build before cmake --preset ci (prevent stale cache)
- workflow: skip upload-artifact when running under act (no node in container)