### PR TITLE
fix: skip update on destroyed xwayland parent

### DIFF
--- a/waylib/src/server/protocols/wxwaylandsurface.cpp
+++ b/waylib/src/server/protocols/wxwaylandsurface.cpp
@@ -9,6 +9,7 @@
 
 #include <qwxwaylandsurface.h>
 #include <qwcompositor.h>
+#include <QPointer>
 
 #include <sys/syscall.h>
 #include <unistd.h>
@@ -61,7 +62,7 @@ public:
     mutable int pidFD = -1;
 
     QList<WXWaylandSurface*> children;
-    WXWaylandSurface *parent = nullptr;
+    QPointer<WXWaylandSurface> parent;
     QRect lastRequestConfigureGeometry;
     WXWaylandSurface::ConfigureFlags lastRequestConfigureFlags = {0};
     WXWaylandSurface::WindowTypes windowTypes = {0};
@@ -196,7 +197,8 @@ void WXWaylandSurfacePrivate::updateParent()
         return;
 
     const bool hasParentChanged = (parent == nullptr) != (newParent == nullptr);
-    if (parent)
+    // QPointer handles destroyed wrappers; isInvalidated() prevents accessing destroyed wlroots objects.
+    if (parent && !parent->isInvalidated())
         parent->d_func()->updateChildren();
     parent = newParent;
     if (parent)


### PR DESCRIPTION
1. Add invalidation check before updating children on old parent
2. Prevent calling updateChildren on a parent that is being destroyed
3. Fix issue where parent destruction triggers child set_parent signal causing invalid parent update

## Summary by Sourcery

Bug Fixes:
- Guard parent updateChildren calls with an invalidation check to avoid acting on a destroyed XWayland parent surface.