### PR TITLE
fix: SSD fallback without PersonalizationV1

### DIFF
--- a/src/modules/personalization/personalizationmanagerinterfacev1.h
+++ b/src/modules/personalization/personalizationmanagerinterfacev1.h
@@ -276,12 +276,12 @@ Q_SIGNALS:
 
 private:
     WWrapPointer<WToplevelSurface> m_target;
-    PersonalizationManagerInterfaceV1 *m_manager;
-    int32_t m_backgroundType;
-    int32_t m_cornerRadius;
-    Shadow m_shadow;
-    Border m_border;
-    PersonalizationWindowContextV1::WindowStates m_states;
+    PersonalizationManagerInterfaceV1 *m_manager = nullptr;
+    int32_t m_backgroundType = Personalization::BackgroundType::Normal;
+    int32_t m_cornerRadius = 0;
+    Shadow m_shadow {};
+    Border m_border {};
+    PersonalizationWindowContextV1::WindowStates m_states {};
 
     QMetaObject::Connection m_connection;
 };


### PR DESCRIPTION
1. Adding default in-class initializers ensures predictable behavior and prevents undefined state propagation during object construction

Log: Fixed an issue where SSD applications occasionally lacked a title bar due to uninitialized window states

## Summary by Sourcery

Bug Fixes:
- Prevent occasional missing SSD window title bars caused by uninitialized personalization window state.