### PR TITLE
feat: disable maximize for non-maximizable windows

### DIFF
--- a/src/core/qml/TitleBar.qml
+++ b/src/core/qml/TitleBar.qml
@@ -13,6 +13,7 @@ Control {
 
     required property SurfaceWrapper surface
     readonly property SurfaceItem surfaceItem: surface.surfaceItem
+    readonly property bool canToggleMaximize: surface.surfaceState === SurfaceWrapper.State.Maximized || surface.isMaximizable
     readonly property bool noRadius: surface.radius === 0 || surface.noCornerRadius || GraphicsInfo.api === GraphicsInfo.Software
     property D.Palette backgroundColor: D.Palette {
         normal: ("#ffffff")
@@ -50,7 +51,8 @@ Control {
                 surface.requestMove()
         }
         onDoubleTapped: {
-            surface.requestToggleMaximize()
+            if (root.canToggleMaximize)
+                surface.requestToggleMaximize()
         }
     }
 
@@ -66,7 +68,10 @@ Control {
     TapHandler {
         acceptedButtons: Qt.NoButton
         acceptedDevices: PointerDevice.TouchScreen
-        onDoubleTapped: surface.requestToggleMaximize()
+        onDoubleTapped: {
+            if (root.canToggleMaximize)
+                surface.requestToggleMaximize()
+        }
         onLongPressed: surface.requestShowWindowMenu(point.position)
     }
 
@@ -118,6 +123,7 @@ Control {
             Loader {
                 id: maxOrWindedBtn
                 objectName: "maxOrWindedBtn"
+                active: root.canToggleMaximize
                 sourceComponent: D.WindowButton {
                     icon.name: surface.shellSurface.isMaximized ? "window_restore" : "window_maximize"
                     textColor: root.textColor

--- a/src/core/qml/WindowMenu.qml
+++ b/src/core/qml/WindowMenu.qml
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import Waylib.Server
@@ -10,6 +10,9 @@ D.Menu {
     modal: true
 
     property SurfaceWrapper surface: null
+    readonly property bool canToggleMaximize: surface
+        ? surface.surfaceState === SurfaceWrapper.State.Maximized || surface.isMaximizable
+        : false
 
     onActiveFocusChanged: {
         if (!activeFocus)
@@ -33,6 +36,7 @@ D.Menu {
 
     D.MenuItem {
         text: surface?.surfaceState === SurfaceWrapper.State.Maximized ? qsTr("Unmaximize") : qsTr("Maximize")
+        enabled: menu.canToggleMaximize
         onTriggered: surface.requestToggleMaximize()
     }
 

--- a/src/modules/shortcut/shortcutrunner.cpp
+++ b/src/modules/shortcut/shortcutrunner.cpp
@@ -100,7 +100,7 @@ void ShortcutRunner::onActionTrigger(ShortcutAction action, const QString &name,
         break;
     case ShortcutAction::Maximize: {
         auto surface = helper->activatedSurface();
-        if (surface) {
+        if (surface && surface->isMaximizable()) {
             surface->requestMaximize();
         }
         break;

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -63,6 +63,8 @@ SurfaceWrapper::SurfaceWrapper(QmlEngine *qmlEngine,
     , m_blur(false)
     , m_isActivated(false)
     , m_attention(false)
+    , m_resizable(false)
+    , m_maximizable(false)
     , m_appId(appId)
 {
     QQmlEngine::setContextForObject(this, qmlEngine->rootContext());
@@ -96,6 +98,8 @@ SurfaceWrapper::SurfaceWrapper(SurfaceWrapper *original, QQuickItem *parent)
     , m_blur(false)
     , m_isActivated(false)
     , m_attention(false)
+    , m_resizable(false)
+    , m_maximizable(false)
     , m_appId(original->m_appId)
 {
     QQmlEngine::setContextForObject(this, m_engine->rootContext());
@@ -162,6 +166,8 @@ SurfaceWrapper::SurfaceWrapper(QmlEngine *qmlEngine,
     , m_blur(false)
     , m_isActivated(false)
     , m_attention(false)
+    , m_resizable(false)
+    , m_maximizable(false)
     , m_appId(appId)
 {
     QQmlEngine::setContextForObject(this, qmlEngine->rootContext());
@@ -337,6 +343,16 @@ void SurfaceWrapper::setup()
         });
     }
 
+    if (m_type == Type::XdgToplevel || m_type == Type::XWayland) {
+        m_shellSurface->safeConnect(&WToplevelSurface::minimumSizeChanged,
+                                    this,
+                                    &SurfaceWrapper::updateSizeCapabilities);
+        m_shellSurface->safeConnect(&WToplevelSurface::maximumSizeChanged,
+                                    this,
+                                    &SurfaceWrapper::updateSizeCapabilities);
+    }
+    updateSizeCapabilities();
+
     if (!m_prelaunchSplash) {
         setImplicitSize(m_surfaceItem->implicitWidth(), m_surfaceItem->implicitHeight());
         connect(m_surfaceItem, &WSurfaceItem::implicitWidthChanged, this, [this] {
@@ -424,11 +440,17 @@ void SurfaceWrapper::setup()
         connect(xwaylandSurface,
                 &WXWaylandSurface::bypassManagerChanged,
                 this,
-                updateX11shouldSkipDock);
+                [this, updateX11shouldSkipDock]() {
+                    updateX11shouldSkipDock();
+                    updateSizeCapabilities();
+                });
         connect(xwaylandSurface,
                 &WXWaylandSurface::windowTypesChanged,
                 this,
-                updateX11shouldSkipDock);
+                [this, updateX11shouldSkipDock]() {
+                    updateX11shouldSkipDock();
+                    updateSizeCapabilities();
+                });
         updateX11shouldSkipDock();
     }
 }
@@ -1603,7 +1625,8 @@ void SurfaceWrapper::requestCancelMinimize(bool onAnimation)
 
 void SurfaceWrapper::requestMaximize()
 {
-    if (m_surfaceState == State::Minimized || m_surfaceState == State::Fullscreen)
+    if (m_surfaceState == State::Minimized || m_surfaceState == State::Fullscreen
+        || !isMaximizable())
         return;
 
     setSurfaceState(State::Maximized);
@@ -1974,6 +1997,16 @@ bool SurfaceWrapper::showOnWorkspace(int workspaceIndex) const
     return showOnAllWorkspace();
 }
 
+bool SurfaceWrapper::isResizable() const
+{
+    return m_resizable;
+}
+
+bool SurfaceWrapper::isMaximizable() const
+{
+    return m_maximizable;
+}
+
 bool SurfaceWrapper::blur() const
 {
     return m_blur;
@@ -2066,6 +2099,26 @@ void SurfaceWrapper::updateExplicitAlwaysOnTop()
     setZ(m_explicitAlwaysOnTop ? ALWAYSONTOPLAYER : 0);
     for (const auto &sub : std::as_const(m_subSurfaces))
         sub->updateExplicitAlwaysOnTop();
+}
+
+void SurfaceWrapper::updateSizeCapabilities()
+{
+    if (!m_shellSurface) {
+        return;
+    }
+
+    const bool resizable = m_shellSurface->hasCapability(WToplevelSurface::Capability::Resize);
+    const bool maximizable = m_shellSurface->hasCapability(WToplevelSurface::Capability::Maximized);
+
+    if (m_resizable != resizable) {
+        m_resizable = resizable;
+        Q_EMIT resizableChanged();
+    }
+
+    if (m_maximizable != maximizable) {
+        m_maximizable = maximizable;
+        Q_EMIT maximizableChanged();
+    }
 }
 
 void SurfaceWrapper::updateHasActiveCapability(ActiveControlState state, bool value)

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -81,6 +81,8 @@ class SurfaceWrapper : public QQuickItem
     Q_PROPERTY(bool coverEnabled READ coverEnabled NOTIFY coverEnabledChanged FINAL)
     Q_PROPERTY(bool acceptKeyboardFocus READ acceptKeyboardFocus NOTIFY acceptKeyboardFocusChanged FINAL)
     Q_PROPERTY(bool isActivated READ isActivated NOTIFY isActivatedChanged FINAL)
+    Q_PROPERTY(bool isResizable READ isResizable NOTIFY resizableChanged FINAL)
+    Q_PROPERTY(bool isMaximizable READ isMaximizable NOTIFY maximizableChanged FINAL)
 
 public:
     enum class Type
@@ -237,6 +239,11 @@ public:
     bool showOnAllWorkspace() const;
     bool showOnWorkspace(int workspaceIndex) const;
 
+    // Keep this policy on SurfaceWrapper so future window rules can override it
+    // without pushing policy into waylib or QML.
+    bool isResizable() const;
+    bool isMaximizable() const;
+
     bool hasActiveCapability() const;
     bool hasCapability(WToplevelSurface::Capability cap) const;
 
@@ -343,6 +350,8 @@ Q_SIGNALS:
     void aboutToBeInvalidated();
     void acceptKeyboardFocusChanged();
     void isActivatedChanged();
+    void resizableChanged();
+    void maximizableChanged();
     void attentionChanged();
     void surfaceItemCreated(); // Emitted once after surfaceItem is constructed
     void prelaunchSplashChanged();
@@ -389,6 +398,7 @@ private:
     Q_SLOT void onShowAnimationFinished();
     Q_SLOT void onHideAnimationFinished();
     void updateExplicitAlwaysOnTop();
+    void updateSizeCapabilities();
     void startMinimizeAnimation(const QRectF &iconGeometry, uint direction);
     Q_SLOT void onMinimizeAnimationFinished();
     void startShowDesktopAnimation(bool show);
@@ -464,6 +474,8 @@ private:
     uint m_blur : 1;
     uint m_isActivated : 1;
     uint m_attention : 1;
+    uint m_resizable : 1;
+    uint m_maximizable : 1;
     SurfaceRole m_surfaceRole = SurfaceRole::Normal;
     quint32 m_autoPlaceYOffset = 0;
     QPoint m_clientRequstPos;

--- a/waylib/src/server/kernel/wtoplevelsurface.h
+++ b/waylib/src/server/kernel/wtoplevelsurface.h
@@ -112,6 +112,8 @@ Q_SIGNALS:
     void fullscreenChanged();
     void titleChanged();
     void appIdChanged();
+    void minimumSizeChanged(const QSize &size);
+    void maximumSizeChanged(const QSize &size);
 
     void requestMove(WSeat *seat, quint32 serial);
     void requestResize(WSeat *seat, Qt::Edges edge, quint32 serial);

--- a/waylib/src/server/protocols/winputpopupsurface.cpp
+++ b/waylib/src/server/protocols/winputpopupsurface.cpp
@@ -48,11 +48,12 @@ bool WInputPopupSurface::hasCapability(Capability cap) const
 {
     switch (cap) {
         using enum Capability;
+    case Resize:
+        return true;
     case Focus:
     case Activate:
     case Maximized:
     case FullScreen:
-    case Resize:
         return false;
     default:
         break;

--- a/waylib/src/server/protocols/wlayersurface.cpp
+++ b/waylib/src/server/protocols/wlayersurface.cpp
@@ -268,7 +268,6 @@ bool WLayerSurface::hasCapability(Capability cap) const
     Q_UNREACHABLE();
 }
 
-
 WSurface *WLayerSurface::surface() const
 {
     W_D(const WLayerSurface);

--- a/waylib/src/server/protocols/wxdgpopupsurface.cpp
+++ b/waylib/src/server/protocols/wxdgpopupsurface.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wxdgpopupsurface.h"
@@ -185,6 +185,4 @@ QPointF WXdgPopupSurface::getPopupPosition() const
             static_cast<qreal>(wpopup->current.geometry.y)};
 }
 
-
 WAYLIB_SERVER_END_NAMESPACE
-

--- a/waylib/src/server/protocols/wxdgtoplevelsurface.cpp
+++ b/waylib/src/server/protocols/wxdgtoplevelsurface.cpp
@@ -2,14 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wxdgtoplevelsurface.h"
+
 #include "private/wtoplevelsurface_p.h"
 #include "wseat.h"
 #include "wtools.h"
 
-#include <qwxdgshell.h>
+#include <qwbox.h>
 #include <qwcompositor.h>
 #include <qwseat.h>
-#include <qwbox.h>
+#include <qwxdgshell.h>
+
+#include <climits>
 
 QW_USE_NAMESPACE
 WAYLIB_SERVER_BEGIN_NAMESPACE
@@ -34,6 +37,7 @@ public:
     void connect();
 
     void instantRelease() override;
+    void updateSizeFromCommit();
 
     W_DECLARE_PUBLIC(WXdgToplevelSurface)
 
@@ -44,6 +48,8 @@ public:
     uint maximized:1;
     uint minimized:1;
     uint fullscreen:1;
+    QSize minimumSize;
+    QSize maximumSize = QSize(INT_MAX, INT_MAX);
 
     QString tag;
     QString description;
@@ -104,6 +110,27 @@ void WXdgToplevelSurfacePrivate::on_configure(wlr_xdg_surface_configure *event)
     }
 }
 
+void WXdgToplevelSurfacePrivate::updateSizeFromCommit()
+{
+    W_Q(WXdgToplevelSurface);
+
+    const QSize minimumSize(qMax(0, nativeHandle()->current.min_width),
+                            qMax(0, nativeHandle()->current.min_height));
+    const QSize maximumSize(
+        nativeHandle()->current.max_width > 0 ? nativeHandle()->current.max_width : INT_MAX,
+        nativeHandle()->current.max_height > 0 ? nativeHandle()->current.max_height : INT_MAX);
+
+    if (this->minimumSize != minimumSize) {
+        this->minimumSize = minimumSize;
+        Q_EMIT q->minimumSizeChanged(this->minimumSize);
+    }
+
+    if (this->maximumSize != maximumSize) {
+        this->maximumSize = maximumSize;
+        Q_EMIT q->maximumSizeChanged(this->maximumSize);
+    }
+}
+
 void WXdgToplevelSurfacePrivate::init()
 {
     W_Q(WXdgToplevelSurface);
@@ -121,6 +148,9 @@ void WXdgToplevelSurfacePrivate::connect()
     W_Q(WXdgToplevelSurface);
 
     auto surface = qw_xdg_surface::from(nativeHandle()->base);
+    q->surface()->safeConnect(&WSurface::commit, q, [this] {
+        updateSizeFromCommit();
+    });
     QObject::connect(surface, &qw_xdg_surface::notify_configure, q, [this] (wlr_xdg_surface_configure *event) {
         on_configure(event);
     });
@@ -180,10 +210,18 @@ bool WXdgToplevelSurface::hasCapability(Capability cap) const
 {
     switch (cap) {
         using enum Capability;
-    case Resize:
+    case Resize: {
+        const QSize min = minSize();
+        const QSize max = maxSize();
+        return min.width() < max.width() || min.height() < max.height();
+    }
+    case Maximized: {
+        const QSize min = minSize();
+        const QSize max = maxSize();
+        return min.width() < max.width() && min.height() < max.height();
+    }
     case Focus:
     case Activate:
-    case Maximized:
     case FullScreen:
         return true;
     default:
@@ -273,19 +311,13 @@ QRect WXdgToplevelSurface::getContentGeometry() const
 QSize WXdgToplevelSurface::minSize() const
 {
     W_DC(WXdgToplevelSurface);
-    auto wtoplevel = d->nativeHandle();
-    return QSize(wtoplevel->current.min_width,
-                 wtoplevel->current.min_height);
-
+    return d->minimumSize;
 }
 
 QSize WXdgToplevelSurface::maxSize() const
 {
     W_DC(WXdgToplevelSurface);
-    auto wtoplevel = d->nativeHandle();
-    return QSize(wtoplevel->current.max_width,
-                 wtoplevel->current.max_height);
-
+    return d->maximumSize;
 }
 
 QString WXdgToplevelSurface::title() const

--- a/waylib/src/server/protocols/wxwaylandsurface.cpp
+++ b/waylib/src/server/protocols/wxwaylandsurface.cpp
@@ -2,17 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wxwaylandsurface.h"
+
+#include "private/wtoplevelsurface_p.h"
 #include "wsurface.h"
 #include "wtools.h"
 #include "wxwayland.h"
-#include "private/wtoplevelsurface_p.h"
-
-#include <qwxwaylandsurface.h>
-#include <qwcompositor.h>
-#include <QPointer>
 
 #include <sys/syscall.h>
+
+#include <climits>
+
+#include <qwcompositor.h>
+#include <qwxwaylandsurface.h>
+
+#include <QPointer>
+
 #include <unistd.h>
+
+#include <xcb/xcb_icccm.h>
 
 #define XCOORD_MAX 32767
 
@@ -53,6 +60,7 @@ public:
     void init();
     void updateChildren();
     void updateParent();
+    void updateSizeHints();
     void updateWindowTypes();
 
     W_DECLARE_PUBLIC(WXWaylandSurface)
@@ -66,6 +74,8 @@ public:
     QRect lastRequestConfigureGeometry;
     WXWaylandSurface::ConfigureFlags lastRequestConfigureFlags = {0};
     WXWaylandSurface::WindowTypes windowTypes = {0};
+    QSize minimumSize;
+    QSize maximumSize = QSize(INT_MAX, INT_MAX);
     uint maximized:1;
     uint minimized:1;
     uint fullscreen:1;
@@ -152,6 +162,9 @@ void WXWaylandSurfacePrivate::init()
                      q, &WXWaylandSurface::bypassManagerChanged);
     QObject::connect(handle(), &qw_xwayland_surface::notify_set_geometry,
                      q, &WXWaylandSurface::geometryChanged);
+    QObject::connect(handle(), &qw_xwayland_surface::notify_set_hints, q, [this] {
+        updateSizeHints();
+    });
     QObject::connect(handle(), &qw_xwayland_surface::notify_set_window_type,
                      q, [this] {
                          updateWindowTypes();
@@ -164,7 +177,37 @@ void WXWaylandSurfacePrivate::init()
                      q, &WXWaylandSurface::appIdChanged);
     updateChildren();
     updateParent();
+    updateSizeHints();
     updateWindowTypes();
+}
+
+void WXWaylandSurfacePrivate::updateSizeHints()
+{
+    W_Q(WXWaylandSurface);
+
+    QSize minimumSize;
+    QSize maximumSize(INT_MAX, INT_MAX);
+
+    if (nativeHandle()->size_hints) {
+        if (nativeHandle()->size_hints->flags & XCB_ICCCM_SIZE_HINT_P_MIN_SIZE) {
+            minimumSize = QSize(nativeHandle()->size_hints->min_width,
+                                nativeHandle()->size_hints->min_height);
+        }
+        if (nativeHandle()->size_hints->flags & XCB_ICCCM_SIZE_HINT_P_MAX_SIZE) {
+            maximumSize = QSize(nativeHandle()->size_hints->max_width,
+                                nativeHandle()->size_hints->max_height);
+        }
+    }
+
+    if (this->minimumSize != minimumSize) {
+        this->minimumSize = minimumSize;
+        Q_EMIT q->minimumSizeChanged(this->minimumSize);
+    }
+
+    if (this->maximumSize != maximumSize) {
+        this->maximumSize = maximumSize;
+        Q_EMIT q->maximumSizeChanged(this->maximumSize);
+    }
 }
 
 void WXWaylandSurfacePrivate::updateChildren()
@@ -366,14 +409,24 @@ bool WXWaylandSurface::hasCapability(Capability cap) const
     W_DC(WXWaylandSurface);
     switch (cap) {
         using enum Capability;
+    case Resize:
+        return !isBypassManager() && (minSize().width() < maxSize().width()
+                                      || minSize().height() < maxSize().height());
+    case Maximized:
+        if (isBypassManager()) {
+            return false;
+        }
+        return (minSize().width() < maxSize().width() && minSize().height() < maxSize().height())
+            && !(d->windowTypes
+                 & (NET_WM_WINDOW_TYPE_UTILITY | NET_WM_WINDOW_TYPE_TOOLTIP | NET_WM_WINDOW_TYPE_DND
+                    | NET_WM_WINDOW_TYPE_DROPDOWN_MENU | NET_WM_WINDOW_TYPE_POPUP_MENU
+                    | NET_WM_WINDOW_TYPE_COMBO | NET_WM_WINDOW_TYPE_MENU
+                    | NET_WM_WINDOW_TYPE_NOTIFICATION | NET_WM_WINDOW_TYPE_SPLASH));
     case Focus:
         return wlr_xwayland_surface_override_redirect_wants_focus(d->nativeHandle())
             && wlr_xwayland_surface_icccm_input_model(d->nativeHandle()) != WLR_ICCCM_INPUT_MODEL_NONE;
     case Activate:
-    case Maximized:
     case FullScreen:
-    case Resize:
-        // TODO: should check WindowType
         return !isBypassManager();
     default:
         break;
@@ -384,29 +437,13 @@ bool WXWaylandSurface::hasCapability(Capability cap) const
 QSize WXWaylandSurface::minSize() const
 {
     W_DC(WXWaylandSurface);
-
-    if (!d->nativeHandle()->size_hints)
-        return QSize();
-
-    if (!(d->nativeHandle()->size_hints->flags & XCB_ICCCM_SIZE_HINT_P_MIN_SIZE))
-        return QSize();
-
-    return QSize(d->nativeHandle()->size_hints->min_width,
-                 d->nativeHandle()->size_hints->min_height);
+    return d->minimumSize;
 }
 
 QSize WXWaylandSurface::maxSize() const
 {
     W_DC(WXWaylandSurface);
-
-    if (!d->nativeHandle()->size_hints)
-        return QSize();
-
-    if (!(d->nativeHandle()->size_hints->flags & XCB_ICCCM_SIZE_HINT_P_MAX_SIZE))
-        return QSize();
-
-    return QSize(d->nativeHandle()->size_hints->max_width,
-                 d->nativeHandle()->size_hints->max_height);
+    return d->maximumSize;
 }
 
 QRect WXWaylandSurface::geometry() const


### PR DESCRIPTION
Add min/max size caching in XdgToplevel and XWayland surfaces, updating
from surface commit and XCB size hints respectively. Implement
Capability::Resize and Capability::Maximized in hasCapability() to check
if windows can be resized (min < max on either axis) and maximized
(min < max on BOTH axes). This correctly handles fixed-size windows
that should not be maximizable.

Hide the maximize button and menu item in QML for non-maximizable
windows. Add guards in SurfaceWrapper and shortcut runner to prevent
maximize requests on non-maximizable surfaces.