### PR TITLE
fix: decouple title bar palette from DTK style constants

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -383,6 +383,7 @@ target_include_directories(${BIN_NAME} PRIVATE
 
 target_link_libraries(${BIN_NAME} PRIVATE
     libtreeland
+    Qt6::GuiPrivate
 )
 
 install(TARGETS ${BIN_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/src/core/qml/TitleBar.qml
+++ b/src/core/qml/TitleBar.qml
@@ -7,7 +7,6 @@ import QtQuick.Shapes
 import Waylib.Server
 import Treeland
 import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
 
 Control {
     id: root
@@ -15,14 +14,18 @@ Control {
     required property SurfaceWrapper surface
     readonly property SurfaceItem surfaceItem: surface.surfaceItem
     readonly property bool noRadius: surface.radius === 0 || surface.noCornerRadius || GraphicsInfo.api === GraphicsInfo.Software
-    property D.Palette backgroundColor: DS.Style.highlightPanel.background
-    property D.Palette outerShadowColor: DS.Style.highlightPanel.dropShadow
-    property D.Palette innerShadowColor: DS.Style.highlightPanel.innerShadow
-    readonly property bool darkTheme: Helper.config.windowThemeType === 2
-    readonly property color activeTitlebarColor: darkTheme ? "#282828" : '#ffffff'
-    readonly property color inactiveTitlebarColor: darkTheme ? "#262626" : "#FCFCFC"
-    readonly property color activeTextColor: darkTheme ? "#8c8c8c" : "#303030"
-    readonly property color inactiveTextColor: darkTheme ? "#656565" : "#969696"
+    property D.Palette backgroundColor: D.Palette {
+        normal: ("#ffffff")
+        normalDark: ("#282828")
+    }
+    property D.Palette textColor: D.Palette {
+        normal: ("#303030")
+        normalDark: ("#8c8c8c")
+        pressed: ("#0081FF")
+        pressedDark: ("#0081FF")
+    }
+    D.ColorSelector.inactived: !surface.isActivated
+    D.ColorSelector.hovered: false
 
     height: Helper.config.windowTitlebarHeight
     width: surfaceItem.width
@@ -70,7 +73,7 @@ Control {
     Rectangle {
         id: titlebar
         anchors.fill: parent
-        color: surface.isActivated ? root.activeTitlebarColor : root.inactiveTitlebarColor
+        color: root.D.ColorSelector.backgroundColor
         layer.enabled: !root.noRadius
         layer.smooth: !root.noRadius
         opacity: !root.noRadius ? 0 : parent.opacity
@@ -85,7 +88,7 @@ Control {
             verticalAlignment: Text.AlignVCenter
             text: surface.shellSurface.title
             elide: Text.ElideRight
-            color: surface.isActivated ? root.activeTextColor : root.inactiveTextColor
+            color: root.D.ColorSelector.textColor
             font.family: Helper.config.font
             font.pointSize: Helper.config.fontSize / 10
             font.weight: Font.Medium
@@ -97,20 +100,14 @@ Control {
                 right: parent.right
             }
 
-            Item {
-                id: control
-
-                property D.Palette textColor: DS.Style.button.text
-                property D.Palette backgroundColor: DS.Style.windowButton.background
-            }
-
             Loader {
                 objectName: "minimizeBtn"
                 sourceComponent: D.WindowButton {
                     icon.name: "window_minimize"
-                    textColor: control.textColor
+                    textColor: root.textColor
                     height: root.height
                     focusPolicy: Qt.NoFocus
+                    D.ColorSelector.inactived: !surface.isActivated
 
                     onClicked: {
                         surface.requestMinimize()
@@ -120,13 +117,13 @@ Control {
 
             Loader {
                 id: maxOrWindedBtn
-
                 objectName: "maxOrWindedBtn"
                 sourceComponent: D.WindowButton {
                     icon.name: surface.shellSurface.isMaximized ? "window_restore" : "window_maximize"
-                    textColor: control.textColor
+                    textColor: root.textColor
                     height: root.height
                     focusPolicy: Qt.NoFocus
+                    D.ColorSelector.inactived: !surface.isActivated
 
                     onClicked: {
                         Helper.activateSurface(surface)
@@ -147,9 +144,10 @@ Control {
                     D.WindowButton {
                         id: closeBtn
                         icon.name: "window_close"
-                        textColor: control.textColor
+                        textColor: root.textColor
                         height: parent.height
                         focusPolicy: Qt.NoFocus
+                        D.ColorSelector.inactived: !surface.isActivated
 
                         onClicked: {
                             surface.requestClose()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,18 +9,49 @@
 #include <qwbuffer.h>
 #include <qwlogging.h>
 
+#include <DGuiApplicationHelper>
 #include <DLog>
 
 #include <QGuiApplication>
 #include <QMetaType>
+#include <QPalette>
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+#  include <private/qgenericunixtheme_p.h>
+#else
+#  include <private/qgenericunixthemes_p.h>
+#endif
+
+#include <wserver.h>
+
+#include <qpa/qplatformtheme.h>
 
 WAYLIB_SERVER_USE_NAMESPACE
 DCORE_USE_NAMESPACE;
 
+class QDeepinTheme : public QGenericUnixTheme
+{
+public:
+    const QPalette *palette(QPlatformTheme::Palette type) const override
+    {
+        if (type != QPlatformTheme::SystemPalette) {
+            return QGenericUnixTheme::palette(type);
+        }
+        static QPalette palette;
+        palette = Dtk::Gui::DGuiApplicationHelper::instance()->applicationPalette();
+        return &palette;
+    }
+};
+
 int main(int argc, char *argv[])
 {
     qw_log::init();
-    WServer::initializeQPA();
+    DTK_GUI_NAMESPACE::DGuiApplicationHelper::setAttribute(
+        DTK_GUI_NAMESPACE::DGuiApplicationHelper::DontSaveApplicationTheme,
+        true);
+    WServer::initializeQPA({}, [](const QString &) {
+        return static_cast<QPlatformTheme *>(new QDeepinTheme());
+    });
     //    QQuickStyle::setStyle("Material");
 
     QGuiApplication::setAttribute(Qt::AA_UseOpenGLES);

--- a/src/modules/personalization/personalizationmanagerinterfacev1.cpp
+++ b/src/modules/personalization/personalizationmanagerinterfacev1.cpp
@@ -1084,6 +1084,7 @@ void PersonalizationManagerInterfaceV1::onAppearanceContextCreated(Personalizati
         const auto dconfigType = protocolWindowThemeTypeToDConfig(type);
         if (dconfigType.has_value()) {
             Helper::instance()->config()->setWindowThemeType(*dconfigType);
+            Helper::syncPaletteTypeWithWindowThemeType(*dconfigType);
         }
         for (auto *c : s_appearanceContexts) {
             c->sendWindowThemeType(type);

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -24,26 +24,27 @@
 #include "core/treeland.h"
 #include "core/windowpicker.h"
 #include "greeter/greeterproxy.h"
-#include "greeter/usermodel.h"
 #include "greeter/sessionmodel.h"
+#include "greeter/usermodel.h"
 #include "input/inputdevice.h"
+#include "inputmanager.h"
 #include "interfaces/multitaskviewinterface.h"
 #include "modules/capture/capture.h"
 #include "modules/dde-shell/ddeshellattached.h"
 #include "modules/dde-shell/ddeshellmanagerinterfacev1.h"
 #include "modules/ddm/ddminterfacev1.h"
+#include "modules/input-manager/inputmanagerinterfacev1.h"
+#include "modules/keyboard-state-notify/keyboardstatenotifymanagerinterfacev1.h"
 #include "modules/output-manager/outputmanagement.h"
 #include "modules/personalization/personalizationmanagerinterfacev1.h"
+#include "modules/resource/treelandremotesource.h"
 #include "modules/screensaver/screensaverinterfacev1.h"
 #include "modules/shortcut/shortcutcontroller.h"
 #include "modules/shortcut/shortcutmanager.h"
 #include "modules/shortcut/shortcutrunner.h"
 #include "modules/wallpaper-color/wallpapercolorinterfacev1.h"
-#include "modules/input-manager/inputmanagerinterfacev1.h"
-#include "modules/keyboard-state-notify/keyboardstatenotifymanagerinterfacev1.h"
-#include "modules/resource/treelandremotesource.h"
-#include "output/outputconfigstate.h"
 #include "output/output.h"
+#include "output/outputconfigstate.h"
 #include "output/outputlifecyclemanager.h"
 #include "session/session.h"
 #include "surface/surfacecontainer.h"
@@ -52,20 +53,24 @@
 #include "treelanduserconfig.hpp"
 #include "utils/cmdline.h"
 #include "utils/fpsdisplaymanager.h"
-#include "workspace/workspace.h"
 #include "wallpaper/wallpapermanager.h"
 #include "wallpapershellinterfacev1.h"
-#include "inputmanager.h"
+#include "workspace/workspace.h"
 
+#include <rhi/qrhi.h>
 #include <xcb/xcb.h>
 #include <xcb/xproto.h>
 
 #include <WBackend>
+#include <WForeignToplevel>
+#include <WOutput>
+#include <WServer>
+#include <WSurfaceItem>
+#include <WXdgOutput>
+#include <wayland-util.h>
 #include <wcursorshapemanagerv1.h>
 #include <wextimagecapturesourcev1impl.h>
-#include <WForeignToplevel>
 #include <wlayersurface.h>
-#include <WOutput>
 #include <woutputhelper.h>
 #include <woutputitem.h>
 #include <woutputlayout.h>
@@ -77,11 +82,8 @@
 #include <wrenderhelper.h>
 #include <wseat.h>
 #include <wsecuritycontextmanager.h>
-#include <WServer>
 #include <wsocket.h>
-#include <WSurfaceItem>
 #include <wtoplevelsurface.h>
-#include <WXdgOutput>
 #include <wxdgshell.h>
 #include <wxdgtoplevelsurface.h>
 #include <wxdgtopleveltagmanager.h>
@@ -121,6 +123,8 @@
 #include <qwxwayland.h>
 #include <qwxwaylandsurface.h>
 
+#include <DGuiApplicationHelper>
+
 #include <QAction>
 #include <QDBusConnection>
 #include <QDBusInterface>
@@ -131,13 +135,11 @@
 #include <QQmlContext>
 #include <QQuickWindow>
 #include <QtConcurrent>
-#include <rhi/qrhi.h>
 
 #include <functional>
 #include <pwd.h>
 #include <unistd.h>
 #include <utility>
-#include <wayland-util.h>
 
 #define EXT_DATA_CONTROL_MANAGER_V1_VERSION 1
 #define WLR_FRACTIONAL_SCALE_V1_VERSION 1
@@ -332,6 +334,32 @@ TreelandUserConfig *Helper::config()
 TreelandConfig *Helper::globalConfig()
 {
     return m_globalConfig.get();
+}
+
+void Helper::syncPaletteTypeWithWindowThemeType(int32_t themeType)
+{
+    auto *guiHelper = DTK_GUI_NAMESPACE::DGuiApplicationHelper::instance();
+    if (!guiHelper) {
+        qCCritical(treelandConfig) << "DGuiApplicationHelper instance not available, cannot sync "
+                                      "palette type with window theme type.";
+        return;
+    }
+
+    qCDebug(treelandConfig) << "Syncing palette type with window theme type:" << themeType;
+
+    switch (themeType) {
+    case 2:
+        guiHelper->setPaletteType(Dtk::Gui::DGuiApplicationHelper::DarkType);
+        break;
+    case 1:
+        guiHelper->setPaletteType(Dtk::Gui::DGuiApplicationHelper::LightType);
+        break;
+    default:
+        qCWarning(treelandConfig) << "Unknown windowThemeType:" << themeType
+                                  << ", fallback to light.";
+        guiHelper->setPaletteType(Dtk::Gui::DGuiApplicationHelper::LightType);
+        break;
+    }
 }
 
 void Helper::tryInitRemoteSource()
@@ -1353,6 +1381,7 @@ void Helper::init(Treeland::Treeland *treeland)
 #else
         if (m_config->isInitializeSucceed()) {
 #endif
+            syncPaletteTypeWithWindowThemeType(m_config->windowThemeType());
             m_wallpaperManager->updateWallpaperConfig();
             tryInitRemoteSource();
         } else {
@@ -1360,6 +1389,9 @@ void Helper::init(Treeland::Treeland *treeland)
                     &TreelandUserConfig::configInitializeSucceed,
                     m_wallpaperManager,
                     &WallpaperManager::updateWallpaperConfig);
+            connect(m_config.get(), &TreelandUserConfig::configInitializeSucceed, this, [this] {
+                syncPaletteTypeWithWindowThemeType(m_config->windowThemeType());
+            });
             connect(m_config.get(),
                     &TreelandUserConfig::configInitializeSucceed,
                     this,

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -165,6 +165,8 @@ public:
     explicit Helper(QObject *parent = nullptr);
     ~Helper() override;
 
+    static void syncPaletteTypeWithWindowThemeType(int32_t themeType);
+
     enum class OutputMode
     {
         Copy,

--- a/waylib/src/server/kernel/wserver.cpp
+++ b/waylib/src/server/kernel/wserver.cpp
@@ -355,8 +355,13 @@ void WServer::start()
     d->init();
 }
 
-void WServer::initializeQPA(const QStringList &parameters)
+void WServer::initializeQPA(const QStringList &parameters,
+                            std::function<QPlatformTheme *(const QString &)> createPlatformTheme)
 {
+    if (createPlatformTheme) {
+        QWlrootsIntegration::setCreatePlatformThemeCallback(std::move(createPlatformTheme));
+    }
+
     if (!initializeQtPlatform(parameters, nullptr)) {
         qFatal("Can't initialize Qt platform plugin.");
         return;

--- a/waylib/src/server/kernel/wserver.h
+++ b/waylib/src/server/kernel/wserver.h
@@ -4,13 +4,17 @@
 #pragma once
 
 #include <wglobal.h>
+
 #include <qwglobal.h>
 
 #include <QDeadlineTimer>
 #include <QFuture>
 #include <QObject>
 
+#include <functional>
+
 QT_BEGIN_NAMESPACE
+class QPlatformTheme;
 class QProcess;
 QT_END_NAMESPACE
 
@@ -135,7 +139,9 @@ public:
 
     void start();
     void stop();
-    static void initializeQPA(const QStringList &parameters = {});
+    static void initializeQPA(
+        const QStringList &parameters = {},
+        std::function<QPlatformTheme *(const QString &)> createPlatformTheme = {});
 
     bool isRunning() const;
     void addSocket(WSocket *socket);

--- a/waylib/src/server/platformplugin/qwlrootsintegration.cpp
+++ b/waylib/src/server/platformplugin/qwlrootsintegration.cpp
@@ -442,9 +442,18 @@ QStringList QWlrootsIntegration::themeNames() const
     return QPlatformIntegration::themeNames();
 }
 
+QWlrootsIntegration::CreatePlatformThemeCallback QWlrootsIntegration::s_createPlatformThemeCallback;
+
+void QWlrootsIntegration::setCreatePlatformThemeCallback(CreatePlatformThemeCallback callback)
+{
+    s_createPlatformThemeCallback = std::move(callback);
+}
+
 QPlatformTheme *QWlrootsIntegration::createPlatformTheme([[maybe_unused]] const QString &name) const
 {
-    // TODO: use custom platform theme to allow compositor set some hints, like as font
+    if (s_createPlatformThemeCallback) {
+        return s_createPlatformThemeCallback(name);
+    }
     return new QGenericUnixTheme();
 }
 

--- a/waylib/src/server/platformplugin/qwlrootsintegration.h
+++ b/waylib/src/server/platformplugin/qwlrootsintegration.h
@@ -86,6 +86,10 @@ public:
     QStringList themeNames() const override;
     QPlatformTheme *createPlatformTheme(const QString &name) const override;
 
+    using CreatePlatformThemeCallback = std::function<QPlatformTheme *(const QString &name)>;
+    static WAYLIB_SERVER_EXPORT void setCreatePlatformThemeCallback(
+        CreatePlatformThemeCallback callback);
+
     QPlatformOffscreenSurface *createPlatformOffscreenSurface(QOffscreenSurface *surface) const override;
 
 #ifndef QT_NO_SESSIONMANAGER
@@ -110,6 +114,7 @@ public:
 private:
     friend class QWlrootsScreen;
 
+    static CreatePlatformThemeCallback s_createPlatformThemeCallback;
     mutable std::unique_ptr<QPlatformFontDatabase> m_fontDb;
     std::unique_ptr<QPlatformServices> m_services;
     std::unique_ptr<QPlatformPlaceholderScreen> m_placeholderScreen;


### PR DESCRIPTION
  - introduce TitleBarPalette for title bar background/text/button colors
  - stop reading palette.window back through the child control to avoid binding loops
  - keep window button colors driven by DTK palette state
  - add TitleBarPalette to the QML module resources

Influence:
1. Verify window button text colors change correctly when window loses focus
2. Test behavior with both light and dark themes

PMS: 364025