### PR TITLE
fix(render): fix texture copy crash when window partially off-screen

### DIFF
--- a/waylib/src/server/qtquick/private/wrenderbuffernode.cpp
+++ b/waylib/src/server/qtquick/private/wrenderbuffernode.cpp
@@ -749,13 +749,19 @@ public:
                        texture->data->pixelSize().height() / float(m_rect.height() * devicePixelRatio)});
             rhi->render(renderData->rt.get());
         } else {
-            auto rhi = this->rhi->rhi();
-            QPointF sourcePos = renderMatrix.map(m_rect.topLeft()) * devicePixelRatio;
+            const QPoint sourcePos = (renderMatrix.map(m_rect.topLeft()) * devicePixelRatio).toPoint();
+            const QRect sourceTextureRect(sourcePos, texture->data->pixelSize());
+            const QRect renderTargetRect(QPoint(0, 0), ct->pixelSize());
+            const QRect copySourceRect = sourceTextureRect.intersected(renderTargetRect);
+            if (copySourceRect.isEmpty())
+                return;
 
+            auto rhi = this->rhi->rhi();
             auto rub = rhi->nextResourceUpdateBatch();
             QRhiTextureCopyDescription desc;
-            desc.setPixelSize(texture->data->pixelSize());
-            desc.setSourceTopLeft(sourcePos.toPoint());
+            desc.setPixelSize(copySourceRect.size());
+            desc.setSourceTopLeft(copySourceRect.topLeft());
+            desc.setDestinationTopLeft(copySourceRect.topLeft() - sourcePos);
             rub->copyTexture(texture->data, ct, desc);
 
             QRhiCommandBuffer *cb = nullptr;


### PR DESCRIPTION
PMS: BUG-332025

Log:
- When window is partially off-screen, sourcePos calculated from renderMatrix and devicePixelRatio (often fractional) can result in non-integer coordinates.
- Original code used .toPoint() directly without proper clipping, causing the copy rectangle to slightly exceed render target bounds.
- This produced invalid QRhiTextureCopyDescription, leading to memory corruption in QRhi rendering pipeline ("corrupted size vs. prev_size").

Influence:
- Rendering stability when windows are near screen edges

copyTexture() 这个 API 属于底层操作，它不会做复杂的边界检查和裁剪。
如果你传入负坐标、超出范围的 rect，QRhi 后端（尤其是 Vulkan / Metal / D3D12）可能直接把参数扔给 GPU 驱动，产生未定义行为（UB