### PR TITLE
feat(virtual-output): persist virtual output config across client dis…

### DIFF
--- a/examples/test_virtual_output/CMakeLists.txt
+++ b/examples/test_virtual_output/CMakeLists.txt
@@ -8,6 +8,12 @@ set(BIN_NAME test-virtual-output)
 
 qt_add_executable(${BIN_NAME}
     main.cpp
+    virtualclient.h
+    virtualclient.cpp
+    virtualoutput.h
+    virtualoutput.cpp
+    virtualoutputmanager.h
+    virtualoutputmanager.cpp
 )
 
 qt_generate_wayland_protocol_client_sources(${BIN_NAME}
@@ -25,4 +31,3 @@ target_link_libraries(${BIN_NAME}
 )
 
 install(TARGETS ${BIN_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
-

--- a/examples/test_virtual_output/main.cpp
+++ b/examples/test_virtual_output/main.cpp
@@ -1,133 +1,24 @@
-// Copyright (C) 2024 Lu YaNing <luyaning@uniontech.com>.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
-#include "qwayland-treeland-virtual-output-manager-v1.h"
-
-#include <private/qwaylandscreen_p.h>
-#include <private/qwaylandwindow_p.h>
-
-#include <qwindow.h>
+#include "virtualclient.h"
 
 #include <QApplication>
-#include <QPushButton>
-#include <QtWaylandClient/QWaylandClientExtension>
-
-class VirtualOutputManager
-    : public QWaylandClientExtensionTemplate<VirtualOutputManager>
-    , public QtWayland::treeland_virtual_output_manager_v1
-{
-    Q_OBJECT
-public:
-    explicit VirtualOutputManager();
-
-    void virtual_output_manager_v1_virtual_output_list([[maybe_unused]] wl_array *names) { }
-};
-
-VirtualOutputManager::VirtualOutputManager()
-    : QWaylandClientExtensionTemplate<VirtualOutputManager>(1)
-{
-}
-
-class VirtualOutput
-    : public QWaylandClientExtensionTemplate<VirtualOutput>
-    , public QtWayland::treeland_virtual_output_v1
-{
-    Q_OBJECT
-public:
-    explicit VirtualOutput(struct ::treeland_virtual_output_v1 *object);
-
-    void virtual_output_v1_outputs(const QString &name, [[maybe_unused]] wl_array *outputs)
-    {
-        qInfo() << "Screen group name: " << name;
-    }
-
-    void virtual_output_v1_error(uint32_t code, const QString &message)
-    {
-
-        qInfo() << "error code:" << code << " error message:" << message;
-    }
-};
-
-VirtualOutput::VirtualOutput(struct ::treeland_virtual_output_v1 *object)
-    : QWaylandClientExtensionTemplate<VirtualOutput>(1)
-    , QtWayland::treeland_virtual_output_v1(object)
-{
-}
 
 // ./test-virtual-output HDMI-A-1 VGA-1
-
-// 点击设置界面恢复按钮，恢复设置
 
 int main(int argc, char *argv[])
 {
     qputenv("QT_QPA_PLATFORM", "wayland");
     QApplication app(argc, argv);
-    VirtualOutputManager manager;
 
-    QObject::connect(
-        &manager,
-        &VirtualOutputManager::activeChanged,
-        &manager,
-        [&manager, argc, argv] {
-            if (manager.isActive()) {
-                QWidget *widget = new QWidget;
-                widget->setAttribute(Qt::WA_TranslucentBackground);
-                widget->resize(640, 480);
+    // Print help tip if no screen names provided via argv
+    if (argc < 3) {
+        qInfo() << "Tip: Specify screen names to clone:";
+        qInfo() << "  ./test-virtual-output HDMI-A-1 VGA-1";
+    }
 
-                QPushButton *button = new QPushButton("Restore settings", widget);
-                button->setGeometry(0, 0, 150, 50);
-
-                widget->show();
-
-                QWindow *window = widget->windowHandle();
-
-                if (window && window->handle()) {
-                    QtWaylandClient::QWaylandWindow *waylandWindow =
-                        static_cast<QtWaylandClient::QWaylandWindow *>(window->handle());
-                    QList<QtWaylandClient::QWaylandScreen *> screens =
-                        waylandWindow->display()->screens();
-
-                    if (argc < 3) {
-                        qInfo() << "Please refer to the following input screen "
-                                   "name: ";
-                        qInfo() << "  ./test-virtual-output HDMI-A-1 VGA-1  ";
-                        for (auto *screen : screens) {
-                            QString address = screen->name();
-                            qInfo() << "Screen name is: " << address;
-                        }
-                        exit(0);
-                    }
-
-                    QList<QString> screeNames;
-                    for (int i = 1; i < argc; ++i) {
-                        screeNames.append(QString::fromUtf8(argv[i]));
-                    }
-
-                    // 实际使用需要判断主屏（被镜像的屏幕），将主屏放在wl_array的第一个,复制屏幕依次填充
-                    if (!screens.isEmpty()) {
-                        QByteArray screenNameArray;
-                        for (auto screen : screeNames) {
-                            screenNameArray.append(screen.toUtf8());
-                            screenNameArray.append('\0');
-                        }
-
-                        // screenNmaeArray.append("HDMI-test"); // test error
-                        screenNameArray.append('\0');
-
-                        VirtualOutput *screen_output = new VirtualOutput(
-                            manager.create_virtual_output("copyscreen1",
-                                                          screenNameArray)); //"copyscreen1":
-                                                                             // 客户端自定义分组名称
-
-                        QObject::connect(button, &QPushButton::clicked, [screen_output]() {
-                            screen_output->destroy();
-                        });
-                    }
-                }
-            }
-        });
+    VirtualClient client(argc, argv);
 
     return app.exec();
 }
-
-#include "main.moc"

--- a/examples/test_virtual_output/virtualclient.cpp
+++ b/examples/test_virtual_output/virtualclient.cpp
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "virtualclient.h"
+#include "virtualoutput.h"
+#include "virtualoutputmanager.h"
+
+#include <private/qwaylandwindow_p.h>
+
+#include <QApplication>
+#include <QPushButton>
+#include <QWidget>
+#include <QtWaylandClient/QWaylandClientExtension>
+#include <QtWaylandClient/private/qwaylandscreen_p.h>
+#include <qlogging.h>
+
+VirtualClient::VirtualClient(int argc, char *argv[], QObject *parent)
+    : QObject(parent)
+    , m_argc(argc)
+    , m_argv(argv)
+{
+    m_manager = std::make_unique<VirtualOutputManager>();
+
+    if (m_argc >= 3) {
+        for (int i = 1; i < m_argc; ++i) {
+            m_screenNames.append(QString::fromUtf8(m_argv[i]));
+        }
+    }
+
+    connect(m_manager.get(), &VirtualOutputManager::activeChanged, this, [this]() {
+        if (m_manager->isActive()) {
+            setupUi();
+        }
+    });
+}
+
+VirtualClient::~VirtualClient() = default;
+
+bool VirtualClient::isValid() const
+{
+    return m_manager && m_manager->isInitialized();
+}
+
+void VirtualClient::setupUi()
+{
+    m_widget = new QWidget;
+    m_widget->setAttribute(Qt::WA_TranslucentBackground);
+    m_widget->resize(640, 480);
+
+    m_createButton = new QPushButton("Create virtual output", m_widget);
+    m_createButton->setGeometry(0, 0, 150, 50);
+
+    m_restoreButton = new QPushButton("Restore settings", m_widget);
+    m_restoreButton->setGeometry(0, 60, 150, 50);
+
+    m_listButton = new QPushButton("Get virtual output list", m_widget);
+    m_listButton->setGeometry(0, 120, 150, 50);
+
+    connect(m_createButton, &QPushButton::clicked, this, &VirtualClient::onCreateVirtualOutput);
+    connect(m_restoreButton, &QPushButton::clicked, this, &VirtualClient::onRestoreSettings);
+    connect(m_listButton, &QPushButton::clicked, this, &VirtualClient::onGetVirtualOutputList);
+
+    connect(m_manager.get(),
+            &VirtualOutputManager::virtualOutputListReceived,
+            this,
+            &VirtualClient::onVirtualOutputListReceived);
+
+    m_widget->show();
+
+    // Collect available screens
+    QWindow *window = m_widget->windowHandle();
+    QList<QtWaylandClient::QWaylandScreen *> screens;
+    if (window && window->handle()) {
+        QtWaylandClient::QWaylandWindow *waylandWindow =
+            static_cast<QtWaylandClient::QWaylandWindow *>(window->handle());
+        screens = waylandWindow->display()->screens();
+
+        qInfo() << "Available screens:";
+        for (auto *screen : screens) {
+            qInfo() << "  Screen name:" << screen->name();
+        }
+    }
+}
+
+void VirtualClient::onVirtualOutputListReceived(const QStringList &names){
+    qInfo() << names;
+    for (const auto &name : names) {
+        auto *obj = m_manager->getVirtualOutput(name);
+        if (!obj) {
+            qWarning() << "  Failed to get virtual output for:" << name;
+            continue;
+        }
+
+        auto *vo = new VirtualOutput(obj);
+
+        // Save as the current virtual output
+        m_currentOutput.reset(vo);
+    }
+}
+
+void VirtualClient::onCreateVirtualOutput()
+{
+    // If already has a virtual output, do nothing
+    if (m_currentOutput && m_currentOutput->isInitialized()) {
+        qInfo() << "Virtual output already exists, skipping creation";
+        return;
+    }
+
+    if (m_screenNames.isEmpty()) {
+        qInfo() << "No screens available to create virtual output";
+        return;
+    }
+
+    // 实际使用需要判断主屏（被镜像的屏幕），将主屏放在wl_array的第一个,复制屏幕依次填充
+    QByteArray screenNameArray;
+    for (auto screen : m_screenNames) {
+        screenNameArray.append(screen.toUtf8());
+        screenNameArray.append('\0');
+    }
+    screenNameArray.append('\0');
+
+    m_currentOutput.reset(
+        new VirtualOutput(m_manager->createVirtualOutput("copyscreen1", screenNameArray)));
+
+    qInfo() << "Virtual output created with screens:" << m_screenNames;
+}
+
+void VirtualClient::onRestoreSettings()
+{
+    if (m_currentOutput && m_currentOutput->isInitialized()) {
+        m_currentOutput->destroy();
+        m_currentOutput.reset();
+        qInfo() << "Virtual output destroyed via restore";
+    }
+}
+
+void VirtualClient::onGetVirtualOutputList()
+{
+    if (m_currentOutput && m_currentOutput->isInitialized()) {
+        qInfo() << "Use already exit outputs: %s" << m_screenNames;
+        return;
+    }
+    m_manager->getVirtualOutputList();
+}

--- a/examples/test_virtual_output/virtualclient.h
+++ b/examples/test_virtual_output/virtualclient.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+#pragma once
+
+#include <QObject>
+#include <QSharedPointer>
+#include <qcontainerfwd.h>
+
+#include <memory>
+
+class QWidget;
+class QPushButton;
+class VirtualOutputManager;
+class VirtualOutput;
+
+class VirtualClient : public QObject
+{
+    Q_OBJECT
+public:
+    explicit VirtualClient(int argc, char *argv[], QObject *parent = nullptr);
+    ~VirtualClient();
+
+    bool isValid() const;
+
+private:
+    void setupUi();
+    void onCreateVirtualOutput();
+    void onRestoreSettings();
+    void onGetVirtualOutputList();
+    void onVirtualOutputListReceived(const QStringList &names);
+
+    std::unique_ptr<VirtualOutputManager> m_manager;
+    QSharedPointer<VirtualOutput> m_currentOutput;
+    QWidget *m_widget = nullptr;
+    QPushButton *m_createButton = nullptr;
+    QPushButton *m_restoreButton = nullptr;
+    QPushButton *m_listButton = nullptr;
+    QStringList m_screenNames;
+    int m_argc = 0;
+    char **m_argv = nullptr;
+};

--- a/examples/test_virtual_output/virtualoutput.cpp
+++ b/examples/test_virtual_output/virtualoutput.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "virtualoutput.h"
+
+#include <QDebug>
+
+VirtualOutput::VirtualOutput(struct ::treeland_virtual_output_v1 *object)
+    : QtWayland::treeland_virtual_output_v1(object)
+{
+}
+
+VirtualOutput::~VirtualOutput()
+{
+}
+
+void VirtualOutput::treeland_virtual_output_v1_outputs(const QString &name, wl_array *outputs)
+{
+    if (!outputs || outputs->size == 0) {
+        qInfo() << "  No outputs (not found or empty)";
+        return;
+    }
+
+    char *data = static_cast<char *>(outputs->data);
+    char *end = data + outputs->size;
+    QStringList outputList;
+
+    while (data < end && *data != '\0') {
+        QString output = QString::fromUtf8(data);
+        outputList << output;
+        data += output.size() + 1;
+    }
+
+    qInfo() << "Screen group name:" << name;
+    qInfo() << "  Outputs:" << outputList;
+
+    Q_EMIT outputsReceived(name, outputList);
+}
+
+void VirtualOutput::treeland_virtual_output_v1_error(uint32_t code, const QString &message)
+{
+    qInfo() << "error code:" << code << " error message:" << message;
+    Q_EMIT errorOccurred(code, message);
+}

--- a/examples/test_virtual_output/virtualoutput.h
+++ b/examples/test_virtual_output/virtualoutput.h
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+#pragma once
+
+#include "qwayland-treeland-virtual-output-manager-v1.h"
+
+#include <QObject>
+#include <QStringList>
+
+class VirtualOutput
+    : public QObject
+    , public QtWayland::treeland_virtual_output_v1
+{
+    Q_OBJECT
+public:
+    explicit VirtualOutput(struct ::treeland_virtual_output_v1 *object);
+    ~VirtualOutput();
+
+Q_SIGNALS:
+    void outputsReceived(const QString &name, const QStringList &outputs);
+    void errorOccurred(uint32_t code, const QString &message);
+
+protected:
+    void treeland_virtual_output_v1_outputs(const QString &name, wl_array *outputs) override;
+    void treeland_virtual_output_v1_error(uint32_t code, const QString &message) override;
+};

--- a/examples/test_virtual_output/virtualoutputmanager.cpp
+++ b/examples/test_virtual_output/virtualoutputmanager.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "virtualoutputmanager.h"
+
+#include <QDebug>
+
+#define VIRTUAL_OUTPUT_MANAGER_V1_VERSION 1
+
+VirtualOutputManager::VirtualOutputManager()
+    : QWaylandClientExtensionTemplate<VirtualOutputManager>(
+        VIRTUAL_OUTPUT_MANAGER_V1_VERSION)
+{
+}
+
+VirtualOutputManager::~VirtualOutputManager()
+{
+    if (isInitialized()) {
+        destroy();
+    }
+}
+
+void VirtualOutputManager::instantiate()
+{
+    initialize();
+}
+
+struct ::treeland_virtual_output_v1 *
+VirtualOutputManager::createVirtualOutput(const QString &name, const QByteArray &outputs)
+{
+    if (!isInitialized()) {
+        return nullptr;
+    }
+    return create_virtual_output(name, outputs);
+}
+
+void VirtualOutputManager::getVirtualOutputList()
+{
+    if (!isInitialized()) {
+        return;
+    }
+    get_virtual_output_list();
+}
+
+struct ::treeland_virtual_output_v1 *
+VirtualOutputManager::getVirtualOutput(const QString &name)
+{
+    if (!isInitialized()) {
+        return nullptr;
+    }
+    return get_virtual_output(name);
+}
+
+void VirtualOutputManager::treeland_virtual_output_manager_v1_virtual_output_list(
+    wl_array *names)
+{
+    if (!names || names->size == 0)
+        return;
+
+    char *data = static_cast<char *>(names->data);
+    char *end = data + names->size;
+    QStringList nameList;
+
+    while (data < end && *data != '\0') {
+        QString name = QString::fromUtf8(data);
+        nameList << name;
+        data += name.size() + 1;
+    }
+
+    qInfo() << "Virtual output list:" << nameList;
+    Q_EMIT virtualOutputListReceived(nameList);
+}

--- a/examples/test_virtual_output/virtualoutputmanager.h
+++ b/examples/test_virtual_output/virtualoutputmanager.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+#pragma once
+
+#include "qwayland-treeland-virtual-output-manager-v1.h"
+
+#include <QObject>
+#include <QStringList>
+#include <QWaylandClientExtension>
+
+class VirtualOutputManager
+    : public QWaylandClientExtensionTemplate<VirtualOutputManager>
+    , public QtWayland::treeland_virtual_output_manager_v1
+{
+    Q_OBJECT
+public:
+    explicit VirtualOutputManager();
+    ~VirtualOutputManager();
+
+    void instantiate();
+
+    struct ::treeland_virtual_output_v1 *createVirtualOutput(const QString &name,
+                                                             const QByteArray &outputs);
+    void getVirtualOutputList();
+    struct ::treeland_virtual_output_v1 *getVirtualOutput(const QString &name);
+
+Q_SIGNALS:
+    void virtualOutputListReceived(const QStringList &names);
+
+protected:
+    void treeland_virtual_output_manager_v1_virtual_output_list(wl_array *names) override;
+};

--- a/src/modules/virtual-output/virtualoutputmanagerinterfacev1.cpp
+++ b/src/modules/virtual-output/virtualoutputmanagerinterfacev1.cpp
@@ -8,7 +8,9 @@
 
 #include <qwdisplay.h>
 
-static QList<VirtualOutputInterfaceV1 *> s_virtualOutputs;
+#include <QHash>
+#include <QPointer>
+#include <QScopeGuard>
 
 static void wlarrayToStringList(const wl_array *wl_array, QStringList &stringList)
 {
@@ -20,6 +22,19 @@ static void wlarrayToStringList(const wl_array *wl_array, QStringList &stringLis
         stringList << str;
         currentPos += str.toLocal8Bit().length() + 1;
     }
+}
+
+static bool stringListToWlArray(const QStringList &list, wl_array *array)
+{
+    for (const QString &str : list) {
+        QByteArray data = str.toUtf8();
+        char *target = static_cast<char *>(wl_array_add(array, data.size() + 1));
+        if (!target) [[unlikely]]
+            return false;
+        memcpy(target, data.constData(), static_cast<size_t>(data.size()));
+        target[data.size()] = '\0';
+    }
+    return true;
 }
 
 class VirtualOutputInterfaceV1Private : public QtWaylandServer::treeland_virtual_output_v1
@@ -69,7 +84,21 @@ public:
     VirtualOutputManagerInterfaceV1Private(VirtualOutputManagerInterfaceV1 *_q);
     wl_global *global() const;
 
+    struct VirtualOutputConfig {
+        QStringList outputs;
+        QPointer<VirtualOutputInterfaceV1> virtualOutput;
+    };
+    QHash<QString, VirtualOutputConfig> m_configs;
+
     VirtualOutputManagerInterfaceV1 *q;
+
+    VirtualOutputInterfaceV1 *createVirtualOutputInternal(Resource *resource,
+                                                          uint32_t id,
+                                                          const QString &name,
+                                                          wl_array *outputs);
+
+    void attachDestroyCleanup(const QString &name, VirtualOutputInterfaceV1 *virtualOutput);
+
 protected:
     // TODO(YaoBing Xiao): treeland-virtual-output-manager-v1 is missing the 'destroy' request.
     // void destroy(Resource *resource) override;
@@ -89,6 +118,37 @@ wl_global *VirtualOutputManagerInterfaceV1Private::global() const
     return m_global;
 }
 
+VirtualOutputInterfaceV1 *VirtualOutputManagerInterfaceV1Private::createVirtualOutputInternal(Resource *resource,
+                                                                                               uint32_t id,
+                                                                                               const QString &name,
+                                                                                               wl_array *outputs)
+{
+    wl_resource *outputResource = wl_resource_create(resource->client(),
+                                                     &treeland_virtual_output_v1_interface,
+                                                     resource->version(),
+                                                     id);
+    if (!outputResource) {
+        wl_client_post_no_memory(resource->client());
+        return nullptr;
+    }
+
+    auto virtualOutput = new VirtualOutputInterfaceV1(name, outputs, outputResource);
+    attachDestroyCleanup(name, virtualOutput);
+    return virtualOutput;
+}
+
+void VirtualOutputManagerInterfaceV1Private::attachDestroyCleanup(
+    const QString &name, VirtualOutputInterfaceV1 *virtualOutput)
+{
+    QObject::connect(virtualOutput, &VirtualOutputInterfaceV1::beforeDestroy,
+                     q, &VirtualOutputManagerInterfaceV1::destroyVirtualOutput);
+
+    QObject::connect(virtualOutput, &VirtualOutputInterfaceV1::beforeDestroy,
+                     q, [this, name]() {
+        m_configs.remove(name);
+    });
+}
+
 // void VirtualOutputManagerInterfaceV1Private::destroy(Resource *resource)
 // {
 //     wl_resource_destroy(resource->handle);
@@ -96,29 +156,17 @@ wl_global *VirtualOutputManagerInterfaceV1Private::global() const
 
 void VirtualOutputManagerInterfaceV1Private::create_virtual_output(Resource *resource,
                                                                    uint32_t id,
-                                                                   const QString &name, wl_array *outputs)
+                                                                   const QString &name,
+                                                                   wl_array *outputs)
 {
     if (!outputs) {
         wl_resource_post_error(resource->handle, 0, "outputs array is NULL!");
         return;
     }
 
-    wl_resource *outputResource = wl_resource_create(resource->client(),
-                                                     &treeland_virtual_output_v1_interface,
-                                                     resource->version(),
-                                                     id);
-    if (!outputResource) {
-        wl_client_post_no_memory(resource->client());
+    auto virtualOutput = createVirtualOutputInternal(resource, id, name, outputs);
+    if (!virtualOutput)
         return;
-    }
-
-    auto virtualOutput = new VirtualOutputInterfaceV1(name, outputs, outputResource);
-    s_virtualOutputs.append(virtualOutput);
-    QObject::connect(virtualOutput, &VirtualOutputInterfaceV1::beforeDestroy,
-                     q, &VirtualOutputManagerInterfaceV1::destroyVirtualOutput);
-    QObject::connect(virtualOutput, &QObject::destroyed, [virtualOutput]() {
-        s_virtualOutputs.removeOne(virtualOutput);
-    });
 
     if (name.isEmpty()) {
         virtualOutput->sendError(TREELAND_VIRTUAL_OUTPUT_V1_ERROR_INVALID_GROUP_NAME,
@@ -132,30 +180,61 @@ void VirtualOutputManagerInterfaceV1Private::create_virtual_output(Resource *res
         return;
     }
 
+    // Store persistent config (survives client disconnection)
+    QStringList outputList;
+    wlarrayToStringList(outputs, outputList);
+
+    // Enforce unique names — name is the key for config lookup/removal
+    if (m_configs.contains(name)) {
+        virtualOutput->sendError(TREELAND_VIRTUAL_OUTPUT_V1_ERROR_INVALID_GROUP_NAME,
+                                 "A virtual output with this name already exists!");
+        return;
+    }
+
+    m_configs.insert(name, {outputList, virtualOutput});
+
     Q_EMIT q->requestCreateVirtualOutput(virtualOutput);
 }
 
 void VirtualOutputManagerInterfaceV1Private::get_virtual_output_list(Resource *resource)
 {
-    QStringList names;
-    for (auto interface : std::as_const(s_virtualOutputs)) {
-        names << interface->d->name;
-    }
-    const QByteArray arr = names.join('\0').toLatin1();
-
+    const QByteArray arr = m_configs.keys().join('\0').toLatin1();
     send_virtual_output_list(resource->handle, arr);
 }
 
-void VirtualOutputManagerInterfaceV1Private::get_virtual_output([[maybe_unused]] Resource *resource,
-                                                                const QString &name,
-                                                                [[maybe_unused]] uint32_t id)
+void VirtualOutputManagerInterfaceV1Private::get_virtual_output(Resource *resource,
+                                                                 const QString &name,
+                                                                 uint32_t id)
 {
-    for (auto interface : std::as_const(s_virtualOutputs)) {
-        if (interface->d->name == name) {
-            const QByteArray arr = interface->outputList().join('\0').toLatin1();
-            interface->sendOutputs(name, arr);
-        }
+    auto it = m_configs.find(name);
+    if (it == m_configs.end()) {
+        wl_resource_post_error(resource->handle, 0,
+            "Virtual output '%s' not found!", name.toUtf8().constData());
+        return;
     }
+
+    auto &config = it.value();
+    auto virtualOutput = config.virtualOutput;
+    if (!virtualOutput) {
+        // Create a new VirtualOutputInterfaceV1 from the persistent config
+        wl_array arr;
+        wl_array_init(&arr);
+        auto cleanup = qScopeGuard([&arr] { wl_array_release(&arr); });
+
+        if (!stringListToWlArray(config.outputs, &arr)) {
+            wl_client_post_no_memory(resource->client());
+            return;
+        }
+        virtualOutput = createVirtualOutputInternal(resource, id, name, &arr);
+        if (!virtualOutput)
+            return;
+
+        config.virtualOutput = virtualOutput;
+    }
+
+    // Send the outputs event to the requesting client
+    const QByteArray arrSend = config.outputs.join('\0').toLatin1();
+    virtualOutput->sendOutputs(name, arrSend);
 }
 
 VirtualOutputManagerInterfaceV1::VirtualOutputManagerInterfaceV1(QObject *parent)
@@ -213,13 +292,3 @@ void VirtualOutputInterfaceV1::sendError(uint32_t code, const QString &message)
     d->send_error(code, message);
 }
 
-VirtualOutputInterfaceV1 *VirtualOutputInterfaceV1::get(wl_resource *resource)
-{
-    for (auto interface : s_virtualOutputs) {
-        if (interface->resource() == resource) {
-            return interface;
-        }
-    }
-
-    return nullptr;
-}

--- a/src/modules/virtual-output/virtualoutputmanagerinterfacev1.h
+++ b/src/modules/virtual-output/virtualoutputmanagerinterfacev1.h
@@ -54,7 +54,6 @@ public:
     QStringList outputList() const;
     void sendOutputs(const QString &name, const QByteArray &outputs);
     void sendError(uint32_t code, const QString &message);
-    static VirtualOutputInterfaceV1 *get(wl_resource *resource);
 
 Q_SIGNALS:
     void beforeDestroy(VirtualOutputInterfaceV1 *ouput);


### PR DESCRIPTION
…connections

Replace the static s_virtualOutputs list with a persistent config store (m_configs) that survives client disconnection. Add createVirtualOutputInternal to extract resource creation. Extend get_virtual_output to rebuild the virtual output from stored config when the original was destroyed.

将虚拟输出的配置存储从静态列表改为持久化存储，客户端断开连接后配置不
丢失。抽取资源创建逻辑到独立方法，支持从持久配置重建虚拟输出。

Log: 虚拟输出配置持久化，跨客户端连接生命周期
PMS: TASK-390011
Influence: 虚拟输出配置现可跨客户端连接生命周期持久保留，客户端断连重
连后虚拟输出状态不丢失。

## Summary by Sourcery

Persist virtual output configuration across client connections and allow reconstruction and querying of virtual outputs from stored configs.

New Features:
- Persist virtual output configurations on the compositor side so they survive client disconnections and can be restored later.
- Expose protocol support for querying the list of virtual outputs and recreating a virtual output by name from persisted configuration.
- Extend the example virtual-output client UI with controls to create, destroy, and list virtual outputs, including basic screen discovery and logging.

Enhancements:
- Refactor virtual output creation into a reusable internal helper to centralize resource initialization and wiring.
- Replace the global virtual output tracking list with a structured configuration store that also retains metadata needed to rebuild virtual outputs.