### PR TITLE
fix: resolve splash transition size issue

### DIFF
--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -316,13 +316,12 @@ void SurfaceWrapper::setup()
                                     &SurfaceWrapper::requestCancelFullscreen);
 
         if (m_type == Type::XdgToplevel) {
-            m_shellSurface->safeConnect(
-                &WToplevelSurface::requestShowWindowMenu,
-                this,
-                [this](WSeat *, QPoint pos, quint32) {
-                    Q_EMIT requestShowWindowMenu(
-                        m_surfaceItem->mapFromSurface(pos).toPoint());
-                });
+            m_shellSurface->safeConnect(&WToplevelSurface::requestShowWindowMenu,
+                                        this,
+                                        [this](WSeat *, QPoint pos, quint32) {
+                                            Q_EMIT requestShowWindowMenu(
+                                                m_surfaceItem->mapFromSurface(pos).toPoint());
+                                        });
         }
     }
     m_shellSurface->surface()->safeConnect(&WSurface::mappedChanged,
@@ -533,16 +532,40 @@ void SurfaceWrapper::syncPrelaunchMappedState()
 
 void SurfaceWrapper::startPrelaunchSplashHideSequence()
 {
-    auto surf = surface();
-    Q_ASSERT(surf != nullptr && m_surfaceItem != nullptr);
-    // A newly created QQuickItem may report implicitWidth/implicitHeight as 0
-    // before polish/layout. WSurface::size() is already stable after mapped.
-    QSizeF targetImplicitSize = surf->size();
+    Q_ASSERT(m_surfaceItem != nullptr);
+    if (m_windowAnimation) {
+        qCDebug(treelandSurface) << "prelaunch splash transition is starting while window "
+                                    "animation is still running,"
+                                    "this may cause visual glitches, will delay the transition "
+                                    "until window animation finishes";
+        return;
+    }
+    if (m_geometryAnimation) {
+        qCDebug(treelandSurface) << "prelaunch splash transition already prepared or running, skip";
+        return;
+    }
+
+    // Wait until surfaceItem has computed a valid scene-space implicit size.
+    // For XWayland, this happens in updateSurfaceState() after the first surface commit;
+    // for other types it may be deferred until componentComplete + first polish.
+    if (!m_surfaceItem->isReady()) {
+        connect(m_surfaceItem,
+                &WSurfaceItem::readyChanged,
+                this,
+                &SurfaceWrapper::startPrelaunchSplashHideSequence,
+                Qt::SingleShotConnection);
+        return;
+    }
+
+    // Use surfaceItem's scene-space implicit size: for XWayland, surf->size() is
+    // buffer-space and differs from scene-space after DPR scaling via surfaceSizeRatio.
+    const QSizeF targetImplicitSize(m_surfaceItem->implicitWidth(),
+                                    m_surfaceItem->implicitHeight());
     const bool hasValidTargetImplicitSize =
         targetImplicitSize.width() > 0 && targetImplicitSize.height() > 0;
     if (!hasValidTargetImplicitSize) {
         qCCritical(treelandSurface) << "Invalid target implicit size, skip transition animation"
-                                   << "targetImplicit=" << targetImplicitSize;
+                                    << "targetImplicit=" << targetImplicitSize;
     }
 
     const bool needImplicitSizeTransition = hasValidTargetImplicitSize && (container() != nullptr)
@@ -550,19 +573,6 @@ void SurfaceWrapper::startPrelaunchSplashHideSequence()
             || !qFuzzyCompare(implicitHeight() + 1.0, targetImplicitSize.height() + 1.0));
 
     if (needImplicitSizeTransition) {
-        if (m_windowAnimation) {
-            qCDebug(treelandSurface) << "prelaunch splash transition is starting while window "
-                                        "animation is still running,"
-                                        "this may cause visual glitches, will delay the transition "
-                                        "until window animation finishes";
-            return;
-        }
-        if (m_geometryAnimation) {
-            qCWarning(treelandSurface)
-                << "prelaunch splash transition already prepared or running, skip";
-            return;
-        }
-
         const QRectF fromGeometry(position(), size());
         // XWayland clients manage their own position; respect it and don't shift.
         // For all other types, keep the center fixed so the window expands from center.
@@ -587,8 +597,6 @@ void SurfaceWrapper::startPrelaunchSplashHideSequence()
         ok = QMetaObject::invokeMethod(m_geometryAnimation, "start");
         Q_ASSERT(ok);
     } else {
-        // WSurface size is available when mapped; implicit size of a newly created
-        // QQuickItem can still be 0 before polish/layout in following event loops.
         completeSplashTransition(targetImplicitSize);
     }
 }

--- a/waylib/src/server/qtquick/private/wsurfaceitem_p.h
+++ b/waylib/src/server/qtquick/private/wsurfaceitem_p.h
@@ -82,6 +82,7 @@ public:
 
     uint32_t beforeRequestResizeSurfaceStateSeq = 0;
     QRectF boundingRect;
+    bool ready = false;
 };
 
 WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/qtquick/wsurfaceitem.cpp
+++ b/waylib/src/server/qtquick/wsurfaceitem.cpp
@@ -703,6 +703,10 @@ void WSurfaceItem::setSurface(WSurface *surface)
     auto oldSurface = d->surface;
     d->beforeRequestResizeSurfaceStateSeq = 0;
     d->surface = surface;
+    if (d->ready) {
+        d->ready = false;
+        Q_EMIT readyChanged();
+    }
     if (d->componentComplete) {
         if (oldSurface) {
             oldSurface->safeDisconnect(this);
@@ -1155,6 +1159,11 @@ void WSurfaceItem::updateSurfaceState()
     setImplicitSize(d->calculateImplicitWidth(),
                     d->calculateImplicitHeight());
 
+    if (!d->ready && implicitWidth() > 0 && implicitHeight() > 0) {
+        d->ready = true;
+        Q_EMIT readyChanged();
+    }
+
     if (bufferScaleChanged)
         Q_EMIT this->bufferScaleChanged();
 }
@@ -1581,6 +1590,12 @@ void WSurfaceItem::setSubsurfacesVisible(bool newSubsurfacesVisible)
     if (d->aboveSubsurfaceContainer)
         d->aboveSubsurfaceContainer->setVisible(d->subsurfacesVisible);
     Q_EMIT subsurfacesVisibleChanged();
+}
+
+bool WSurfaceItem::isReady() const
+{
+    Q_D(const WSurfaceItem);
+    return d->ready;
 }
 
 WSurfaceItemContent *WSurfaceItem::findItemContent() const

--- a/waylib/src/server/qtquick/wsurfaceitem.h
+++ b/waylib/src/server/qtquick/wsurfaceitem.h
@@ -116,6 +116,7 @@ class WAYLIB_SERVER_EXPORT WSurfaceItem : public QQuickItem
     Q_PROPERTY(QQmlComponent* delegate READ delegate WRITE setDelegate NOTIFY delegateChanged FINAL)
     Q_PROPERTY(QRectF boundingRect READ boundingRect NOTIFY boundingRectChanged)
     Q_PROPERTY(bool subsurfacesVisible READ subsurfacesVisible WRITE setSubsurfacesVisible NOTIFY subsurfacesVisibleChanged FINAL)
+    Q_PROPERTY(bool ready READ isReady NOTIFY readyChanged FINAL)
     QML_NAMED_ELEMENT(SurfaceItem)
 
 public:
@@ -193,6 +194,8 @@ public:
     bool subsurfacesVisible() const;
     void setSubsurfacesVisible(bool newSubsurfacesVisible);
 
+    bool isReady() const;
+
     // Find WSurfaceItemContent in child items
     WSurfaceItemContent *findItemContent() const;
 
@@ -217,6 +220,7 @@ Q_SIGNALS:
     void shellSurfaceChanged();
     void boundingRectChanged();
     void subsurfacesVisibleChanged();
+    void readyChanged();
 
 protected:
     explicit WSurfaceItem(WSurfaceItemPrivate &dd, QQuickItem *parent = nullptr);


### PR DESCRIPTION
This change fixes visual glitches during prelaunch splash hide sequence. For XWayland clients, WSurface::size() returns buffer-space size which differs from scene-space after DPR scaling via surfaceSizeRatio. Additionally, a newly created QQuickItem may report 0 for implicit dimensions before polish/layout. The new implicitSizeReady property ensures we only start the transition animation when valid scene-space dimensions are available.

Influence:
1. Test XWayland application launch to verify splash screen transitions smoothly without size jumps

PMS: BUG-363265