### PR TITLE
feat(examples): remove unnecessary Qt::Widgets dependency

### DIFF
--- a/examples/test_color_control/CMakeLists.txt
+++ b/examples/test_color_control/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS WaylandClient Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Gui WaylandClient)
 find_package(TreelandProtocols REQUIRED)
 
 set(BIN_NAME test-color-control)
@@ -15,7 +15,6 @@ qt_generate_wayland_protocol_client_sources(${BIN_NAME}
 target_link_libraries(${BIN_NAME}
     PRIVATE
         Qt6::Gui
-        Qt6::Widgets
         Qt6::WaylandClient
 )
 

--- a/examples/test_color_control/main.cpp
+++ b/examples/test_color_control/main.cpp
@@ -1,7 +1,7 @@
-// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2025-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
-#include <QApplication>
+#include <QGuiApplication>
 #include <QObject>
 #include <QScreen>
 #include <QWaylandClientExtension>
@@ -76,7 +76,7 @@ protected:
 int main(int argc, char *argv[])
 {
     qputenv("QT_QPA_PLATFORM", "wayland");
-    QApplication app(argc, argv);
+    QGuiApplication app(argc, argv);
     QCommandLineParser parser;
     parser.setApplicationDescription("Test Color Control V1");
     parser.addHelpOption();
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
     parser.addOption(colorTempOption);
     parser.addOption(brightnessOption);
     parser.addPositionalArgument("output", "Name of the output to control.");
-    parser.process(QApplication::arguments());
+    parser.process(QGuiApplication::arguments());
     auto colorTemperature = parser.value(colorTempOption).toUInt();
     auto brightness = parser.value(brightnessOption).toDouble();
     auto outputName = parser.positionalArguments().value(0);

--- a/examples/test_hide_window/CMakeLists.txt
+++ b/examples/test_hide_window/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Gui Widgets)
 
 set(BIN_NAME test-hide-window)
 
@@ -8,6 +8,7 @@ qt_add_executable(${BIN_NAME}
 
 target_link_libraries(${BIN_NAME}
     PRIVATE
+        Qt6::Gui
         Qt6::Widgets
 )
 

--- a/examples/test_keystate/CMakeLists.txt
+++ b/examples/test_keystate/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS WaylandClient Widgets)
+find_package(Qt6 REQUIRED COMPONENTS WaylandClient)
 find_package(TreelandProtocols REQUIRED)
 
 set(BIN_NAME test-keystate)
@@ -15,7 +15,6 @@ qt_generate_wayland_protocol_client_sources(${BIN_NAME}
 target_link_libraries(${BIN_NAME}
     PRIVATE
         Qt6::Gui
-        Qt6::Widgets
         Qt6::WaylandClient
 )
 

--- a/examples/test_keystate/main.cpp
+++ b/examples/test_keystate/main.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include <qwaylandclientextension.h>
-#include <qapplication.h>
+#include <qguiapplication.h>
 
 #include "qwayland-kde-keystate.h"
 
@@ -59,7 +59,7 @@ public Q_SLOTS:
 int main(int argc, char *argv[])
 {
     qputenv("QT_QPA_PLATFORM", "wayland");
-    QApplication app(argc, argv);
+    QGuiApplication app(argc, argv);
     KeyStateV5 keyState;
     keyState.setParent(&app);
     QObject::connect(&keyState, &KeyStateV5::activeChanged,

--- a/examples/test_monitor_active_event/CMakeLists.txt
+++ b/examples/test_monitor_active_event/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS WaylandClient Widgets)
+find_package(Qt6 REQUIRED COMPONENTS WaylandClient)
 find_package(TreelandProtocols REQUIRED)
 
 set(BIN_NAME test-monitor-active_event)
@@ -16,7 +16,6 @@ qt_generate_wayland_protocol_client_sources(${BIN_NAME}
 target_link_libraries(${BIN_NAME}
     PRIVATE
         Qt6::Gui
-        Qt6::Widgets
         Qt6::WaylandClient
 )
 

--- a/examples/test_multitaskview/CMakeLists.txt
+++ b/examples/test_multitaskview/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS WaylandClient Quick)
+find_package(Qt6 REQUIRED COMPONENTS Gui Quick WaylandClient)
 if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10)
     find_package(Qt6 REQUIRED COMPONENTS WaylandClientPrivate)
 endif()
@@ -30,6 +30,7 @@ qt_generate_wayland_protocol_client_sources(${BIN_NAME}
 
 target_link_libraries(${BIN_NAME}
     PRIVATE
+        Qt6::Gui
         Qt6::Quick
         Qt6::WaylandClient
         Qt6::WaylandClientPrivate

--- a/examples/test_pinch_handler/CMakeLists.txt
+++ b/examples/test_pinch_handler/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(BIN_NAME test-pinch-handler)
 
-find_package(Qt6 REQUIRED COMPONENTS Quick)
+find_package(Qt6 REQUIRED COMPONENTS Gui Quick)
 
 qt_add_executable(${BIN_NAME}
     main.cpp
@@ -14,7 +14,8 @@ qt_add_qml_module(${BIN_NAME}
 )
 
 target_link_libraries(${BIN_NAME}
-    PRIVATE Qt6::Quick
+    PRIVATE Qt6::Gui
+    Qt6::Quick
 )
 
 install(TARGETS ${BIN_NAME}

--- a/examples/test_primary_output/CMakeLists.txt
+++ b/examples/test_primary_output/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS WaylandClient Widgets)
+find_package(Qt6 REQUIRED COMPONENTS WaylandClient)
 find_package(TreelandProtocols REQUIRED)
 
 set(BIN_NAME test-primary-output)
@@ -15,7 +15,6 @@ qt_generate_wayland_protocol_client_sources(${BIN_NAME}
 target_link_libraries(${BIN_NAME}
     PRIVATE
         Qt6::Gui
-        Qt6::Widgets
         Qt6::WaylandClient
 )
 

--- a/examples/test_primary_output/main.cpp
+++ b/examples/test_primary_output/main.cpp
@@ -1,9 +1,9 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "qwayland-treeland-output-manager-v1.h"
 
-#include <QApplication>
+#include <QGuiApplication>
 #include <QObject>
 #include <QWaylandClientExtension>
 
@@ -30,7 +30,7 @@ OutputManagerV1::OutputManagerV1()
 int main(int argc, char *argv[])
 {
     qputenv("QT_QPA_PLATFORM", "wayland");
-    QApplication app(argc, argv);
+    QGuiApplication app(argc, argv);
     OutputManagerV1 manager;
 
     QObject::connect(&manager, &OutputManagerV1::activeChanged, &manager, [&manager, argc, argv] {

--- a/examples/test_set_wallpaper/CMakeLists.txt
+++ b/examples/test_set_wallpaper/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 COMPONENTS REQUIRED Gui DBus WaylandClient Widgets)
+find_package(Qt6 COMPONENTS REQUIRED Gui DBus WaylandClient)
 if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10)
   find_package(Qt6 COMPONENTS GuiPrivate WaylandClientPrivate REQUIRED)
 endif()
@@ -22,7 +22,6 @@ target_link_libraries(${BIN_NAME}
     PRIVATE
         Qt6::Gui
         Qt6::GuiPrivate
-        Qt6::Widgets
         Qt6::WaylandClient
         Qt6::WaylandClientPrivate
 )

--- a/examples/test_set_wallpaper/main.cpp
+++ b/examples/test_set_wallpaper/main.cpp
@@ -3,7 +3,7 @@
 
 #include "treelandwallpapermanagerclient.h"
 
-#include <QApplication>
+#include <QGuiApplication>
 #include <QCommandLineOption>
 #include <QCommandLineParser>
 #include <QGuiApplication>
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
     if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM"))
         qputenv("QT_QPA_PLATFORM", "wayland");
 
-    QApplication app(argc, argv);
+    QGuiApplication app(argc, argv);
 
     QCommandLineParser parser;
     parser.setApplicationDescription(QStringLiteral("Treeland Wallpaper Client"));

--- a/examples/test_shortcut_capture/CMakeLists.txt
+++ b/examples/test_shortcut_capture/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS WaylandClient Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Gui WaylandClient Widgets)
 if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10)
     find_package(Qt6 REQUIRED COMPONENTS GuiPrivate WaylandClientPrivate)
 endif()

--- a/examples/test_shortcut_manager/CMakeLists.txt
+++ b/examples/test_shortcut_manager/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS WaylandClient Widgets)
+find_package(Qt6 REQUIRED COMPONENTS WaylandClient)
 find_package(TreelandProtocols REQUIRED)
 
 set(BIN_NAME test-shortcut-manager)
@@ -15,7 +15,6 @@ qt_generate_wayland_protocol_client_sources(${BIN_NAME}
 target_link_libraries(${BIN_NAME}
     PRIVATE
         Qt6::Gui
-        Qt6::Widgets
         Qt6::WaylandClient
 )
 

--- a/examples/test_shortcut_manager/main.cpp
+++ b/examples/test_shortcut_manager/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2025-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 // This is a simple test application for the Treeland Shortcut Manager V2 protocol.
@@ -17,7 +17,7 @@
 //        ...
 //    ]
 
-#include <QApplication>
+#include <QGuiApplication>
 #include <QObject>
 #include <QScreen>
 #include <QWaylandClientExtension>
@@ -61,7 +61,7 @@ signals:
 int main(int argc, char *argv[])
 {
     qputenv("QT_QPA_PLATFORM", "wayland");
-    QApplication app(argc, argv);
+    QGuiApplication app(argc, argv);
     QCommandLineParser parser;
     parser.setApplicationDescription("Test Shortcut Manager V2");
     parser.addHelpOption();

--- a/examples/test_show_desktop/CMakeLists.txt
+++ b/examples/test_show_desktop/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS WaylandClient Widgets)
+find_package(Qt6 REQUIRED COMPONENTS WaylandClient)
 if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10)
     find_package(Qt6 REQUIRED COMPONENTS GuiPrivate WaylandClientPrivate)
 endif()
@@ -18,7 +18,6 @@ qt_generate_wayland_protocol_client_sources(${BIN_NAME}
 target_link_libraries(${BIN_NAME}
     PRIVATE
         Qt6::Gui
-        Qt6::Widgets
         Qt6::WaylandClient
         Qt6::GuiPrivate
         Qt6::WaylandClientPrivate

--- a/examples/test_show_desktop/main.cpp
+++ b/examples/test_show_desktop/main.cpp
@@ -1,9 +1,9 @@
-// Copyright (C) 2024 Lu YaNing <luyaning@uniontech.com>.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "qwayland-treeland-window-management-v1.h"
 
-#include <QApplication>
+#include <QGuiApplication>
 #include <QtWaylandClient/QWaylandClientExtension>
 
 class WindowManager
@@ -34,7 +34,7 @@ WindowManager::WindowManager()
 int main(int argc, char *argv[])
 {
     qputenv("QT_QPA_PLATFORM", "wayland");
-    QApplication app(argc, argv);
+    QGuiApplication app(argc, argv);
     WindowManager manager;
 
     QObject::connect(&manager, &WindowManager::activeChanged, &manager, [&manager, argc, argv] {

--- a/examples/test_super_overlay_surface/CMakeLists.txt
+++ b/examples/test_super_overlay_surface/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS WaylandClient Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Gui WaylandClient Widgets)
 if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10)
     find_package(Qt6 REQUIRED COMPONENTS WaylandClientPrivate)
 endif()

--- a/examples/test_toplevel_tag/CMakeLists.txt
+++ b/examples/test_toplevel_tag/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS WaylandClient Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Gui WaylandClient Widgets)
 if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10)
     find_package(Qt6 REQUIRED COMPONENTS GuiPrivate WaylandClientPrivate)
 endif()

--- a/examples/test_virtual_output/CMakeLists.txt
+++ b/examples/test_virtual_output/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS WaylandClient Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Gui WaylandClient Widgets)
 if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10)
     find_package(Qt6 REQUIRED COMPONENTS GuiPrivate WaylandClientPrivate)
 endif()

--- a/examples/test_window_bg/CMakeLists.txt
+++ b/examples/test_window_bg/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS WaylandClient Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Gui WaylandClient Widgets)
 if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10)
     find_package(Qt6 REQUIRED COMPONENTS GuiPrivate WaylandClientPrivate)
 endif()

--- a/examples/test_window_picker/CMakeLists.txt
+++ b/examples/test_window_picker/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS WaylandClient Quick)
+find_package(Qt6 REQUIRED COMPONENTS Gui Quick WaylandClient)
 if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10)
     find_package(Qt6 REQUIRED COMPONENTS WaylandClientPrivate)
 endif()
@@ -30,6 +30,7 @@ qt_generate_wayland_protocol_client_sources(${BIN_NAME}
 
 target_link_libraries(${BIN_NAME}
     PRIVATE
+        Qt6::Gui
         Qt6::Quick
         Qt6::WaylandClient
         Qt6::WaylandClientPrivate

--- a/examples/test_xdgport_wallpaper/CMakeLists.txt
+++ b/examples/test_xdgport_wallpaper/CMakeLists.txt
@@ -2,7 +2,7 @@ set(CMAKE_AUTOUIC ON)
 
 set(BIN_NAME test-xdg-wallpaper)
 
-find_package(Qt6 REQUIRED COMPONENTS Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Gui Widgets)
 find_package(TreelandProtocols REQUIRED)
 
 qt_add_executable(${BIN_NAME}
@@ -13,6 +13,7 @@ qt_add_executable(${BIN_NAME}
 )
 
 target_link_libraries(${BIN_NAME} PRIVATE
+    Qt6::Gui
     Qt6::Widgets
     Qt6::DBus
 )


### PR DESCRIPTION
For the examples that only used QApplication without other widgets, switch to QGuiApplication to fully drop the Widgets dependency.

Add missing Gui component to find_package and target_link_libraries in examples that rely on Gui but didn't declare it explicitly.

Log: remove unnecessary Qt::Widgets dependency
Influence: