### PR TITLE
chore: bump version to 0.8.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.25.0)
 
 project(Treeland
-    VERSION 0.8.6
+    VERSION 0.8.7
     LANGUAGES CXX C)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,42 @@
+treeland (0.8.7) unstable; urgency=medium
+
+  * refactor(virtual-output): use QStringList join for output name
+    serialization
+  * fix(output): fix crash on screen copy mode when hot-plugging
+  * fix(shortcut): task switch shortcuts not responding to key hold auto-
+    repeat
+  * fix(wsocket): fix WClient::get() returning null during client
+    teardown
+  * ci: add unit test step to archlinux build workflows
+  * fix(debian): promote treeland-wallpaper-factory to a hard dependency
+  * fix: remove unused lambda capture in live test
+  * refactor(platformplugin): remove unused isMaster/proxy QPA mode
+  * refactor: replace #define-private-public hacks with template
+    accessor pattern
+  * fix(activation): address PR review findings
+  * feat: add token validation and expiration to xdg-activation
+  * fix: clear attention on activation
+  * feat: differentiate activation token disposition
+  * feat: add attention state to foreign-toplevel
+  * feat: implement xdg-activation-v1 with treeland private protocol
+  * fix(render): fix texture copy crash when window partially off-screen
+  * fix(woutputrenderwindow): destroy wlr layers before invalidating
+    output on removal
+  * fix: avoid crash on invalid image capture buffer
+  * fix: fix build errors with GCC 16.1.1 and Qt 6.11.1 on Arch Linux
+  * fix(virtual-output): move beforeDestroy signal to destroy method
+  * fix: skip redundant minimize requests
+  * fix: crash caused by treeland capture
+  * chore: fix compile warnings reported by clang
+  * fix(capture): avoid double wl_resource_destroy on client teardown
+  * chore(agents): introduce AI agent instructions and skills
+  * docs: migrate logging guidelines to agent skill
+  * feat: add other user login support
+  * feat: refactor treeland-ddm-v1 protocol implementation
+  * fix(build): add missing headers for gcc 16 compatibility
+
+ -- rewine <luhongxu@deepin.org>  Fri, 22 May 2026 10:02:44 +0800
+
 treeland (0.8.6) unstable; urgency=medium
 
   * fix: fix multiple crashes caused by thread affinity and use-after-

--- a/debian/control
+++ b/debian/control
@@ -33,7 +33,7 @@ Build-Depends: cmake (>= 3.25.0),
                qt6-wayland-private-dev,
                wayland-protocols,
                wlr-protocols,
-               treeland-protocols,
+               treeland-protocols (>= 0.5.7),
                libpam0g-dev,
                libmpv-dev,
 Standards-Version: 4.6.0

--- a/src/modules/foreign-toplevel/CMakeLists.txt
+++ b/src/modules/foreign-toplevel/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(TreelandProtocols REQUIRED)
+find_package(TreelandProtocols REQUIRED 0.5.7)
 
 ws_generate_local(server ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-foreign-toplevel-manager-v1.xml treeland-foreign-toplevel-manager-protocol)
 


### PR DESCRIPTION
Log: new tag

## Summary by Sourcery

Bump the core project version and tighten the TreelandProtocols dependency to the new 0.5.7 release.

Build:
- Update project version from 0.8.6 to 0.8.7 in the main CMake configuration.
- Require TreelandProtocols package version 0.5.7 in the foreign-toplevel module CMake configuration.