### PR TITLE
fix: null check in input method grab

### DIFF
--- a/waylib/src/server/protocols/winputmethodhelper.cpp
+++ b/waylib/src/server/protocols/winputmethodhelper.cpp
@@ -42,6 +42,11 @@ void handleKey(struct wlr_seat_keyboard_grab *grab, uint32_t time_msec, uint32_t
             return;
         }
     }
+    if (!arg->grab) {
+        qCCritical(qLcInputMethod) << "Ignore key event for destroyed input method keyboard grab"
+                                  << "key" << key << "state" << state;
+        return;
+    }
     arg->grab->send_key(time_msec, Qt::Key(key), state);
 }
 
@@ -53,6 +58,10 @@ void handleModifiers(struct wlr_seat_keyboard_grab *grab, const struct wlr_keybo
             grab->seat->keyboard_state.default_grab->interface->modifiers(grab, modifiers);
             return;
         }
+    }
+    if (!arg->grab) {
+        qCCritical(qLcInputMethod) << "Ignore modifiers for destroyed input method keyboard grab";
+        return;
     }
     arg->grab->send_modifiers(const_cast<struct wlr_keyboard_modifiers *>(modifiers));
 }
@@ -85,6 +94,53 @@ public:
         Q_ASSERT(textInputManagerV3);
     }
 
+    void endGrab(qw_input_method_keyboard_grab_v2 *kgv2)
+    {
+        if (!seat) {
+            qCCritical(qLcInputMethod) << "Failed to end input method keyboard grab - seat is already destroyed"
+                                      << kgv2;
+            return;
+        }
+
+        auto *kgHandle = kgv2 ? kgv2->handle() : nullptr;
+        if (!kgHandle) {
+            qCCritical(qLcInputMethod) << "Failed to end input method keyboard grab - grab handle is invalid"
+                                      << kgv2;
+            return;
+        }
+
+        if (kgHandle->keyboard) {
+            seat->handle()->keyboard_send_modifiers(&kgHandle->keyboard->modifiers);
+        }
+        seat->handle()->keyboard_end_grab();
+    }
+
+    void setKeyboard(qw_input_method_keyboard_grab_v2 *kgv2, WInputDevice *keyboard)
+    {
+        auto *kgHandle = kgv2 ? kgv2->handle() : nullptr;
+        if (!kgHandle) {
+            qCCritical(qLcInputMethod) << "Failed to set keyboard for input method grab - grab handle is invalid"
+                                      << kgv2 << "keyboard" << keyboard;
+            return;
+        }
+
+        if (keyboard) {
+            auto *virtualKeyboard = wlr_input_device_get_virtual_keyboard(*keyboard->handle());
+            // refer to:
+            // https://github.com/swaywm/sway/blob/master/sway/input/keyboard.c#L391
+            if (virtualKeyboard
+                && virtualKeyboard->resource
+                && kgHandle->resource
+                && wl_resource_get_client(virtualKeyboard->resource)
+                    == wl_resource_get_client(kgHandle->resource)) {
+                return;
+            }
+            kgv2->set_keyboard(wlr_keyboard_from_input_device(*keyboard->handle()));
+        } else {
+            kgv2->set_keyboard(nullptr);
+        }
+    }
+
     const QPointer<WServer> server;
     const QPointer<WSeat> seat;
     const QPointer<WInputMethodManagerV2> inputMethodManagerV2;
@@ -99,6 +155,7 @@ public:
     wlr_seat_keyboard_grab keyboardGrab;
     wlr_keyboard_grab_interface grabInterface;
     GrabHandlerArg handlerArg;
+    QMetaObject::Connection activeKeyboardGrabDestroyConnection;
 
     QList<WTextInput *> textInputs;
     QList<WInputDevice *> virtualKeyboards;
@@ -111,6 +168,10 @@ WInputMethodHelper::WInputMethodHelper(WServer *server, WSeat *seat)
 {
     W_D(WInputMethodHelper);
     d->seat->safeConnect(&WSeat::keyboardFocusSurfaceChanged, this, &WInputMethodHelper::resendKeyboardFocus);
+    d->seat->safeConnect(&WSeat::keyboardChanged, this, [d] {
+        if (auto *activeKG = d->activeKeyboardGrab)
+            d->setKeyboard(activeKG, d->seat->keyboard());
+    });
     connect(d->inputMethodManagerV2, &WInputMethodManagerV2::newInputMethod, this, &WInputMethodHelper::handleNewIMV2);
     connect(d->textInputManagerV3, &WTextInputManagerV3::newTextInput, this, &WInputMethodHelper::handleNewTI);
     connect(d->virtualKeyboardManagerV1, &WVirtualKeyboardManagerV1::newVirtualKeyboard, this, &WInputMethodHelper::handleNewVKV1);
@@ -213,37 +274,13 @@ void WInputMethodHelper::handleNewKGV2(qw_input_method_keyboard_grab_v2 *kgv2)
 {
     W_D(WInputMethodHelper);
     Q_ASSERT(d->seat);
-    auto endGrab = [d](qw_input_method_keyboard_grab_v2 *kgv2) {
-        if (!d->seat)
-            return;
-        if (kgv2->handle()->keyboard) {
-            d->seat->handle()->keyboard_send_modifiers(&kgv2->handle()->keyboard->modifiers);
-        }
-        d->seat->handle()->keyboard_end_grab();
-    };
-    auto setKeyboard = [](qw_input_method_keyboard_grab_v2 *kgv2, WInputDevice *keyboard) {
-        if (keyboard) {
-            auto *virtualKeyboard = wlr_input_device_get_virtual_keyboard(*keyboard->handle());
-            // refer to:
-            // https://github.com/swaywm/sway/blob/master/sway/input/keyboard.c#L391
-            if (virtualKeyboard
-                && wl_resource_get_client(virtualKeyboard->resource)
-                    == wl_resource_get_client(kgv2->handle()->resource)) {
-                return;
-            }
-            kgv2->set_keyboard(wlr_keyboard_from_input_device(*keyboard->handle()));
-        } else {
-            kgv2->set_keyboard(nullptr);
-        }
-    };
     if (auto activeKG = activeKeyboardGrab()) {
-        endGrab(activeKG);
+        disconnect(d->activeKeyboardGrabDestroyConnection);
+        d->activeKeyboardGrabDestroyConnection = {};
+        d->endGrab(activeKG);
     }
     d->activeKeyboardGrab = kgv2;
-    setKeyboard(kgv2, d->seat->keyboard());
-    connect(d->seat, &WSeat::keyboardChanged, kgv2, [setKeyboard, d, kgv2](){
-        setKeyboard(kgv2, d->seat->keyboard());
-    });
+    d->setKeyboard(kgv2, d->seat->keyboard());
     d->grabInterface = *d->seat->nativeHandle()->keyboard_state.grab->interface;
     d->grabInterface.key = handleKey;
     d->grabInterface.modifiers = handleModifiers;
@@ -252,11 +289,13 @@ void WInputMethodHelper::handleNewKGV2(qw_input_method_keyboard_grab_v2 *kgv2)
     d->keyboardGrab.data = &d->handlerArg;
     d->keyboardGrab.interface = &d->grabInterface;
     d->seat->handle()->keyboard_start_grab(&d->keyboardGrab);
-    connect(kgv2, &qw_input_method_keyboard_grab_v2::before_destroy, this, [this, d, endGrab, kgv2] {
-        if (activeKeyboardGrab() == kgv2) {
-            endGrab(kgv2);
-            d->activeKeyboardGrab = nullptr;
-        }
+    d->activeKeyboardGrabDestroyConnection = connect(kgv2, &qw_input_method_keyboard_grab_v2::before_destroy, this, [this, d] {
+        auto *kgv2 = qobject_cast<qw_input_method_keyboard_grab_v2 *>(sender());
+        Q_ASSERT(activeKeyboardGrab() == kgv2);
+        d->endGrab(kgv2);
+        d->activeKeyboardGrab = nullptr;
+        d->handlerArg.grab = nullptr;
+        d->activeKeyboardGrabDestroyConnection = {};
     });
 }
 


### PR DESCRIPTION
1. Add null checks for arg->grab in handleKey and handleModifiers to prevent crashes when grab is destroyed
2. Move endGrab and setKeyboard lambdas to WInputMethodHelperPrivate class methods for better lifecycle management
3. Add null check for kgv2 parameter in setKeyboard method
4. Add null checks for virtual_keyboard and grab resources before comparing clients
5. Set handlerArg.grab to nullptr when keyboard grab is destroyed to prevent use-after-free

Influence:
1. Test input method activation and deactivation cycles
2. Verify keyboard input works correctly when input method is active
3. Test rapid switching between different input methods
4. Verify no crashes occur when input method client disconnects unexpectedly
5. Test modifier keys (Shift, Ctrl, Alt) handling during input method grab
6. Verify virtual keyboard input is properly forwarded without interference

fix: 输入法键盘抓取空指针检查

1. 在 handleKey 和 handleModifiers 中添加 arg->grab 空指针检查，防止抓取 对象销毁后崩溃
2. 将 endGrab 和 setKeyboard lambda 函数移至 WInputMethodHelperPrivate 类方法，改善生命周期管理
3. 在 setKeyboard 方法中添加 kgv2 参数的空指针检查
4. 在比较客户端之前添加虚拟键盘和抓取资源的空指针检查
5. 当键盘抓取销毁时将 handlerArg.grab 设为空指针，防止使用已释放内存

Influence:
1. 测试输入法激活和停用循环
2. 验证输入法激活时键盘输入正常工作
3. 测试在不同输入法之间快速切换
4. 验证输入法客户端意外断开连接时不会崩溃
5. 测试输入法抓取期间修饰键（Shift、Ctrl、Alt）的处理
6. 验证虚拟键盘输入被正确转发且不受干扰

## Summary by Sourcery

Improve robustness of input method keyboard grab handling to avoid crashes and use-after-free when grabs, seats, or related resources are destroyed.

Bug Fixes:
- Add null checks for input method keyboard grab in key and modifier handlers to prevent dereferencing destroyed grabs.
- Ensure keyboard grab end and keyboard association handle invalid or missing grab handles, seats, and resources safely, avoiding crashes and use-after-free when the grab is destroyed.
- Avoid forwarding virtual keyboard events from the same client as the input method grab by validating virtual keyboard and grab resources before comparing clients.

Enhancements:
- Refactor input method keyboard grab end and keyboard association logic into WInputMethodHelperPrivate methods for clearer lifecycle management.
- Track and manage the active keyboard grab destroy connection and clear grab handler state when the grab is destroyed to keep internal state consistent.