### PR TITLE
fix(input): apply scroll factor per-device instead of iterating all s…

### DIFF
--- a/src/input/inputmanager.cpp
+++ b/src/input/inputmanager.cpp
@@ -58,23 +58,15 @@ void InputManager::setupSeatUserConfig(const QString &userName)
 
 void InputManager::onConfigInitializeSucceed()
 {
-    auto seatMgr = Helper::instance()->seatManager();
-    if (seatMgr) {
-        for (auto *seat : seatMgr->seats()) {
-            if (auto *cursor = seat->cursor())
-                cursor->setScrollFactor(m_seatDConfig->pointerScrollFactor());
-        }
-    }
-
     auto backend = Helper::instance()->backend();
-    connect(backend,
-            &WBackend::inputAdded,
-            this,
-            &InputManager::onInputAdded);
     const auto inputDevices = backend->inputDeviceList();
     for (WInputDevice *device : inputDevices) {
         onInputAdded(device);
     }
+    connect(backend,
+            &WBackend::inputAdded,
+            this,
+            &InputManager::onInputAdded);
 }
 
 void InputManager::onMouseSettingsCreated(MouseSettingsInterfaceV1 *interface)
@@ -552,6 +544,11 @@ void InputManager::onInputAdded(WInputDevice *input)
 
     if (!input->handle()->is_libinput()) {
         return;
+    }
+
+    auto *cursor = input->seat()->cursor();
+    if (cursor) {
+        cursor->setScrollFactor(m_seatDConfig->pointerScrollFactor());
     }
 
     struct libinput_device *inputDevice = wlr_libinput_get_device_handle(input->handle()->handle());


### PR DESCRIPTION
…eats

Move cursor scroll factor initialization from onConfigInitializeSucceed() to onInputAdded(), ensuring each device's seat cursor is configured when the device is registered. Also reorder connect() after initial device iteration to avoid processing existing devices twice via the signal.

Log: apply scroll factor per-device instead of iterating all seats

PMS: TASK-389477

Influence: