### PR TITLE
fix(taskswitch): incorrect task switch active index and interrupted window restore animations

### DIFF
--- a/misc/dconfig/org.deepin.dde.treeland.json
+++ b/misc/dconfig/org.deepin.dde.treeland.json
@@ -2,6 +2,17 @@
     "magic": "dsg.config.meta",
     "version": "1.0",
     "contents": {
+        "quickSwitchTimeout": {
+            "value": 120,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Quick Switch Timeout (ms)",
+            "name[zh_CN]": "快速切换超时（毫秒）",
+            "description": "Timeout to distinguish a quick Alt+Tab toggle from the full task switcher",
+            "description[zh_CN]": "区分快速 Alt+Tab 切换与完整任务切换器的超时时长",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
         "forceSoftwareCursor": {
             "value": false,
             "serial": 0,

--- a/src/core/qml/TaskSwitcher.qml
+++ b/src/core/qml/TaskSwitcher.qml
@@ -287,10 +287,13 @@ Item {
         property int finishedAnimations: 0
         property int totalAnimations: previewWindows.count
         signal animationsFinished
+        signal restoreSurfaces()
 
         delegate: Item {
             id: windowItem
             required property SurfaceWrapper surface
+            property real surfaceX: 0
+            property real surfaceY: 0
 
             ParallelAnimation {
                 id: previewAnimation
@@ -354,11 +357,14 @@ Item {
                     return
 
                 var wh = previewPostion(surface, previewItem)
+                windowItem.surfaceX = surface.x
+                windowItem.surfaceY = surface.y
+
                 previewAnimation.target = surface
                 previewAnimation.xFrom = (40 + previewItem.width - wh.width) / 2.0
                 previewAnimation.yFrom = (104 + previewItem.height - wh.height) / 2.0
-                previewAnimation.xTo = surface.x
-                previewAnimation.yTo = surface.y
+                previewAnimation.xTo = windowItem.surfaceX
+                previewAnimation.yTo = windowItem.surfaceY
                 previewAnimation.scaleFrom = wh.width / surface.width
 
                 if (surface === Helper.activatedSurface) {
@@ -374,6 +380,16 @@ Item {
                 }
 
                 previewAnimation.start()
+            }
+
+            Connections {
+                target: previewWindows
+                function onRestoreSurfaces() {
+                    if (surface && surface.shellSurface) {
+                        surface.x = windowItem.surfaceX
+                        surface.y = windowItem.surfaceY
+                    }
+                }
             }
         }
 
@@ -419,6 +435,15 @@ Item {
     }
 
     function prejudgment() {
+        if (previewWindows.finishedAnimations < previewWindows.totalAnimations) {
+            previewWindows.restoreSurfaces()
+            previewWindows.model = []
+            previewWindows.finishedAnimations = 0
+
+            showTask(false)
+            root.switchOn = false
+        }
+
         if (switchView.count <= 1) {
             if (switchView.count === 1) {
                 previewContext.sourceSurface = switchView.currentItem.surface
@@ -497,6 +522,9 @@ Item {
             root.switchOn = false
             return
         }
+
+        if (previewWindows.finishedAnimations !== previewWindows.totalAnimations)
+            return
 
         if (root.enableAnimation) {
             previewContext.loaderStatus = -1

--- a/src/core/qml/TaskSwitcher.qml
+++ b/src/core/qml/TaskSwitcher.qml
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import QtQuick
@@ -418,7 +418,7 @@ Item {
         }
     }
 
-    function previous() {
+    function prejudgment() {
         if (switchView.count <= 1) {
             if (switchView.count === 1) {
                 previewContext.sourceSurface = switchView.currentItem.surface
@@ -426,8 +426,14 @@ Item {
                     previewContext.sourceComponent = previewContext.previewComponent
                 showTask(true);
             }
-            return;
+            return false;
         }
+        return true;
+    }
+
+    function previous() {
+        if (!prejudgment())
+            return;
 
         var nextIndex = (switchView.currentIndex - 1 + switchView.count) % switchView.count
 
@@ -440,15 +446,8 @@ Item {
     }
 
     function next() {
-        if (switchView.count <= 1) {
-            if (switchView.count === 1) {
-                previewContext.sourceSurface = switchView.currentItem.surface
-                if (!previewContext.sourceComponent && root.enableAnimation)
-                    previewContext.sourceComponent = previewContext.previewComponent
-                showTask(true);
-            }
+        if (!prejudgment())
             return;
-        }
 
         var nextIndex = (switchView.currentIndex + 1) % switchView.count
 
@@ -457,6 +456,17 @@ Item {
             switchView.contentX += switchView.delegateMinWidth / 2
 
         focusReason = Qt.TabFocusReason
+        switchIndex(nextIndex)
+    }
+
+    function show() {
+        if (!prejudgment())
+            return;
+
+        var nextIndex = switchView.currentIndex;
+        switchView.positionViewAtIndex(nextIndex, ListView.End)
+
+        focusReason = Qt.ActiveWindowFocusReason
         switchIndex(nextIndex)
     }
 

--- a/src/modules/shortcut/shortcutcontroller.cpp
+++ b/src/modules/shortcut/shortcutcontroller.cpp
@@ -69,8 +69,10 @@ uint ShortcutController::registerKey(const QString &name, const QString& key, Sh
                                  << "by name" << prevName << "with new name" << name << "and flags" << keybindFlags;
     }
     m_keyMap[combined][action] = std::make_pair(name, keybindFlags);
+    m_actionCombinedMap[action] = combined;
     m_deleters[name] = [this, combined, action]() {
         m_keyMap[combined].remove(action);
+        m_actionCombinedMap.remove(action);
     };
     return 0;
 }
@@ -206,12 +208,23 @@ bool ShortcutController::dispatchKeyEvent(const QKeyEvent *kevent)
     return false;
 }
 
+Qt::KeyboardModifiers ShortcutController::modifierForAction(ShortcutAction action) const
+{
+    auto it = m_actionCombinedMap.find(action);
+    if (it != m_actionCombinedMap.end()) {
+        return QKeyCombination::fromCombined(it.value()).keyboardModifiers()
+            & (Qt::AltModifier | Qt::MetaModifier | Qt::ControlModifier | Qt::ShiftModifier);
+    }
+    return Qt::NoModifier;
+}
+
 void ShortcutController::clear()
 {
     for (const auto& deleter : std::as_const(m_deleters)) {
         deleter();
     }
     m_deleters.clear();
+    m_actionCombinedMap.clear();
 }
 
 QKeyCombination ShortcutController::normalizeKeyCombination(QKeyCombination combination) {

--- a/src/modules/shortcut/shortcutcontroller.h
+++ b/src/modules/shortcut/shortcutcontroller.h
@@ -37,6 +37,7 @@ public:
     bool dispatchKeyEvent(const QKeyEvent *event);
     static QKeyCombination normalizeKeyCombination(QKeyCombination combination);
     static bool isValidShortcutCombination(QKeyCombination combination);
+    Qt::KeyboardModifiers modifierForAction(ShortcutAction action) const;
 
 Q_SIGNALS:
     void actionTriggered(ShortcutAction action, const QString &name, bool isGesture, KeyFlags keyFlags = {});
@@ -49,6 +50,7 @@ private:
     QMap<std::pair<uint, SwipeGesture::Direction>, QMap<ShortcutAction, QString>> m_gesturemap;
     QMap<std::pair<uint, SwipeGesture::Direction>, QObject*> m_gestures;
     QMap<QString, std::function<void()>> m_deleters;
+    QMap<ShortcutAction, int> m_actionCombinedMap;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(ShortcutController::KeyFlags)

--- a/src/modules/shortcut/shortcutmanager.h
+++ b/src/modules/shortcut/shortcutmanager.h
@@ -46,7 +46,6 @@ enum class ShortcutAction : uint32_t {
     Lockscreen            = 20,
     ShutdownMenu          = 21,
     Quit                  = 22,
-    TaskSwitchEnter       = 23,
     TaskSwitchNext        = 24,
     TaskSwitchPrev        = 25,
     TaskSwitchSameAppNext = 26,

--- a/src/modules/shortcut/shortcutrunner.cpp
+++ b/src/modules/shortcut/shortcutrunner.cpp
@@ -3,6 +3,7 @@
 
 #include "shortcutrunner.h"
 #include "seat/helper.h"
+#include "treelandconfig.hpp"
 #include "shortcutcontroller.h"
 #include "workspace/workspace.h"
 #include "modules/window-management/windowmanagementinterfacev1.h"
@@ -18,9 +19,28 @@
 
 #include "qwayland-server-treeland-shortcut-manager-v2.h"
 
+static bool isModifierKeyInMask(int key, Qt::KeyboardModifiers mods)
+{
+    if ((mods & Qt::AltModifier) && key == Qt::Key_Alt)
+        return true;
+    if ((mods & Qt::ControlModifier) && key == Qt::Key_Control)
+        return true;
+    if ((mods & Qt::MetaModifier) && key == Qt::Key_Meta)
+        return true;
+    if ((mods & Qt::ShiftModifier) && key == Qt::Key_Shift)
+        return true;
+    return false;
+}
+
 ShortcutRunner::ShortcutRunner(QObject *parent)
     : QObject(parent)
 {
+    auto *helper = Helper::instance();
+    connect(helper, &Helper::modifierKeyReleased, this, &ShortcutRunner::onModifierReleased);
+
+    m_quickSwitchTimer = new QTimer(this);
+    m_quickSwitchTimer->setSingleShot(true);
+    connect(m_quickSwitchTimer, &QTimer::timeout, this, &ShortcutRunner::onQuickSwitchTimeout);
 }
 
 void ShortcutRunner::onActionTrigger(ShortcutAction action, const QString &name, bool isGesture, ShortcutController::KeyFlags keyFlags)
@@ -32,6 +52,7 @@ void ShortcutRunner::onActionTrigger(ShortcutAction action, const QString &name,
         return;
     }
 
+    m_currentAction = action;
     switch (action) {
     case ShortcutAction::Notify:
         helper->m_shortcutManager->sendActivated(name, keyFlags);
@@ -156,10 +177,6 @@ void ShortcutRunner::onActionTrigger(ShortcutAction action, const QString &name,
         break;
     case ShortcutAction::Quit:
         Q_EMIT helper->requestQuit();
-        break;
-    case ShortcutAction::TaskSwitchEnter:
-        m_taskAltTimestamp = QDateTime::currentMSecsSinceEpoch();
-        m_taskAltCount = 0;
         break;
     case ShortcutAction::TaskSwitchNext:
     case ShortcutAction::TaskSwitchPrev:
@@ -332,14 +349,16 @@ void ShortcutRunner::taskswitchAction(bool isRepeat, bool isSameApp, bool isPrev
     auto *helper = Helper::instance();
     if (helper->currentMode() != Helper::CurrentMode::Normal && helper->currentMode() != Helper::CurrentMode::WindowSwitch)
         return;
-    // Quick Advance
-    quint64 now = QDateTime::currentMSecsSinceEpoch();
-    if (!isRepeat && now - m_taskAltTimestamp < 150) {
+
+    if (!isRepeat && helper->currentMode() == Helper::CurrentMode::Normal) {
         auto current = helper->workspace()->current();
-        Q_ASSERT(current);
-        auto nextSurface = current->findNextActivedSurface();
-        if (nextSurface)
-            helper->forceActivateSurface(nextSurface, Qt::TabFocusReason);
+        if (current) {
+            auto nextSurface = current->findNextActivedSurface();
+            if (nextSurface)
+                helper->forceActivateSurface(nextSurface, Qt::TabFocusReason);
+        }
+        m_quickSwitchTimer->start(helper->globalConfig()->quickSwitchTimeout());
+        m_quickSwitchPending = true;
         return;
     }
 
@@ -358,9 +377,8 @@ void ShortcutRunner::taskswitchAction(bool isRepeat, bool isSameApp, bool isPrev
         m_taskAltCount = 3;
     }
 
-    if (m_taskAltCount < 3) {
+    if (m_taskAltCount < 3)
         return;
-    }
 
     m_taskAltCount = 0;
     helper->setCurrentMode(Helper::CurrentMode::WindowSwitch);
@@ -378,5 +396,58 @@ void ShortcutRunner::taskswitchAction(bool isRepeat, bool isSameApp, bool isPrev
         QMetaObject::invokeMethod(helper->m_taskSwitch, "previous");
     } else {
         QMetaObject::invokeMethod(helper->m_taskSwitch, "next");
+    }
+    qWarning() << "TaskSwitch: navigating in full task switcher";
+}
+
+void ShortcutRunner::onQuickSwitchTimeout()
+{
+    m_quickSwitchPending = false;
+
+    auto *helper = Helper::instance();
+    if (helper->currentMode() != Helper::CurrentMode::Normal)
+        return;
+
+    if (helper->m_taskSwitch.isNull()) {
+        auto contentItem = helper->window()->contentItem();
+        auto output = helper->rootSurfaceContainer()->primaryOutput();
+        helper->m_taskSwitch = helper->qmlEngine()->createTaskSwitcher(output, contentItem);
+        helper->restoreFromShowDesktop();
+        QObject::connect(helper->m_taskSwitch,
+                         SIGNAL(switchOnChanged()),
+                         helper,
+                         SLOT(deleteTaskSwitch()));
+        helper->m_taskSwitch->setZ(RootSurfaceContainer::OverlayZOrder);
+    }
+    helper->setCurrentMode(Helper::CurrentMode::WindowSwitch);
+
+    QMetaObject::invokeMethod(helper->m_taskSwitch, "show");
+}
+
+void ShortcutRunner::onModifierReleased(QKeyEvent *event)
+{
+    auto *helper = Helper::instance();
+
+    if (m_currentAction == ShortcutAction::TaskSwitchNext
+        || m_currentAction == ShortcutAction::TaskSwitchPrev
+        || m_currentAction == ShortcutAction::TaskSwitchSameAppNext
+        || m_currentAction == ShortcutAction::TaskSwitchSameAppPrev) {
+        auto modifiers =
+            helper->m_shortcutManager->controller()->modifierForAction(m_currentAction);
+        if (!isModifierKeyInMask(event->key(), modifiers))
+            return;
+
+        if (m_quickSwitchPending && helper->currentMode() == Helper::CurrentMode::Normal) {
+            m_quickSwitchTimer->stop();
+            m_quickSwitchPending = false;
+            return;
+        }
+
+        if (helper->currentMode() == Helper::CurrentMode::WindowSwitch && helper->m_taskSwitch) {
+            auto filter = helper->workspace()->currentFilter();
+            filter->setFilterAppId("");
+            helper->setCurrentMode(Helper::CurrentMode::Normal);
+            QMetaObject::invokeMethod(helper->m_taskSwitch, "exit");
+        }
     }
 }

--- a/src/modules/shortcut/shortcutrunner.h
+++ b/src/modules/shortcut/shortcutrunner.h
@@ -1,9 +1,11 @@
-// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2025-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #pragma once
 
 #include <QObject>
+#include <QTimer>
+#include <qcoreevent.h>
 #include "shortcutmanager.h"
 
 class ShortcutRunner : public QObject
@@ -17,6 +19,10 @@ public Q_SLOTS:
     void onActionProgress(ShortcutAction action, qreal progress, const QString &name);
     void onActionFinish(ShortcutAction action, const QString &name, bool isTriggered);
 
+private Q_SLOTS:
+    void onModifierReleased(QKeyEvent *event);
+    void onQuickSwitchTimeout();
+
 private:
     void updateWorkspaceSwipe(qreal cb);
     void finishWorkspaceSwipe();
@@ -28,6 +34,8 @@ private:
     bool m_slideEnable = false;
     bool m_slideBounce = false;
 
-    quint64 m_taskAltTimestamp = 0;
+    QTimer *m_quickSwitchTimer = nullptr;
+    ShortcutAction m_currentAction;
+    bool m_quickSwitchPending = false;
     quint32 m_taskAltCount = 0;
 };

--- a/src/plugins/multitaskview/multitaskview.cpp
+++ b/src/plugins/multitaskview/multitaskview.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "multitaskview.h"
@@ -664,13 +664,7 @@ QRectF MultitaskviewSurfaceModel::surfaceGeometry(SurfaceWrapper *surface)
 
 bool MultitaskviewSurfaceModel::laterActiveThan(SurfaceWrapper *a, SurfaceWrapper *b)
 {
-    auto activeIndex = [this](SurfaceWrapper *surface) {
-        auto it = std::find(workspace()->m_activedSurfaceHistory.begin(),
-                            workspace()->m_activedSurfaceHistory.end(),
-                            surface);
-        return std::distance(workspace()->m_activedSurfaceHistory.begin(), it);
-    };
-    return activeIndex(a) < activeIndex(b);
+    return workspace()->laterActiveThan(a, b);
 }
 
 void MultitaskviewSurfaceModel::connectWorkspace(WorkspaceModel *workspace)

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -8,6 +8,7 @@
 #include <QJsonDocument>
 #include <QJsonArray>
 #include <QJsonObject>
+#include <qnamespace.h>
 #ifdef EXT_SESSION_LOCK_V1
 #include "wsessionlock.h"
 #include "wsessionlockmanager.h"
@@ -1872,13 +1873,10 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *targetWindow, QInputEvent 
 
         if (event->type() == QEvent::KeyRelease && !m_captureSelector) {
             auto kevent = static_cast<QKeyEvent *>(event);
-            if (m_taskSwitch && m_taskSwitch->property("switchOn").toBool()) {
-                if (kevent->key() == Qt::Key_Alt || kevent->key() == Qt::Key_Meta) {
-                    auto filter = Helper::instance()->workspace()->currentFilter();
-                    filter->setFilterAppId("");
-                    setCurrentMode(CurrentMode::Normal);
-                    QMetaObject::invokeMethod(m_taskSwitch, "exit");
-                }
+            const int key = kevent->key();
+            if (key == Qt::Key_Alt || key == Qt::Key_Control || key == Qt::Key_Shift
+                || key == Qt::Key_Meta) {
+                Q_EMIT modifierKeyReleased(kevent);
             }
         }
     }

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -24,6 +24,7 @@
 
 #include <QList>
 #include <QMap>
+#include <qevent.h>
 
 #include <optional>
 
@@ -286,6 +287,7 @@ Q_SIGNALS:
     void launchpadMappedChanged(WOutput *output, bool mapped);
     void showDesktopRequested(WOutput *output);
     void startLockscreened(WOutput *output, bool showAnimation);
+    void modifierKeyReleased(QKeyEvent *event);
 
 private Q_SLOTS:
     void onShowDesktop();

--- a/src/surface/surfacefilterproxymodel.cpp
+++ b/src/surface/surfacefilterproxymodel.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "surfacefilterproxymodel.h"
@@ -56,14 +56,11 @@ bool SurfaceFilterProxyModel::lessThan(const QModelIndex &source_left,
                                        const QModelIndex &source_right) const
 {
     WorkspaceModel *model = dynamic_cast<WorkspaceModel *>(sourceModel());
-    SurfaceWrapper *left_surface = sourceModel()->data(source_left).value<SurfaceWrapper *>();
-    SurfaceWrapper *right_surface = sourceModel()->data(source_right).value<SurfaceWrapper *>();
+    SurfaceWrapper *left = sourceModel()->data(source_left).value<SurfaceWrapper *>();
+    SurfaceWrapper *right = sourceModel()->data(source_right).value<SurfaceWrapper *>();
 
-    if (model && left_surface && right_surface) {
-        int left_index = model->findActivedSurfaceHistoryIndex(left_surface);
-        int right_index = model->findActivedSurfaceHistoryIndex(right_surface);
-
-        if (left_index > right_index)
+    if (model && left && right) {
+        if (model->laterActiveThan(left, right))
             return true;
         else
             return false;

--- a/src/treeland-shortcut/shortcut.cpp
+++ b/src/treeland-shortcut/shortcut.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Dingyuan Zhang <zhangdingyuan@uniontech.com>.
+// Copyright (C) 2023-2026 Dingyuan Zhang <zhangdingyuan@uniontech.com>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "shortcut.h"
@@ -40,7 +40,6 @@ static const QMap<QString, ShortcutV2::action> ActionMap = {
     {"Lockscreen", ShortcutV2::action_lockscreen},
     {"ShutdownMenu", ShortcutV2::action_shutdown_menu},
     {"Quit", ShortcutV2::action_quit},
-    {"TaskswitchEnter", ShortcutV2::action_taskswitch_enter},
     {"TaskswitchNext", ShortcutV2::action_taskswitch_next},
     {"TaskswitchPrev", ShortcutV2::action_taskswitch_prev},
     {"TaskswitchSameAppNext", ShortcutV2::action_taskswitch_sameapp_next},

--- a/src/treeland-shortcut/shortcuts/_treeland-taskswitch-enter.ini
+++ b/src/treeland-shortcut/shortcuts/_treeland-taskswitch-enter.ini
@@ -1,6 +1,0 @@
-[Shortcut]
-Shortcut=Alt
-Type="Action"
-
-[Type.Action]
-Action=TaskswitchEnter

--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -257,6 +257,10 @@ SurfaceFilterProxyModel *Workspace::currentFilter()
     m_currentFilter->setSourceModel(wmodel);
     m_currentFilter->invalidate();
     m_currentFilter->sort(0);
+
+    auto *activeSurface = wmodel->latestActiveSurface();
+    m_currentFilter->setActiveIndex(wmodel->activeHistoryIndex(activeSurface));
+
     return m_currentFilter;
 }
 

--- a/src/workspace/workspacemodel.cpp
+++ b/src/workspace/workspacemodel.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "workspacemodel.h"
@@ -133,14 +133,13 @@ void WorkspaceModel::clearActivedSurface()
     m_activedSurfaceHistory.clear();
 }
 
-int WorkspaceModel::findActivedSurfaceHistoryIndex(SurfaceWrapper *surface) const
+int WorkspaceModel::activeHistoryIndex(SurfaceWrapper *surface) const
 {
-    int index = 0;
-    for (auto it = m_activedSurfaceHistory.begin(); it != m_activedSurfaceHistory.end();
-         ++it, ++index) {
-        if (*it == surface) {
-            return index;
-        }
-    }
-    return index;
+    auto it = std::find(m_activedSurfaceHistory.begin(), m_activedSurfaceHistory.end(), surface);
+    return static_cast<int>(std::distance(m_activedSurfaceHistory.begin(), it));
+}
+
+bool WorkspaceModel::laterActiveThan(SurfaceWrapper *a, SurfaceWrapper *b)
+{
+    return activeHistoryIndex(a) < activeHistoryIndex(b);
 }

--- a/src/workspace/workspacemodel.h
+++ b/src/workspace/workspacemodel.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #pragma once
@@ -48,7 +48,9 @@ public:
     void pushActivedSurface(SurfaceWrapper *surface);
     void removeActivedSurface(SurfaceWrapper *surface);
     void clearActivedSurface();
-    int findActivedSurfaceHistoryIndex(SurfaceWrapper *surface) const;
+
+    int activeHistoryIndex(SurfaceWrapper *surface) const;
+    bool laterActiveThan(SurfaceWrapper *a, SurfaceWrapper *b);
 
 Q_SIGNALS:
     void nameChanged();


### PR DESCRIPTION
不再依赖固定的alt 修饰键 依赖用户设置的快捷键的修饰键
调整快速切换逻辑 在规定时间内释放alt算是快速切换 120ms
修复任务切换窗口快速不停的打开关闭导致的窗口无法复位到原始位置的问题
修复taskswitch active index位置不正确的问题