### PR TITLE
fix(output): fix crash on screen copy mode when hot-plugging

### DIFF
--- a/src/core/layersurfacecontainer.cpp
+++ b/src/core/layersurfacecontainer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "layersurfacecontainer.h"
@@ -64,15 +64,17 @@ void LayerSurfaceContainer::removeOutput(Output *output)
     Q_ASSERT(container);
     m_surfaceContainers.removeOne(container);
 
-    for (SurfaceWrapper *surface : container->surfaces()) {
-        container->removeSurface(surface);
+    const auto surfaces = container->surfaces();
+    for (SurfaceWrapper *surface : surfaces) {
         auto layerSurface = qobject_cast<WLayerSurface *>(surface->shellSurface());
         Q_ASSERT(layerSurface);
         // Needs to be moved to the new primary output
-        if (!layerSurface->output() && rootContainer()->primaryOutput())
+        if (!layerSurface->output() && rootContainer()->primaryOutput()) {
+            container->removeSurface(surface);
             addSurfaceToContainer(surface);
-        else
+        } else {
             layerSurface->closed();
+        }
     }
 
     container->deleteLater();

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -46,6 +46,9 @@ Output *Output::create(WOutput *output, QQmlEngine *engine, QObject *parent)
     WOutputItem *outputItem = qobject_cast<WOutputItem *>(obj);
     Q_ASSERT(outputItem);
     QQmlEngine::setObjectOwnership(outputItem, QQmlEngine::CppOwnership);
+
+    auto contentItem = Helper::instance()->window()->contentItem();
+    outputItem->setParentItem(contentItem);
     outputItem->setOutput(output);
 
     connect(Helper::instance()->globalConfig(),
@@ -80,10 +83,6 @@ Output *Output::create(WOutput *output, QQmlEngine *engine, QObject *parent)
                &Output::arrangeAllSurfaces,
                Qt::QueuedConnection);
 
-    auto contentItem = Helper::instance()->window()->contentItem();
-    outputItem->setParentItem(contentItem);
-    // o->m_taskBar = Helper::instance()->qmlEngine()->createTaskBar(o,
-    // contentItem); o->m_taskBar->setZ(RootSurfaceContainer::TaskBarZOrder);
 
     // reset output color to config value
     o->setOutputColor(-1, 0);
@@ -120,6 +119,9 @@ Output *Output::createCopy(WOutput *output, Output *proxy, QQmlEngine *engine, Q
     WOutputItem *outputItem = qobject_cast<WOutputItem *>(obj);
     Q_ASSERT(outputItem);
     QQmlEngine::setObjectOwnership(outputItem, QQmlEngine::CppOwnership);
+
+    auto contentItem = Helper::instance()->window()->contentItem();
+    outputItem->setParentItem(contentItem);
     outputItem->setOutput(output);
 
     auto o = new Output(outputItem, parent);
@@ -127,8 +129,6 @@ Output *Output::createCopy(WOutput *output, Output *proxy, QQmlEngine *engine, Q
     o->m_proxy = proxy;
     obj->setParent(o);
 
-    auto contentItem = Helper::instance()->window()->contentItem();
-    outputItem->setParentItem(contentItem);
     o->updateOutputHardwareLayers();
     connect(proxy->screenViewport(),
             &WOutputViewport::hardwareLayersChanged,

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -504,6 +504,13 @@ void Helper::onOutputRemoved(WOutput *output)
 
         for (int i = 0; i < m_outputList.size(); i++) {
             Output *copyOutput = m_outputList.at(i);
+
+            if (copyOutput->isPrimary()) {
+                if (!primaryCandidate)
+                    primaryCandidate = copyOutput;
+                continue;
+            }
+
             Output *normalOutput = createNormalOutput(copyOutput->output());
             normalOutput->enable();
 
@@ -529,6 +536,7 @@ void Helper::onOutputRemoved(WOutput *output)
         }
 
         for (auto oldOutput : oldOutputsToDelete) {
+            m_rootSurfaceContainer->removeOutput(oldOutput);
             delete oldOutput;
         }
 

--- a/waylib/src/server/qtquick/private/woutputitem_p.h
+++ b/waylib/src/server/qtquick/private/woutputitem_p.h
@@ -24,7 +24,12 @@ public:
     explicit WOutputCursor(WOutputItem *parent);
 
     inline WOutputItem *output() const {
-        return static_cast<WOutputItem*>(parent());;
+        return m_output;
+    }
+
+    inline void invalidate() {
+        m_output.clear();
+        m_cursor.clear();
     }
 
     WCursor *cursor() const;
@@ -37,6 +42,7 @@ private:
     void setVisible(bool newVisible);
 
     QPointer<WCursor> m_cursor;
+    QPointer<WOutputItem> m_output;
     QQuickItem *item = nullptr;
     bool m_visible = true;
 };

--- a/waylib/src/server/qtquick/woutputitem.cpp
+++ b/waylib/src/server/qtquick/woutputitem.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 JiDe Zhang <zhangjide@deepin.org>.
+// Copyright (C) 2023-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "woutputitem.h"
@@ -33,8 +33,11 @@ public:
 
         if (layout)
             layout->remove(q_func());
-        if (output)
-            output->setProperty(DATA_OF_WOUPTUT, QVariant());
+        if (output) {
+            W_Q(WOutputItem);
+            if (WOutputItem::getOutputItem(output) == q)
+                output->setProperty(DATA_OF_WOUPTUT, QVariant());
+        }
     }
 
     void initForOutput();
@@ -99,8 +102,10 @@ void WOutputItemPrivate::initForOutput()
 
 void WOutputItemPrivate::clearCursors()
 {
-    for (auto i : std::as_const(cursors))
+    for (auto i : std::as_const(cursors)) {
+        i.second->invalidate();
         i.second->deleteLater();
+    }
     cursors.clear();
 }
 
@@ -159,7 +164,7 @@ void WOutputItemPrivate::updateCursors()
     for (auto i : std::as_const(tmpCursors)) {
         if (cursors.contains(i))
             continue;
-        i.second->setParent(nullptr);
+        i.second->invalidate();
         i.second->deleteLater();
         cursorsChanged = true;
     }
@@ -196,6 +201,7 @@ WOutputCursor *WOutputItemPrivate::getCursorItemBy(WCursor *cursor) const
 
 WOutputCursor::WOutputCursor(WOutputItem *parent)
     : QObject(parent)
+    , m_output(parent)
 {
 
 }


### PR DESCRIPTION
Fix crash when removing output in copy mode:
- Move setParentItem before setOutput to avoid accessing invalid parent item.
- Skip primary output when rebuilding normal outputs to prevent double processing.
- Fix iterating and removing surface from container simultaneously.
- Only clear output property if the item matches.
- Set cursor parent to nullptr before deleteLater to prevent QML double deletion.

修复屏幕copy模式下拔插屏幕时的崩溃问题：
- 将setParentItem移至setOutput之前调用，避免 访问无效的父项。
- 重建普通输出时跳过主输出，防止重复处理。
- 修复遍历同时移除surface导致的迭代失效。
- 仅当WOutputItem匹配时才清除output属性。
- 在deleteLater之前将光标的父项置空，消除 QML重复析构的问题。

Log: 修复屏幕copy模式下拔插崩溃问题
PMS: BUG-360347
Influence: 修复屏幕copy模式下热插拔输出设备时的崩溃
问题，提升多屏复制模式下的稳定性；同时修复了
layer surface移除时的迭代失效及WOutputItem析构
时属性误清除的问题。

## Summary by Sourcery

Fix crashes and lifecycle issues when removing or hot‑plugging outputs, especially in screen copy mode, and tighten ownership/cleanup of related QML items and layer surfaces.

Bug Fixes:
- Prevent crashes when creating copy-mode outputs by assigning the QQuickItem parent before binding the WOutput object.
- Avoid iterator invalidation and ensure correct handling of layer surfaces when their output container is removed.
- Ensure only the matching WOutputItem clears the output's associated data property on destruction, avoiding accidental state cleanup for other outputs.
- Prevent potential QML double-deletion of cursor items by clearing their parent before scheduling deletion.
- Skip primary outputs when recreating normal outputs on output removal, preventing duplicate processing and selection of an appropriate primary candidate.

Enhancements:
- Update copyright headers to reflect the extended maintenance period for the touched components.