### PR TITLE
fix(debian): avoid restarting treeland on upgrade

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -53,6 +53,7 @@ Depends: qml6-module-qtquick-layouts,
          treeland-data (= ${source:Version}),
          xwayland,
          treeland-wallpaper-factory,
+         ${misc:Depends},
          ${shlibs:Depends},
 Conflicts: libwaylib, qwlroots
 Replaces: libwaylib, qwlroots
@@ -63,7 +64,8 @@ Package: treeland-dev
 Section: libdevel
 Architecture: any
 Multi-Arch: same
-Depends: ${misc:Depends}, treeland( =${source:Version}),
+Depends: ${misc:Depends},
+         treeland (= ${source:Version}),
 Conflicts: libwaylib-dev, qwlroots
 Replaces: libwaylib-dev, qwlroots
 Description: a Wayland compositor based on wlroots and QML, designed with an attractive and elegant appearance.
@@ -72,7 +74,8 @@ Package: treeland-examples
 Section: dde
 Architecture: any
 Multi-Arch: same
-Depends: ${shlibs:Depends},
+Depends: ${misc:Depends},
+         ${shlibs:Depends},
 Description: examples for treeland.
 
 Package: treeland-data

--- a/debian/rules
+++ b/debian/rules
@@ -18,3 +18,6 @@ export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
 override_dh_auto_configure:
 	dh_auto_configure -- -DBUILD_TREELAND_EXAMPLES=ON
+
+override_dh_installsystemd:
+	dh_installsystemd --no-start --no-stop-on-upgrade


### PR DESCRIPTION
treeland.service is managed by DDM at runtime, but the package installs it as a systemd system unit. With the default dh_installsystemd behavior, debhelper generates maintainer script snippets that can start or restart the unit during package install and upgrade. That makes upgrading the treeland package disrupt the active compositor/greeter session.

Override dh_installsystemd with --no-start and --no-stop-on-upgrade so package operations do not change the running treeland.service state. DDM remains responsible for explicitly starting and stopping the compositor.

Also add the missing ${misc:Depends} substitutions and normalize the treeland-dev dependency formatting so debhelper-generated dependencies are preserved in the binary package metadata.

PMS: 364327

## Summary by Sourcery

Adjust Debian packaging for treeland to avoid systemd-managed restarts during package install and upgrade and preserve debhelper-generated dependencies in metadata.

Bug Fixes:
- Prevent treeland.service from being automatically started or restarted by systemd maintainer scripts during package installation or upgrade, avoiding disruption of active sessions.

Build:
- Override dh_installsystemd with flags to avoid starting or stopping treeland.service during package operations.
- Add missing ${misc:Depends} substitution and normalize treeland-dev dependency formatting so debhelper-generated dependencies are retained.