### PR TITLE
feat(ci): add clang-format check workflow and pre-commit script

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,75 @@
+name: clang-format check
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format
+
+      - name: Check C/C++ code formatting
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE_SHA="HEAD~1"
+          fi
+          rc=0
+          output=$(git clang-format "${BASE_SHA}" --diff \
+            --extensions 'c,h,cpp,cc,cxx,hpp' 2>&1) || rc=$?
+
+          # If git-clang-format itself failed (version mismatch, crash, etc.),
+          # report the raw error instead of guessing.
+          if [ $rc -ne 0 ]; then
+            echo "ERROR: git-clang-format failed (exit code ${rc})."
+            echo ""
+            echo "${output}"
+            exit 1
+          fi
+
+          # If no modified files match the extensions, skip.
+          if echo "${output}" | grep -q 'no modified files to format'; then
+            echo "No C/C++ files modified, skipping format check."
+            exit 0
+          fi
+
+          # If already properly formatted, pass.
+          if echo "${output}" | grep -q 'clang-format did not modify any files'; then
+            echo "All code is properly formatted."
+            exit 0
+          fi
+
+          # Empty diff (no output) — also clean.
+          if [ -z "${output}" ]; then
+            echo "All code is properly formatted."
+            exit 0
+          fi
+
+          # Otherwise, formatting issues exist.
+          echo ""
+          echo "============================================"
+          echo "  ERROR: Code formatting issues detected!"
+          echo "  Run the following to fix:"
+          echo ""
+          echo "    git clang-format ${BASE_SHA} --extensions 'c,h,cpp,cc,cxx,hpp'"
+          echo ""
+          echo "============================================"
+          echo "${output}"
+          exit 1

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+#
+# Pre-commit hook: check staged C/C++ files with git-clang-format
+# Only checks the staged diff rather than the entire file for efficiency.
+#
+# Installation:
+#   1. Manual: ln -sf ../../scripts/pre-commit.sh .git/hooks/pre-commit
+#   2. (Legacy) CMake configure — the script is retained as a local
+#      convenience; enforcement is handled by the clang-format CI
+#      workflow on every push / pull request.
+
+set -e
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Verify git-clang-format is available
+if ! command -v git-clang-format &> /dev/null; then
+    echo "Warning: git-clang-format not found — format check skipped."
+    echo "  Formatting is still enforced by CI on every push / pull request."
+    exit 0
+fi
+
+# Verify .clang-format configuration exists
+if [[ ! -f .clang-format ]]; then
+    echo "ERROR: .clang-format configuration file not found."
+    exit 1
+fi
+
+# Capture exit code so real tool failures are not masked.
+rc=0
+output=$(git clang-format --staged --extensions 'c,h,cpp,cc,cxx' --diff 2>&1) || rc=$?
+
+if [[ $rc -ne 0 ]]; then
+    echo "ERROR: git-clang-format failed (exit code ${rc})."
+    echo ""
+    echo "${output}"
+    exit 1
+fi
+
+# Determine whether formatting is needed
+if [[ "$output" == *"no modified files to format"* ]]; then exit 0; fi
+if [[ "$output" == *"clang-format did not modify any files"* ]]; then exit 0; fi
+if [[ -z "$output" ]]; then exit 0; fi
+
+echo "ERROR: Unformatted code detected. Please format first:"
+echo ""
+echo "  git clang-format --staged --extensions 'c,h,cpp,cc,cxx'         # format staged changes"
+echo "  git clang-format --staged --extensions 'c,h,cpp,cc,cxx' --diff  # preview format diff"
+echo ""
+echo "Skip check (not recommended): git commit --no-verify"
+exit 1


### PR DESCRIPTION
Add a GitHub Actions workflow that checks C/C++ formatting with git-clang-format on every push and pull request.  Also add a local pre-commit script for developers who want to catch formatting issues before pushing.

在 GitHub Actions CI 中添加 C/C++ 代码格式检查，同时提供本地
pre-commit 脚本供开发者使用。

Log: 添加 git-clang-format CI 检查和可选本地 pre-commit 脚本
Influence: CI 会在每次推送和 PR 时检查代码格式；本地 pre-commit 脚本供手动安装使用。