### PR TITLE
feat(input): added implementation logic for treeland-input-manager.

### DIFF
--- a/misc/dconfig/org.deepin.dde.treeland.json
+++ b/misc/dconfig/org.deepin.dde.treeland.json
@@ -35,17 +35,6 @@
             "permissions": "readwrite",
             "visibility": "public"
         },
-        "numlock": {
-            "value": false,
-            "serial": 0,
-            "flags": ["global"],
-            "name": "Numlock",
-            "name[zh_CN]": "数字键盘",
-            "description": "Enable Numlock on Treeland startup & new keyboard connection",
-            "description[zh_CN]": "在 Treeland 启动以及新键盘连接时启用数字键盘",
-            "permissions": "readwrite",
-            "visibility": "public"
-        },
         "showOtherUserOption": {
             "value": false,
             "serial": 0,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -162,6 +162,8 @@ qt_add_qml_module(libtreeland
         input/inputdevice.h
         input/togglablegesture.cpp
         input/togglablegesture.h
+        input/inputmanager.cpp
+        input/inputmanager.h
         interfaces/baseplugininterface.h
         interfaces/lockscreeninterface.h
         interfaces/multitaskviewinterface.h

--- a/src/input/inputdevice.cpp
+++ b/src/input/inputdevice.cpp
@@ -28,7 +28,7 @@ static bool ensureStatus(libinput_config_status status)
     return true;
 }
 
-[[maybe_unused]] static bool configSendEventsMode(libinput_device *device, uint32_t mode)
+bool configSendEventsMode(libinput_device *device, uint32_t mode)
 {
     if (libinput_device_config_send_events_get_mode(device) == mode) {
         qCCritical(treelandInput) << "libinput_device_config_send_events_set_mode repeat set mode"
@@ -42,7 +42,7 @@ static bool ensureStatus(libinput_config_status status)
     return ensureStatus(status);
 }
 
-static bool configTapEnabled(libinput_device *device, libinput_config_tap_state tap)
+bool configTapEnabled(libinput_device *device, libinput_config_tap_state tap)
 {
     if (libinput_device_config_tap_get_finger_count(device) <= 0
         || libinput_device_config_tap_get_enabled(device) == tap) {
@@ -103,7 +103,7 @@ static bool configTapEnabled(libinput_device *device, libinput_config_tap_state 
     return ensureStatus(status);
 }
 
-[[maybe_unused]] static bool configAccelSpeed(libinput_device *device, double speed)
+bool configAccelSpeed(libinput_device *device, double speed)
 {
     if (!libinput_device_config_accel_is_available(device)
         || libinput_device_config_accel_get_speed(device) == speed) {
@@ -133,7 +133,7 @@ static bool configTapEnabled(libinput_device *device, libinput_config_tap_state 
     return ensureStatus(status);
 }
 
-[[maybe_unused]] static bool configAccelProfile(libinput_device *device, libinput_config_accel_profile profile)
+bool configAccelProfile(libinput_device *device, libinput_config_accel_profile profile)
 {
     if (!libinput_device_config_accel_is_available(device)
         || libinput_device_config_accel_get_profile(device) == profile) {
@@ -148,7 +148,7 @@ static bool configTapEnabled(libinput_device *device, libinput_config_tap_state 
     return ensureStatus(status);
 }
 
-[[maybe_unused]] static bool configNaturalScroll(libinput_device *device, bool natural)
+bool configNaturalScroll(libinput_device *device, bool natural)
 {
     if (!libinput_device_config_scroll_has_natural_scroll(device)
         || libinput_device_config_scroll_get_natural_scroll_enabled(device) == natural) {
@@ -164,7 +164,7 @@ static bool configTapEnabled(libinput_device *device, libinput_config_tap_state 
     return ensureStatus(status);
 }
 
-[[maybe_unused]] static bool configLeftHanded(libinput_device *device, bool left)
+bool configLeftHanded(libinput_device *device, bool left)
 {
     if (!libinput_device_config_left_handed_is_available(device)
         || libinput_device_config_left_handed_get(device) == left) {
@@ -262,7 +262,7 @@ static bool configTapEnabled(libinput_device *device, libinput_config_tap_state 
     return ensureStatus(status);
 }
 
-[[maybe_unused]] static bool configDwtEnabled(libinput_device *device, enum libinput_config_dwt_state enable)
+bool configDwtEnabled(libinput_device *device, enum libinput_config_dwt_state enable)
 {
     if (!libinput_device_config_dwt_is_available(device)
         || libinput_device_config_dwt_get_enabled(device) == enable) {

--- a/src/input/inputdevice.h
+++ b/src/input/inputdevice.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #pragma once
@@ -64,3 +64,11 @@ private:
     std::unique_ptr<GestureRecognizer> m_touchpadRecognizer;
     uint m_touchpadFingerCount = 0;
 };
+
+bool configAccelSpeed(libinput_device *device, double speed);
+bool configAccelProfile(libinput_device *device, libinput_config_accel_profile profile);
+bool configNaturalScroll(libinput_device *device, bool natural);
+bool configSendEventsMode(libinput_device *device, uint32_t mode);
+bool configTapEnabled(libinput_device *device, libinput_config_tap_state tap);
+bool configDwtEnabled(libinput_device *device, enum libinput_config_dwt_state enable);
+bool configLeftHanded(libinput_device *device, bool left);

--- a/src/input/inputmanager.cpp
+++ b/src/input/inputmanager.cpp
@@ -1,0 +1,588 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "inputmanager.h"
+#include "seatuserconfig.hpp"
+#include "helper.h"
+#include "inputdevice.h"
+#include "modules/input-manager/inputmanagerinterfacev1.h"
+#include "seat/seatsmanager.h"
+#include "session/session.h"
+#include "xsettings/settingmanager.h"
+
+#include <libinput.h>
+
+#include <qwseat.h>
+
+#include <wbackend.h>
+#include <wcursor.h>
+#include <winputdevice.h>
+
+
+InputManager::InputManager(QObject *parent)
+    : QObject(parent)
+{
+}
+
+InputManager::~InputManager()
+{
+    if (m_seatDConfig) {
+        delete m_seatDConfig;
+    }
+}
+
+void InputManager::setupSeatUserConfig(const QString &userName)
+{
+    if (m_seatDConfig) {
+        delete m_seatDConfig;
+    }
+
+    m_seatDConfig = SeatUserDConfig::createByName("org.deepin.dde.treeland.user.seat",
+                                                   "org.deepin.dde.treeland",
+                                                   "/" + userName);
+
+#if SEATUSERDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
+    if (m_seatDConfig->isInitializeSucceeded()) {
+#else
+    if (m_seatDConfig->isInitializeSucceed()) {
+#endif
+        onConfigInitializeSucceed();
+    } else {
+        connect(m_seatDConfig,
+                &SeatUserDConfig::configInitializeSucceed,
+                this,
+                &InputManager::onConfigInitializeSucceed,
+                Qt::SingleShotConnection);
+    }
+}
+
+void InputManager::onConfigInitializeSucceed()
+{
+    auto seatMgr = Helper::instance()->seatManager();
+    if (seatMgr) {
+        for (auto *seat : seatMgr->seats()) {
+            if (auto *cursor = seat->cursor())
+                cursor->setScrollFactor(m_seatDConfig->pointerScrollFactor());
+        }
+    }
+
+    auto backend = Helper::instance()->backend();
+    connect(backend,
+            &WBackend::inputAdded,
+            this,
+            &InputManager::onInputAdded);
+    const auto inputDevices = backend->inputDeviceList();
+    for (WInputDevice *device : inputDevices) {
+        onInputAdded(device);
+    }
+}
+
+void InputManager::onMouseSettingsCreated(MouseSettingsInterfaceV1 *interface)
+{
+    connect(interface,
+            &MouseSettingsInterfaceV1::pointerDeviceConfigurationCreated,
+            this,
+            &InputManager::onMousePointerConfigCreated);
+}
+
+void InputManager::onTouchpadSettingsCreated(TouchpadSettingsInterfaceV1 *interface)
+{
+    connect(interface,
+            &TouchpadSettingsInterfaceV1::pointerDeviceConfigurationCreated,
+            this,
+            &InputManager::onTouchpadPointerConfigCreated);
+}
+
+void InputManager::onKeyboardSettingsCreated(KeyboardSettingsInterfaceV1 *interface)
+{
+    if (!m_seatDConfig)
+        return;
+
+#if SEATUSERDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
+    if (!m_seatDConfig->isInitializeSucceeded()) {
+#else
+    if (!m_seatDConfig->isInitializeSucceed()) {
+#endif
+        return;
+    }
+
+    KeyboardSettingsInterfaceV1::FeatureFlags features;
+    const auto inputDevices = Helper::instance()->backend()->inputDeviceList();
+    for (WInputDevice *device : std::as_const(inputDevices)) {
+        if (!device->handle()->is_libinput()) {
+            continue;
+        }
+
+        if (device->type() != WInputDevice::Type::Keyboard)
+            continue;
+
+        auto *keyboard = qobject_cast<qw_keyboard *>(device->handle());
+        if (!keyboard)
+            continue;
+
+        auto *wlrKeyboard = keyboard->handle();
+        if (!wlrKeyboard || !wlrKeyboard->keymap)
+            continue;
+
+        if (xkb_map_mod_get_index(wlrKeyboard->keymap, XKB_MOD_NAME_NUM) != XKB_MOD_INVALID) {
+            features.setFlag(KeyboardSettingsInterfaceV1::NumLock);
+            break;
+        }
+    }
+
+    interface->sendFeature(features, true);
+    interface->sendNumLock(m_seatDConfig->keyboardNumLock(), true);
+    interface->sendRepeat(m_seatDConfig->keyboardRate(), m_seatDConfig->keyboardDelay(), true);
+    interface->sendDone();
+
+    connect(interface,
+            &KeyboardSettingsInterfaceV1::applied,
+            this,
+            &InputManager::handleKeyboardSettingsApplied);
+}
+
+void InputManager::onMousePointerConfigCreated(PointerDeviceConfigurationV1 *config)
+{
+    if (!m_seatDConfig)
+        return;
+
+#if SEATUSERDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
+    if (!m_seatDConfig->isInitializeSucceeded()) {
+#else
+    if (!m_seatDConfig->isInitializeSucceed()) {
+#endif
+        return;
+    }
+
+    PointerDeviceConfigurationV1::FeatureFlags features;
+    features.setFlag(PointerDeviceConfigurationV1::ScrollFactor);
+    features.setFlag(PointerDeviceConfigurationV1::NaturalScroll);
+    features.setFlag(PointerDeviceConfigurationV1::EventsMode);
+
+    const auto inputDevices = Helper::instance()->backend()->inputDeviceList();
+    for (WInputDevice *device : std::as_const(inputDevices)) {
+        if (!device->handle()->is_libinput()) {
+            continue;
+        }
+
+        if (device->type() != WInputDevice::Type::Pointer) {
+            continue;
+        }
+
+        struct libinput_device *inputDevice = wlr_libinput_get_device_handle(device->handle()->handle());
+        struct udev_device *udevDevice =
+            libinput_device_get_udev_device(inputDevice);
+        if (!udev_device_get_property_value(udevDevice, "ID_INPUT_MOUSE")) {
+            continue;
+        }
+
+        if (libinput_device_config_left_handed_is_available(inputDevice)) {
+            features.setFlag(PointerDeviceConfigurationV1::HandMode);
+        }
+
+        if (libinput_device_config_accel_is_available(inputDevice)) {
+            features.setFlag(PointerDeviceConfigurationV1::AccelProfile);
+            features.setFlag(PointerDeviceConfigurationV1::AccelSpeed);
+        }
+
+        if (libinput_device_config_tap_get_finger_count(inputDevice) > 0) {
+            features.setFlag(PointerDeviceConfigurationV1::TapToClick);
+        }
+
+        if (libinput_device_config_dwt_is_available(inputDevice)) {
+            features.setFlag(PointerDeviceConfigurationV1::DisableWhileTyping);
+        }
+    }
+
+    config->sendFeature(features, true);
+    config->sendScrollFactor(m_seatDConfig->pointerScrollFactor(), true);
+
+    auto handModeStr = m_seatDConfig->pointerHandMode();
+    auto handMode = (handModeStr == "Left")
+        ? PointerDeviceConfigurationV1::Left
+        : PointerDeviceConfigurationV1::Right;
+    config->sendHandedMode(handMode, true);
+
+    config->sendAccelSpeed(m_seatDConfig->mouseAccelSpeed(), true);
+    config->sendAccelerationProfile(static_cast<PointerDeviceConfigurationV1::AccelerationProfile>(m_seatDConfig->mouseAccelerationProfile()), true);
+    config->sendNaturalScroll(m_seatDConfig->mouseNaturalScroll(), true);
+    config->sendDone(0);
+
+    connect(config,
+            &PointerDeviceConfigurationV1::applied,
+            this,
+            &InputManager::handleMousePointerConfigApplied);
+}
+
+void InputManager::handleMousePointerConfigApplied(PointerDeviceConfigurationV1::ChangeFlags changes)
+{
+    auto *interface = static_cast<PointerDeviceConfigurationV1 *>(sender());
+
+    if (!m_seatDConfig) {
+        interface->sendFailed();
+        return;
+    }
+
+#if SEATUSERDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
+    if (!m_seatDConfig->isInitializeSucceeded()) {
+#else
+    if (!m_seatDConfig->isInitializeSucceed()) {
+#endif
+        interface->sendFailed();
+        return;
+    }
+
+    if (changes.testFlag(PointerDeviceConfigurationV1::ScrollFactorChanged)) {
+        m_seatDConfig->setPointerScrollFactor(interface->scrollFactor());
+        if (auto *cursor = interface->wSeat()->cursor())
+            cursor->setScrollFactor(interface->scrollFactor());
+    }
+
+    if (changes.testFlag(PointerDeviceConfigurationV1::HandedModeChanged)) {
+        m_seatDConfig->setPointerHandMode(interface->handedMode() == PointerDeviceConfigurationV1::Left
+                                              ? QStringLiteral("Left")
+                                              : QStringLiteral("Right"));
+    }
+
+    if (changes.testFlag(PointerDeviceConfigurationV1::AccelSpeedChanged)) {
+        m_seatDConfig->setMouseAccelSpeed(interface->accelSpeed());
+    }
+
+    if (changes.testFlag(PointerDeviceConfigurationV1::AccelerationProfileChanged)) {
+        m_seatDConfig->setMouseAccelerationProfile(interface->accelerationProfile());
+    }
+
+    if (changes.testFlag(PointerDeviceConfigurationV1::NaturalScrollChanged)) {
+        m_seatDConfig->setMouseNaturalScroll(interface->naturalScroll());
+    }
+
+    if (changes.testFlag(PointerDeviceConfigurationV1::AccelSpeedChanged)
+        || changes.testFlag(PointerDeviceConfigurationV1::AccelerationProfileChanged)
+        || changes.testFlag(PointerDeviceConfigurationV1::NaturalScrollChanged)
+        || changes.testFlag(PointerDeviceConfigurationV1::HandedModeChanged)) {
+        const auto devices = interface->wSeat()->deviceList();
+        for (WInputDevice *device : devices) {
+            if (!device->handle()->is_libinput()) {
+                continue;
+            }
+
+            if (device->type() != WInputDevice::Type::Pointer) {
+                continue;
+            }
+
+            struct udev_device *udevDevice =
+                libinput_device_get_udev_device(wlr_libinput_get_device_handle(device->handle()->handle()));
+            if (!udev_device_get_property_value(udevDevice, "ID_INPUT_MOUSE")) {
+                continue;
+            }
+
+            struct libinput_device *inputDevice = wlr_libinput_get_device_handle(device->handle()->handle());
+            if (changes.testFlag(PointerDeviceConfigurationV1::AccelSpeedChanged))
+                configAccelSpeed(inputDevice, interface->accelSpeed());
+            if (changes.testFlag(PointerDeviceConfigurationV1::AccelerationProfileChanged))
+                configAccelProfile(inputDevice, static_cast<libinput_config_accel_profile>(interface->accelerationProfile()));
+            if (changes.testFlag(PointerDeviceConfigurationV1::NaturalScrollChanged))
+                configNaturalScroll(inputDevice, interface->naturalScroll());
+
+            if (changes.testFlag(PointerDeviceConfigurationV1::HandedModeChanged)) {
+                bool leftHanded = (interface->handedMode() == PointerDeviceConfigurationV1::Left);
+                configLeftHanded(inputDevice, leftHanded);
+            }
+        }
+    }
+}
+
+void InputManager::onTouchpadPointerConfigCreated(PointerDeviceConfigurationV1 *config)
+{
+    PointerDeviceConfigurationV1::FeatureFlags features;
+    features.setFlag(PointerDeviceConfigurationV1::ScrollFactor);
+    features.setFlag(PointerDeviceConfigurationV1::NaturalScroll);
+    features.setFlag(PointerDeviceConfigurationV1::EventsMode);
+
+    const auto inputDevices = Helper::instance()->backend()->inputDeviceList();
+    for (WInputDevice *device : std::as_const(inputDevices)) {
+        if (!device->handle()->is_libinput()) {
+            continue;
+        }
+
+        if (device->type() != WInputDevice::Type::Pointer) {
+            continue;
+        }
+
+        struct libinput_device *inputDevice = wlr_libinput_get_device_handle(device->handle()->handle());
+        struct udev_device *udevDevice =
+            libinput_device_get_udev_device(inputDevice);
+        if (!udev_device_get_property_value(udevDevice, "ID_INPUT_TOUCHPAD")) {
+            continue;
+        }
+
+        if (libinput_device_config_left_handed_is_available(inputDevice)) {
+            features.setFlag(PointerDeviceConfigurationV1::HandMode);
+        }
+
+        if (libinput_device_config_accel_is_available(inputDevice)) {
+            features.setFlag(PointerDeviceConfigurationV1::AccelProfile);
+            features.setFlag(PointerDeviceConfigurationV1::AccelSpeed);
+        }
+
+        if (libinput_device_config_tap_get_finger_count(inputDevice) > 0) {
+            features.setFlag(PointerDeviceConfigurationV1::TapToClick);
+        }
+
+        if (libinput_device_config_dwt_is_available(inputDevice)) {
+            features.setFlag(PointerDeviceConfigurationV1::DisableWhileTyping);
+        }
+    }
+
+    if (!m_seatDConfig)
+        return;
+
+#if SEATUSERDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
+    if (!m_seatDConfig->isInitializeSucceeded()) {
+#else
+    if (!m_seatDConfig->isInitializeSucceed()) {
+#endif
+        return;
+    }
+
+    config->sendFeature(features, true);
+    config->sendScrollFactor(m_seatDConfig->pointerScrollFactor(), true);
+    config->sendAccelSpeed(m_seatDConfig->touchpadAccelSpeed(), true);
+    config->sendAccelerationProfile(static_cast<PointerDeviceConfigurationV1::AccelerationProfile>(m_seatDConfig->touchpadAccelerationProfile()), true);
+    config->sendNaturalScroll(m_seatDConfig->touchpadNaturalScroll(), true);
+    config->sendSendEventsMode(PointerDeviceConfigurationV1::SendEventsModes::fromInt(m_seatDConfig->touchpadSendEventsMode()), true);
+    config->sendDisableWhileTyping(m_seatDConfig->touchpadDisableWhileTyping(), true);
+    config->sendTapToClick(m_seatDConfig->touchpadTapToClick(), true);
+    config->sendDone(0);
+
+    connect(config,
+            &PointerDeviceConfigurationV1::applied,
+            this,
+            &InputManager::handleTouchpadPointerConfigApplied);
+}
+
+void InputManager::handleTouchpadPointerConfigApplied(PointerDeviceConfigurationV1::ChangeFlags changes)
+{
+    auto *interface = static_cast<PointerDeviceConfigurationV1 *>(sender());
+
+    if (!m_seatDConfig) {
+        interface->sendFailed();
+        return;
+    }
+
+#if SEATUSERDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
+    if (!m_seatDConfig->isInitializeSucceeded()) {
+#else
+    if (!m_seatDConfig->isInitializeSucceed()) {
+#endif
+        interface->sendFailed();
+        return;
+    }
+
+    if (changes.testFlag(PointerDeviceConfigurationV1::ScrollFactorChanged)) {
+        m_seatDConfig->setPointerScrollFactor(interface->scrollFactor());
+        if (auto *cursor = interface->wSeat()->cursor())
+            cursor->setScrollFactor(interface->scrollFactor());
+    }
+
+    if (changes.testFlag(PointerDeviceConfigurationV1::AccelSpeedChanged)) {
+        m_seatDConfig->setTouchpadAccelSpeed(interface->accelSpeed());
+    }
+
+    if (changes.testFlag(PointerDeviceConfigurationV1::NaturalScrollChanged)) {
+        m_seatDConfig->setTouchpadNaturalScroll(interface->naturalScroll());
+    }
+
+    if (changes.testFlag(PointerDeviceConfigurationV1::SendEventsModeChanged)) {
+        m_seatDConfig->setTouchpadSendEventsMode(interface->sendEventsMode().toInt());
+    }
+
+    if (changes.testFlag(PointerDeviceConfigurationV1::DisableWhileTypingChanged)) {
+        m_seatDConfig->setTouchpadDisableWhileTyping(interface->disableWhileTyping());
+    }
+
+    if (changes.testFlag(PointerDeviceConfigurationV1::TapToClickChanged)) {
+        m_seatDConfig->setTouchpadTapToClick(interface->tapToClick());
+    }
+
+    const auto devices = interface->wSeat()->deviceList();
+    for (WInputDevice *device : devices) {
+        if (!device->handle()->is_libinput())
+            continue;
+
+        if (device->type() != WInputDevice::Type::Pointer) {
+            continue;
+        }
+
+        struct udev_device *udevDevice =
+            libinput_device_get_udev_device(wlr_libinput_get_device_handle(device->handle()->handle()));
+
+        if (!udev_device_get_property_value(udevDevice, "ID_INPUT_TOUCHPAD")) {
+            continue;
+        }
+
+        struct libinput_device *inputDevice = wlr_libinput_get_device_handle(device->handle()->handle());
+        if (changes.testFlag(PointerDeviceConfigurationV1::AccelSpeedChanged)) {
+            configAccelSpeed(inputDevice, interface->accelSpeed());
+        }
+
+        if (changes.testFlag(PointerDeviceConfigurationV1::AccelerationProfileChanged)) {
+            configAccelProfile(inputDevice,
+                               static_cast<libinput_config_accel_profile>(interface->accelerationProfile()));
+        }
+
+        if (changes.testFlag(PointerDeviceConfigurationV1::SendEventsModeChanged)) {
+            configSendEventsMode(inputDevice, interface->sendEventsMode().toInt());
+        }
+
+        if (changes.testFlag(PointerDeviceConfigurationV1::DisableWhileTypingChanged)) {
+            configDwtEnabled(inputDevice, interface->disableWhileTyping()
+                             ? LIBINPUT_CONFIG_DWT_ENABLED
+                             : LIBINPUT_CONFIG_DWT_DISABLED);
+        }
+
+        if (changes.testFlag(PointerDeviceConfigurationV1::TapToClickChanged)) {
+            configTapEnabled(inputDevice, interface->tapToClick()
+                             ? LIBINPUT_CONFIG_TAP_ENABLED
+                             : LIBINPUT_CONFIG_TAP_DISABLED);
+        }
+
+        if (changes.testFlag(PointerDeviceConfigurationV1::NaturalScrollChanged)) {
+            configNaturalScroll(inputDevice, interface->naturalScroll());
+        }
+    }
+}
+
+void InputManager::handleKeyboardSettingsApplied(KeyboardSettingsInterfaceV1::ChangeFlags changes)
+{
+    KeyboardSettingsInterfaceV1 *interface =
+        static_cast<KeyboardSettingsInterfaceV1 *>(sender());
+    if (!m_seatDConfig) {
+        interface->sendFailed();
+        return;
+    }
+
+#if SEATUSERDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
+    if (!m_seatDConfig->isInitializeSucceeded()) {
+#else
+    if (!m_seatDConfig->isInitializeSucceed()) {
+#endif
+        interface->sendFailed();
+        return;
+    }
+
+    if (changes.testFlag(KeyboardSettingsInterfaceV1::NumLockChanged)) {
+        m_seatDConfig->setKeyboardNumLock(interface->numLock());
+    }
+
+    if (changes.testFlag(KeyboardSettingsInterfaceV1::RepeatChanged)) {
+        m_seatDConfig->setKeyboardDelay(interface->repeatDelay());
+        m_seatDConfig->setKeyboardRate(interface->repeatRate());
+    }
+
+    auto *keyboardDevice = interface->wSeat()->keyboard();
+    if (keyboardDevice) {
+        auto *keyboard = qobject_cast<qw_keyboard *>(keyboardDevice->handle());
+        if (keyboard) {
+            if (changes.testFlag(KeyboardSettingsInterfaceV1::RepeatChanged)) {
+                keyboard->set_repeat_info(interface->repeatRate(), interface->repeatDelay());
+            }
+        }
+    }
+
+    const auto devices = interface->wSeat()->deviceList();
+    for (WInputDevice *device : devices) {
+        if (device->type() != WInputDevice::Type::Keyboard)
+            continue;
+
+        if (changes.testFlag(KeyboardSettingsInterfaceV1::NumLockChanged)) {
+            setNumLockForDevice(device, interface->numLock());
+        }
+    }
+}
+
+void InputManager::setNumLockForDevice(WInputDevice *device, bool enabled)
+{
+    if (!device || device->type() != WInputDevice::Type::Keyboard)
+        return;
+
+    auto *keyboard = qobject_cast<qw_keyboard *>(device->handle());
+    if (!keyboard)
+        return;
+    auto *wlrKeyboard = keyboard->handle();
+    if (!wlrKeyboard || !wlrKeyboard->keymap || !wlrKeyboard->xkb_state)
+        return;
+
+    xkb_mod_index_t numlock = xkb_keymap_mod_get_index(wlrKeyboard->keymap, XKB_MOD_NAME_NUM);
+    if (numlock == XKB_MOD_INVALID)
+        return;
+
+    xkb_mod_mask_t locked = xkb_state_serialize_mods(wlrKeyboard->xkb_state, XKB_STATE_MODS_LOCKED);
+    if (enabled) {
+        locked |= (1u << numlock);
+    } else {
+        locked &= ~(1u << numlock);
+    }
+    xkb_state_update_mask(wlrKeyboard->xkb_state,
+                          xkb_state_serialize_mods(wlrKeyboard->xkb_state, XKB_STATE_MODS_DEPRESSED),
+                          xkb_state_serialize_mods(wlrKeyboard->xkb_state, XKB_STATE_MODS_LATCHED),
+                          locked, 0, 0, 0);
+
+    uint32_t leds = wlrKeyboard->leds;
+    if (enabled) {
+        leds |= WLR_LED_NUM_LOCK;
+    } else {
+        leds &= ~WLR_LED_NUM_LOCK;
+    }
+    wlr_keyboard_led_update(wlrKeyboard, leds);
+}
+
+void InputManager::onInputAdded(WInputDevice *input)
+{
+    if (!m_seatDConfig)
+        return;
+
+#if SEATUSERDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
+    if (!m_seatDConfig->isInitializeSucceeded()) {
+#else
+    if (!m_seatDConfig->isInitializeSucceed()) {
+#endif
+        return;
+    }
+
+    if (!input->handle()->is_libinput()) {
+        return;
+    }
+
+    struct libinput_device *inputDevice = wlr_libinput_get_device_handle(input->handle()->handle());
+    struct udev_device *udevDevice = libinput_device_get_udev_device(inputDevice);
+    bool leftHanded = (m_seatDConfig->pointerHandMode() == "Left");
+
+    if (input->type() == WInputDevice::Type::Keyboard) {
+        if (auto *keyboard = qobject_cast<qw_keyboard *>(input->handle())) {
+            keyboard->set_repeat_info(m_seatDConfig->keyboardRate(), m_seatDConfig->keyboardDelay());
+        }
+        setNumLockForDevice(input, m_seatDConfig->keyboardNumLock());
+    }
+
+    if (udev_device_get_property_value(udevDevice, "ID_INPUT_MOUSE")) {
+        configLeftHanded(inputDevice, leftHanded);
+        configAccelSpeed(inputDevice, m_seatDConfig->mouseAccelSpeed());
+        configAccelProfile(inputDevice, static_cast<libinput_config_accel_profile>(m_seatDConfig->mouseAccelerationProfile()));
+        configNaturalScroll(inputDevice, m_seatDConfig->mouseNaturalScroll());
+    }
+
+    if (udev_device_get_property_value(udevDevice, "ID_INPUT_TOUCHPAD")) {
+        configLeftHanded(inputDevice, leftHanded);
+        configAccelSpeed(inputDevice, m_seatDConfig->touchpadAccelSpeed());
+        configAccelProfile(inputDevice, static_cast<libinput_config_accel_profile>(m_seatDConfig->touchpadAccelerationProfile()));
+        configNaturalScroll(inputDevice, m_seatDConfig->touchpadNaturalScroll());
+        configSendEventsMode(inputDevice, m_seatDConfig->touchpadSendEventsMode());
+        configDwtEnabled(inputDevice, m_seatDConfig->touchpadDisableWhileTyping()
+                                             ? LIBINPUT_CONFIG_DWT_ENABLED
+                                             : LIBINPUT_CONFIG_DWT_DISABLED);
+        configTapEnabled(inputDevice, m_seatDConfig->touchpadTapToClick()
+                                         ? LIBINPUT_CONFIG_TAP_ENABLED
+                                         : LIBINPUT_CONFIG_TAP_DISABLED);
+    }
+}

--- a/src/input/inputmanager.h
+++ b/src/input/inputmanager.h
@@ -1,0 +1,45 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include "modules/input-manager/inputmanagerinterfacev1.h"
+Q_MOC_INCLUDE("seatuserconfig.hpp")
+
+#include <wayland-server-core.h>
+
+#include <qwinputdevice.h>
+
+#include <QObject>
+#include <QMap>
+
+class SeatUserDConfig;
+
+class InputManager : public QObject
+{
+    Q_OBJECT
+public:
+    explicit InputManager(QObject *parent = nullptr);
+    ~InputManager() override;
+
+    static void setNumLockForDevice(WInputDevice *device, bool enabled);
+
+    void setupSeatUserConfig(const QString &userName);
+
+public Q_SLOTS:
+    void onMouseSettingsCreated(MouseSettingsInterfaceV1 *interface);
+    void onTouchpadSettingsCreated(TouchpadSettingsInterfaceV1 *interface);
+    void onKeyboardSettingsCreated(KeyboardSettingsInterfaceV1 *interface);
+    void onMousePointerConfigCreated(PointerDeviceConfigurationV1 *config);
+    void onTouchpadPointerConfigCreated(PointerDeviceConfigurationV1 *config);
+
+private Q_SLOTS:
+    void handleMousePointerConfigApplied(PointerDeviceConfigurationV1::ChangeFlags changes);
+    void handleTouchpadPointerConfigApplied(PointerDeviceConfigurationV1::ChangeFlags changes);
+    void handleKeyboardSettingsApplied(KeyboardSettingsInterfaceV1::ChangeFlags changes);
+    void onInputAdded(WInputDevice *input);
+    void onConfigInitializeSucceed();
+
+private:
+    SeatUserDConfig* m_seatDConfig = nullptr;
+};

--- a/src/modules/input-manager/inputmanagerinterfacev1.cpp
+++ b/src/modules/input-manager/inputmanagerinterfacev1.cpp
@@ -317,7 +317,7 @@ public:
     double scrollFactor = 0;
     PointerDeviceConfigurationV1::HandedMode handedMode = PointerDeviceConfigurationV1::Right;
     double accelSpeed = 0;
-    PointerDeviceConfigurationV1::AccelerationProfiles accelerationProfile = PointerDeviceConfigurationV1::None;
+    PointerDeviceConfigurationV1::AccelerationProfile accelerationProfile = PointerDeviceConfigurationV1::None;
     PointerDeviceConfigurationV1::SendEventsModes sendEventsMode = PointerDeviceConfigurationV1::Enabled;
     bool naturalScroll = false;
     bool disableWhileTyping = false;
@@ -395,7 +395,7 @@ void PointerDeviceConfigurationV1Private::set_acceleration_profile([[maybe_unuse
         return;
     }
 
-    accelerationProfile = PointerDeviceConfigurationV1::AccelerationProfiles(profile);
+    accelerationProfile = PointerDeviceConfigurationV1::AccelerationProfile(profile);
     pendingChanges |= PointerDeviceConfigurationV1::AccelerationProfileChanged;
 }
 
@@ -518,7 +518,7 @@ void PointerDeviceConfigurationV1::sendAccelSpeed(double speed, bool force)
     d->accelSpeed = speed;
 }
 
-void PointerDeviceConfigurationV1::sendAccelerationProfile(AccelerationProfiles profile, bool force)
+void PointerDeviceConfigurationV1::sendAccelerationProfile(AccelerationProfile profile, bool force)
 {
     if (!force && d->accelerationProfile == profile) {
         return;
@@ -599,7 +599,7 @@ double PointerDeviceConfigurationV1::accelSpeed() const
     return d->accelSpeed;
 }
 
-PointerDeviceConfigurationV1::AccelerationProfiles PointerDeviceConfigurationV1::accelerationProfile() const
+PointerDeviceConfigurationV1::AccelerationProfile PointerDeviceConfigurationV1::accelerationProfile() const
 {
     return d->accelerationProfile;
 }

--- a/src/modules/input-manager/inputmanagerinterfacev1.h
+++ b/src/modules/input-manager/inputmanagerinterfacev1.h
@@ -113,8 +113,6 @@ public:
         Adaptive = 1 << 1,
         Custom = 1 << 2,
     };
-    Q_DECLARE_FLAGS(AccelerationProfiles, AccelerationProfile)
-    Q_FLAG(AccelerationProfiles)
 
     enum SendEventsMode {
         Enabled = 0,
@@ -128,7 +126,7 @@ public:
     void sendScrollFactor(double factor, bool force = false);
     void sendHandedMode(HandedMode mode, bool force = false);
     void sendAccelSpeed(double speed, bool force = false);
-    void sendAccelerationProfile(AccelerationProfiles profile, bool force = false);
+    void sendAccelerationProfile(AccelerationProfile profile, bool force = false);
     void sendSendEventsMode(SendEventsModes mode, bool force = false);
     void sendNaturalScroll(bool enable, bool force = false);
     void sendDisableWhileTyping(bool enable, bool force = false);
@@ -139,7 +137,7 @@ public:
     double scrollFactor() const;
     HandedMode handedMode() const;
     double accelSpeed() const;
-    AccelerationProfiles accelerationProfile() const;
+    AccelerationProfile accelerationProfile() const;
     SendEventsModes sendEventsMode() const;
     bool naturalScroll() const;
     bool disableWhileTyping() const;

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -40,6 +40,7 @@
 #include "modules/shortcut/shortcutmanager.h"
 #include "modules/shortcut/shortcutrunner.h"
 #include "modules/wallpaper-color/wallpapercolorinterfacev1.h"
+#include "modules/input-manager/inputmanagerinterfacev1.h"
 #include "output/outputconfigstate.h"
 #include "output/output.h"
 #include "output/outputlifecyclemanager.h"
@@ -53,6 +54,7 @@
 #include "workspace/workspace.h"
 #include "wallpaper/wallpapermanager.h"
 #include "wallpapershellinterfacev1.h"
+#include "inputmanager.h"
 
 #include <xcb/xcb.h>
 #include <xcb/xproto.h>
@@ -182,6 +184,7 @@ Helper::Helper(QObject *parent)
     , m_renderWindow(new WOutputRenderWindow(this))
     , m_server(new WServer(this))
     , m_rootSurfaceContainer(new RootSurfaceContainer(m_renderWindow->contentItem()))
+    , m_inputManager(new InputManager(this))
 {
     m_isDDMDisplay = qEnvironmentVariableIsSet("DDM_DISPLAY_MANAGER");
     Q_ASSERT(!m_instance);
@@ -1334,6 +1337,7 @@ void Helper::init(Treeland::Treeland *treeland)
             return;
         }
 
+        m_inputManager->setupSeatUserConfig(m_userModel->currentUserName());
         // TODO(YaoBing Xiao): pre-initialize dconfig, remove isInitializeSucceeded
 #if TREELANDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
         if (m_config->isInitializeSucceeded()) {
@@ -1627,18 +1631,26 @@ void Helper::init(Treeland::Treeland *treeland)
 
     m_server->attach<KeyStateV5>(m_seat);
 
+    m_inputManagerInterfaceV1 = m_server->attach<TreelandInputManagerInterfaceV1>();
+    connect(m_inputManagerInterfaceV1,
+            &TreelandInputManagerInterfaceV1::mouseSettingsCreated,
+            m_inputManager,
+            &InputManager::onMouseSettingsCreated);
+    connect(m_inputManagerInterfaceV1,
+            &TreelandInputManagerInterfaceV1::touchpadSettingsCreated,
+            m_inputManager,
+            &InputManager::onTouchpadSettingsCreated);
+    connect(m_inputManagerInterfaceV1,
+            &TreelandInputManagerInterfaceV1::keyboardSettingsCreated,
+            m_inputManager,
+            &InputManager::onKeyboardSettingsCreated);
+
 #if TREELANDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
     if (m_globalConfig->isInitializeSucceeded()) {
 #else
     if (m_globalConfig->isInitializeSucceed()) {
 #endif
-        configureNumlock();
     } else {
-        connect(m_globalConfig.get(),
-                &TreelandConfig::configInitializeSucceed,
-                this,
-                &Helper::configureNumlock,
-                Qt::SingleShotConnection);
     }
 
     m_backend->handle()->start();
@@ -2811,33 +2823,6 @@ void Helper::restoreCopyMode()
 
     const auto &allSurfaces = getWorkspaceSurfaces();
     applyCopyModeToOutputs(primaryOutput, allSurfaces);
-}
-
-static void setNumlockForDevice(WInputDevice *device) {
-    if (!device || device->type() != WInputDevice::Type::Keyboard)
-        return;
-
-    auto keyboard = qobject_cast<qw_keyboard *>(device->handle());
-    if (!keyboard)
-        return;
-    auto wlrKeyboard = keyboard->handle();
-    if (!wlrKeyboard || !wlrKeyboard->keymap || !wlrKeyboard->xkb_state)
-        return;
-    xkb_mod_index_t numlock = xkb_keymap_mod_get_index(wlrKeyboard->keymap, XKB_MOD_NAME_NUM);
-    if (numlock == XKB_MOD_INVALID)
-        return;
-    xkb_state_update_mask(wlrKeyboard->xkb_state, 0, 0, (1u << numlock), 0, 0, 0);
-    wlr_keyboard_led_update(wlrKeyboard, wlrKeyboard->leds | WLR_LED_NUM_LOCK);
-}
-
-void Helper::configureNumlock() {
-    if (!m_globalConfig->numlock())
-        return;
-    connect(m_backend, &WBackend::inputAdded, this, setNumlockForDevice);
-    const auto inputDevices = m_backend->inputDeviceList();
-    for (WInputDevice *device : inputDevices) {
-        setNumlockForDevice(device);
-    }
 }
 
 /**

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -131,6 +131,8 @@ class WindowManagementInterfaceV1;
 class WindowPickerInterface;
 class WallpaperManager;
 class WallpaperItem;
+class TreelandInputManagerInterfaceV1;
+class InputManager;
 
 struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request;
 struct wlr_idle_inhibitor_v1;
@@ -311,6 +313,7 @@ private:
     friend class SessionManager;
     friend class WallpaperManager;
     friend class WallpaperItem;
+    friend class InputManager;
 
     void allowNonDrmOutputAutoChangeMode(WOutput *output);
     int indexOfOutput(WOutput *output) const;
@@ -343,7 +346,6 @@ private:
     void setWorkspaceVisible(bool visible);
     void restoreFromShowDesktop(SurfaceWrapper *activeSurface = nullptr);
     void setNoAnimation(bool noAnimation);
-    void configureNumlock();
 
     void updateSurfaceSeatInteraction(SurfaceWrapper *surface, WSeat *seat);
 
@@ -445,4 +447,6 @@ private:
     void onOutputCommitFinished(qw_output_configuration_v1 *config, bool success);
 
     SeatsManager *m_seatManager = nullptr;
+    InputManager *m_inputManager = nullptr;
+    TreelandInputManagerInterfaceV1 *m_inputManagerInterfaceV1 = nullptr;
 };

--- a/waylib/src/server/kernel/private/wcursor_p.h
+++ b/waylib/src/server/kernel/private/wcursor_p.h
@@ -88,6 +88,7 @@ public:
     Qt::MouseButton button = Qt::NoButton;
     QPointF lastPressedOrTouchDownPosition;
     bool visible = true;
+    double scrollFactor = 1.0;
 };
 
 WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/kernel/wcursor.cpp
+++ b/waylib/src/server/kernel/wcursor.cpp
@@ -137,7 +137,7 @@ void WCursorPrivate::on_axis(wlr_pointer_axis_event *event)
             deviceSeat->notifyAxis(q_func(), inputDevice, event->source,
                                  event->orientation == WL_POINTER_AXIS_HORIZONTAL_SCROLL
                                  ? Qt::Horizontal : Qt::Vertical, event->relative_direction,
-                                 event->delta, event->delta_discrete, event->time_msec);
+                                 event->delta * scrollFactor, event->delta_discrete, event->time_msec);
         }
     }
 }
@@ -713,6 +713,21 @@ QPointF WCursor::lastPressedOrTouchDownPosition() const
 {
     W_DC(WCursor);
     return d->lastPressedOrTouchDownPosition;
+}
+
+double WCursor::scrollFactor() const
+{
+    W_DC(WCursor);
+    return d->scrollFactor;
+}
+
+void WCursor::setScrollFactor(double factor)
+{
+    W_D(WCursor);
+    if (qFuzzyCompare(d->scrollFactor, factor))
+        return;
+    d->scrollFactor = factor;
+    Q_EMIT scrollFactorChanged();
 }
 
 WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/kernel/wcursor.h
+++ b/waylib/src/server/kernel/wcursor.h
@@ -36,6 +36,7 @@ class WAYLIB_SERVER_EXPORT WCursor : public WWrapObject
     Q_PROPERTY(QCursor cursor READ cursor WRITE setCursor NOTIFY cursorChanged FINAL)
     Q_PROPERTY(QPointF position READ position NOTIFY positionChanged FINAL)
     Q_PROPERTY(WAYLIB_SERVER_NAMESPACE::WSurface* requestedDragSurface READ requestedDragSurface NOTIFY requestedDragSurfaceChanged FINAL)
+    Q_PROPERTY(double scrollFactor READ scrollFactor WRITE setScrollFactor NOTIFY scrollFactorChanged FINAL)
     QML_ANONYMOUS
 
 public:
@@ -80,6 +81,9 @@ public:
     QPointF position() const;
     QPointF lastPressedOrTouchDownPosition() const;
 
+    double scrollFactor() const;
+    void setScrollFactor(double factor);
+
 Q_SIGNALS:
     void positionChanged();
     void seatChanged();
@@ -89,6 +93,7 @@ Q_SIGNALS:
     void layoutChanged();
     void cursorChanged();
     void visibleChanged();
+    void scrollFactorChanged();
 
 protected:
     WCursor(WCursorPrivate &dd, QObject *parent = nullptr);


### PR DESCRIPTION
-Initialize treeland-input-manager-unstable-v1 global registration. -Implement features, requests, and events for mouse, touchpads, and keyboards.

Log: added implementation logic for treeland-input-manager
Tasks: https://pms.uniontech.com/task-view-389477.html

Influence:

## Summary by Sourcery

Introduce a centralized input manager and wire it into the compositor to manage per-user input configuration and treeland-input-manager-unstable-v1 integration.

New Features:
- Expose treeland-input-manager-unstable-v1 on the compositor and connect its mouse, touchpad, and keyboard settings to a new InputManager.
- Add per-seat scroll factor support on cursors, configurable via the input manager and persisted in per-user seat configuration.
- Provide configurable mouse and touchpad behavior (handedness, acceleration, natural scrolling, tap-to-click, disable-while-typing, send-events mode) driven by libinput and user settings.
- Support keyboard features configuration including numlock state and key repeat rate/delay, applied to all keyboards on the seat.

Enhancements:
- Refactor numlock handling to use InputManager::setNumLockForDevice and apply it consistently to new input devices.
- Promote various libinput configuration helpers from static/private scope to reusable functions for input configuration logic.