### PR TITLE
refactor(virtual-output): use QStringList join for output name serial…

### DIFF
--- a/src/modules/virtual-output/virtualoutputmanagerinterfacev1.cpp
+++ b/src/modules/virtual-output/virtualoutputmanagerinterfacev1.cpp
@@ -137,10 +137,11 @@ void VirtualOutputManagerInterfaceV1Private::create_virtual_output(Resource *res
 
 void VirtualOutputManagerInterfaceV1Private::get_virtual_output_list(Resource *resource)
 {
-    QByteArray arr;
+    QStringList names;
     for (auto interface : std::as_const(s_virtualOutputs)) {
-        arr.append(interface->d->name.toLatin1());
+        names << interface->d->name;
     }
+    const QByteArray arr = names.join('\0').toLatin1();
 
     send_virtual_output_list(resource->handle, arr);
 }
@@ -151,10 +152,7 @@ void VirtualOutputManagerInterfaceV1Private::get_virtual_output([[maybe_unused]]
 {
     for (auto interface : std::as_const(s_virtualOutputs)) {
         if (interface->d->name == name) {
-            QByteArray arr;
-            for (auto str : interface->outputList()) {
-                arr.append(str.toLatin1());
-            }
+            const QByteArray arr = interface->outputList().join('\0').toLatin1();
             interface->sendOutputs(name, arr);
         }
     }


### PR DESCRIPTION
…ization

Replace manual QByteArray string building with QStringList::join('\0') to properly null-separate output names for Wayland protocol serialization.

使用 QStringList::join('\0') 替代手动循环拼接 QByteArray，
以正确使用 null 字节分隔输出名称，符合 Wayland 协议约定。

Log: 重构虚拟输出名称序列化方式
PMS: TASK-390011
Influence: 修复虚拟输出名称序列化，确保名称间使用 null 字节分隔，避免协议解析错误。

## Summary by Sourcery

Enhancements:
- Use QStringList::join with null separators for serializing virtual output names instead of manual QByteArray concatenation.