### PR TITLE
fix(input): allow Esc key to cancel move/resize operation

### DIFF
--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -740,6 +740,14 @@ void RootSurfaceContainer::endMoveResizeForSeat(WSeat *seat)
     }
 }
 
+void RootSurfaceContainer::cancelMoveResizeForSeat(WSeat *seat)
+{
+    auto *container = getSeatContainerOrDefault(seat);
+    if (container) {
+        container->cancelMoveResize();
+    }
+}
+
 SurfaceWrapper *RootSurfaceContainer::getMoveResizeSurfaceForSeat(WSeat *seat) const
 {
     auto *container = getSeatContainerOrDefault(seat);

--- a/src/core/rootsurfacecontainer.h
+++ b/src/core/rootsurfacecontainer.h
@@ -70,6 +70,7 @@ public:
     void beginMoveResizeForSeat(WSeat *seat, SurfaceWrapper *surface, Qt::Edges edges);
     void doMoveResizeForSeat(WSeat *seat, const QPointF &delta);
     void endMoveResizeForSeat(WSeat *seat);
+    void cancelMoveResizeForSeat(WSeat *seat);
     SurfaceWrapper *getMoveResizeSurfaceForSeat(WSeat *seat) const;
     void setActivatedSurfaceForSeat(WSeat *seat, SurfaceWrapper *surface,
                                     Qt::FocusReason reason);

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1918,6 +1918,10 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *targetWindow, QInputEvent 
             m_rootSurfaceContainer->doMoveResizeForSeat(seat, increment_pos);
 
             return true;
+        } else if (event->type() == QEvent::KeyPress
+                   && static_cast<QKeyEvent *>(event)->key() == Qt::Key_Escape) {
+            m_rootSurfaceContainer->cancelMoveResizeForSeat(seat);
+            return true;
         } else if (event->type() == QEvent::MouseButtonRelease
                    || event->type() == QEvent::TouchEnd) {
             m_rootSurfaceContainer->endMoveResizeForSeat(seat);

--- a/src/surface/seatsurfacemanager.cpp
+++ b/src/surface/seatsurfacemanager.cpp
@@ -170,6 +170,24 @@ SurfaceWrapper *SeatSurfaceManager::moveResizeSurface() const
     return m_moveResizeState.surface;
 }
 
+void SeatSurfaceManager::cancelMoveResize()
+{
+    if (!m_moveResizeState.surface)
+        return;
+
+    auto surface = m_moveResizeState.surface;
+    auto startGeo = m_moveResizeState.startGeometry;
+
+    // Restore original geometry before ending
+    if (m_moveResizeState.edges != Qt::Edges()) {
+        surface->resize(surface->alignGeometryToPixelGrid(startGeo).size());
+    } else {
+        surface->setPosition(surface->alignToPixelGrid(startGeo.topLeft()));
+    }
+
+    endMoveResize();
+}
+
 void SeatSurfaceManager::cancelMoveResize(SurfaceWrapper *surface)
 {
     // Only cancel if this surface is the one being moved/resized

--- a/src/surface/seatsurfacemanager.h
+++ b/src/surface/seatsurfacemanager.h
@@ -41,6 +41,7 @@ public:
     void endMoveResize();
     SurfaceWrapper *moveResizeSurface() const;
     void cancelMoveResize(SurfaceWrapper *surface);
+    void cancelMoveResize();
     bool shouldHandleShortcuts() const;
     bool metaKeyPressed() const { return m_metaKeyPressed; }
     void setMetaKeyPressed(bool pressed);


### PR DESCRIPTION
Escape key now interrupts ongoing window move or resize,
restoring the window to its original geometry.

Esc 键现在可以中断正在进行的窗口移动或调整大小操作，
将窗口恢复到操作开始前的原始几何。

Log: 支持按 Esc 键取消窗口调整大小/移动操作
PMS: BUG-290903
Influence: 修复窗口更改大小/移动模式下 Esc 无法中断操作的问题