### PR TITLE
fix(virtual-output): move beforeDestroy signal to destroy method

### DIFF
--- a/src/modules/virtual-output/virtualoutputmanagerinterfacev1.cpp
+++ b/src/modules/virtual-output/virtualoutputmanagerinterfacev1.cpp
@@ -54,12 +54,12 @@ VirtualOutputInterfaceV1Private::VirtualOutputInterfaceV1Private(VirtualOutputIn
 
 void VirtualOutputInterfaceV1Private::destroy_resource([[maybe_unused]] Resource *resource)
 {
-    Q_EMIT q->beforeDestroy(q);
     delete q;
 }
 
 void VirtualOutputInterfaceV1Private::destroy(Resource *resource)
 {
+    Q_EMIT q->beforeDestroy(q);
     wl_resource_destroy(resource->handle);
 }
 


### PR DESCRIPTION
Move the `beforeDestroy` signal emission from `destroy_resource` to `destroy`. This prevents immediate virtual output restoration when a client exits unexpectedly.

将 `beforeDestroy` 信号从 `destroy_resource` 移动到 `destroy` 中。 防止客户端退出时立即还原虚拟屏，仅在客户端显式调用销毁
时才执行还原逻辑。

PMS: BUG-361711
Log: 修复虚拟屏在客户端退出时被立即还原的问题
Influence: 修复虚拟输出还原时机，影响客户端退出与显式销毁时虚拟屏的还原行为