### PR TITLE
fix(wsocket): fix WClient::get() returning null during client teardown

### DIFF
--- a/waylib/src/server/kernel/wsocket.cpp
+++ b/waylib/src/server/kernel/wsocket.cpp
@@ -212,8 +212,8 @@ WlClientDestroyListener *WlClientDestroyListener::get(const wl_client *client)
 
 WlClientDestroyListener *WlClientDestroyListener::get_late(const wl_client *client)
 {
-    wl_listener *listener = wl_client_get_destroy_listener(const_cast<wl_client*>(client),
-                                                           WlClientDestroyListener::handle_destroy_late);
+    wl_listener *listener = wl_client_get_destroy_late_listener(const_cast<wl_client*>(client),
+                                                                WlClientDestroyListener::handle_destroy_late);
     if (!listener) {
         return nullptr;
     }
@@ -384,7 +384,12 @@ QSharedPointer<WClient::Credentials> WClient::getCredentials(const wl_client *cl
 
 WClient *WClient::get(const wl_client *client)
 {
+    // Fast path: client is alive, its early destroy listener is in destroy_signal.
     if (auto tmp = WlClientDestroyListener::get(client))
+        return tmp->client;
+    // Dying path: handle_destroy has fired (wl_priv_signal_final_emit removed the
+    // early listener before calling it), but handle_destroy_late has not yet fired.
+    if (auto tmp = WlClientDestroyListener::get_late(client))
         return tmp->client;
     return nullptr;
 }


### PR DESCRIPTION
libwayland's wl_priv_signal_final_emit removes each listener from its list *before* calling its notify callback. This means that by the time handle_destroy fires, wl_client_get_destroy_listener() can no longer find the early listener, causing WlClientDestroyListener::get() to return null. The old code cleared WClient::handle in handle_destroy, so WClient::get() returned null for the entire window between handle_destroy and handle_destroy_late — while Wayland resources (e.g. wlr_surface) were still being torn down and could still call waylandClient(). This caused Q_ASSERT(wclient) crashes in WObject::waylandClient().

The root cause of the original get_late() being broken was that it called wl_client_get_destroy_listener(), which only searches destroy_signal, while handle_destroy_late was registered to destroy_late_signal via wl_client_add_destroy_late_listener(). The two signals have separate listener lists, so lookup always returned null.

Fix:
- Use wl_client_get_destroy_late_listener() (available since libwayland 1.22) in get_late() so it correctly searches destroy_late_signal.
- Move the handle = nullptr clear from handle_destroy to handle_destroy_late. This keeps handle() valid during the dying window so callers can detect the dying state.
- Add a get_late() fallback in WClient::get() for the dying window (after handle_destroy but before handle_destroy_late). Callers that receive a dying WClient can check handle() == nullptr to distinguish it from a fully live client.

## Summary by Sourcery

Ensure Wayland clients can still be resolved during the teardown window and are only cleared once late-destroy handling completes.

Bug Fixes:
- Fix WlClientDestroyListener::get_late() to look up the correct destroy-late listener so it can find clients during late-destroy callbacks.
- Prevent WClient::get() from returning null during client teardown by falling back to the destroy-late listener lookup.
- Delay clearing the WClient handle until the late-destroy phase so callers can safely distinguish between live, dying, and fully destroyed clients.