### PR TITLE
fix(dockpreview): drop invalidated wrappers from preview

### DIFF
--- a/src/core/qml/DockPreview.qml
+++ b/src/core/qml/DockPreview.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import QtQuick
@@ -74,6 +74,18 @@ Item {
             if (newSize < oldSize) {
                 filterSurfaceModel.remove(newSize, oldSize - newSize)
             }
+        }
+
+        function removeSurface(surfaceWrapper) {
+            if (!surfaceWrapper)
+                return;
+
+            var index = desiredSurfaces.indexOf(surfaceWrapper);
+            if (index < 0)
+                return;
+
+            desiredSurfaces.splice(index, 1);
+            updateModel();
         }
 
         function activateWindow(surfaceWrapper) {
@@ -470,6 +482,13 @@ Item {
 
             implicitHeight: root.isHorizontal ? 120 : Math.max(80, Math.min(120, 240 * wrapper.height / wrapper.width))
             implicitWidth: root.isHorizontal ? Math.max(80, Math.min(240, 120 * wrapper.width / wrapper.height)) : 240
+
+            Connections {
+                target: wrapper
+                function onAboutToBeInvalidated() {
+                    listview.model.removeSurface(wrapper)
+                }
+            }
 
             ListView.onRemove: {
                 if (filterSurfaceModel.count) {


### PR DESCRIPTION
Remove dock preview entries when their SurfaceWrapper becomes invalidated to avoid reading deleted objects in QML.

Log: Remove invalidated dock preview wrappers
PMS: BUG-363155 1162
Influence: Prevent dock preview crashes from stale SurfaceWrapper references.

```
(gdb) bt
#0  0x00007eaea736fd22 in QQmlData::wasDeleted (priv=0xd17f567d89efd88f) at ./src/qml/qml/qqmldata_p.h:309
#1  QQmlData::wasDeleted (object=0x5e35fd53f7f0) at ./src/qml/qml/qqmldata_p.h:322
#2  QV4::QObjectWrapper::wrap (engine=0x5e35f98fe640, object=0x5e35fd53f7f0) at ./src/qml/jsruntime/qv4qobjectwrapper_p.h:227
#3  0x00007eaea73aa9da in QV4::ExecutionEngine::fromData (this=0x5e35f98fe640, metaType=..., ptr=<optimized out>, container=<optimized out>, property=<optimized out>, flags=<optimized out>)
    at ./src/qml/jsruntime/qv4engine.cpp:1872
#4  0x00007eaea7432032 in QV4::doGetIndexed (s=0x7eae983af628, index=0) at ./src/qml/jsruntime/qv4sequenceobject.cpp:37
#5  0x00007eaea737fd3a in QV4::ArrayIteratorPrototype::method_next (b=<optimized out>, that=0x7eae983af590) at ./src/qml/jsruntime/qv4arrayiterator.cpp:52
#6  0x00007eaea7426dd8 in QV4::FunctionObject::call (argc=0, argv=0x0, thisObject=0x7eae983af590, this=0x7eae983af620) at ./src/qml/jsruntime/qv4functionobject_p.h:187
#7  QV4::FunctionObject::call (data=<synthetic pointer>..., this=0x7eae983af620) at ./src/qml/jsruntime/qv4jscall_p.h:105
#8  QV4::Runtime::IteratorNext::call (engine=0x5e35f98fe640, iterator=..., value=0x7eae983af5c8) at ./src/qml/jsruntime/qv4runtime.cpp:856
#9  0x00007eaea7473017 in QV4::Moth::VME::interpret (frame=0x5e35f98fe640, frame@entry=0x7ffc63182b60, engine=0x5e35f98fe640, 
    code=0x7eaea9e1ebda <QmlCacheGeneratedCode::_qt_qml_Treeland_core_qml_DockPreview_qml::qmlData+10634> "\001\002\n\001\026\t\030", <incomplete sequence \302>) at ./src/qml/jsruntime/qv4vme_moth.cpp:321
#10 0x00007eaea74755d8 in QV4::Moth::VME::exec (frame=<optimized out>, engine=<optimized out>) at ./src/qml/jsruntime/qv4vme_moth.cpp:487
#11 0x00007eaea73ca08f in QV4::Moth::VME::exec (engine=0x5e35f98fe640, frame=0x7ffc63182b60) at ./src/qml/jsruntime/qv4engine_p.h:828
#12 qfoDoCall (fo=<optimized out>, thisObject=<optimized out>, argv=<optimized out>, argc=<optimized out>) at ./src/qml/jsruntime/qv4functionobject.cpp:527
#13 0x00007eaea7472616 in QV4::Moth::VME::interpret (frame=0x5e35f98fe640, frame@entry=0x7ffc63183010, engine=0x5e35f98fe640, code=0x7eae983af538 "@\030Nv\256~") at ./src/qml/jsruntime/qv4vme_moth.cpp:798
#14 0x00007eaea74755d8 in QV4::Moth::VME::exec (frame=<optimized out>, engine=<optimized out>) at ./src/qml/jsruntime/qv4vme_moth.cpp:487
#15 0x00007eaea73bd04c in QV4::doCall (self=<optimized out>, thisObject=<optimized out>, argv=<optimized out>, argc=<optimized out>, context=<optimized out>) at ./src/qml/jsruntime/qv4function.cpp:52
#16 0x00007eaea73c4983 in QV4::Function::call (this=this@entry=0x5e35fa318f60, thisObject=<optimized out>, argv=argv@entry=0x7eae983af4f8, argc=argc@entry=0, context=context@entry=0x7eae74dd16d8)
    at ./src/qml/jsruntime/qv4function.cpp:77
#17 0x00007eaea73c4aed in operator() (argc=0, argv=0x7eae983af4f8, thisObject=<optimized out>, __closure=<synthetic pointer>) at ./src/qml/jsruntime/qv4function.cpp:28
#18 QV4::convertAndCall<QV4::Function::call(QObject*, void**, const QMetaType*, int, QV4::ExecutionContext*)::<lambda(const QV4::Value*, const QV4::Value*, int)> > (call=..., argc=0, types=0x7ffc63183290, 
    a=0x7ffc631832a0, thisObject=<optimized out>, engine=<optimized out>) at ./src/qml/jsruntime/qv4jscall_p.h:199
#19 QV4::Function::call (this=0x5e35fa318f60, thisObject=<optimized out>, a=0x7ffc631832a0, types=0x7ffc63183290, argc=0, context=0x7eae74dd16d8) at ./src/qml/jsruntime/qv4function.cpp:25
#20 0x00007eaea74f7989 in QQmlJavaScriptExpression::evaluate (this=<optimized out>, a=<optimized out>, types=<optimized out>, argc=<optimized out>) at ./src/qml/qml/qqmljavascriptexpression.cpp:270
#21 0x00007eaea74a08cb in QQmlBoundSignalExpression::evaluate (this=this@entry=0x5e35f9988890, a=a@entry=0x0) at ./src/qml/qml/qqmlboundsignal.cpp:200
#22 0x00007eaea74a487b in QQmlBoundSignal_callback (a=0x0, e=0x5e35f9988900) at ./src/qml/qml/ftw/qqmlrefcount_p.h:73
#23 QQmlBoundSignal_callback (e=0x5e35f9988900, a=0x0) at ./src/qml/qml/qqmlboundsignal.cpp:294
#24 0x00007eaea7517109 in QQmlNotifier::emitNotify (endpoint=<optimized out>, a=0x0) at ./src/qml/qml/qqmlnotifier.cpp:70
#25 0x00007eaea903f270 in doActivate<false> (sender=0x5e35f994caa0, signal_index=65, argv=0x0) at ./src/corelib/kernel/qobject.cpp:4010
#26 0x00007eae762620ba in QQuickAbstractButtonPrivate::handleRelease(QPointF const&, unsigned long) () from /lib/x86_64-linux-gnu/libQt6QuickTemplates2.so.6
#27 0x00007eae7627134d in QQuickControl::mouseReleaseEvent(QMouseEvent*) () from /lib/x86_64-linux-gnu/libQt6QuickTemplates2.so.6
#28 0x00007eaea798edf4 in QQuickItemPrivate::deliverPointerEvent(QEvent*) () from /usr/bin/../lib/x86_64-linux-gnu/libQt6Quick.so.6
#29 0x00007eaea7998258 in QQuickItem::event(QEvent*) () from /usr/bin/../lib/x86_64-linux-gnu/libQt6Quick.so.6
#30 0x00007eaea8ff2eb8 in QCoreApplication::notifyInternal2 (receiver=0x5e35f994caa0, event=0x7ffc63185830) at ./src/corelib/kernel/qcoreapplication.cpp:1165
#31 0x00007eaea7b21ac2 in QQuickDeliveryAgentPrivate::deliverMatchingPointsToItem(QQuickItem*, bool, QPointerEvent*, bool) () from /usr/bin/../lib/x86_64-linux-gnu/libQt6Quick.so.6
#32 0x00007eaea7b2209e in QQuickDeliveryAgentPrivate::deliverUpdatedPoints(QPointerEvent*) () from /usr/bin/../lib/x86_64-linux-gnu/libQt6Quick.so.6
#33 0x00007eaea7b23c83 in QQuickDeliveryAgentPrivate::deliverPointerEvent(QPointerEvent*) () from /usr/bin/../lib/x86_64-linux-gnu/libQt6Quick.so.6
#34 0x00007eaea7b24d84 in QQuickDeliveryAgentPrivate::handleMouseEvent(QMouseEvent*) () from /usr/bin/../lib/x86_64-linux-gnu/libQt6Quick.so.6
#35 0x00007eaea7b25518 in QQuickDeliveryAgent::event(QEvent*) () from /usr/bin/../lib/x86_64-linux-gnu/libQt6Quick.so.6
#36 0x00007eaea7a387a1 in QQuickWindow::event(QEvent*) () from /usr/bin/../lib/x86_64-linux-gnu/libQt6Quick.so.6
#37 0x00007eaea975d822 in Waylib::Server::WOutputRenderWindow::event (this=0x5e35f977c280, event=0x7ffc63185830) at ./waylib/src/server/qtquick/woutputrenderwindow.cpp:2021
#38 0x00007eaea8ff2eb8 in QCoreApplication::notifyInternal2 (receiver=0x5e35f977c280, event=0x7ffc63185830) at ./src/corelib/kernel/qcoreapplication.cpp:1165
#39 0x00007eaea8ff2efd in QCoreApplication::sendEvent (receiver=<optimized out>, event=<optimized out>) at ./src/corelib/kernel/qcoreapplication.cpp:1609
#40 0x00007eaea972ade0 in Waylib::Server::WSeat::notifyButton (this=<optimized out>, cursor=<optimized out>, device=device@entry=0x5e35fa868f60, button=Qt::LeftButton, state=<optimized out>, timestamp=362008)
    at ./waylib/src/server/kernel/wseat.cpp:1175
#41 0x00007eaea97165dc in Waylib::Server::WCursorPrivate::on_button (this=0x5e35f97b4340, event=0x7ffc63185be0) at ./waylib/src/server/kernel/wcursor.cpp:126
#42 0x00007eaea903f46c in QtPrivate::QSlotObjectBase::call (a=<optimized out>, r=<optimized out>, this=<optimized out>, this=<optimized out>, r=<optimized out>, a=<optimized out>)
--Type <RET> for more, q to quit, c to continue without paging--
    at ./src/corelib/kernel/qobjectdefs_impl.h:486
#43 doActivate<false> (sender=0x5e35f977cf70, signal_index=6, argv=0x7ffc63185aa0) at ./src/corelib/kernel/qobject.cpp:4120
#44 0x00007eaea98079a6 in qw_cursor::notify_button (this=<optimized out>, _t1=<optimized out>) at ./obj-x86_64-linux-gnu/waylib/qwlroots/src/qwlroots_autogen/GZRP3O7STM/moc_qwcursor.cpp:466
#45 0x00007eaea9c5465f in std::function<void(void*, void*)>::operator() (__args#1=<optimized out>, __args#0=<optimized out>, this=<optimized out>) at /usr/include/c++/12/bits/std_function.h:591
#46 qw_signal_connector::callMfp (wl_listener=<optimized out>, data=<optimized out>) at ./qwlroots/src/util/qwsignalconnector.h:206
#47 0x00007eaea6f5cafc in wl_signal_emit_mutable (signal=<optimized out>, data=0x7ffc63185be0) at ../src/wayland-server.c:2314
#48 0x00007eaea6f5cafc in wl_signal_emit_mutable (signal=signal@entry=0x5e35fa85aa20, data=data@entry=0x7ffc63185be0) at ../src/wayland-server.c:2314
#49 0x00007eaea94baf00 in wlr_pointer_notify_button (pointer=pointer@entry=0x5e35fa85a980, event=event@entry=0x7ffc63185be0) at ../types/wlr_pointer.c:81
#50 0x00007eaea9475ea6 in handle_pointer_button (event=<optimized out>, pointer=0x5e35fa85a980) at ../backend/libinput/pointer.c:72
#51 0x00007eaea9474d9b in handle_libinput_readable (fd=<optimized out>, mask=<optimized out>, _backend=<optimized out>) at ../backend/libinput/backend.c:59
#52 handle_libinput_readable (fd=<optimized out>, mask=<optimized out>, _backend=0x5e35fa1e1920) at ../backend/libinput/backend.c:49
#53 0x00007eaea6f5ec52 in wl_event_loop_dispatch (loop=0x5e35f97b3e10, timeout=<optimized out>) at ../src/event-loop.c:1105
#54 0x00007eaea973269a in operator() (__closure=<optimized out>) at ./waylib/src/server/kernel/wserver.cpp:115
#55 operator() (__closure=<optimized out>) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:141
#56 QtPrivate::FunctorCallBase::call_internal<void, QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, Waylib::Server::WServerPrivate::init()::<lambda()> >::call(Waylib::Server::WServerPrivate::init()::<lambda()>&, void**)::<lambda()> > (fn=..., args=<optimized out>) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:65
#57 QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, Waylib::Server::WServerPrivate::init()::<lambda()> >::call (arg=<optimized out>, f=...)
    at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:140
#58 QtPrivate::FunctorCallable<Waylib::Server::WServerPrivate::init()::<lambda()> >::call<QtPrivate::List<>, void> (arg=<optimized out>, f=...) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:362
#59 QtPrivate::QCallableObject<Waylib::Server::WServerPrivate::init()::<lambda()>, QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase *, QObject *, void **, bool *) (which=<optimized out>, 
    this_=<optimized out>, r=<optimized out>, a=<optimized out>, ret=<optimized out>) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:572
#60 0x00007eaea903f46c in QtPrivate::QSlotObjectBase::call (a=<optimized out>, r=<optimized out>, this=<optimized out>, this=<optimized out>, r=<optimized out>, a=<optimized out>)
    at ./src/corelib/kernel/qobjectdefs_impl.h:486
#61 doActivate<false> (sender=0x5e35fa1e6bb0, signal_index=3, argv=0x7ffc63185f70) at ./src/corelib/kernel/qobject.cpp:4120
#62 0x00007eaea9049a13 in QSocketNotifier::activated (this=this@entry=0x5e35fa1e6bb0, _t1=..., _t2=<optimized out>, _t3=...) at ./obj-x86_64-linux-gnu/src/corelib/Core_autogen/include/moc_qsocketnotifier.cpp:195
#63 0x00007eaea9049b43 in QSocketNotifier::event (this=0x5e35fa1e6bb0, e=<optimized out>) at ./src/corelib/kernel/qsocketnotifier.cpp:327
#64 0x00007eaea8ff2eb8 in QCoreApplication::notifyInternal2 (receiver=0x5e35fa1e6bb0, event=0x7ffc63186080) at ./src/corelib/kernel/qcoreapplication.cpp:1165
#65 0x00007eaea91f023f in socketNotifierSourceDispatch (source=0x5e35f96cd710) at ./src/corelib/kernel/qeventdispatcher_glib.cpp:77
#66 0x00007eaea6462879 in ?? () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#67 0x00007eaea6464977 in ?? () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#68 0x00007eaea6464f80 in g_main_context_iteration () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#69 0x00007eaea91e7d50 in QEventDispatcherGlib::processEvents (this=0x5e35f9686230, flags=...) at ./src/corelib/kernel/qeventdispatcher_glib.cpp:396
#70 0x00007eaea8ffbc2a in QEventLoop::exec (this=0x7ffc63186370, flags=...) at ./src/corelib/global/qflags.h:34
#71 0x00007eaea8ff5ce8 in QCoreApplication::exec () at ./src/corelib/global/qflags.h:74
#72 0x00005e35bffb24a3 in main (argc=<optimized out>, argv=<optimized out>) at ./src/main.cpp:52
```
dock preview 持有了会失效的对象引用