### PR TITLE
chore(shortcut): add option to disable built-in shortcut daemon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,9 @@ if (DISABLE_DDM)
     add_compile_definitions("DISABLE_DDM")
 endif()
 
+# Only disables the bundled client daemon; the protocol (src/modules/shortcut) is unaffected.
+option(DISABLE_BUILTIN_SHORTCUTS "Disable Treeland's built-in shortcut daemon and its bundled default shortcuts" ON)
+
 # Alternative lock mechanism: Wayland ext-session-lock
 option(EXT_SESSION_LOCK_V1 "Enable Wayland ext-session-lock support (alternative to DDM)" ON)
 add_feature_info(ext_session_lock_v1 EXT_SESSION_LOCK_V1 "Enable ext-session-lock-v1 protocol support in Treeland")

--- a/debian/treeland-data.install
+++ b/debian/treeland-data.install
@@ -1,4 +1,3 @@
 usr/share/dsg/configs/*
-usr/share/treeland/shortcuts/*
 usr/share/wayland-sessions/treeland.desktop
 usr/share/dbus-1/interfaces/org.freedesktop.ScreenSaver.xml

--- a/misc/systemd/CMakeLists.txt
+++ b/misc/systemd/CMakeLists.txt
@@ -16,9 +16,18 @@ macro(install_symlink filepath wantsdir)
     install(FILES ${PROJECT_BINARY_DIR}/link/${wantsdir}/${filepath} DESTINATION ${SYSTEMD_USER_UNIT_DIR}/${wantsdir}/)
 endmacro(install_symlink)
 
+# Drop the built-in shortcut daemon's unit (and its ordering in treeland.service) when disabled.
+if (DISABLE_BUILTIN_SHORTCUTS)
+    set(TREELAND_SHORTCUT_SERVICE_DEPS "")
+else()
+    set(TREELAND_SHORTCUT_SERVICE_DEPS "Wants=treeland-shortcut.service\nBefore=treeland-shortcut.service")
+endif()
+
 configure_file("dde-session-pre.target.wants/treeland-sd.service.in" "dde-session-pre.target.wants/treeland-sd.service" IMMEDIATE @ONLY)
 configure_file("dde-session-pre.target.wants/treeland-xwayland.service.in" "dde-session-pre.target.wants/treeland-xwayland.service" IMMEDIATE @ONLY)
-configure_file("dde-session-pre.target.wants/treeland-shortcut.service.in" "dde-session-pre.target.wants/treeland-shortcut.service" IMMEDIATE @ONLY)
+if (NOT DISABLE_BUILTIN_SHORTCUTS)
+    configure_file("dde-session-pre.target.wants/treeland-shortcut.service.in" "dde-session-pre.target.wants/treeland-shortcut.service" IMMEDIATE @ONLY)
+endif()
 configure_file("dde-session-pre.target.wants/treeland.service.in" "dde-session-pre.target.wants/treeland.service" IMMEDIATE @ONLY)
 configure_file("treeland-session-helper.service.in" "treeland-session-helper.service" IMMEDIATE @ONLY)
 configure_file("treeland-screensaver.service.in" "treeland-screensaver.service" IMMEDIATE @ONLY)
@@ -37,16 +46,22 @@ set(DDE_SESSION_PRE_WANTS
     dde-session-shutdown.target.wants/treeland-session-shutdown.service
     ${CMAKE_CURRENT_BINARY_DIR}/dde-session-pre.target.wants/treeland-sd.service
     ${CMAKE_CURRENT_BINARY_DIR}/dde-session-pre.target.wants/treeland-xwayland.service
-    ${CMAKE_CURRENT_BINARY_DIR}/dde-session-pre.target.wants/treeland-shortcut.service
     ${CMAKE_CURRENT_BINARY_DIR}/dde-session-pre.target.wants/treeland.service
 )
+if (NOT DISABLE_BUILTIN_SHORTCUTS)
+    list(APPEND DDE_SESSION_PRE_WANTS
+        ${CMAKE_CURRENT_BINARY_DIR}/dde-session-pre.target.wants/treeland-shortcut.service
+    )
+endif()
 
 install(FILES ${DDE_SESSION_PRE_WANTS} DESTINATION ${SYSTEMD_USER_UNIT_DIR})
 install_symlink(treeland-sd.socket dde-session-pre.target.wants)
 install_symlink(treeland-sd.service dde-session-pre.target.wants)
 install_symlink(treeland-xwayland.socket dde-session-pre.target.wants)
 install_symlink(treeland-xwayland.service dde-session-pre.target.wants)
-install_symlink(treeland-shortcut.service dde-session-pre.target.wants)
+if (NOT DISABLE_BUILTIN_SHORTCUTS)
+    install_symlink(treeland-shortcut.service dde-session-pre.target.wants)
+endif()
 install_symlink(treeland.service dde-session-pre.target.wants)
 install_symlink(treeland-session-shutdown.service dde-session-shutdown.target.wants)
 install_symlink(treeland-session-helper.service treeland.service.wants)

--- a/misc/systemd/dde-session-pre.target.wants/treeland.service.in
+++ b/misc/systemd/dde-session-pre.target.wants/treeland.service.in
@@ -12,8 +12,7 @@ Before=treeland-sd.service
 Wants=treeland-xwayland.service
 Before=treeland-xwayland.service
 
-Wants=treeland-shortcut.service
-Before=treeland-shortcut.service
+@TREELAND_SHORTCUT_SERVICE_DEPS@
 
 Requisite=dde-session-pre.target
 PartOf=dde-session-pre.target

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -365,7 +365,9 @@ target_link_libraries(libtreeland
 
 add_subdirectory(plugins)
 add_subdirectory(modules)
-add_subdirectory(treeland-shortcut)
+if(NOT DISABLE_BUILTIN_SHORTCUTS)
+    add_subdirectory(treeland-shortcut)
+endif()
 add_subdirectory(treeland-screensaver)
 
 set(BIN_NAME treeland)


### PR DESCRIPTION
Treeland ships a small built-in shortcut client daemon (src/treeland-shortcut) that loads the bundled *.ini definitions and registers the default desktop shortcuts over the
treeland-shortcut-manager-v2 protocol.

Add a DISABLE_BUILTIN_SHORTCUTS CMake option (default ON) that skips building and installing this daemon along with its systemd autostart, and strips the now-dangling Wants=/Before= ordering from treeland.service. The compositor-side protocol implementation (src/modules/shortcut) is left untouched, so other clients can still register shortcuts.

Treeland 自带一个简单的快捷键客户端守护进程（src/treeland-shortcut），它 读取内置的 *.ini 定义，并通过 treeland-shortcut-manager-v2 协议注册默认 桌面快捷键。

新增 DISABLE_BUILTIN_SHORTCUTS 构建选项（默认 ON）：屏蔽时不编译、不安装 该守护进程及其 systemd 自启动，并移除 treeland.service 中残留的
Wants=/Before= 顺序依赖。合成器端的协议实现（src/modules/shortcut）保持 不变，其他客户端仍可注册快捷键。

Log: add option to disable built-in shortcut daemon
Change-Id: I59613d8b134f965ea8e7e3c00c71b5a2a28fc8e8