### PR TITLE
fix: use safe xwayland surface signals

### DIFF
--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -539,7 +539,7 @@ void ShellHandler::onXdgPopupSurfaceRemoved(WXdgPopupSurface *surface)
 
 void ShellHandler::onXWaylandSurfaceAdded(WXWaylandSurface *surface)
 {
-    surface->safeConnect(&qw_xwayland_surface::notify_associate,
+    surface->safeConnect(&WXWaylandSurface::associated,
                          this,
                          [this, surface = QPointer<WXWaylandSurface>(surface)] {
                              auto raw = surface.data();
@@ -582,14 +582,14 @@ void ShellHandler::onXWaylandSurfaceAdded(WXWaylandSurface *surface)
                              // fallback retrieval)
                              ensureXwaylandWrapper(raw, QString());
                          });
-    surface->safeConnect(&qw_xwayland_surface::notify_dissociate, this, [this, surface] {
-        auto wrapper = m_rootSurfaceContainer->getSurface(surface->surface());
-        qCDebug(treelandShell) << "WXWayland::notify_dissociate" << surface << wrapper;
+    surface->safeConnect(&WXWaylandSurface::aboutToDissociate, this, [this, surface] {
+        auto wrapper = m_rootSurfaceContainer->getSurface(surface);
+        qCDebug(treelandShell) << "WXWayland::aboutToDissociate" << surface << wrapper;
         // Cancel pending async resolve if still present. If wrapper never created, return.
         if (!wrapper) {
             if (!m_pendingAppIdResolveToplevels.removeOne(surface)) {
                 qCWarning(treelandShell)
-                    << "WXWayland::notify_dissociate for unknown surface" << surface;
+                    << "WXWayland::aboutToDissociate for unknown surface" << surface;
             }
             return; // never created
         }

--- a/waylib/src/server/protocols/wxwaylandsurface.cpp
+++ b/waylib/src/server/protocols/wxwaylandsurface.cpp
@@ -93,9 +93,11 @@ void WXWaylandSurfacePrivate::init()
         surface = new WSurface(qw_surface::from(nativeHandle()->surface), q);
         surface->setAttachedData<WXWaylandSurface>(q);
         Q_EMIT q->surfaceChanged();
+        Q_EMIT q->associated();
     });
     QObject::connect(handle(), &qw_xwayland_surface::notify_dissociate, q, [this, q] {
         Q_ASSERT(surface);
+        Q_EMIT q->aboutToDissociate();
         surface->safeDeleteLater();
         surface = nullptr;
         Q_EMIT q->surfaceChanged();

--- a/waylib/src/server/protocols/wxwaylandsurface.h
+++ b/waylib/src/server/protocols/wxwaylandsurface.h
@@ -128,6 +128,11 @@ public Q_SLOTS:
     void restack(WXWaylandSurface *sibling, StackMode mode);
 
 Q_SIGNALS:
+    // Emitted after WXWaylandSurfacePrivate finishes handling notify_associate.
+    void associated();
+    // Emitted before WXWaylandSurfacePrivate handles notify_dissociate cleanup.
+    void aboutToDissociate();
+
     void parentXWaylandSurfaceChanged();
     void childrenChanged();
     void isToplevelChanged();


### PR DESCRIPTION
1. Replace low-level notify_associate and notify_dissociate signals with new high-level associated and aboutToDissociate signals in WXWaylandSurface
2. Emit associated signal after the internal WSurface is fully initialized to prevent accessing invalid state
3. Emit aboutToDissociate signal before the internal WSurface is cleaned up and set to null, ensuring it remains valid during signal handling

Influence:
1. Test launching and closing XWayland applications to ensure they map and unmap correctly

ISSUE: 909

## Summary by Sourcery

Switch XWayland surface handling to new high-level association lifecycle signals to avoid accessing invalid internal surfaces during associate/dissociate events.

Bug Fixes:
- Ensure XWayland surface association handlers run only after the internal WSurface is fully initialized.
- Ensure XWayland surface dissociation handlers run before the internal WSurface is cleaned up so it remains valid during signal handling.

Enhancements:
- Introduce WXWaylandSurface::associated and WXWaylandSurface::aboutToDissociate signals to encapsulate XWayland lifecycle events and decouple callers from low-level notify_associate/notify_dissociate signals.