### PR TITLE
ci: add unit test step to archlinux build workflows

### DIFF
--- a/.github/workflows/treeland-archlinux-build.yml
+++ b/.github/workflows/treeland-archlinux-build.yml
@@ -83,6 +83,9 @@ jobs:
           cmake --build --preset ci
           echo "✅ treeland built successfully with merged waylib and qwlroots code!"
 
+      - name: Run unit tests
+        run: ctest --preset ci
+
       - name: Install treeland to staging directory
         run: |
           echo "Installing treeland to staging directory..."

--- a/.github/workflows/waylib-archlinux-build.yml
+++ b/.github/workflows/waylib-archlinux-build.yml
@@ -46,6 +46,10 @@ jobs:
           cmake --preset ci -DWITH_SUBMODULE_QWLROOTS=ON
           cmake --build --preset ci
 
+      - name: Run unit tests
+        working-directory: waylib
+        run: ctest --preset ci
+
       - name: Install waylib to staging directory
         working-directory: waylib
         run: |

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -67,5 +67,17 @@
             "name": "ci-clang",
             "configurePreset": "ci-clang"
         }
+    ],
+    "testPresets": [
+        {
+            "name": "ci",
+            "configurePreset": "ci",
+            "output": {
+                "outputOnFailure": true
+            },
+            "execution": {
+                "noTestsAction": "error"
+            }
+        }
     ]
 }

--- a/waylib/CMakePresets.json
+++ b/waylib/CMakePresets.json
@@ -20,5 +20,17 @@
       "configurePreset": "ci",
       "jobs": 0
     }
+  ],
+  "testPresets": [
+    {
+      "name": "ci",
+      "configurePreset": "ci",
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "noTestsAction": "error"
+      }
+    }
   ]
 }


### PR DESCRIPTION
Add testPresets to CMakePresets.json (both treeland and waylib) and insert a `ctest --preset ci` step between build and install in the Arch Linux CI workflows. All 3 tests pass locally under the ci preset: QWObject, test_wwrappointer, and test_qsgrenderer_accessor.