### PR TITLE
fix(csd-popup): correct popup position for CSD surfaces

### DIFF
--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -26,6 +26,8 @@
 #include <wxdgpopupsurface.h>
 #include <wxdgpopupsurfaceitem.h>
 
+#include <optional>
+
 #include <qwlayershellv1.h>
 #include <qwoutputlayout.h>
 
@@ -729,6 +731,41 @@ void Output::arrangeNonLayerSurface(SurfaceWrapper *surface, const QSizeF &sizeD
     } while (false);
 }
 
+namespace {
+// Get the popup position (dPos) from the surface-local coordinate space,
+// adjusted to the SurfaceWrapper coordinate space.
+// - XDG popups: implicitPosition from wlr_xdg_popup_get_position already
+//   subtracts parent_geom, so it's relative to content geometry (no adjustment).
+// - Input popups: cursorRect is in raw surface coordinates; adjust by
+//   content geometry offset (e.g., CSD title bar) to match the rendering
+//   position of WSurfaceItem's contentContainer.
+std::optional<QPointF> popupDPos(SurfaceWrapper *surface)
+{
+    using Type = SurfaceWrapper::Type;
+    if (surface->type() == Type::XdgPopup) {
+        auto *item = qobject_cast<WXdgPopupSurfaceItem *>(surface->surfaceItem());
+        if (item)
+            return item->implicitPosition();
+    }
+
+    if (surface->type() == Type::InputPopup) {
+        auto *shell = qobject_cast<WInputPopupSurface *>(surface->shellSurface());
+        if (shell) {
+            QPointF dPos = shell->cursorRect().bottomLeft();
+            auto parent = surface->parentSurface();
+            if (parent && parent->shellSurface()) {
+                const QPoint offset = parent->shellSurface()->getContentGeometry().topLeft();
+                dPos -= QPointF(offset.x(), offset.y());
+            }
+            return dPos;
+        }
+    }
+
+    qCWarning(treelandOutput) << " Invalid popup surface type:" << surface->type();
+    return std::nullopt;
+}
+} // namespace
+
 QPointF Output::calculateBasePosition(SurfaceWrapper *surface, const QPointF &dPos) const
 {
     auto parent = surface->parentSurface();
@@ -770,18 +807,11 @@ void Output::handleLayerShellPopup(SurfaceWrapper *surface, const QRectF &normal
     }
 
     auto parentOutput = surface->parentSurface()->ownsOutput()->outputItem();
-    auto xdgPopupSurfaceItem = qobject_cast<WXdgPopupSurfaceItem *>(surface->surfaceItem());
-    auto inputPopupSurface = qobject_cast<WInputPopupSurface *>(surface->shellSurface());
-
-    if (!xdgPopupSurfaceItem && !inputPopupSurface) {
-        qCWarning(treelandOutput) << " Invalid popup surface type!";
+    auto dPos = popupDPos(surface);
+    if (!dPos.has_value())
         return;
-    }
 
-    QPointF dPos = xdgPopupSurfaceItem ? xdgPopupSurfaceItem->implicitPosition()
-                                       : inputPopupSurface->cursorRect().bottomLeft();
-
-    QPointF pos = calculateBasePosition(surface, dPos);
+    QPointF pos = calculateBasePosition(surface, dPos.value());
     if (pos.isNull()) {
         return;
     }
@@ -799,18 +829,11 @@ void Output::handleRegularPopup(SurfaceWrapper *surface, const QRectF &normalGeo
 
     auto parentSurfaceWrapper = surface->parentSurface();
 
-    auto xdgPopupSurfaceItem = qobject_cast<WXdgPopupSurfaceItem *>(surface->surfaceItem());
-    auto inputPopupSurface = qobject_cast<WInputPopupSurface *>(surface->shellSurface());
-
-    if (!xdgPopupSurfaceItem && !inputPopupSurface) {
-        qCWarning(treelandOutput) << " Invalid popup surface type!";
+    auto dPos = popupDPos(surface);
+    if (!dPos.has_value())
         return;
-    }
 
-    QPointF dPos = xdgPopupSurfaceItem ? xdgPopupSurfaceItem->implicitPosition()
-                                       : inputPopupSurface->cursorRect().bottomLeft();
-
-    QPointF pos = calculateBasePosition(surface, dPos);
+    QPointF pos = calculateBasePosition(surface, dPos.value());
     if (pos.isNull()) {
         return;
     }

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -289,13 +289,13 @@ void SurfaceWrapper::setup()
                                     &SurfaceWrapper::requestCancelFullscreen);
 
         if (m_type == Type::XdgToplevel) {
-            m_shellSurface->safeConnect(&WToplevelSurface::requestShowWindowMenu,
-                                        this,
-                                        [this](WSeat *, QPoint pos, quint32) {
-                                            Q_EMIT requestShowWindowMenu(
-                                                { pos.x() + m_surfaceItem->leftPadding(),
-                                                  pos.y() + m_surfaceItem->topPadding() });
-                                        });
+            m_shellSurface->safeConnect(
+                &WToplevelSurface::requestShowWindowMenu,
+                this,
+                [this](WSeat *, QPoint pos, quint32) {
+                    Q_EMIT requestShowWindowMenu(
+                        m_surfaceItem->mapFromSurface(pos).toPoint());
+                });
         }
     }
     m_shellSurface->surface()->safeConnect(&WSurface::mappedChanged,

--- a/waylib/src/server/qtquick/wsurfaceitem.cpp
+++ b/waylib/src/server/qtquick/wsurfaceitem.cpp
@@ -1094,6 +1094,13 @@ QRectF WSurfaceItem::getContentGeometry() const
     return QRectF(QPointF(0, 0), d->surface->size());
 }
 
+QPointF WSurfaceItem::mapFromSurface(const QPointF &point) const
+{
+    const QPointF offset = getContentGeometry().topLeft();
+    return QPointF(point.x() + leftPadding() - offset.x(),
+                   point.y() + topPadding() - offset.y());
+}
+
 QSizeF WSurfaceItem::getContentSize() const
 {
     Q_D(const WSurfaceItem);

--- a/waylib/src/server/qtquick/wsurfaceitem.h
+++ b/waylib/src/server/qtquick/wsurfaceitem.h
@@ -196,6 +196,8 @@ public:
     // Find WSurfaceItemContent in child items
     WSurfaceItemContent *findItemContent() const;
 
+    QPointF mapFromSurface(const QPointF &point) const;
+
 Q_SIGNALS:
     void surfaceChanged();
     void subsurfaceAdded(WAYLIB_SERVER_NAMESPACE::WSurfaceItem *item);


### PR DESCRIPTION
Extract popup dPos calculation into a shared helper that adjusts surface-local coordinates by the content geometry offset.

将弹窗dPos计算抽取为共享辅助函数，修正CSD应用（如GTK）
弹窗和菜单的坐标转换。

Log: 修正CSD弹窗位置计算
PMS: BUG-362993
Influence: 修复CSD模式应用（如GTK）弹窗和右键菜单位置偏
移问题，坐标转换更加准确。