### PR TITLE
fix(surface): fullscreen window size reduced by titlebar height

### DIFF
--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -692,13 +692,13 @@ QString SurfaceWrapper::appId() const
     return QString();
 }
 
-bool SurfaceWrapper::resize(const QSizeF &size)
+bool SurfaceWrapper::resize(const QSizeF &size, bool tryExec)
 {
     // No surfaceItem in prelaunch mode -> return false
     if (!m_surfaceItem)
         return false;
 
-    return m_surfaceItem->resizeSurface(size);
+    return m_surfaceItem->resizeSurface(size, tryExec);
 }
 
 void SurfaceWrapper::close()
@@ -1363,8 +1363,8 @@ void SurfaceWrapper::onAnimationReady()
     Q_ASSERT(m_pendingState != m_surfaceState);
     Q_ASSERT(m_pendingGeometry.isValid());
 
-    if (!resize(m_pendingGeometry.size())) {
-        // abort change state if resize failed
+    if (!resize(m_pendingGeometry.size(), true)) {
+        // abort change state if cannot resize
         m_geometryAnimation->disconnect(this);
         m_geometryAnimation->deleteLater();
         m_geometryAnimation = nullptr;
@@ -1374,6 +1374,7 @@ void SurfaceWrapper::onAnimationReady()
     QPointF alignedPos = alignToPixelGrid(m_pendingGeometry.topLeft());
     setPosition(alignedPos);
     doSetSurfaceState(m_pendingState);
+    resize(m_pendingGeometry.size());
 }
 
 void SurfaceWrapper::onAnimationFinished()

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -148,7 +148,7 @@ public:
     WSurfaceItem *surfaceItem() const;
     QQuickItem *prelaunchSplash() const;
     QString appId() const;
-    bool resize(const QSizeF &size);
+    bool resize(const QSizeF &size, bool tryExec = false);
     void close();
 
     QRectF titlebarGeometry() const;

--- a/waylib/src/server/qtquick/wsurfaceitem.cpp
+++ b/waylib/src/server/qtquick/wsurfaceitem.cpp
@@ -1087,11 +1087,14 @@ void WSurfaceItem::onSurfaceCommit()
     d->updateSubsurfaceItem();
 }
 
-bool WSurfaceItem::resizeSurface(const QSizeF &newSize)
+bool WSurfaceItem::resizeSurface(const QSizeF &newSize, bool tryExec)
 {
     Q_D(const WSurfaceItem);
     if (!d->shellSurface || !d->contentContainer)
         return false;
+    if (tryExec)
+        return true;
+
     QRectF tmp(0, 0, newSize.width(), newSize.height());
     tmp -= d->paddings;
     // See surfaceSizeRatio, the content item maybe has been scaled.

--- a/waylib/src/server/qtquick/wsurfaceitem.h
+++ b/waylib/src/server/qtquick/wsurfaceitem.h
@@ -190,7 +190,7 @@ public:
     void setDelegate(QQmlComponent *newDelegate);
     
     // resize internal surface, should be in SizeFromSurface mode
-    bool resizeSurface(const QSizeF &newSize);
+    bool resizeSurface(const QSizeF &newSize, bool tryExec = false);
     bool subsurfacesVisible() const;
     void setSubsurfacesVisible(bool newSubsurfacesVisible);
 


### PR DESCRIPTION
Move doSetSurfaceState() before resize() in onAnimationReady() to ensure titlebar is hidden before computing fullscreen geometry.

Extract resize pre-check into checkResizeSurface() so that resizability can be verified before state change and resize.

在 onAnimationReady 中将 doSetSurfaceState 移到 resize 之前， 确保标题栏隐藏后再计算全屏尺寸。
提取 checkResizeSurface 以便在状态变更和 resize 前验证可调整性。

Log: 修复全屏窗口配置尺寸被标题栏高度缩减的问题
PMS: BUG-359605
Issue: Fixes #744
Influence: 全屏窗口获得正确的配置尺寸。