### PR TITLE
fix: drain residual key release after capture shortcut

### DIFF
--- a/src/modules/shortcut/shortcutcontroller.cpp
+++ b/src/modules/shortcut/shortcutcontroller.cpp
@@ -51,7 +51,7 @@ uint ShortcutController::registerKey(const QString &name, const QString& key, Sh
         return BindError::bind_error_invalid_argument;
     }
     auto keyComb = normalizeKeyCombination(keySeq[0]);
-    if (keyComb == QKeyCombination(Qt::NoModifier, Qt::Key_unknown)) {
+    if (!isValidShortcutCombination(keyComb)) {
         return BindError::bind_error_invalid_argument;
     }
     int combined = keyComb.toCombined();
@@ -239,4 +239,70 @@ QKeyCombination ShortcutController::normalizeKeyCombination(QKeyCombination comb
     }
 
     return QKeyCombination(mods, nornalizedKey);
+}
+
+
+// Decide whether a normalized (modifiers + key) combination is accepted as a
+// valid shortcut. Mirrors dde-daemon's IsGood()/isGoodNoMods()/isGoodModShift().
+bool ShortcutController::isValidShortcutCombination(QKeyCombination combination)
+{
+    const auto normalized = normalizeKeyCombination(combination);
+    const Qt::KeyboardModifiers mods = normalized.keyboardModifiers()
+        & (Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier | Qt::ShiftModifier);
+    const Qt::Key key = normalized.key();
+
+    // Modifier-only combinations: only Meta is accepted as a standalone shortcut.
+    if (key == Qt::Key_unknown)
+        return mods == Qt::MetaModifier;
+
+    // Rule 1: Ctrl / Alt / Meta + any non-modifier key.
+    if (mods & (Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier))
+        return true;
+
+    // Rule 2: Function keys.
+    if (key >= Qt::Key_F1 && key <= Qt::Key_F35)
+        return true;
+
+    // Rule 3: Misc function keys.
+    switch (key) {
+    case Qt::Key_Delete:
+    case Qt::Key_Backspace:
+    case Qt::Key_Pause:
+    case Qt::Key_Print:
+    case Qt::Key_Insert:
+    case Qt::Key_Help:
+    case Qt::Key_Menu:
+    case Qt::Key_Cancel:
+        return true;
+    default:
+        break;
+    }
+
+    // Rule 4: Shift + selected special/navigation keys.
+    if (mods == Qt::ShiftModifier) {
+        switch (key) {
+        case Qt::Key_Space:
+        case Qt::Key_Escape:
+        case Qt::Key_Tab:
+            return true;
+        default:
+            break;
+        }
+
+        if ((key >= Qt::Key_Home && key <= Qt::Key_PageDown)
+            || (key >= Qt::Key_Left && key <= Qt::Key_Down))
+            return true;
+    }
+
+    // Rule 5: Media / browser / hardware keys without modifiers.
+    if (mods == Qt::NoModifier) {
+        if (key >= Qt::Key_Back && key <= Qt::Key_KeyboardBrightnessDown)
+            return true;
+        if (key >= Qt::Key_LaunchMail && key <= Qt::Key_Launch9)
+            return true;
+        if (key >= Qt::Key_MediaPlay && key <= Qt::Key_MediaLast)
+            return true;
+    }
+
+    return false;
 }

--- a/src/modules/shortcut/shortcutcontroller.h
+++ b/src/modules/shortcut/shortcutcontroller.h
@@ -36,6 +36,7 @@ public:
     void clear();
     bool dispatchKeyEvent(const QKeyEvent *event);
     static QKeyCombination normalizeKeyCombination(QKeyCombination combination);
+    static bool isValidShortcutCombination(QKeyCombination combination);
 
 Q_SIGNALS:
     void actionTriggered(ShortcutAction action, const QString &name, bool isGesture, KeyFlags keyFlags = {});

--- a/src/modules/shortcut/shortcutmanager.cpp
+++ b/src/modules/shortcut/shortcutmanager.cpp
@@ -96,84 +96,6 @@ static bool isPureModifierKey(Qt::Key key)
     }
 }
 
-// For a non-modifier key press, decide whether the (modifiers + key) combination
-// constitutes a valid shortcut that should be captured.
-// Mirrors dde-daemon's Keystroke.IsGood(), isGoodNoMods() and isGoodModShift().
-// Called only for regular non-modifier, non-Win key presses.
-//
-// Rules (in priority order):
-//  1. Ctrl / Alt / Meta held + any non-modifier key  → always valid.
-//  2. Function keys F1–F35, with or without Shift      → valid.
-//  3. Misc function keys (Delete, Backspace, Insert, …) → valid.
-//  4. Shift + cursor/navigation keys, Escape, Space, Tab   → valid.
-//  5. Media / hardware / XF86 keys without modifiers       → valid.
-//  6. Everything else (bare letters, digits, Escape, …)    → invalid.
-static bool isValidShortcutCombo(const QKeyEvent *kevent)
-{
-    Qt::Key key = static_cast<Qt::Key>(kevent->key());
-    // The caller guarantees this is not a pure modifier or Win key.
-    Q_ASSERT(!isPureModifierKey(key));
-    Q_ASSERT(key != Qt::Key_Super_L && key != Qt::Key_Super_R && key != Qt::Key_Meta);
-
-    // modifiers() already reflects all currently held modifier keys,
-    // including ones pressed before this event.
-    Qt::KeyboardModifiers mods = kevent->modifiers()
-        & (Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier | Qt::ShiftModifier);
-
-    // Rule 1: Ctrl / Alt / Meta + anything → always good.
-    if (mods & (Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier))
-        return true;
-
-    // Rule 2: Function keys (with or without Shift).
-    if (key >= Qt::Key_F1 && key <= Qt::Key_F35)
-        return true;
-
-    // Rule 3: Misc function keys valid with no modifier or with Shift.
-    // Mirrors dde-daemon isGoodNoMods() XK_BackSpace/Delete/Pause and IsMiscFunctionKey().
-    switch (key) {
-    case Qt::Key_Delete:
-    case Qt::Key_Backspace:
-    case Qt::Key_Pause:
-    case Qt::Key_Print:
-    case Qt::Key_Insert: // XK_Insert  — IsMiscFunctionKey in dde-daemon
-    case Qt::Key_Help:   // XK_Help    — IsMiscFunctionKey in dde-daemon
-    case Qt::Key_Menu:   // XK_Menu    — IsMiscFunctionKey in dde-daemon
-    case Qt::Key_Cancel: // XK_Cancel  — IsMiscFunctionKey in dde-daemon
-        return true;
-    default:
-        break;
-    }
-
-    // Rule 4: Shift + extra special keys (mirrors dde-daemon isGoodModShift).
-    if (mods == Qt::ShiftModifier) {
-        switch (key) {
-        case Qt::Key_Space:
-        case Qt::Key_Escape:
-        case Qt::Key_Tab:
-            return true;
-        default:
-            break;
-        }
-        // Shift + cursor / navigation keys.
-        if ((key >= Qt::Key_Home && key <= Qt::Key_PageDown)
-            || (key >= Qt::Key_Left && key <= Qt::Key_Down))
-            return true;
-    }
-
-    // Rule 5: Media / browser / hardware (XF86) keys — no modifier needed.
-    // Qt groups these between Key_Back and Key_LaunchMedia / Key_Launch9.
-    if (mods == Qt::NoModifier) {
-        if (key >= Qt::Key_Back && key <= Qt::Key_KeyboardBrightnessDown)
-            return true;
-        if (key >= Qt::Key_LaunchMail && key <= Qt::Key_Launch9)
-            return true;
-        if (key >= Qt::Key_MediaPlay && key <= Qt::Key_MediaLast)
-            return true;
-    }
-
-    return false;
-}
-
 class ShortcutCaptureV1 : public QtWaylandServer::treeland_shortcut_capture_v1
 {
 public:
@@ -647,7 +569,8 @@ ShortcutCaptureV1 *ShortcutManagerV2Private::resetCaptureState()
 //   Win key (Super_L/R or Meta)      — consumed on press; KeyRelease → emit "Meta" if
 //                                      no other modifier is held (any regular key pressed
 //                                      while Win is held terminates capture on KeyPress).
-//   all other keys                   — terminate on KeyPress via isValidShortcutCombo().
+//   all other keys                   — terminate on KeyPress via
+//                                      ShortcutController::isValidShortcutCombination().
 bool ShortcutManagerV2Private::tryHandleCaptureEvent(WSeat *seat, QInputEvent *event)
 {
     // Post-capture drain: consume residual KeyRelease events from the captured session.
@@ -712,7 +635,7 @@ bool ShortcutManagerV2Private::tryHandleCaptureEvent(WSeat *seat, QInputEvent *e
         }
 
         // Regular non-modifier key: terminate capture immediately on KeyPress.
-        if (isValidShortcutCombo(kevent)) {
+        if (ShortcutController::isValidShortcutCombination(kevent->keyCombination())) {
             // Arm drain before resetting (resetCaptureState clears m_pendingSeat).
             m_drainKey = key;
             m_drainSeat = m_pendingSeat;

--- a/src/modules/shortcut/shortcutmanager.cpp
+++ b/src/modules/shortcut/shortcutmanager.cpp
@@ -261,6 +261,8 @@ public:
     // Seat whose keyboard focus was validated at capture start.
     // Events from other seats are ignored during capture.
     WSeat *m_pendingSeat = nullptr;
+    Qt::Key m_drainKey = Qt::Key_unknown;
+    WSeat *m_drainSeat = nullptr;
     // Target surface that requested the capture. Capture must fail once it loses focus.
     QPointer<WSurface> m_pendingSurface;
     WSocket* m_activeSessionSocket = nullptr;
@@ -579,7 +581,7 @@ void ShortcutManagerV2Private::capture_next_shortcut(Resource *resource,
         new ShortcutCaptureV1(this, resource->client(), capture, resource->version());
 
     // Check if another capture is already in progress.
-    if (m_pendingCapture) {
+    if (m_pendingCapture || m_drainKey != Qt::Key_unknown) {
         captureObj->sendFailed(ShortcutCaptureV1::failed_reason_busy);
         return;
     }
@@ -648,6 +650,19 @@ ShortcutCaptureV1 *ShortcutManagerV2Private::resetCaptureState()
 //   all other keys                   — terminate on KeyPress via isValidShortcutCombo().
 bool ShortcutManagerV2Private::tryHandleCaptureEvent(WSeat *seat, QInputEvent *event)
 {
+    // Post-capture drain: consume residual KeyRelease events from the captured session.
+    // This prevents the release of the captured key from immediately firing a newly
+    // bound shortcut that uses KeyRelease trigger semantics.
+    if (m_drainKey != Qt::Key_unknown && seat == m_drainSeat
+        && event->type() == QEvent::KeyRelease) {
+        auto *ke = static_cast<QKeyEvent *>(event);
+        if (static_cast<Qt::Key>(ke->key()) == m_drainKey) {
+            m_drainKey = Qt::Key_unknown;
+            m_drainSeat = nullptr;
+        }
+        return true; // consume all key releases until the captured key is released
+    }
+
     if (!m_pendingCapture)
         return false;
 
@@ -698,6 +713,9 @@ bool ShortcutManagerV2Private::tryHandleCaptureEvent(WSeat *seat, QInputEvent *e
 
         // Regular non-modifier key: terminate capture immediately on KeyPress.
         if (isValidShortcutCombo(kevent)) {
+            // Arm drain before resetting (resetCaptureState clears m_pendingSeat).
+            m_drainKey = key;
+            m_drainSeat = m_pendingSeat;
             auto keyComb = ShortcutController::normalizeKeyCombination(kevent->keyCombination());
             auto captured = QKeySequence(keyComb).toString(QKeySequence::PortableText);
             resetCaptureState()->sendCaptured(captured);
@@ -748,11 +766,6 @@ void ShortcutManagerV2::destroy(WServer *server)
 wl_global *ShortcutManagerV2::global() const
 {
     return d->global();
-}
-
-bool ShortcutManagerV2::hasPendingCapture() const
-{
-    return d->m_pendingCapture != nullptr;
 }
 
 bool ShortcutManagerV2::tryHandleCaptureEvent(WSeat *seat, QInputEvent *event)

--- a/src/modules/shortcut/shortcutmanager.h
+++ b/src/modules/shortcut/shortcutmanager.h
@@ -68,7 +68,6 @@ public:
     ShortcutController* controller();
     void sendActivated(const QString& name, ShortcutController::KeyFlags keyFlags);
 
-    bool hasPendingCapture() const;
     bool tryHandleCaptureEvent(WAYLIB_SERVER_NAMESPACE::WSeat *seat, QInputEvent *event);
 
 public Q_SLOTS:

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1896,10 +1896,8 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *targetWindow, QInputEvent 
     }
 
     // handle shortcut
-    if (m_shortcutManager->hasPendingCapture()) {
-        if (m_shortcutManager->tryHandleCaptureEvent(seat, event))
-            return true;
-    }
+    if (m_shortcutManager->tryHandleCaptureEvent(seat, event))
+        return true;
 
     if (seat == m_seat && !m_captureSelector && m_currentMode != CurrentMode::LockScreen &&
         (event->type() == QEvent::KeyPress || event->type() == QEvent::KeyRelease)) {


### PR DESCRIPTION
This fix addresses a bug where after a KeyPress-triggered shortcut capture completes,
the triggering key's KeyRelease event remains in-flight and could incorrectly activate
a newly bound shortcut that uses KeyRelease trigger semantics. The drain mechanism
consumes all KeyRelease events from the captured seat until the specific captured key
is released, preventing false shortcut activation.

Influence:
Test shortcut capture with KeyPress trigger to verify completion still works