### PR TITLE
refactor: rename and split surface destruction logic

### DIFF
--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -121,7 +121,7 @@ void RootSurfaceContainer::destroyForSurface(SurfaceWrapper *wrapper)
         helper->setActivatedSurface(nullptr);
     }
 
-    wrapper->markWrapperToRemoved();
+    wrapper->destroy();
 }
 
 void RootSurfaceContainer::addOutput(Output *output)

--- a/src/surface/surfaceproxy.cpp
+++ b/src/surface/surfaceproxy.cpp
@@ -16,7 +16,7 @@ SurfaceProxy::SurfaceProxy(QQuickItem *parent)
 SurfaceProxy::~SurfaceProxy()
 {
     if (m_proxySurface) {
-        m_proxySurface->markWrapperToRemoved();
+        m_proxySurface->destroy();
         m_proxySurface = nullptr;
     }
 }
@@ -38,7 +38,7 @@ void SurfaceProxy::setSurface(SurfaceWrapper *newSurface)
 
     m_sourceSurface = newSurface;
     if (m_proxySurface) {
-        m_proxySurface->markWrapperToRemoved();
+        m_proxySurface->destroy();
         m_proxySurface = nullptr;
     }
 

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -179,19 +179,46 @@ SurfaceWrapper::SurfaceWrapper(QmlEngine *qmlEngine,
     updateHasActiveCapability(ActiveControlState::MappedOrSplash, true); // Splash is true
 }
 
-SurfaceWrapper::~SurfaceWrapper()
+void SurfaceWrapper::invalidate()
 {
-    Q_ASSERT_X(m_wrapperAboutToRemove,
-               Q_FUNC_INFO,
-               "SurfaceWrapper must be removed via markWrapperToRemoved before destruction");
-
-    Q_ASSERT(!m_ownsOutput);
-    Q_ASSERT(!m_container);
-    Q_ASSERT(!m_parentSurface);
-    Q_ASSERT(m_subSurfaces.isEmpty());
+    Q_ASSERT_X(!m_wrapperAboutToRemove, Q_FUNC_INFO, "Can't call `invalidate` twice!");
+    m_wrapperAboutToRemove = true;
+    Q_EMIT aboutToBeInvalidated();
 
     if (!m_skipDockPreView)
         setSkipDockPreView(true);
+
+    if (m_container) {
+        m_container->removeSurface(this);
+        m_container = nullptr;
+    }
+    if (m_ownsOutput) {
+        m_ownsOutput->removeSurface(this);
+        m_ownsOutput = nullptr;
+    }
+    if (m_parentSurface) {
+        m_parentSurface->removeSubSurface(this);
+        m_parentSurface = nullptr;
+    }
+    for (auto subS : std::as_const(m_subSurfaces)) {
+        subS->m_parentSurface = nullptr;
+    }
+    m_subSurfaces.clear();
+    m_shellSurface = nullptr;
+    if (m_surfaceItem)
+        m_surfaceItem->disconnect(this);
+}
+
+SurfaceWrapper::~SurfaceWrapper()
+{
+    if (!m_wrapperAboutToRemove) {
+        if (isWindowAnimationRunning()) {
+            qCWarning(treelandSurface)
+                << "SurfaceWrapper is being destroyed without destroy(); expected external"
+                   " destroy() rather than QObject parent-child destruction";
+        }
+        invalidate();
+    }
     if (m_titleBar) {
         delete m_titleBar;
         m_titleBar = nullptr;
@@ -983,38 +1010,12 @@ bool SurfaceWrapper::isWindowAnimationRunning() const
     return !m_windowAnimation.isNull();
 }
 
-void SurfaceWrapper::markWrapperToRemoved()
+void SurfaceWrapper::destroy()
 {
-    Q_ASSERT_X(!m_wrapperAboutToRemove, Q_FUNC_INFO, "Can't call `markWrapperToRemoved` twice!");
-    m_wrapperAboutToRemove = true;
-    Q_EMIT aboutToBeInvalidated();
-
-    if (!m_skipDockPreView)
-        setSkipDockPreView(true);
-
-    if (m_container) {
-        m_container->removeSurface(this);
-        m_container = nullptr;
-    }
-    if (m_ownsOutput) {
-        m_ownsOutput->removeSurface(this);
-        m_ownsOutput = nullptr;
-    }
-    if (m_parentSurface) {
-        m_parentSurface->removeSubSurface(this);
-        m_parentSurface = nullptr;
-    }
-    for (auto subS : std::as_const(m_subSurfaces)) {
-        subS->m_parentSurface = nullptr;
-    }
-    m_subSurfaces.clear();
-    m_shellSurface = nullptr;
-    if (m_surfaceItem)
-        m_surfaceItem->disconnect(this);
-
-    if (!isWindowAnimationRunning()) {
+    invalidate();
+    if (!isWindowAnimationRunning())
         deleteLater();
-    } // else delete this in Animation(for window close animation) finish
+    // else delete this in Animation(for window close animation) finish
 }
 
 bool SurfaceWrapper::acceptKeyboardFocus() const

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -271,7 +271,7 @@ public:
     void setHideByShowDesk(bool show);
     void setHideByLockScreen(bool hide);
 
-    void markWrapperToRemoved();
+    void destroy();
 
     bool acceptKeyboardFocus() const; // set by treeland-dde-shell
     void setAcceptKeyboardFocus(bool accept);
@@ -365,6 +365,7 @@ private:
     void setContainer(SurfaceContainer *newContainer);
     void setVisibleDecoration(bool newVisibleDecoration);
 
+    void invalidate();
     void setup(); // Initialize m_surfaceItem related features
     void convertToNormalSurface(WToplevelSurface *shellSurface,
                                 Type type); // Transition from pre-launch mode to normal mode


### PR DESCRIPTION
1. Renamed markWrapperToRemoved to destroy for clearer intent
2. Extracted cleanup logic into prepareDestruction method
3. Added safety fallback in destructor if destroy was not called
4. Removed redundant destructor in SurfaceProxy class
5. Relaxed strict assertions in destructor to handle edge cases

The previous implementation required explicit call to markWrapperToRemoved before destruction with strict assertions that could crash in edge cases. The refactored code separates cleanup concerns where prepareDestruction handles resource cleanup and destroy handles the full destruction flow including deferred deletion. The destructor now safely calls prepareDestruction as a fallback, improving robustness.

Influence:
1. Test closing normal windows to verify proper cleanup
2. Test closing windows with animations to ensure deletion after animation
3. Test destroying surfaces in various states like minimized or maximized
4. Test subsurface cleanup when parent surface is destroyed
5. Test surface proxy reassignment to verify old surface cleanup
6. Verify no memory leaks during repeated surface creation and destruction

PMS: 363365

## Summary by Sourcery

Refactor surface destruction to separate cleanup from deletion, rename the public destruction API, and make destruction more robust in edge cases.

Enhancements:
- Introduce a prepareDestruction helper to centralize surface cleanup prior to deletion.
- Rename SurfaceWrapper::markWrapperToRemoved to destroy and use it as the main destruction entry point, including deferred deletion when animations are running.
- Simplify SurfaceProxy by removing its destructor and delegating proxy surface cleanup to the updated destroy method.

