### PR TITLE
fix(scanner): remove redundant non-const resourceMap overload

### DIFF
--- a/src/modules/tools/qtwaylandscanner.cpp
+++ b/src/modules/tools/qtwaylandscanner.cpp
@@ -579,9 +579,7 @@ bool Scanner::process()
             printf("        Resource *resource() { return m_resource; }\n");
             printf("        const Resource *resource() const { return m_resource; }\n");
             printf("\n");
-            printf("        QMultiMap<struct ::wl_client*, Resource*> resourceMap() { return "
-                   "m_resource_map; }\n");
-            printf("        const QMultiMap<struct ::wl_client*, Resource*> resourceMap() const { "
+            printf("        const QMultiMap<struct ::wl_client*, Resource*> &resourceMap() const { "
                    "return m_resource_map; }\n");
             printf("\n");
             printf("        bool isGlobalRemoved() const { return m_globalRemovedEvent; }\n");


### PR DESCRIPTION
1. Remove the non-const overload of resourceMap() in generated code
2. Keep only the const version which is sufficient for all use cases
3. Avoid unnecessary mutable access to internal resource map

Log: Removed non-const resourceMap() to prevent unintended modification of internal resource tracking

Influence:
1. Verify all existing callers of resourceMap() still compile correctly
2. Check that no code relies on the mutable version for resource managemen

## Summary by Sourcery

Enhancements:
- Simplify generated Wayland interface API by dropping the non-const resourceMap() overload and returning a const reference instead.