### PR TITLE
[codex] raise Treeland service resource priority

### DIFF
--- a/misc/systemd/treeland.service.in
+++ b/misc/systemd/treeland.service.in
@@ -13,6 +13,7 @@ RuntimeDirectory=treeland
 RuntimeDirectoryMode=0700
 Environment="XDG_RUNTIME_DIR=%t/treeland"
 Environment=LIBSEAT_BACKEND=seatd
+Environment=SEATD_SOCK=/run/dde-seatd.sock
 Environment=DSG_APP_ID=org.deepin.dde.treeland
 Environment=ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
 # For Debug: if enable asan, you can't get it's log from journalctl, so ensure the log to a file
@@ -27,8 +28,14 @@ StandardOutput=null
 StandardError=null
 
 NoNewPrivileges=true
-OOMScoreAdjust=-300
-Nice=-15
+OOMScoreAdjust=-1000
+Nice=-20
+CPUWeight=10000
+CPUSchedulingPolicy=rr
+CPUSchedulingPriority=20
+IOWeight=10000
+IOSchedulingClass=realtime
+IOSchedulingPriority=0
 
 # Enable MemoryDenyWriteExecute will cause Treeland crash in certain
 # condition (observed on arm64 virtual machine). The coredump indicate


### PR DESCRIPTION
## Summary

- raise the Treeland DDM-mode systemd service to the highest normal CPU, I/O, and OOM-protection priorities
- own the dde-seatd socket environment directly in `treeland.service`

## Impact

Treeland gets preferential CPU and I/O access under contention. The seatd connection settings now live with the service that consumes them, allowing the DDM-owned `10-dde-seatd.conf` drop-in to be removed.

## Related PRs

- linuxdeepin/ddm#97
- linuxdeepin/dde-seatd#6

## Validation

- `systemd-analyze verify` on the configured service
- `cmake --preset default`
- `cmake --build --preset default -j4`
- `ctest --test-dir build --output-on-failure` (10/10 passed)

## Summary by Sourcery

Increase the Treeland systemd service’s runtime priority and internalize its seatd socket configuration.

Enhancements:
- Raise Treeland’s systemd service to the highest normal CPU, I/O, and OOM-protection priorities.
- Move ownership of the dde-seatd socket environment into treeland.service so the DDM drop-in configuration can be removed.