### PR TITLE
fix(seat/helper): use WOutputLayout::move for output position update

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -739,17 +739,9 @@ void Helper::onOutputTestOrApply(qw_output_configuration_v1 *config, bool onlyTe
         }
 
         if (state.enabled) {
-            auto outputItem = qobject_cast<WOutputItem*>(viewport->parentItem());
-            if (outputItem) {
-                qreal currentX = outputItem->x();
-                qreal currentY = outputItem->y();
-                bool shouldPreservePosition = (state.x == 0 && state.y == 0) &&
-                                             (currentX != 0 || currentY != 0);
-
-                if (!shouldPreservePosition) {
-                    outputItem->setX(state.x);
-                    outputItem->setY(state.y);
-                }
+            auto *layout = m_rootSurfaceContainer->outputLayout();
+            if (layout) {
+                layout->move(state.output, QPoint(state.x, state.y));
             }
         }
 


### PR DESCRIPTION
Replace direct setX/setY on WOutputItem with WOutputLayout::move() when applying output configuration from wlr-output-manager protocol.

Remove the shouldPreservePosition check which incorrectly skipped position update when state position was (0,0), causing both outputs to overlap at the same coordinate after a position swap.

应用 wlr-output-manager 协议的输出配置时，改用
WOutputLayout::move() 代替直接操作 WOutputItem 的 setX/setY。 移除 shouldPreservePosition 检查，该检查在交换位置时错误地跳过了
HDMI 输出移到 (0,0) 的位置更新，导致两个 WOutputItem 重叠。

Log: 修复 wlr-randr 交换屏幕位置后内容显示异常的问题
PMS: BUG-348597
Influence: 修复后使用 wlr-randr 交换双屏位置时，HDMI 屏幕不再显示
eDP 的内容，位置切换正确。