### PR TITLE
refactor(wine): clean up naming and use std::ranges in wine modules

### DIFF
--- a/examples/test_virtual_output/virtualclient.cpp
+++ b/examples/test_virtual_output/virtualclient.cpp
@@ -12,7 +12,6 @@
 #include <QWidget>
 #include <QtWaylandClient/QWaylandClientExtension>
 #include <QtWaylandClient/private/qwaylandscreen_p.h>
-#include <qlogging.h>
 
 VirtualClient::VirtualClient(int argc, char *argv[], QObject *parent)
     : QObject(parent)

--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -11,16 +11,16 @@
 #include "modules/dde-shell/ddeshellmanagerinterfacev1.h"
 #include "modules/foreign-toplevel/foreigntoplevelmanagerv1.h"
 #include "modules/prelaunch-splash/prelaunchsplash.h"
-#include "modules/wine-window-state/winewindowstate.h"
 #include "modules/wine-window-management/winewindowmanagement.h"
+#include "modules/wine-window-state/winewindowstate.h"
 #include "rootsurfacecontainer.h"
 #include "seat/helper.h"
+#include "session/session.h"
 #include "surface/surfacewrapper.h"
 #include "treelandconfig.hpp"
 #include "treelanduserconfig.hpp"
-#include "workspace/workspace.h"
-#include "session/session.h"
 #include "wallpapershellinterfacev1.h"
+#include "workspace/workspace.h"
 
 #include <xcb/xcb.h>
 
@@ -66,11 +66,12 @@ ShellHandler::ShellHandler(RootSurfaceContainer *rootContainer, WServer *server)
 {
     m_treelandForeignToplevel = server->attach<ForeignToplevelManagerInterfaceV1>();
     Q_ASSERT(m_treelandForeignToplevel);
-    qmlRegisterSingletonInstance<ForeignToplevelManagerInterfaceV1>("Treeland.Protocols",
-                                                    1,
-                                                    0,
-                                                    "ForeignToplevelManagerInterfaceV1",
-                                                    m_treelandForeignToplevel);
+    qmlRegisterSingletonInstance<ForeignToplevelManagerInterfaceV1>(
+        "Treeland.Protocols",
+        1,
+        0,
+        "ForeignToplevelManagerInterfaceV1",
+        m_treelandForeignToplevel);
     qRegisterMetaType<ForeignToplevelManagerInterfaceV1::PreviewDirection>();
 
     m_backgroundContainer->setZ(RootSurfaceContainer::BackgroundZOrder);
@@ -285,7 +286,7 @@ void ShellHandler::init(WServer *server, WSeat *seat)
     Q_ASSERT_X(!m_prelaunchSplash, Q_FUNC_INFO, "Only init once!");
     Q_ASSERT_X(!m_appIdResolverManager, Q_FUNC_INFO, "Only init once!");
     Q_ASSERT_X(!m_wineWindowStateManager, Q_FUNC_INFO, "Only init once!");
-    Q_ASSERT_X(!m_wineWindowManagementManager, Q_FUNC_INFO, "Only init once!");
+    Q_ASSERT_X(!m_wineWindowManager, Q_FUNC_INFO, "Only init once!");
     Q_ASSERT_X(!m_xdgShell, Q_FUNC_INFO, "Only init once!");
     Q_ASSERT_X(!m_layerShell, Q_FUNC_INFO, "Only init once!");
     Q_ASSERT_X(!m_wallpaperShell, Q_FUNC_INFO, "Only init once!");
@@ -303,7 +304,7 @@ void ShellHandler::init(WServer *server, WSeat *seat)
 
     m_appIdResolverManager = server->attach<AppIdResolverManager>();
     m_wineWindowStateManager = server->attach<WineWindowStateManager>();
-    m_wineWindowManagementManager = server->attach<WineWindowManagementManager>();
+    m_wineWindowManager = server->attach<WineWindowManager>();
 
     m_xdgShell = server->attach<WXdgShell>(TREELAND_XDG_SHELL_VERSION);
     connect(m_xdgShell,
@@ -326,7 +327,9 @@ void ShellHandler::init(WServer *server, WSeat *seat)
 
     m_wallpaperShell = server->attach<TreelandWallpaperShellInterfaceV1>(m_wallpaperShell);
     if (Helper::instance()->isDDMDisplay()) {
-        m_wallpaperShell->setFilter([](WClient *client) { return Helper::instance()->sessionManager()->isDDEUserClient(client); });
+        m_wallpaperShell->setFilter([](WClient *client) {
+            return Helper::instance()->sessionManager()->isDDEUserClient(client);
+        });
     }
 
     m_inputMethodHelper = new WInputMethodHelper(server, seat);
@@ -725,10 +728,11 @@ void ShellHandler::onDockPreview(std::vector<SurfaceWrapper *> surfaces,
                               QVariant::fromValue(direction));
 }
 
-void ShellHandler::onDockPreviewTooltip(QString tooltip,
-                                        WSurface *target,
-                                        QPoint pos,
-                                        ForeignToplevelManagerInterfaceV1::PreviewDirection direction)
+void ShellHandler::onDockPreviewTooltip(
+    QString tooltip,
+    WSurface *target,
+    QPoint pos,
+    ForeignToplevelManagerInterfaceV1::PreviewDirection direction)
 {
     if (!m_dockPreview)
         return;

--- a/src/core/shellhandler.h
+++ b/src/core/shellhandler.h
@@ -32,7 +32,7 @@ class QmlEngine;
 class ForeignToplevelManagerInterfaceV1;
 class PrelaunchSplash;
 class WineWindowStateManager;
-class WineWindowManagementManager;
+class WineWindowManager;
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 class WServer;
@@ -75,8 +75,7 @@ public:
     [[nodiscard]] Workspace *workspace() const;
 
     void createComponent(QmlEngine *engine, QQuickItem *parentItem);
-    void init(WAYLIB_SERVER_NAMESPACE::WServer *server,
-              WAYLIB_SERVER_NAMESPACE::WSeat *seat);
+    void init(WAYLIB_SERVER_NAMESPACE::WServer *server, WAYLIB_SERVER_NAMESPACE::WSeat *seat);
     [[nodiscard]] WAYLIB_SERVER_NAMESPACE::WXWayland *createXWayland(
         WAYLIB_SERVER_NAMESPACE::WServer *server,
         WAYLIB_SERVER_NAMESPACE::WSeat *seat,
@@ -88,9 +87,11 @@ public:
     WAYLIB_SERVER_NAMESPACE::WXWayland *defaultXWaylandSocket() const;
     void setupDockPreview(QObject *dockPreview);
 
-    TreelandWallpaperShellInterfaceV1 *wallpaperShell() const {
+    TreelandWallpaperShellInterfaceV1 *wallpaperShell() const
+    {
         return m_wallpaperShell;
     }
+
 Q_SIGNALS:
     void surfaceWrapperAdded(SurfaceWrapper *wrapper);
     void surfaceWrapperAboutToRemove(SurfaceWrapper *wrapper);
@@ -133,8 +134,8 @@ private:
     // Prelaunch splash related: creates a prelaunch SurfaceWrapper when
     // PrelaunchSplash::splashRequested
     void handlePrelaunchSplashRequested(const QString &appId,
-                                       const QString &instanceId,
-                                       QW_NAMESPACE::qw_buffer *iconBuffer);
+                                        const QString &instanceId,
+                                        QW_NAMESPACE::qw_buffer *iconBuffer);
     void handlePrelaunchSplashClosed(const QString &appId, const QString &instanceId);
     void createPrelaunchSplash(const QString &appId,
                                const QString &instanceId,
@@ -161,7 +162,7 @@ private:
     WAYLIB_SERVER_NAMESPACE::WInputMethodHelper *m_inputMethodHelper = nullptr;
     PrelaunchSplash *m_prelaunchSplash = nullptr;
     WineWindowStateManager *m_wineWindowStateManager = nullptr;
-    WineWindowManagementManager *m_wineWindowManagementManager = nullptr;
+    WineWindowManager *m_wineWindowManager = nullptr;
     QList<WAYLIB_SERVER_NAMESPACE::WXWayland *> m_xwaylands;
     ForeignToplevelManagerInterfaceV1 *m_treelandForeignToplevel = nullptr;
 

--- a/src/modules/wine-window-management/winewindowmanagement.cpp
+++ b/src/modules/wine-window-management/winewindowmanagement.cpp
@@ -21,18 +21,23 @@ QW_USE_NAMESPACE
 
 class WineWindowControl;
 
-class WineWindowManagementManagerPrivate
-    : public QtWaylandServer::treeland_wine_window_manager_v1
+class WineWindowManagerPrivate : public QtWaylandServer::treeland_wine_window_manager_v1
 {
 public:
-    explicit WineWindowManagementManagerPrivate(WineWindowManagementManager *q)
+    explicit WineWindowManagerPrivate(WineWindowManager *q)
         : q(q)
     {
     }
 
-    wl_global *globalHandle() const { return m_global; }
+    wl_global *globalHandle() const
+    {
+        return m_global;
+    }
 
-    uint32_t nextWindowId() { return ++m_nextId; }
+    uint32_t nextWindowId()
+    {
+        return ++m_nextId;
+    }
 
     WineWindowControl *controlForId(uint32_t id) const
     {
@@ -60,10 +65,13 @@ public:
 protected:
     void destroy_global() override
     {
-        qCDebug(treelandProtocol) << "WineWindowManagementManager global destroyed";
+        qCDebug(treelandProtocol) << "WineWindowManager global destroyed";
     }
 
-    void destroy(Resource *resource) override { wl_resource_destroy(resource->handle); }
+    void destroy(Resource *resource) override
+    {
+        wl_resource_destroy(resource->handle);
+    }
 
     void get_window_control(Resource *resource,
                             uint32_t id,
@@ -77,7 +85,7 @@ private:
         WineWindowControl *control{ nullptr };
     };
 
-    WineWindowManagementManager *q{ nullptr };
+    WineWindowManager *q{ nullptr };
     uint32_t m_nextId = 0;
     QList<ControlEntry> m_controls;
 };
@@ -88,7 +96,7 @@ class WineWindowControl
 {
 public:
     WineWindowControl(QObject *parent,
-                      WineWindowManagementManagerPrivate *manager,
+                      WineWindowManagerPrivate *manager,
                       uint32_t windowId,
                       SurfaceWrapper *wrapper,
                       wl_client *client,
@@ -101,7 +109,9 @@ public:
         , m_wrapper(wrapper)
     {
         Q_ASSERT_X(m_wrapper, Q_FUNC_INFO, "wrapper must not be null");
-        Q_ASSERT_X(m_wrapper->shellSurface(), Q_FUNC_INFO, "wrapper->shellSurface() must not be null");
+        Q_ASSERT_X(m_wrapper->shellSurface(),
+                   Q_FUNC_INFO,
+                   "wrapper->shellSurface() must not be null");
 
         connect(m_wrapper, &SurfaceWrapper::aboutToBeInvalidated, this, [this] {
             if (m_manager) {
@@ -128,12 +138,21 @@ public:
         sendConfigureStacking();
     }
 
-    uint32_t windowId() const { return m_windowId; }
+    uint32_t windowId() const
+    {
+        return m_windowId;
+    }
 
-    SurfaceWrapper *wrapper() const { return m_wrapper; }
+    SurfaceWrapper *wrapper() const
+    {
+        return m_wrapper;
+    }
 
 protected:
-    void destroy(Resource *resource) override { wl_resource_destroy(resource->handle); }
+    void destroy(Resource *resource) override
+    {
+        wl_resource_destroy(resource->handle);
+    }
 
     void destroy_resource([[maybe_unused]] Resource *resource) override
     {
@@ -153,8 +172,8 @@ protected:
             return;
         }
 
-        qCDebug(treelandProtocol)
-            << "set_position serial" << x << y << serial << "for window_id" << m_windowId;
+        qCDebug(treelandProtocol) << "set_position serial" << x << y << serial << "for window_id"
+                                  << m_windowId;
 
         m_wrapper->setPositionAutomatic(false);
         // Suppress only this class's xChanged/yChanged handlers to avoid
@@ -166,9 +185,7 @@ protected:
         sendConfigurePosition(serial);
     }
 
-    void set_z_order([[maybe_unused]] Resource *resource,
-                     uint32_t op,
-                     uint32_t sibling_id) override
+    void set_z_order([[maybe_unused]] Resource *resource, uint32_t op, uint32_t sibling_id) override
     {
         if (!m_wrapper) {
             return;
@@ -181,7 +198,8 @@ protected:
         if (op != z_order_op_hwnd_insert_after && sibling_id != 0) {
             wl_resource_post_error(resource->handle,
                                    error_invalid_sibling,
-                                   "sibling_id must be 0 for op %u", op);
+                                   "sibling_id must be 0 for op %u",
+                                   op);
             return;
         }
 
@@ -278,15 +296,15 @@ private:
     }
 
 private:
-    WineWindowManagementManagerPrivate *m_manager = nullptr;
+    WineWindowManagerPrivate *m_manager = nullptr;
     uint32_t m_windowId = 0;
     SurfaceWrapper *m_wrapper = nullptr;
     bool m_suppressPositionEvents = false;
 };
 
-void WineWindowManagementManagerPrivate::get_window_control(Resource *resource,
-                                                            uint32_t id,
-                                                            struct ::wl_resource *toplevelResource)
+void WineWindowManagerPrivate::get_window_control(Resource *resource,
+                                                  uint32_t id,
+                                                  struct ::wl_resource *toplevelResource)
 {
     auto *qXdgToplevel = qw_xdg_toplevel::from_resource(toplevelResource);
     if (!qXdgToplevel) {
@@ -331,38 +349,37 @@ void WineWindowManagementManagerPrivate::get_window_control(Resource *resource,
                                           id);
     registerControl(windowId, xdgToplevel, control);
 
-    qCDebug(treelandProtocol)
-        << "Created WineWindowControl for toplevel, window_id =" << windowId;
+    qCDebug(treelandProtocol) << "Created WineWindowControl for toplevel, window_id =" << windowId;
 }
 
 // ---------------------------------------------------------------------------
-// WineWindowManagementManager public interface
+// WineWindowManager public interface
 // ---------------------------------------------------------------------------
 
-WineWindowManagementManager::WineWindowManagementManager(QObject *parent)
+WineWindowManager::WineWindowManager(QObject *parent)
     : QObject(parent)
-    , d(std::make_unique<WineWindowManagementManagerPrivate>(this))
+    , d(std::make_unique<WineWindowManagerPrivate>(this))
 {
 }
 
-WineWindowManagementManager::~WineWindowManagementManager() = default;
+WineWindowManager::~WineWindowManager() = default;
 
-void WineWindowManagementManager::create(WServer *server)
+void WineWindowManager::create(WServer *server)
 {
     d->init(*server->handle(), InterfaceVersion);
 }
 
-void WineWindowManagementManager::destroy(WServer * /*server*/)
+void WineWindowManager::destroy(WServer * /*server*/)
 {
     d->globalRemove();
 }
 
-wl_global *WineWindowManagementManager::global() const
+wl_global *WineWindowManager::global() const
 {
     return d->globalHandle();
 }
 
-QByteArrayView WineWindowManagementManager::interfaceName() const
+QByteArrayView WineWindowManager::interfaceName() const
 {
     return QtWaylandServer::treeland_wine_window_manager_v1::interfaceName();
 }

--- a/src/modules/wine-window-management/winewindowmanagement.h
+++ b/src/modules/wine-window-management/winewindowmanagement.h
@@ -11,16 +11,16 @@
 
 #include <memory>
 
-class WineWindowManagementManagerPrivate;
+class WineWindowManagerPrivate;
 
-class WineWindowManagementManager
+class WineWindowManager
     : public QObject
     , public WAYLIB_SERVER_NAMESPACE::WServerInterface
 {
     Q_OBJECT
 public:
-    explicit WineWindowManagementManager(QObject *parent = nullptr);
-    ~WineWindowManagementManager() override;
+    explicit WineWindowManager(QObject *parent = nullptr);
+    ~WineWindowManager() override;
     static constexpr int InterfaceVersion = 1;
 
 protected:
@@ -30,5 +30,5 @@ protected:
     QByteArrayView interfaceName() const override;
 
 private:
-    std::unique_ptr<WineWindowManagementManagerPrivate> d;
+    std::unique_ptr<WineWindowManagerPrivate> d;
 };

--- a/src/modules/wine-window-state/winewindowstate.cpp
+++ b/src/modules/wine-window-state/winewindowstate.cpp
@@ -17,6 +17,8 @@
 #include <QList>
 #include <QTimer>
 
+#include <algorithm>
+
 WAYLIB_SERVER_USE_NAMESPACE
 QW_USE_NAMESPACE
 
@@ -85,7 +87,9 @@ public:
         , m_wrapper(wrapper)
     {
         Q_ASSERT_X(m_wrapper, Q_FUNC_INFO, "wrapper must not be null");
-        Q_ASSERT_X(m_wrapper->shellSurface(), Q_FUNC_INFO, "wrapper->shellSurface() must not be null");
+        Q_ASSERT_X(m_wrapper->shellSurface(),
+                   Q_FUNC_INFO,
+                   "wrapper->shellSurface() must not be null");
 
         m_wrapper->shellSurface()->safeConnect(&WToplevelSurface::minimizeChanged, this, [this] {
             sendStateChanged();
@@ -211,8 +215,8 @@ void WineWindowStateManagerPrivate::removeState(WineWindowState *state)
 }
 
 void WineWindowStateManagerPrivate::get_window_state(Resource *resource,
-                                                      uint32_t id,
-                                                      struct ::wl_resource *toplevelResource)
+                                                     uint32_t id,
+                                                     struct ::wl_resource *toplevelResource)
 {
     auto *qXdgToplevel = qw_xdg_toplevel::from_resource(toplevelResource);
     if (!qXdgToplevel) {
@@ -234,12 +238,12 @@ void WineWindowStateManagerPrivate::get_window_state(Resource *resource,
         return;
     }
 
-    const bool alreadyBound = [&] {
-        for (const auto &e : m_states)
-            if (e.toplevel == xdgToplevel)
-                return true;
-        return false;
-    }();
+    const bool alreadyBound = std::ranges::any_of(
+        m_states,
+        [&](const WXdgToplevelSurface *t) {
+            return t == xdgToplevel;
+        },
+        &StateEntry::toplevel);
     if (alreadyBound) {
         wl_resource_post_error(resource->handle,
                                TREELAND_WINE_WINDOW_STATE_MANAGER_V1_ERROR_TOPLEVEL_ALREADY_BOUND,
@@ -247,12 +251,8 @@ void WineWindowStateManagerPrivate::get_window_state(Resource *resource,
         return;
     }
 
-    auto *state = new WineWindowState(q,
-                                      this,
-                                      wrapper,
-                                      resource->client(),
-                                      resource->version(),
-                                      id);
+    auto *state =
+        new WineWindowState(q, this, wrapper, resource->client(), resource->version(), id);
     bindState(xdgToplevel, state);
 }
 

--- a/waylib/src/server/qtquick/woutputrenderwindow.cpp
+++ b/waylib/src/server/qtquick/woutputrenderwindow.cpp
@@ -39,7 +39,6 @@
 #include <QOpenGLFunctions>
 #include <QLoggingCategory>
 #include <QRunnable>
-#include <qlogging.h>
 #include <memory>
 
 #include <private/qsgrenderer_p.h>


### PR DESCRIPTION
wine-window-state: replace hand-rolled loop with std::ranges::any_of wine-window-management: rename WineWindowManagementManager → WineWindowManager No behaviour changes in either module.

Task: 390751