### PR TITLE
fix: correct xwayland child change detection logic

### DIFF
--- a/waylib/src/server/protocols/wxwaylandsurface.cpp
+++ b/waylib/src/server/protocols/wxwaylandsurface.cpp
@@ -178,7 +178,7 @@ void WXWaylandSurfacePrivate::updateChildren()
     if (children == list)
         return;
 
-    const bool hasChildChanged = children.isEmpty() || list.isEmpty();
+    const bool hasChildChanged = children.isEmpty() != list.isEmpty();
     children = list;
 
     W_Q(WXWaylandSurface);


### PR DESCRIPTION
Log: Fix the logic for detecting child surface changes in WXWaylandSurface

## Summary by Sourcery

Bug Fixes:
- Correct child surface change detection to only treat transitions between empty and non-empty child lists as changes, rather than any case where either list is empty.