### PR TITLE
fix(vt): switch VT through wlroots session

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Build-Depends: cmake (>= 3.25.0),
                debhelper-compat (= 13),
                ninja-build,
                extra-cmake-modules (>= 1.4.0~),
-               libddm-dev (>= 0.3.3),
+               libddm-dev (>> 0.3.4),
                libdtk6core-bin,
                libdtk6core-dev,
                libdtk6declarative-dev,
@@ -55,7 +55,7 @@ Depends: qml6-module-qtquick-layouts,
          ${shlibs:Depends},
 Conflicts: libwaylib, qwlroots
 Replaces: libwaylib, qwlroots
-Recommends: ddm (>= 0.3.3),
+         Recommends: ddm (>> 0.3.4),
 Description: a Wayland compositor based on wlroots and QML, designed with an attractive and elegant appearance.
 
 Package: treeland-dev

--- a/debian/control
+++ b/debian/control
@@ -55,7 +55,7 @@ Depends: qml6-module-qtquick-layouts,
          ${shlibs:Depends},
 Conflicts: libwaylib, qwlroots
 Replaces: libwaylib, qwlroots
-         Recommends: ddm (>> 0.3.4),
+Recommends: ddm (>> 0.3.4),
 Description: a Wayland compositor based on wlroots and QML, designed with an attractive and elegant appearance.
 
 Package: treeland-dev

--- a/misc/systemd/treeland.service.in
+++ b/misc/systemd/treeland.service.in
@@ -4,8 +4,8 @@ PartOf=graphical.target
 StartLimitIntervalSec=30
 StartLimitBurst=2
 
-Requires=seatd.service
-After=seatd.service
+Requires=dde-seatd.service
+After=dde-seatd.service
 
 [Service]
 User=dde

--- a/src/modules/ddm/ddminterfacev1.cpp
+++ b/src/modules/ddm/ddminterfacev1.cpp
@@ -51,18 +51,20 @@ void DDMInterfaceV1Private::destroy(Resource *resource)
 
 void DDMInterfaceV1Private::bind_resource(Resource *resource)
 {
-    send_acquire_vt(resource->handle, 0);
+    Q_UNUSED(resource)
 }
 
 void DDMInterfaceV1Private::switch_to_greeter([[maybe_unused]] Resource *resource)
 {
+    qCWarning(treelandCore) << "DDM protocol: switch_to_greeter";
     Helper::instance()->showLockScreen(false);
 }
 
 void DDMInterfaceV1Private::switch_to_user([[maybe_unused]] Resource *resource, const QString &username)
 {
+    qCWarning(treelandCore) << "DDM protocol: switch_to_user" << username;
     auto helper = Helper::instance();
-    if (username == "ddm") {
+    if (username == "dde") {
         helper->showLockScreen(false);
     } else if (username != helper->userModel()->currentUserName()) {
         helper->userModel()->setCurrentUserName(username);
@@ -72,16 +74,19 @@ void DDMInterfaceV1Private::switch_to_user([[maybe_unused]] Resource *resource, 
 
 void DDMInterfaceV1Private::activate_session([[maybe_unused]] Resource *resource)
 {
+    qCWarning(treelandCore) << "DDM protocol: activate_session";
     Helper::instance()->activateSession();
 }
 
 void DDMInterfaceV1Private::deactivate_session([[maybe_unused]] Resource *resource)
 {
+    qCWarning(treelandCore) << "DDM protocol: deactivate_session";
     Helper::instance()->deactivateSession();
 }
 
 void DDMInterfaceV1Private::enable_render([[maybe_unused]] Resource *resource)
 {
+    qCWarning(treelandCore) << "DDM protocol: enable_render";
     Helper::instance()->enableRender();
 }
 
@@ -111,28 +116,6 @@ QByteArrayView DDMInterfaceV1::interfaceName() const
 bool DDMInterfaceV1::isConnected() const
 {
     return !d->resourceMap().isEmpty();
-}
-
-void DDMInterfaceV1::switchToVt(const int vtnr)
-{
-    if (isConnected()) {
-        for (const auto &resource : d->resourceMap()) {
-            d->send_switch_to_vt(resource->handle, vtnr);
-        }
-    } else {
-        qCWarning(treelandCore) << "DDM is not connected when trying to call switchToVt";
-    }
-}
-
-void DDMInterfaceV1::acquireVt(const int vtnr)
-{
-    if (isConnected()) {
-        for (const auto &resource : d->resourceMap()) {
-            d->send_acquire_vt(resource->handle, vtnr);
-        }
-    } else {
-        qCWarning(treelandCore) << "DDM is not connected when trying to call acquireVt";
-    }
 }
 
 void DDMInterfaceV1::create(WServer *server)

--- a/src/modules/ddm/ddminterfacev1.h
+++ b/src/modules/ddm/ddminterfacev1.h
@@ -15,8 +15,6 @@ public:
     ~DDMInterfaceV1() override;
 
     bool isConnected() const;
-    void switchToVt(const int vtnr);
-    void acquireVt(const int vtnr);
 
     QByteArrayView interfaceName() const override;
     static constexpr int InterfaceVersion = 1;

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -131,9 +131,7 @@
 #include <rhi/qrhi.h>
 
 #include <functional>
-#include <linux/input.h>
 #include <pwd.h>
-#include <sys/ioctl.h>
 #include <unistd.h>
 #include <utility>
 #include <wayland-util.h>
@@ -1761,6 +1759,29 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *targetWindow, QInputEvent 
     if (event->isInputEvent()) {
         m_idleNotifier->notify_activity(seat->nativeHandle());
     }
+
+    if (event->type() == QEvent::KeyPress) {
+        auto kevent = static_cast<QKeyEvent *>(event);
+        const auto modifiers = kevent->modifiers();
+        const auto ctrlAlt = Qt::ControlModifier | Qt::AltModifier;
+        if ((modifiers & ctrlAlt) == ctrlAlt) {
+            const auto key = kevent->key();
+            if (key >= Qt::Key_F1 && key <= Qt::Key_F12) {
+                const int vtnr = key - Qt::Key_F1 + 1;
+                const bool sessionActive = m_backend->isSessionActive();
+                qCWarning(treelandCore) << "Ctrl+Alt+Fn VT shortcut received"
+                                        << vtnr << "sessionActive" << sessionActive;
+                if (!sessionActive) {
+                    return true;
+                }
+
+                qCWarning(treelandCore) << "Ctrl+Alt+Fn VT shortcut requested" << vtnr;
+                m_backend->session()->change_vt(vtnr);
+                return true;
+            }
+        }
+    }
+
     WSeat *targetSeat = seat;
     if (event->device()) {
         WInputDevice *device = WInputDevice::from(event->device());
@@ -1814,26 +1835,6 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *targetWindow, QInputEvent 
                     return true;
             }
 #endif
-
-            // Switch TTY with Ctrl + Alt + F1-F12
-            if (kevent->modifiers() == (Qt::ControlModifier | Qt::AltModifier)) {
-                auto key = kevent->key();
-                // We don't call libseat_disable_seat after switching TTY by
-                // calling DDM, which will cause the keyboard stuck in current
-                // state (Ctrl + Alt + Fx), and send switchToVt repeatly.
-                // Check if the backend is active to avoid this.
-                if (key >= Qt::Key_F1 && key <= Qt::Key_F12 && m_backend->isSessionActive()) {
-                    const int vtnr = key - Qt::Key_F1 + 1;
-                    if (m_ddmInterfaceV1 && m_ddmInterfaceV1->isConnected()) {
-                        m_ddmInterfaceV1->switchToVt(vtnr);
-                    } else {
-                        qCDebug(treelandCore) << "DDM is not connected";
-                        showLockScreen(false);
-                        m_backend->session()->change_vt(vtnr);
-                    }
-                    return true;
-                }
-            }
 
             if (m_captureSelector) {
                 if (event->modifiers() == Qt::NoModifier && kevent->key() == Qt::Key_Escape)
@@ -2721,19 +2722,6 @@ void Helper::enableRender() {
 
 void Helper::disableRender() {
     m_renderWindow->setRenderEnabled(false);
-
-    // Revoke all evdev devices to prevent accidental events during switch
-    static const char prefix[] = "/dev/input/";
-    static const int prefixLen = strlen(prefix);
-    struct wlr_session *session = m_backend->session()->handle();
-    struct wlr_device *device = nullptr;
-    wl_list_for_each(device, &session->devices, link) {
-        char path[32];
-        if (readlink(qPrintable(QStringLiteral("/proc/self/fd/%1").arg(device->fd)), path, 32) < 0)
-            qCWarning(treelandCore) << "Failed to read path of file descriptor " << device->fd;
-        else if (strncmp(prefix, path, prefixLen))
-            ioctl(device->fd, EVIOCREVOKE, nullptr);
-    }
 }
 
 void Helper::setBlockActivateSurface(bool block)

--- a/waylib/src/server/kernel/wseat.cpp
+++ b/waylib/src/server/kernel/wseat.cpp
@@ -547,7 +547,8 @@ void WSeatPrivate::on_keyboard_key(wlr_keyboard_key_event *event, WInputDevice *
         "XKB_KEY_XF86Switch_VT_1..12 and XKB_KEY_F1..F12 must be contiguous and ordered for keysym calculation"
     );
     if (sym >= XKB_KEY_XF86Switch_VT_1 && sym <= XKB_KEY_XF86Switch_VT_12) {
-        if (keyModifiers == (Qt::ControlModifier | Qt::AltModifier)) {
+        constexpr auto ctrlAlt = Qt::ControlModifier | Qt::AltModifier;
+        if ((keyModifiers & ctrlAlt) == ctrlAlt) {
             sym = XKB_KEY_F1 + (sym - XKB_KEY_XF86Switch_VT_1);
         }
     }


### PR DESCRIPTION
This updates Treeland VT handling for the dde-seatd/vt-bound flow.

- switch Ctrl+Alt+Fn directly through the wlroots/libseat session
- remove the old DDM VT detour and input device revoke workaround
- refresh the greeter/lock screen state deterministically when re-entering Treeland
- align the systemd dependency with `dde-seatd.service`

This is the Treeland side of the DDM + Treeland VT switching cleanup.

## Summary by Sourcery

Run CTest-based unit tests in CI for waylib and treeland builds.

CI:
- Add execution of `ctest --preset ci` to waylib Arch Linux CI workflow.
- Add execution of `ctest --preset ci` to treeland Arch Linux CI workflow.