### PR TITLE
fix(shortcut): task switch shortcuts not responding to key hold auto-…

### DIFF
--- a/src/treeland-shortcut/shortcuts/_treeland-taskswitch-next.ini
+++ b/src/treeland-shortcut/shortcuts/_treeland-taskswitch-next.ini
@@ -1,5 +1,6 @@
 [Shortcut]
 Shortcut=Alt+Tab
+KeybindMode=KeyPressRepeat
 Type="Action"
 
 [Type.Action]

--- a/src/treeland-shortcut/shortcuts/_treeland-taskswitch-prev.ini
+++ b/src/treeland-shortcut/shortcuts/_treeland-taskswitch-prev.ini
@@ -1,5 +1,6 @@
 [Shortcut]
 Shortcut=Alt+Shift+Backtab
+KeybindMode=KeyPressRepeat
 Type="Action"
 
 [Type.Action]

--- a/src/treeland-shortcut/shortcuts/_treeland-taskswitch-sameapp-next.ini
+++ b/src/treeland-shortcut/shortcuts/_treeland-taskswitch-sameapp-next.ini
@@ -1,5 +1,6 @@
 [Shortcut]
 Shortcut=Alt+`
+KeybindMode=KeyPressRepeat
 Type="Action"
 
 [Type.Action]

--- a/src/treeland-shortcut/shortcuts/_treeland-taskswitch-sameapp-prev.ini
+++ b/src/treeland-shortcut/shortcuts/_treeland-taskswitch-sameapp-prev.ini
@@ -1,5 +1,6 @@
 [Shortcut]
 Shortcut=Alt+Shift+~
+KeybindMode=KeyPressRepeat
 Type="Action"
 
 [Type.Action]


### PR DESCRIPTION
…repeat

PMS: BUG-339455
Log: When holding Alt+Tab (and similar task-switch shortcuts) without releasing, auto-repeat key events were filtered out in dispatchKeyEvent because the key binding flags only contained KeyPress without the Repeat flag.
Influence: Task switching via Alt+Tab, Alt+Shift+Backtab, Alt+`, Alt+Shift+~ now responds to continuous key hold.


任务切换器允许长按时连续快速切换

## Summary by Sourcery

Bug Fixes:
- Fix task switch shortcuts ignoring auto-repeat events when holding the key combination.