### PR TITLE
feat(input): support virtual keyboard in keyboard group

### DIFF
--- a/src/input/inputmanager.cpp
+++ b/src/input/inputmanager.cpp
@@ -480,7 +480,7 @@ void InputManager::handleKeyboardSettingsApplied(KeyboardSettingsInterfaceV1::Ch
         m_seatDConfig->setKeyboardRate(interface->repeatRate());
     }
 
-    auto *keyboardDevice = interface->wSeat()->keyboard();
+    auto *keyboardDevice = interface->wSeat()->keyboardGroupKeyboard();
     if (keyboardDevice) {
         auto *keyboard = qobject_cast<qw_keyboard *>(keyboardDevice->handle());
         if (keyboard) {

--- a/src/modules/keyboard-state-notify/keyboardstatenotifymanagerinterfacev1.cpp
+++ b/src/modules/keyboard-state-notify/keyboardstatenotifymanagerinterfacev1.cpp
@@ -132,7 +132,7 @@ void TreelandKeyboardStateNotifyManagerInterfaceV1Private::onModifiersEvent(WSea
     if (s_watchers.isEmpty())
         return;
 
-    qw_keyboard *keyboard = qobject_cast<qw_keyboard*>(seat->keyboard()->handle());
+    qw_keyboard *keyboard = qobject_cast<qw_keyboard*>(seat->keyboardGroupKeyboard()->handle());
     const auto *wlrKeyboard = keyboard->handle();
     if (!wlrKeyboard || !wlrKeyboard->xkb_state)
         return;
@@ -214,7 +214,7 @@ void TreelandKeyboardStateNotifyManagerInterfaceV1Private::get_keyboard_state_wa
 
 void TreelandKeyboardStateNotifyManagerInterfaceV1Private::handleSeatAdded(WSeat *seat)
 {
-    auto *keyboardevice = seat->keyboard();
+    auto *keyboardevice = seat->keyboardGroupKeyboard();
     if (keyboardevice) {
         connectKeyboardGroup(seat, keyboardevice);
     }

--- a/waylib/src/server/kernel/winputdevice.cpp
+++ b/waylib/src/server/kernel/winputdevice.cpp
@@ -87,8 +87,9 @@ QString DeviceInfoParser::getPhysicalPath(const QString& deviceName)
 class Q_DECL_HIDDEN WInputDevicePrivate : public WWrapObjectPrivate
 {
 public:
-    WInputDevicePrivate(WInputDevice *qq, void *handle)
+    WInputDevicePrivate(WInputDevice *qq, void *handle, bool _isVirtual)
         : WWrapObjectPrivate(qq)
+        , isVirtual(_isVirtual)
     {
         initHandle(reinterpret_cast<qw_input_device*>(handle));
         this->handle()->set_data(this, qq);
@@ -111,10 +112,11 @@ public:
     QPointer<QInputDevice> qtDevice;
     QPointer<QObject> hoverTarget;
     WSeat *seat = nullptr;
+    bool isVirtual = false;
 };
 
-WInputDevice::WInputDevice(qw_input_device *handle)
-    : WWrapObject(*new WInputDevicePrivate(this, handle))
+WInputDevice::WInputDevice(qw_input_device *handle, bool isVirtual)
+    : WWrapObject(*new WInputDevicePrivate(this, handle, isVirtual))
 {
 
 }
@@ -234,6 +236,13 @@ QString WInputDevice::devicePath() const
         return procPhysPath;
     }
     return QString();
+}
+
+bool WInputDevice::isVirtual() const
+{
+    W_DC(WInputDevice);
+
+    return d->isVirtual;
 }
 
 void WInputDevice::setExclusiveGrabber(QObject *grabber)

--- a/waylib/src/server/kernel/winputdevice.h
+++ b/waylib/src/server/kernel/winputdevice.h
@@ -62,7 +62,7 @@ public:
     };
     Q_ENUM(Type)
 
-    WInputDevice(QW_NAMESPACE::qw_input_device *handle);
+    WInputDevice(QW_NAMESPACE::qw_input_device *handle, bool isVirtual = false);
 
     QW_NAMESPACE::qw_input_device *handle() const;
 
@@ -80,6 +80,8 @@ public:
     void setSeat(WSeat *seat);
     WSeat *seat() const;
     QString devicePath() const;
+
+    bool isVirtual() const;
 
 private:
     friend class QWlrootsIntegration;

--- a/waylib/src/server/kernel/wseat.cpp
+++ b/waylib/src/server/kernel/wseat.cpp
@@ -664,7 +664,7 @@ void WSeatPrivate::attachInputDevice(WInputDevice *device)
         keyboard->set_keymap(keymap);
         xkb_keymap_unref(keymap);
         xkb_context_unref(context);
-        if (device == groupkeyboardDevice) {
+        if (device == groupkeyboardDevice || device->isVirtual()) {
             device->safeConnect(&qw_keyboard::notify_key, q, [this, device] (wlr_keyboard_key_event *event) {
                 on_keyboard_key(event, device);
             });
@@ -1103,6 +1103,13 @@ void WSeat::clearKeyboardFocusWindow()
 {
     W_D(WSeat);
     d->focusWindow = nullptr;
+}
+
+WInputDevice *WSeat::keyboardGroupKeyboard() const
+{
+    W_DC(WSeat);
+
+    return d->groupkeyboardDevice;
 }
 
 WInputDevice *WSeat::keyboard() const

--- a/waylib/src/server/kernel/wseat.h
+++ b/waylib/src/server/kernel/wseat.h
@@ -100,6 +100,7 @@ public:
     QWindow *keyboardFocusWindow() const;
     void clearKeyboardFocusWindow();
 
+    WInputDevice *keyboardGroupKeyboard() const;
     WInputDevice *keyboard() const;
     void setKeyboard(WInputDevice *newKeyboard);
 

--- a/waylib/src/server/protocols/winputmethodhelper.cpp
+++ b/waylib/src/server/protocols/winputmethodhelper.cpp
@@ -323,7 +323,7 @@ void WInputMethodHelper::handleNewIPSV2(qw_input_popup_surface_v2 *ipsv2)
 void WInputMethodHelper::handleNewVKV1(wlr_virtual_keyboard_v1 *vkv1)
 {
     W_D(WInputMethodHelper);
-    WInputDevice *keyboard = new WInputDevice(qw_input_device::from(&vkv1->keyboard.base));
+    WInputDevice *keyboard = new WInputDevice(qw_input_device::from(&vkv1->keyboard.base), true);
     d->virtualKeyboards.append(keyboard);
     d->seat->attachInputDevice(keyboard);
     keyboard->safeConnect(&qw_input_device::before_destroy, this, [d, keyboard] () {


### PR DESCRIPTION
Track virtual keyboard devices with an `isVirtual` flag so they can bypass the keyboard group gate on key events.  Expose `keyboardGroupActiveKeyboard()` and use it in the keyboard-state-notify module so that modifier/xkb state queries target the correct keyboard handle rather than the raw seat keyboard.

Log: support virtual keyboard in keyboard group

PMS: TASK-390137

Influence: