### PR TITLE
fix: avoid crash on invalid image capture buffer

### DIFF
--- a/waylib/src/server/utils/wextimagecapturesourcev1impl.cpp
+++ b/waylib/src/server/utils/wextimagecapturesourcev1impl.cpp
@@ -301,14 +301,18 @@ void WExtImageCaptureSourceV1Impl::copy_frame(wlr_ext_image_copy_capture_frame_v
     }
 
     auto buffer = textureProvider->qwBuffer();
-    if (!buffer) {
+    if (!buffer || !buffer->handle()) {
         qCWarning(qLcImageCapture) << "No internal buffer available";
         qw_ext_image_copy_capture_frame_v1::from(dst_frame)->fail(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
         return;
     }
 
     // Lock the buffer for the duration of the copy to prevent races during resize
-    buffer->lock();
+    if (!buffer->lock()) {
+        qCWarning(qLcImageCapture) << "Failed to lock internal buffer";
+        qw_ext_image_copy_capture_frame_v1::from(dst_frame)->fail(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
+        return;
+    }
     std::unique_ptr<qw_buffer, qw_buffer::unlocker> bufferGuard(buffer);
     
     // Get renderer


### PR DESCRIPTION
PMS: BUG-339455

Log: Check native buffer handle and lock result before copying image capture frames

Influence: Prevents ext image capture from crashing when the cached source buffer is invalid