### PR TITLE
fix(debian): promote treeland-wallpaper-factory to a hard dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -51,11 +51,11 @@ Depends: qml6-module-qtquick-layouts,
          qml6-module-qtquick-particles,
          treeland-data (= ${source:Version}),
          xwayland,
+         treeland-wallpaper-factory,
          ${shlibs:Depends},
 Conflicts: libwaylib, qwlroots
 Replaces: libwaylib, qwlroots
 Recommends: ddm (>= 0.3.3),
-            treeland-wallpaper-factory,
 Description: a Wayland compositor based on wlroots and QML, designed with an attractive and elegant appearance.
 
 Package: treeland-dev


### PR DESCRIPTION
Move treeland-wallpaper-factory from Recommends to Depends in the control file to ensure it is always installed alongside treeland. This guarantees wallpaper functionality is reliably available out of the box.

Log: Fix treeland-wallpaper-factory dependency by promoting it from Recommends to Depends PMS: BUG-362039
Influence: Ensure treeland-wallpaper-factory is always installed with treeland to prevent functional issues caused by missing wallpaper components.

## Summary by Sourcery

Promote treeland-wallpaper-factory from a recommended package to a hard dependency in the Debian control file to ensure it is always installed with treeland.

Bug Fixes:
- Resolve missing wallpaper functionality by making treeland-wallpaper-factory a required dependency instead of a recommendation in the Debian packaging metadata.

Build:
- Update Debian control packaging to list treeland-wallpaper-factory under Depends rather than Recommends for the treeland package.