### PR TITLE
chore(waylib): remove unnecessary include of qlogging.h

### DIFF
--- a/waylib/src/server/qtquick/woutputrenderwindow.cpp
+++ b/waylib/src/server/qtquick/woutputrenderwindow.cpp
@@ -39,7 +39,6 @@
 #include <QOpenGLFunctions>
 #include <QLoggingCategory>
 #include <QRunnable>
-#include <qlogging.h>
 #include <memory>
 
 #include <private/qsgrenderer_p.h>


### PR DESCRIPTION
Log: 移除不必要的头文件引用
PMS: TASK-390751
Influence: 无功能影响，仅清理代码。

## Summary by Sourcery

Remove an unused qlogging.h include from the Waylib QtQuick output render window implementation to clean up redundant dependencies.