### PR TITLE
fix(lockscreen): refresh greeter state on re-entry

### DIFF
--- a/src/core/lockscreen.cpp
+++ b/src/core/lockscreen.cpp
@@ -46,6 +46,13 @@ void LockScreen::lock()
         m_greeterProxy->lock();
 }
 
+void LockScreen::refresh()
+{
+    for (const auto &[_, component] : m_components) {
+        QMetaObject::invokeMethod(component.get(), "ensureShown");
+    }
+}
+
 void LockScreen::shutdown()
 {
     // ext_session_lock_v1 does not support shutdown

--- a/src/core/lockscreen.h
+++ b/src/core/lockscreen.h
@@ -41,6 +41,7 @@ public:
     bool available() const;
     bool isLocked() const;
     void lock();
+    void refresh();
     void shutdown();
     void switchUser();
     void setPrimaryOutputName(const QString &primaryOutputName);

--- a/src/greeter/greeterproxy.cpp
+++ b/src/greeter/greeterproxy.cpp
@@ -472,7 +472,10 @@ void GreeterProxy::readyRead()
             Q_EMIT informationMessage(message);
         } break;
         case DaemonMessages::SwitchToGreeter: {
-            qCInfo(treelandGreeter) << "switch to greeter";
+            qCWarning(treelandGreeter) << "daemon message: SwitchToGreeter"
+                                       << "locked" << m_isLocked
+                                       << "lockScreen" << m_lockScreen
+                                       << "lockScreenVisible" << (m_lockScreen ? m_lockScreen->isVisible() : false);
             lock();
         } break;
         case DaemonMessages::UserActivateMessage: {
@@ -482,14 +485,20 @@ void GreeterProxy::readyRead()
 
             // NOTE: maybe DDM will active dde user.
             if (!userModel()->getUser(user)) {
-                qCInfo(treelandGreeter) << "activate user, but switch to greeter";
+                qCWarning(treelandGreeter) << "daemon message: UserActivateMessage fallback to greeter"
+                                           << "user" << user
+                                           << "sessionId" << sessionId
+                                           << "locked" << m_isLocked;
                 lock();
                 break;
             }
 
             userModel()->setCurrentUserName(user);
 
-            qCInfo(treelandGreeter) << "activate successfully: " << user << ", XDG_SESSION_ID: " << sessionId;
+            qCWarning(treelandGreeter) << "daemon message: UserActivateMessage success"
+                                       << "user" << user
+                                       << "sessionId" << sessionId
+                                       << "locked" << m_isLocked;
         } break;
         case DaemonMessages::UserLoggedIn: {
             QString user;

--- a/src/plugins/lockscreen/qml/Greeter.qml
+++ b/src/plugins/lockscreen/qml/Greeter.qml
@@ -16,14 +16,18 @@ FocusScope {
     required property QtObject output
     required property QtObject outputItem
     property string primaryOutputName
-    visible: primaryOutputName === "" || primaryOutputName === output.name
+    visible: output && (primaryOutputName === "" || primaryOutputName === output.name)
 
-    x: outputItem.x
-    y: outputItem.y
-    width: outputItem.width
-    height: outputItem.height
+    x: outputItem ? outputItem.x : 0
+    y: outputItem ? outputItem.y : 0
+    width: outputItem ? outputItem.width : 0
+    height: outputItem ? outputItem.height : 0
 
     palette.windowText: Qt.rgba(1.0, 1.0, 1.0, 1.0)
+
+    function ensureShown() {
+        background.updateShownState(background.state === "Show")
+    }
 
     /**************/
     /* Components */
@@ -94,15 +98,24 @@ FocusScope {
                 }
             }
         ]
-        onStateChanged: {
-            if (state === "Show") {
-                Helper.startLockscreen(root.output, true);
-                wallpaper.play = true;
+        function updateShownState(shown) {
+            if (shown) {
+                if (root.output) {
+                    Helper.startLockscreen(root.output, true);
+                }
+                lockView.ensureShown()
+                wallpaper.play = true
             } else {
-                wallpaper.play = false;
-                Helper.showDesktop(root.output)
+                wallpaper.play = false
+                if (root.output) {
+                    Helper.showDesktop(root.output)
+                }
             }
         }
+
+        onStateChanged: updateShownState(state === "Show")
+        Component.onCompleted: updateShownState(state === "Show")
+        onVisibleChanged: if (visible) updateShownState(state === "Show")
 
         Wallpaper {
             id: wallpaper

--- a/src/plugins/lockscreen/qml/LockView.qml
+++ b/src/plugins/lockscreen/qml/LockView.qml
@@ -186,6 +186,21 @@ FocusScope {
         root.animationPlayFinished.connect(root.__showUserList)
     }
 
+    function ensureShown() {
+        root.forceActiveFocus()
+        root.visible = true
+        root.state = LoginAnimation.Show
+
+        if (leftAnimation.item)
+            leftAnimation.item.reset()
+        if (logoAnimation.item)
+            logoAnimation.item.reset()
+        if (rightAnimation.item)
+            rightAnimation.item.reset()
+        if (bottomAnimation.item)
+            bottomAnimation.item.reset()
+    }
+
     function __showUserList() {
         controlAction.showUserList()
         root.animationPlayFinished.disconnect(root.__showUserList)

--- a/src/plugins/lockscreen/qml/LoginAnimation.qml
+++ b/src/plugins/lockscreen/qml/LoginAnimation.qml
@@ -45,11 +45,16 @@ Item {
         stopped()
     }
 
+    function reset() {
+        visible = false
+        effect.sourceItem = null
+    }
+
     ShaderEffectSource {
         id: effect
         live: true
         hideSource: true
-        sourceItem: root.target
+        sourceItem: null
         width: root.target.width
         height: root.target.height
         x: root.target.x

--- a/src/plugins/lockscreen/qml/SessionList.qml
+++ b/src/plugins/lockscreen/qml/SessionList.qml
@@ -38,7 +38,7 @@ Popup {
         delegate: Item {
             required property string name
             required property int index
-            width: parent.width
+            width: parent ? parent.width : 0
             height: 60
             MouseArea {
                 anchors.fill: parent

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2547,6 +2547,8 @@ void Helper::setCurrentMode(CurrentMode mode)
 void Helper::showLockScreen(bool switchToGreeter)
 {
     if (m_lockScreen->isLocked()) {
+        qCWarning(treelandCore) << "Lock screen is already locked, refreshing greeter UI";
+        m_lockScreen->refresh();
         return;
     }
 


### PR DESCRIPTION
This splits the non-VT lock screen / greeter refresh changes out of #913.

- refresh the lock screen when Treeland re-enters an already locked state
- keep the greeter QML state deterministic on repeated activation
- avoid mixing UI refresh logic into the VT switching adaptation PR

This is intentionally separated from the VT switching path so #913 stays focused on wlroots/libseat VT adaptation.