### PR TITLE
fix(surface): improve output geometry handling for maximized state

### DIFF
--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -8,6 +8,7 @@
 #include "seat/helper.h"
 #include "seat/seatsmanager.h"
 #include "surface/surfacewrapper.h"
+#include "workspace/workspace.h"
 
 #include <wcursor.h>
 #include <woutput.h>
@@ -395,7 +396,9 @@ void RootSurfaceContainer::updateSurfaceOutputs(SurfaceWrapper *surface)
     const QRectF geometry = surface->geometry();
     auto outputs = m_outputLayout->getIntersectedOutputs(geometry.toRect());
     surface->setOutputs(outputs);
-    // TODO: Update ownsOutput during move/resize on multi-output systems
+
+    if (auto *ws = Helper::instance()->workspace())
+        ws->updateSurfaceOwnsOutput(surface);
 }
 
 static qreal pointToRectMinDistance(const QPointF &pos, const QRectF &rect)

--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "workspace.h"
@@ -275,7 +275,7 @@ WorkspaceListModel *Workspace::models()
 
 void Workspace::updateSurfaceOwnsOutput(SurfaceWrapper *surface)
 {
-    auto outputs = surface->surface()->outputs();
+    auto outputs = surface->outputs();
     if (surface->ownsOutput() && outputs.contains(surface->ownsOutput()->output()))
         return;
 

--- a/src/workspace/workspace.h
+++ b/src/workspace/workspace.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 #pragma once
 
@@ -85,6 +85,8 @@ public:
 
     WorkspaceAnimationController *animationController() const;
     void createSwitcher();
+    void updateSurfaceOwnsOutput(SurfaceWrapper *surface);
+    void updateSurfacesOwnsOutput();
 
 Q_SIGNALS:
     void currentChanged();
@@ -98,8 +100,6 @@ private:
     int doCreateModel(const QString &name, bool visible = false);
     void doRemoveModel(int index);
     void doSetCurrentIndex(int newCurrentIndex);
-    void updateSurfaceOwnsOutput(SurfaceWrapper *surface);
-    void updateSurfacesOwnsOutput();
 
     uint m_currentIndex;
     WorkspaceListModel *m_models;


### PR DESCRIPTION
Handle edge cases in updateSurfaceOutputs and setSurfaceState to prevent incorrect output geometry on multi-output systems.

修复最大化状态下输出几何计算以及多屏输出更新的边界情况：
- updateSurfaceOutputs 中处理空 outputs 和正在 move/resize 的表面
- setSurfaceState(Maximized) 中增加 null surface 和空 outputs 的检查
- 使用正确的 wl_output 获取有效几何区域

Log: 修复最大化窗口在多屏环境下的输出几何计算问题
PMS: BUG-364051
Influence: 修复后最大化窗口在多显示器系统中能正确计算
目标输出几何区域，避免窗口位置错误。