### PR TITLE
fix: avoid stale foreign toplevel callbacks after surface removal

### DIFF
--- a/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
+++ b/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
@@ -437,8 +437,13 @@ void ForeignToplevelManagerInterfaceV1::initializeToplevelHandle(SurfaceWrapper 
         handle->set_attention(wrapper->attention());
     });
 
-    surface->safeConnect(&WToplevelSurface::appIdChanged, handle, [handle, wrapper] {
-        handle->set_app_id(wrapper->appId());
+    const QPointer<SurfaceWrapper> wrapperGuard(wrapper);
+    surface->safeConnect(&WToplevelSurface::appIdChanged, handle, [handle, wrapperGuard] {
+        if (!wrapperGuard) {
+            return;
+        }
+
+        handle->set_app_id(wrapperGuard->appId());
     });
 
     surface->surface()->safeConnect(&WSurface::outputEntered, handle, [handle](WOutput *output) {
@@ -1053,6 +1058,10 @@ SurfaceEntry *ForeignToplevelHandleV1::entry() const
 
 void ForeignToplevelHandleV1::clearEntry()
 {
+    QObject::disconnect(this, nullptr, nullptr, nullptr);
+    QObject::disconnect(nullptr, nullptr, this, nullptr);
+    d->outputs.clear();
+    d->parent = nullptr;
     d->entry = nullptr;
 }
 


### PR DESCRIPTION
Closed foreign toplevel handles could remain alive until the client destroyed the protocol resource, while signal connections from the old toplevel surface were still active. An XWayland appIdChanged signal could then call back into a destroyed SurfaceWrapper and crash.

Guard the wrapper access with QPointer and disconnect handle signal routes when clearing the SurfaceEntry.

该崩溃会在使用master分支的dde-shell与dde-tray-loader时, 点击系统托盘激活后台应用窗口引发dde-shell崩溃时概率引发的treeland伴随崩溃

## Summary by Sourcery

Prevent crashes from stale foreign toplevel callbacks by guarding surface wrappers and clearing handle connections when the surface entry is cleared.

Bug Fixes:
- Avoid accessing destroyed SurfaceWrapper instances in appIdChanged callbacks by guarding with QPointer.
- Ensure foreign toplevel handle signals and parent/output associations are disconnected when clearing the surface entry to prevent use-after-free scenarios.