### PR TITLE
fix: only dismiss grabbed popups on outside click

### DIFF
--- a/src/core/popupsurfacecontainer.cpp
+++ b/src/core/popupsurfacecontainer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2025-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "popupsurfacecontainer.h"
@@ -8,6 +8,47 @@
 
 #include <QLoggingCategory>
 
+#include <wxdgpopupsurface.h>
+#include <qwxdgshell.h>
+
+#include <wayland-util.h>
+
+extern "C" {
+#include <wlr/types/wlr_xdg_shell.h>
+}
+
+/**
+ * Check if a popup has grabbed input.
+ * 
+ * In Wayland, popups that call xdg_popup.grab() are "real" popups (menus, dropdowns, etc.)
+ * that should be dismissed when clicking outside. Popups without grab (like tooltips)
+ * should NOT be dismissed by the compositor.
+ */
+static bool popupHasGrab(SurfaceWrapper *surface)
+{
+    if (!surface || surface->type() != SurfaceWrapper::Type::XdgPopup)
+        return false;
+
+    auto shellSurface = surface->shellSurface();
+    if (!shellSurface)
+        return false;
+
+    auto popupSurface = qobject_cast<WAYLIB_SERVER_NAMESPACE::WXdgPopupSurface *>(shellSurface);
+    if (!popupSurface)
+        return false;
+
+    auto handle = popupSurface->handle();
+    if (!handle)
+        return false;
+
+    auto wlrPopup = handle->handle();
+    if (!wlrPopup)
+        return false;
+
+    // Check if the popup has grabbed input by testing if grab_link is non-empty
+    // wl_list_empty() returns true when grab_link.next == &grab_link (self-referential)
+    return !wl_list_empty(&wlrPopup->grab_link);
+}
 
 PopupSurfaceContainer::PopupSurfaceContainer(SurfaceContainer *parent)
     : SurfaceContainer(parent)
@@ -17,21 +58,22 @@ PopupSurfaceContainer::PopupSurfaceContainer(SurfaceContainer *parent)
 
 void PopupSurfaceContainer::mousePressEvent(QMouseEvent *event)
 {
-    // Filter surfaces to only include XdgPopup type surfaces
-    QList<SurfaceWrapper *> xdgPopupSurfaces;
+    // Filter surfaces to only include XdgPopup type surfaces that have grabbed input
+    // Only these popups should be dismissed when clicking outside
+    QList<SurfaceWrapper *> grabbedPopupSurfaces;
     for (auto surface : std::as_const(surfaces())) {
-        if (surface->type() == SurfaceWrapper::Type::XdgPopup) {
-            xdgPopupSurfaces.append(surface);
+        if (popupHasGrab(surface)) {
+            grabbedPopupSurfaces.append(surface);
         }
     }
 
-    if (!xdgPopupSurfaces.isEmpty()) {
-        qCDebug(treelandShell) << "Intercepting mouse press event due to active popup surfaces";
+    if (!grabbedPopupSurfaces.isEmpty()) {
+        qCDebug(treelandShell) << "Intercepting mouse press event due to active grabbed popup surfaces";
         // If surfaces are not empty, intercept the mouse press event to prevent it from reaching
         // lower z-index components
         event->accept();
         // Get all surfaces in this container and close them
-        for (auto surface : xdgPopupSurfaces) {
+        for (auto surface : grabbedPopupSurfaces) {
             // Maybe the surface is removed by it's parent surface
             if (!surfaces().contains(surface)) {
                 continue;

--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -7,6 +7,7 @@
 #include "core/qmlengine.h"
 #include "core/windowconfigstore.h"
 #include "layersurfacecontainer.h"
+#include "popupsurfacecontainer.h"
 #include "modules/app-id-resolver/appidresolver.h"
 #include "modules/dde-shell/ddeshellmanagerinterfacev1.h"
 #include "modules/foreign-toplevel/foreigntoplevelmanagerv1.h"
@@ -61,7 +62,7 @@ ShellHandler::ShellHandler(RootSurfaceContainer *rootContainer, WServer *server)
     , m_workspace(new Workspace(rootContainer))
     , m_topContainer(new LayerSurfaceContainer(rootContainer))
     , m_overlayContainer(new LayerSurfaceContainer(rootContainer))
-    , m_popupContainer(new SurfaceContainer(rootContainer))
+    , m_popupContainer(new PopupSurfaceContainer(rootContainer))
     , m_windowConfigStore(new WindowConfigStore(this))
 {
     m_treelandForeignToplevel = server->attach<ForeignToplevelV1>();

--- a/src/core/shellhandler.h
+++ b/src/core/shellhandler.h
@@ -171,9 +171,9 @@ private:
     Workspace *m_workspace = nullptr;
     LayerSurfaceContainer *m_topContainer = nullptr;
     LayerSurfaceContainer *m_overlayContainer = nullptr;
-    // FIXME: https://github.com/linuxdeepin/treeland/pull/428 Caused damage to the tooltip
-    // Need to find a better way to handle popup click events
-    SurfaceContainer *m_popupContainer = nullptr;
+    // PopupSurfaceContainer only dismisses popups that have grabbed input (via xdg_popup.grab)
+    // This allows tooltips (which don't grab) to remain visible when clicking outside
+    PopupSurfaceContainer *m_popupContainer = nullptr;
     QObject *m_windowMenu = nullptr;
     // Prelaunch wrappers created before binding to a real shell surface
     QList<SurfaceWrapper *> m_prelaunchWrappers;


### PR DESCRIPTION
The previous implementation dismissed all XdgPopup surfaces when clicking on the popup parent window, which incorrectly closed tooltips that should remain visible. This fix adds a check to only dismiss popups that have grabbed input via xdg_popup.grab().

1. Add popupHasGrab() function to check if a popup has grabbed input
2. Filter popup surfaces to only include those with grab when handling mouse press events
3. Change PopupSurfaceContainer type from SurfaceContainer to use proper popup handling
4. Only intercept mouse press events for grabbed popups, allowing tooltips to stay open

Log: Fix popup dismissal behavior - only close menus/dropdowns on outside click, not tooltips

Influence:
1. Test that popup menus (with grab) close when clicking on parent window
2. Verify tooltips remain visible when clicking on parent window
3. Test dropdown menus still work correctly
4. Verify no regression in popup interaction behavior
5. Test multiple nested popups maintain correct behavior

fix: 只应在点击外部时关闭已捕获输入弹窗

之前的实现在点击弹窗父窗口时会关闭所有 XdgPopup 表面，这错误地关闭了应该
保持可见的工具提示。此修复增加了检查，只关闭通过 xdg_popup.grab() 捕获了
输入的弹窗。

1. 添加 popupHasGrab() 函数检查弹窗是否捕获了输入
2. 在处理鼠标按压事件时只过滤出有捕获的弹窗表面
3. 将 PopupSurfaceContainer 类型从 SurfaceContainer 改为使用正确的弹窗 处理
4. 只拦截已捕获弹窗的鼠标按压事件，允许工具提示保持打开状态

Log: 修复弹窗关闭行为 - 只在点击外部时关闭菜单/下拉列表，不关闭工具提示

Influence:
1. 测试弹窗菜单（有捕获）在点击父窗口时关闭
2. 验证工具提示在点击父窗口时保持可见
3. 测试下拉菜单功能正常
4. 验证弹窗交互行为没有回归
5. 测试多个嵌套弹窗保持正确行为

PMS: BUG-344227

## Summary by Sourcery

Limit popup dismissal on outside clicks to popups that have grabbed input, preserving tooltip visibility while keeping menu and dropdown behavior intact.

Bug Fixes:
- Fix unintended closing of non-grabbed popups such as tooltips when clicking on a popup’s parent window.

Enhancements:
- Introduce a grab-awareness helper and a dedicated PopupSurfaceContainer to selectively intercept mouse press events for grabbed popups only.