### PR TITLE
feat: support relative pointer and pointer constraints

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1436,7 +1436,7 @@ void Helper::init(Treeland::Treeland *treeland)
     m_foreignToplevel = m_server->attach<WForeignToplevel>();
     m_extForeignToplevelListV1 = m_server->attach<WExtForeignToplevelListV1>();
     m_server->attach<WRelativePointerManagerV1>();
-    m_server->attach<WPointerConstraintsV1>();
+    auto *pointerConstraints = m_server->attach<WPointerConstraintsV1>();
 
     connect(m_shellHandler,
             &ShellHandler::surfaceWrapperAdded,
@@ -1615,6 +1615,135 @@ void Helper::init(Treeland::Treeland *treeland)
     if (m_rootSurfaceContainer) {
         m_rootSurfaceContainer->setupSeatManagement();
     }
+
+    auto installPointerConstraintPolicy = [this](WSeat *seat) {
+        if (!seat)
+            return;
+
+        seat->setPointerConstraintActivationFilter(
+            [this](const WSeat::PointerConstraintActivationContext &context, QString *reason) {
+                auto setReason = [reason](const QString &text) {
+                    if (reason)
+                        *reason = text;
+                };
+
+                if (context.constraintType == WSeat::PointerConstraintType::Confined)
+                    return true;
+
+                if (!context.seat) {
+                    setReason(QStringLiteral("seat is null"));
+                    return false;
+                }
+
+                if (!context.surface) {
+                    setReason(QStringLiteral("surface is null"));
+                    return false;
+                }
+
+                if (m_currentMode != CurrentMode::Normal) {
+                    setReason(QStringLiteral("current mode is %1, not normal")
+                                  .arg(static_cast<int>(m_currentMode)));
+                    return false;
+                }
+
+                if (m_showDesktop == WindowManagementInterfaceV1::DesktopState::Show) {
+                    setReason(QStringLiteral("show desktop is active"));
+                    return false;
+                }
+
+                auto *currentWorkspace = workspace();
+                if (!m_rootSurfaceContainer || !currentWorkspace || !currentWorkspace->current()) {
+                    setReason(QStringLiteral("workspace/root container is not ready"));
+                    return false;
+                }
+
+                auto *wrapper = m_rootSurfaceContainer->getSurface(context.surface);
+                if (!wrapper) {
+                    setReason(QStringLiteral("surface has no wrapper"));
+                    return false;
+                }
+
+                if (!wrapper->surface() || !wrapper->surface()->mapped()) {
+                    setReason(QStringLiteral("wrapper surface is not mapped"));
+                    return false;
+                }
+
+                if (!wrapper->isVisible()) {
+                    setReason(QStringLiteral("wrapper is not visible"));
+                    return false;
+                }
+
+                if (wrapper->isMinimized()) {
+                    setReason(QStringLiteral("wrapper is minimized"));
+                    return false;
+                }
+
+                if (!wrapper->showOnWorkspace(currentWorkspace->current()->id())) {
+                    setReason(QStringLiteral("wrapper is not on current workspace"));
+                    return false;
+                }
+
+                auto *activated = m_rootSurfaceContainer->getActivatedSurfaceForSeat(context.seat);
+                if (activated != wrapper) {
+                    setReason(QStringLiteral("wrapper is not activated for seat"));
+                    return false;
+                }
+
+                return true;
+            });
+
+        connect(this,
+                &Helper::currentModeChanged,
+                seat,
+                &WSeat::reevaluatePointerConstraint,
+                Qt::UniqueConnection);
+
+        if (m_windowManagementInterfaceV1) {
+            connect(m_windowManagementInterfaceV1,
+                    &WindowManagementInterfaceV1::desktopStateChanged,
+                    seat,
+                    &WSeat::reevaluatePointerConstraint,
+                    Qt::UniqueConnection);
+        }
+
+        if (auto *currentWorkspace = workspace()) {
+            connect(currentWorkspace,
+                    &Workspace::currentChanged,
+                    seat,
+                    &WSeat::reevaluatePointerConstraint,
+                    Qt::UniqueConnection);
+        }
+
+        if (auto *seatContainer = m_rootSurfaceContainer
+                ? m_rootSurfaceContainer->getSeatContainer(seat)
+                : nullptr) {
+            connect(seatContainer,
+                    &SeatSurfaceManager::activatedSurfaceChanged,
+                    seat,
+                    &WSeat::reevaluatePointerConstraint,
+                    Qt::UniqueConnection);
+        }
+
+        seat->reevaluatePointerConstraint();
+    };
+
+    for (auto *seat : m_seatManager->seats()) {
+        installPointerConstraintPolicy(seat);
+    }
+
+    connect(m_seatManager,
+            &SeatsManager::seatAdded,
+            this,
+            installPointerConstraintPolicy);
+
+    connect(pointerConstraints,
+            &WPointerConstraintsV1::newConstraint,
+            this,
+            [this](qw_pointer_constraint_v1 *) {
+                for (auto *seat : m_seatManager->seats()) {
+                    seat->reevaluatePointerConstraint();
+                }
+            });
 
     if (!m_primarySeat) {
         qCCritical(lcTlCore) << "No seat available after initialization, cannot continue";

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -84,7 +84,9 @@
 #include <woutputrenderwindow.h>
 #include <woutputviewport.h>
 #include <wqmlcreator.h>
+#include <wpointerconstraintsv1.h>
 #include <wquickcursor.h>
+#include <wrelativepointermanagerv1.h>
 #include <wrenderhelper.h>
 #include <wseat.h>
 #include <wsecuritycontextmanager.h>
@@ -1433,6 +1435,8 @@ void Helper::init(Treeland::Treeland *treeland)
 
     m_foreignToplevel = m_server->attach<WForeignToplevel>();
     m_extForeignToplevelListV1 = m_server->attach<WExtForeignToplevelListV1>();
+    m_server->attach<WRelativePointerManagerV1>();
+    m_server->attach<WPointerConstraintsV1>();
 
     connect(m_shellHandler,
             &ShellHandler::surfaceWrapperAdded,

--- a/waylib/src/server/CMakeLists.txt
+++ b/waylib/src/server/CMakeLists.txt
@@ -196,6 +196,8 @@ set(SOURCES
     protocols/private/wvirtualkeyboardv1.cpp
     protocols/ext_foreign_toplevel_image_capture_source.c #TODO: Remove after wlroots 0.20
     protocols/wcursorshapemanagerv1.cpp
+    protocols/wrelativepointermanagerv1.cpp
+    protocols/wpointerconstraintsv1.cpp
     protocols/woutputmanagerv1.cpp
     protocols/wextforeigntoplevellistv1.cpp
     protocols/wxdgdialogmanagerv1.cpp
@@ -292,6 +294,10 @@ set(HEADERS
     protocols/WInputPopupSurface
     protocols/wcursorshapemanagerv1.h
     protocols/WCursorShapeManagerV1
+    protocols/wrelativepointermanagerv1.h
+    protocols/WRelativePointerManagerV1
+    protocols/wpointerconstraintsv1.h
+    protocols/WPointerConstraintsV1
     protocols/woutputmanagerv1.h
     protocols/WOutputManagerV1
     protocols/wlayershell.h

--- a/waylib/src/server/kernel/wcursor.cpp
+++ b/waylib/src/server/kernel/wcursor.cpp
@@ -85,6 +85,17 @@ void WCursorPrivate::sendLeaveEvent(WInputDevice *device)
 void WCursorPrivate::on_motion(wlr_pointer_motion_event *event)
 {
     auto device = qw_pointer::from(event->pointer);
+    if (auto inputDevice = WInputDevice::fromHandle(device)) {
+        if (auto deviceSeat = inputDevice->seat()) {
+            deviceSeat->refreshPointerConstraint();
+            deviceSeat->notifyRelativeMotion(event->time_msec,
+                                             QPointF(event->delta_x, event->delta_y),
+                                             QPointF(event->unaccel_dx, event->unaccel_dy));
+            if (deviceSeat->pointerMotionLocked())
+                return;
+        }
+    }
+
     q_func()->move(device, QPointF(event->delta_x, event->delta_y));
     processCursorMotion(device, event->time_msec);
 }

--- a/waylib/src/server/kernel/wseat.cpp
+++ b/waylib/src/server/kernel/wseat.cpp
@@ -32,11 +32,14 @@
 #include <QTimer>
 
 #include <cmath>
+#include <sys/types.h>
+#include <utility>
 
 #include <qpa/qwindowsysteminterface.h>
 #include <private/qxkbcommon_p.h>
 #include <private/qquickwindow_p.h>
 #include <private/qquickdeliveryagent_p_p.h>
+#include <wayland-server-core.h>
 
 QT_BEGIN_NAMESPACE
 Q_GUI_EXPORT bool qt_sendShortcutOverrideEvent(QObject *o, ulong timestamp, int k, Qt::KeyboardModifiers mods, const QString &text = QString(), bool autorep = false, ushort count = 1);
@@ -44,6 +47,66 @@ QT_END_NAMESPACE
 
 QW_USE_NAMESPACE
 WAYLIB_SERVER_BEGIN_NAMESPACE
+
+static const char *pointerConstraintTypeName(WSeat::PointerConstraintType type)
+{
+    switch (type) {
+    case WSeat::PointerConstraintType::Locked:
+        return "locked";
+    case WSeat::PointerConstraintType::Confined:
+        return "confined";
+    }
+
+    Q_UNREACHABLE_RETURN("unknown");
+}
+
+static WSeat::PointerConstraintType pointerConstraintType(qw_pointer_constraint_v1 *constraint)
+{
+    Q_ASSERT(constraint && constraint->handle());
+    return constraint->handle()->type == WLR_POINTER_CONSTRAINT_V1_LOCKED
+        ? WSeat::PointerConstraintType::Locked
+        : WSeat::PointerConstraintType::Confined;
+}
+
+static const char *focusedCursorRequestName(WSeat::FocusedCursorRequest request)
+{
+    switch (request) {
+    case WSeat::FocusedCursorRequest::None:
+        return "none";
+    case WSeat::FocusedCursorRequest::Hidden:
+        return "hidden";
+    case WSeat::FocusedCursorRequest::Surface:
+        return "surface";
+    case WSeat::FocusedCursorRequest::Shape:
+        return "shape";
+    }
+
+    Q_UNREACHABLE_RETURN("unknown");
+}
+
+static const char *pointerConstraintLifetimeName(uint32_t lifetime)
+{
+    switch (lifetime) {
+    case ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_ONESHOT:
+        return "oneshot";
+    case ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT:
+        return "persistent";
+    }
+
+    return "unknown";
+}
+
+static qint64 pointerConstraintClientPid(wlr_pointer_constraint_v1 *constraint)
+{
+    if (!constraint || !constraint->resource)
+        return -1;
+
+    pid_t pid = -1;
+    uid_t uid = 0;
+    gid_t gid = 0;
+    wl_client_get_credentials(wl_resource_get_client(constraint->resource), &pid, &uid, &gid);
+    return pid;
+}
 
 #if QT_CONFIG(wheelevent)
 class Q_DECL_HIDDEN WSeatWheelEvent : public QWheelEvent {
@@ -165,8 +228,63 @@ public:
             && activePointerConstraint->handle()->type == WLR_POINTER_CONSTRAINT_V1_LOCKED;
     }
 
-    inline void deactivatePointerConstraint() {
+    inline WSeat::FocusedCursorRequest focusedCursorRequestKind() const {
+        if (!cursorClient || cursorClient != nativeHandle()->pointer_state.focused_client)
+            return WSeat::FocusedCursorRequest::None;
+
+        return focusedCursorRequest;
+    }
+
+    inline WSeat::PointerConstraintActivationContext pointerConstraintActivationContext(
+        qw_pointer_constraint_v1 *constraint,
+        WSurface *surface) {
+        WSeat::PointerConstraintActivationContext context;
+        context.constraintType = pointerConstraintType(constraint);
+        context.cursorRequest = focusedCursorRequestKind();
+        context.surface = surface;
+        context.seat = q_func();
+        context.constraint = constraint;
+        return context;
+    }
+
+    inline bool pointerConstraintActivationAllowed(qw_pointer_constraint_v1 *constraint,
+                                                   WSurface *surface,
+                                                   QString *reason = nullptr) {
+        if (!constraint || !constraint->handle()) {
+            if (reason)
+                *reason = QStringLiteral("constraint handle is null");
+            return false;
+        }
+
+        const auto context = pointerConstraintActivationContext(constraint, surface);
+
+        if (context.constraintType == WSeat::PointerConstraintType::Locked
+            && context.cursorRequest != WSeat::FocusedCursorRequest::Hidden) {
+            if (reason) {
+                *reason = QStringLiteral("focused cursor request is %1, not hidden")
+                    .arg(QLatin1String(focusedCursorRequestName(context.cursorRequest)));
+            }
+            return false;
+        }
+
+        if (pointerConstraintActivationFilter) {
+            QString filterReason;
+            if (!pointerConstraintActivationFilter(context, &filterReason)) {
+                if (reason) {
+                    *reason = filterReason.isEmpty()
+                        ? QStringLiteral("compositor policy rejected activation")
+                        : filterReason;
+                }
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    inline void deactivatePointerConstraint(const QString &reason = QString()) {
         auto *constraint = activePointerConstraint.data();
+        auto *handle = constraint ? constraint->handle() : nullptr;
 
         activePointerConstraint.clear();
         QObject::disconnect(activePointerConstraintDestroyConnection);
@@ -174,29 +292,66 @@ public:
         activePointerConstraintDestroyConnection = {};
         activePointerConstraintRegionConnection = {};
 
-        if (constraint && constraint->handle())
+        if (handle) {
+            qCInfo(lcWlSeat)
+                << "Deactivating pointer constraint"
+                << "type =" << pointerConstraintTypeName(pointerConstraintType(constraint))
+                << "lifetime =" << pointerConstraintLifetimeName(handle->lifetime)
+                << "constraint =" << handle
+                << "surface =" << handle->surface
+                << "seat =" << handle->seat
+                << "clientPid =" << pointerConstraintClientPid(handle)
+                << "reason =" << reason;
             constraint->send_deactivated();
+        }
     }
 
     inline void updatePointerConstraint(WSurface *surface, const QPointF &surfacePos) {
         auto *constraint = constraintForSurface(surface);
         if (!constraint) {
             if (activePointerConstraint)
-                deactivatePointerConstraint();
+                deactivatePointerConstraint(QStringLiteral("focused surface has no pointer constraint"));
             return;
         }
 
         if (activePointerConstraint && activePointerConstraint->handle() == constraint->handle()) {
-            if (!pointerConstraintContains(constraint, surfacePos))
-                deactivatePointerConstraint();
+            if (!pointerConstraintContains(constraint, surfacePos)) {
+                deactivatePointerConstraint(QStringLiteral("pointer left constraint region"));
+                return;
+            }
+
+            QString denyReason;
+            if (!pointerConstraintActivationAllowed(constraint, surface, &denyReason))
+                deactivatePointerConstraint(denyReason);
             return;
         }
 
         if (activePointerConstraint)
-            deactivatePointerConstraint();
+            deactivatePointerConstraint(QStringLiteral("switching active pointer constraint"));
 
-        if (!pointerConstraintContains(constraint, surfacePos))
+        if (!pointerConstraintContains(constraint, surfacePos)) {
+            qCDebug(lcWlSeat)
+                << "Not activating pointer constraint: pointer outside region"
+                << "type =" << pointerConstraintTypeName(pointerConstraintType(constraint))
+                << "constraint =" << constraint->handle()
+                << "surface =" << surface
+                << "surfacePos =" << surfacePos;
             return;
+        }
+
+        QString denyReason;
+        if (!pointerConstraintActivationAllowed(constraint, surface, &denyReason)) {
+            qCDebug(lcWlSeat)
+                << "Not activating pointer constraint"
+                << "type =" << pointerConstraintTypeName(pointerConstraintType(constraint))
+                << "lifetime =" << pointerConstraintLifetimeName(constraint->handle()->lifetime)
+                << "constraint =" << constraint->handle()
+                << "surface =" << surface
+                << "seat =" << q_func()
+                << "clientPid =" << pointerConstraintClientPid(constraint->handle())
+                << "reason =" << denyReason;
+            return;
+        }
 
         activePointerConstraint = constraint;
         activePointerConstraintDestroyConnection =
@@ -213,6 +368,15 @@ public:
                              q_func(), [this] {
                                  updatePointerConstraint();
                              });
+        qCInfo(lcWlSeat)
+            << "Activating pointer constraint"
+            << "type =" << pointerConstraintTypeName(pointerConstraintType(constraint))
+            << "lifetime =" << pointerConstraintLifetimeName(constraint->handle()->lifetime)
+            << "constraint =" << constraint->handle()
+            << "surface =" << surface
+            << "seat =" << q_func()
+            << "clientPid =" << pointerConstraintClientPid(constraint->handle())
+            << "cursorRequest =" << focusedCursorRequestName(focusedCursorRequestKind());
         constraint->send_activated();
     }
 
@@ -287,7 +451,7 @@ public:
         auto tmp = oldPointerFocusSurface;
         oldPointerFocusSurface = handle()->handle()->pointer_state.focused_surface;
         if (activePointerConstraint && activePointerConstraint->handle()->surface != surface->handle()->handle())
-            deactivatePointerConstraint();
+            deactivatePointerConstraint(QStringLiteral("pointer entered another surface"));
 
         handle()->pointer_notify_enter(surface->handle()->handle(), position.x(), position.y());
         if (!pointerFocusSurface()) {
@@ -319,7 +483,7 @@ public:
     }
     inline void doClearPointerFocus() {
         if (activePointerConstraint)
-            deactivatePointerConstraint();
+            deactivatePointerConstraint(QStringLiteral("pointer focus cleared"));
         pointerFocusEventObject.clear();
         handle()->pointer_notify_clear_focus();
         Q_ASSERT(!handle()->handle()->pointer_state.focused_surface);
@@ -485,6 +649,8 @@ public:
     QPointer<QObject> pointerFocusEventObject;
     QPointer<WSurface> m_keyboardFocusSurface;
     QPointer<qw_pointer_constraint_v1> activePointerConstraint;
+    WSeat::FocusedCursorRequest focusedCursorRequest = WSeat::FocusedCursorRequest::None;
+    WSeat::PointerConstraintActivationFilter pointerConstraintActivationFilter;
     QMetaObject::Connection onEventObjectDestroy;
     QMetaObject::Connection activePointerConstraintDestroyConnection;
     QMetaObject::Connection activePointerConstraintRegionConnection;
@@ -583,6 +749,8 @@ void WSeatPrivate::on_request_set_cursor(wlr_seat_pointer_request_set_cursor_eve
         auto *surface = event->surface ? qw_surface::from(event->surface) : nullptr;
         cursorClient = event->seat_client;
         cursorShape = WGlobal::CursorShape::Invalid;
+        focusedCursorRequest = surface ? WSeat::FocusedCursorRequest::Surface
+                                       : WSeat::FocusedCursorRequest::Hidden;
 
         if (cursorSurface)
             cursorSurface->safeDeleteLater();
@@ -598,7 +766,14 @@ void WSeatPrivate::on_request_set_cursor(wlr_seat_pointer_request_set_cursor_eve
         cursorSurfaceHotspot.rx() = event->hotspot_x;
         cursorSurfaceHotspot.ry() = event->hotspot_y;
 
+        qCDebug(lcWlSeat)
+            << "Focused client requested cursor surface"
+            << "seat =" << q_func()
+            << "seatClient =" << event->seat_client
+            << "surface =" << event->surface
+            << "cursorRequest =" << focusedCursorRequestName(focusedCursorRequest);
         Q_EMIT q->requestCursorSurface(cursorSurface, cursorSurfaceHotspot);
+        updatePointerConstraint();
     }
 }
 
@@ -1285,6 +1460,21 @@ void WSeat::setAlwaysUpdateHoverTarget(bool newIgnoreSurfacePointerEventExclusiv
     Q_EMIT alwaysUpdateHoverTargetChanged();
 }
 
+void WSeat::setPointerConstraintActivationFilter(PointerConstraintActivationFilter filter)
+{
+    W_D(WSeat);
+    d->pointerConstraintActivationFilter = std::move(filter);
+    if (isValid())
+        d->updatePointerConstraint();
+}
+
+void WSeat::reevaluatePointerConstraint()
+{
+    W_D(WSeat);
+    if (isValid())
+        d->updatePointerConstraint();
+}
+
 void WSeat::notifyRelativeMotion(uint32_t timestamp, const QPointF &delta,
                                  const QPointF &unacceleratedDelta)
 {
@@ -1295,7 +1485,8 @@ void WSeat::notifyRelativeMotion(uint32_t timestamp, const QPointF &delta,
 void WSeat::refreshPointerConstraint()
 {
     W_D(WSeat);
-    d->updatePointerConstraint();
+    if (isValid())
+        d->updatePointerConstraint();
 }
 
 bool WSeat::pointerMotionLocked() const
@@ -1618,11 +1809,18 @@ void WSeat::setCursorShape(wlr_seat_client *client, WGlobal::CursorShape shape)
         return;
     d->cursorShape = shape;
     d->cursorClient = client;
+    d->focusedCursorRequest = FocusedCursorRequest::Shape;
 
     if (d->cursorSurface)
         d->cursorSurface->safeDeleteLater();
 
+    qCDebug(lcWlSeat)
+        << "Focused client requested cursor shape"
+        << "seat =" << this
+        << "seatClient =" << client
+        << "shape =" << static_cast<int>(shape);
     Q_EMIT requestCursorShape(shape);
+    d->updatePointerConstraint();
 }
 
 WSeatEventFilter *WSeat::eventFilter() const

--- a/waylib/src/server/kernel/wseat.cpp
+++ b/waylib/src/server/kernel/wseat.cpp
@@ -5,6 +5,8 @@
 #include "wcursor.h"
 #include "winputdevice.h"
 #include "woutput.h"
+#include "wpointerconstraintsv1.h"
+#include "wrelativepointermanagerv1.h"
 #include "wsurface.h"
 #include "wxdgsurface.h"
 #include "platformplugin/qwlrootsintegration.h"
@@ -16,6 +18,7 @@
 #include <qwcursor.h>
 #include <qwcompositor.h>
 #include <qwdatadevice.h>
+#include <qwpointerconstraintsv1.h>
 #include <qwpointergesturesv1.h>
 #include <qwcompositor.h>
 #include <qwdisplay.h>
@@ -27,6 +30,8 @@
 #include <QQuickItem>
 #include <QDebug>
 #include <QTimer>
+
+#include <cmath>
 
 #include <qpa/qwindowsysteminterface.h>
 #include <private/qxkbcommon_p.h>
@@ -132,6 +137,104 @@ public:
         return nativeHandle()->keyboard_state.focused_surface;
     }
 
+    inline WPointerConstraintsV1 *pointerConstraints() const {
+        const auto *server = q_func()->server();
+        return server ? server->findInterface<WPointerConstraintsV1>() : nullptr;
+    }
+
+    inline qw_pointer_constraint_v1 *constraintForSurface(WSurface *surface) const {
+        auto *constraints = pointerConstraints();
+        return constraints ? constraints->constraintForSurface(surface, q_func()) : nullptr;
+    }
+
+    inline bool pointerConstraintContains(qw_pointer_constraint_v1 *constraint,
+                                          const QPointF &surfacePos) const {
+        if (!constraint || !constraint->handle())
+            return false;
+
+        pixman_box32_t box;
+        return pixman_region32_contains_point(&constraint->handle()->region,
+                                              std::floor(surfacePos.x()),
+                                              std::floor(surfacePos.y()),
+                                              &box);
+    }
+
+    inline bool pointerMotionLocked() const {
+        return activePointerConstraint
+            && activePointerConstraint->handle()
+            && activePointerConstraint->handle()->type == WLR_POINTER_CONSTRAINT_V1_LOCKED;
+    }
+
+    inline void deactivatePointerConstraint() {
+        auto *constraint = activePointerConstraint.data();
+
+        activePointerConstraint.clear();
+        QObject::disconnect(activePointerConstraintDestroyConnection);
+        QObject::disconnect(activePointerConstraintRegionConnection);
+        activePointerConstraintDestroyConnection = {};
+        activePointerConstraintRegionConnection = {};
+
+        if (constraint && constraint->handle())
+            constraint->send_deactivated();
+    }
+
+    inline void updatePointerConstraint(WSurface *surface, const QPointF &surfacePos) {
+        auto *constraint = constraintForSurface(surface);
+        if (!constraint) {
+            if (activePointerConstraint)
+                deactivatePointerConstraint();
+            return;
+        }
+
+        if (activePointerConstraint && activePointerConstraint->handle() == constraint->handle()) {
+            if (!pointerConstraintContains(constraint, surfacePos))
+                deactivatePointerConstraint();
+            return;
+        }
+
+        if (activePointerConstraint)
+            deactivatePointerConstraint();
+
+        if (!pointerConstraintContains(constraint, surfacePos))
+            return;
+
+        activePointerConstraint = constraint;
+        activePointerConstraintDestroyConnection =
+            QObject::connect(constraint, &qw_pointer_constraint_v1::before_destroy,
+                             q_func(), [this] {
+                                 activePointerConstraint.clear();
+                                 QObject::disconnect(activePointerConstraintDestroyConnection);
+                                 QObject::disconnect(activePointerConstraintRegionConnection);
+                                 activePointerConstraintDestroyConnection = {};
+                                 activePointerConstraintRegionConnection = {};
+                             });
+        activePointerConstraintRegionConnection =
+            QObject::connect(constraint, &qw_pointer_constraint_v1::notify_set_region,
+                             q_func(), [this] {
+                                 updatePointerConstraint();
+                             });
+        constraint->send_activated();
+    }
+
+    inline void updatePointerConstraint() {
+        auto *focus = pointerFocusSurface();
+        if (!focus) {
+            if (activePointerConstraint)
+                deactivatePointerConstraint();
+            return;
+        }
+
+        auto *surface = WSurface::fromHandle(focus);
+        if (!surface) {
+            if (activePointerConstraint)
+                deactivatePointerConstraint();
+            return;
+        }
+
+        const auto &pointerState = nativeHandle()->pointer_state;
+        updatePointerConstraint(surface, QPointF(pointerState.sx, pointerState.sy));
+    }
+
     inline bool doNotifyMotion(WSurface *target, QObject *eventObject, QPointF localPos, uint32_t timestamp) {
         if (target) {
             if (pointerFocusSurface()) {
@@ -143,7 +246,12 @@ public:
                 // take pointer focus for this surface.
                 doEnter(target, eventObject, localPos);
             }
+
+            updatePointerConstraint(target, localPos);
         }
+
+        if (pointerMotionLocked())
+            return true;
 
         handle()->pointer_notify_motion(timestamp, localPos.x(), localPos.y());
         return true;
@@ -178,6 +286,9 @@ public:
         }
         auto tmp = oldPointerFocusSurface;
         oldPointerFocusSurface = handle()->handle()->pointer_state.focused_surface;
+        if (activePointerConstraint && activePointerConstraint->handle()->surface != surface->handle()->handle())
+            deactivatePointerConstraint();
+
         handle()->pointer_notify_enter(surface->handle()->handle(), position.x(), position.y());
         if (!pointerFocusSurface()) {
             // Because if the last pointer focus surface is a popup, the 'pointerNotifyEnter'
@@ -202,9 +313,13 @@ public:
             });
         }
 
+        updatePointerConstraint(surface, position);
+
         return true;
     }
     inline void doClearPointerFocus() {
+        if (activePointerConstraint)
+            deactivatePointerConstraint();
         pointerFocusEventObject.clear();
         handle()->pointer_notify_clear_focus();
         Q_ASSERT(!handle()->handle()->pointer_state.focused_surface);
@@ -369,7 +484,10 @@ public:
     QPointer<QWindow> focusWindow;
     QPointer<QObject> pointerFocusEventObject;
     QPointer<WSurface> m_keyboardFocusSurface;
+    QPointer<qw_pointer_constraint_v1> activePointerConstraint;
     QMetaObject::Connection onEventObjectDestroy;
+    QMetaObject::Connection activePointerConstraintDestroyConnection;
+    QMetaObject::Connection activePointerConstraintRegionConnection;
     wlr_surface *oldPointerFocusSurface = nullptr;
 
     bool gestureActive = false;
@@ -1165,6 +1283,25 @@ void WSeat::setAlwaysUpdateHoverTarget(bool newIgnoreSurfacePointerEventExclusiv
     }
 
     Q_EMIT alwaysUpdateHoverTargetChanged();
+}
+
+void WSeat::notifyRelativeMotion(uint32_t timestamp, const QPointF &delta,
+                                 const QPointF &unacceleratedDelta)
+{
+    if (auto *manager = server() ? server()->findInterface<WRelativePointerManagerV1>() : nullptr)
+        manager->sendRelativeMotion(this, timestamp, delta, unacceleratedDelta);
+}
+
+void WSeat::refreshPointerConstraint()
+{
+    W_D(WSeat);
+    d->updatePointerConstraint();
+}
+
+bool WSeat::pointerMotionLocked() const
+{
+    W_DC(WSeat);
+    return d->pointerMotionLocked();
 }
 
 void WSeat::notifyMotion(WCursor *cursor, WInputDevice *device, uint32_t timestamp)

--- a/waylib/src/server/kernel/wseat.h
+++ b/waylib/src/server/kernel/wseat.h
@@ -10,9 +10,12 @@
 #include <QEvent>
 #include <QSharedData>
 
+#include <functional>
+
 Q_MOC_INCLUDE(<wsurface.h>)
 
 QW_BEGIN_NAMESPACE
+class qw_pointer_constraint_v1;
 class qw_seat;
 class qw_surface;
 QW_END_NAMESPACE
@@ -64,6 +67,29 @@ class WAYLIB_SERVER_EXPORT WSeat : public WWrapObject, public WServerInterface
 public:
     WSeat(const QString &name = QStringLiteral("seat0"));
 
+    enum class PointerConstraintType {
+        Locked,
+        Confined,
+    };
+
+    enum class FocusedCursorRequest {
+        None,
+        Hidden,
+        Surface,
+        Shape,
+    };
+
+    struct PointerConstraintActivationContext {
+        PointerConstraintType constraintType = PointerConstraintType::Confined;
+        FocusedCursorRequest cursorRequest = FocusedCursorRequest::None;
+        WSurface *surface = nullptr;
+        WSeat *seat = nullptr;
+        QW_NAMESPACE::qw_pointer_constraint_v1 *constraint = nullptr;
+    };
+
+    using PointerConstraintActivationFilter =
+        std::function<bool(const PointerConstraintActivationContext &context, QString *reason)>;
+
     static WSeat *fromHandle(const QW_NAMESPACE::qw_seat *handle);
     static WSeat *fromInputEvent(QInputEvent *event);
     QW_NAMESPACE::qw_seat *handle() const;
@@ -106,6 +132,9 @@ public:
 
     bool alwaysUpdateHoverTarget() const;
     void setAlwaysUpdateHoverTarget(bool newIgnoreSurfacePointerEventExclusiveGrabber);
+
+    void setPointerConstraintActivationFilter(PointerConstraintActivationFilter filter);
+    void reevaluatePointerConstraint();
 
     QList<WInputDevice*> deviceList() const;
 

--- a/waylib/src/server/kernel/wseat.h
+++ b/waylib/src/server/kernel/wseat.h
@@ -140,6 +140,10 @@ protected:
     bool filterUnacceptedEvent(QWindow *targetWindow, QInputEvent *event);
 
     // pointer
+    void notifyRelativeMotion(uint32_t timestamp, const QPointF &delta,
+                              const QPointF &unacceleratedDelta);
+    void refreshPointerConstraint();
+    bool pointerMotionLocked() const;
     void notifyMotion(WCursor *cursor, WInputDevice *device, uint32_t timestamp);
     void notifyButton(WCursor *cursor, WInputDevice *device,
                       Qt::MouseButton button, wl_pointer_button_state_t state,

--- a/waylib/src/server/protocols/WPointerConstraintsV1
+++ b/waylib/src/server/protocols/WPointerConstraintsV1
@@ -1,0 +1,1 @@
+#include "wpointerconstraintsv1.h"

--- a/waylib/src/server/protocols/WRelativePointerManagerV1
+++ b/waylib/src/server/protocols/WRelativePointerManagerV1
@@ -1,0 +1,1 @@
+#include "wrelativepointermanagerv1.h"

--- a/waylib/src/server/protocols/wpointerconstraintsv1.cpp
+++ b/waylib/src/server/protocols/wpointerconstraintsv1.cpp
@@ -7,13 +7,56 @@
 #include "wsurface.h"
 
 #include "private/wglobal_p.h"
+#include "wayliblogging.h"
 
 #include <qwcompositor.h>
 #include <qwdisplay.h>
 #include <qwpointerconstraintsv1.h>
 
+#include <sys/types.h>
+#include <wayland-server-core.h>
+
 QW_USE_NAMESPACE
 WAYLIB_SERVER_BEGIN_NAMESPACE
+
+static const char *constraintTypeName(wlr_pointer_constraint_v1 *constraint)
+{
+    if (!constraint)
+        return "unknown";
+
+    switch (constraint->type) {
+    case WLR_POINTER_CONSTRAINT_V1_LOCKED:
+        return "locked";
+    case WLR_POINTER_CONSTRAINT_V1_CONFINED:
+        return "confined";
+    }
+
+    return "unknown";
+}
+
+static const char *constraintLifetimeName(uint32_t lifetime)
+{
+    switch (lifetime) {
+    case ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_ONESHOT:
+        return "oneshot";
+    case ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT:
+        return "persistent";
+    }
+
+    return "unknown";
+}
+
+static qint64 constraintClientPid(wlr_pointer_constraint_v1 *constraint)
+{
+    if (!constraint || !constraint->resource)
+        return -1;
+
+    pid_t pid = -1;
+    uid_t uid = 0;
+    gid_t gid = 0;
+    wl_client_get_credentials(wl_resource_get_client(constraint->resource), &pid, &uid, &gid);
+    return pid;
+}
 
 class Q_DECL_HIDDEN WPointerConstraintsV1Private : public WObjectPrivate
 {
@@ -57,6 +100,20 @@ void WPointerConstraintsV1::create(WServer *server)
     m_handle = qw_pointer_constraints_v1::create(*server->handle());
     QObject::connect(handle(), &qw_pointer_constraints_v1::notify_new_constraint,
                      this, [this](wlr_pointer_constraint_v1 *constraint) {
+                         if (!constraint) {
+                             qCWarning(lcWlSeat)
+                                 << "Ignoring null pointer constraint notification";
+                             return;
+                         }
+
+                         qCInfo(lcWlSeat)
+                             << "New pointer constraint"
+                             << "type =" << constraintTypeName(constraint)
+                             << "lifetime =" << constraintLifetimeName(constraint->lifetime)
+                             << "constraint =" << constraint
+                             << "surface =" << constraint->surface
+                             << "seat =" << constraint->seat
+                             << "clientPid =" << constraintClientPid(constraint);
                          Q_EMIT newConstraint(qw_pointer_constraint_v1::from(constraint));
                      });
 }

--- a/waylib/src/server/protocols/wpointerconstraintsv1.cpp
+++ b/waylib/src/server/protocols/wpointerconstraintsv1.cpp
@@ -1,0 +1,72 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "wpointerconstraintsv1.h"
+
+#include "wseat.h"
+#include "wsurface.h"
+
+#include "private/wglobal_p.h"
+
+#include <qwcompositor.h>
+#include <qwdisplay.h>
+#include <qwpointerconstraintsv1.h>
+
+QW_USE_NAMESPACE
+WAYLIB_SERVER_BEGIN_NAMESPACE
+
+class Q_DECL_HIDDEN WPointerConstraintsV1Private : public WObjectPrivate
+{
+public:
+    explicit WPointerConstraintsV1Private(WPointerConstraintsV1 *qq)
+        : WObjectPrivate(qq)
+    {
+    }
+};
+
+WPointerConstraintsV1::WPointerConstraintsV1()
+    : WObject(*new WPointerConstraintsV1Private(this))
+{
+}
+
+qw_pointer_constraints_v1 *WPointerConstraintsV1::handle() const
+{
+    return nativeInterface<qw_pointer_constraints_v1>();
+}
+
+qw_pointer_constraint_v1 *WPointerConstraintsV1::constraintForSurface(WSurface *surface,
+                                                                      const WSeat *seat) const
+{
+    if (!handle() || !surface || !seat)
+        return nullptr;
+
+    return qw_pointer_constraint_v1::from(
+        handle()->constraint_for_surface(surface->handle()->handle(), seat->nativeHandle()));
+}
+
+QByteArrayView WPointerConstraintsV1::interfaceName() const
+{
+    return "zwp_pointer_constraints_v1";
+}
+
+void WPointerConstraintsV1::create(WServer *server)
+{
+    if (m_handle)
+        return;
+
+    m_handle = qw_pointer_constraints_v1::create(*server->handle());
+    QObject::connect(handle(), &qw_pointer_constraints_v1::notify_new_constraint,
+                     this, [this](wlr_pointer_constraint_v1 *constraint) {
+                         Q_EMIT newConstraint(qw_pointer_constraint_v1::from(constraint));
+                     });
+}
+
+wl_global *WPointerConstraintsV1::global() const
+{
+    if (!handle())
+        return nullptr;
+
+    return handle()->handle()->global;
+}
+
+WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/protocols/wpointerconstraintsv1.h
+++ b/waylib/src/server/protocols/wpointerconstraintsv1.h
@@ -1,0 +1,42 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <WServer>
+
+#include <QObject>
+
+QW_BEGIN_NAMESPACE
+class qw_pointer_constraint_v1;
+class qw_pointer_constraints_v1;
+QW_END_NAMESPACE
+
+struct wlr_pointer_constraint_v1;
+
+WAYLIB_SERVER_BEGIN_NAMESPACE
+
+class WSeat;
+class WSurface;
+
+class WAYLIB_SERVER_EXPORT WPointerConstraintsV1 : public QObject, public WObject, public WServerInterface
+{
+    Q_OBJECT
+
+public:
+    explicit WPointerConstraintsV1();
+
+    QW_NAMESPACE::qw_pointer_constraints_v1 *handle() const;
+    QW_NAMESPACE::qw_pointer_constraint_v1 *constraintForSurface(WSurface *surface, const WSeat *seat) const;
+
+    QByteArrayView interfaceName() const override;
+
+Q_SIGNALS:
+    void newConstraint(QW_NAMESPACE::qw_pointer_constraint_v1 *constraint);
+
+protected:
+    void create(WServer *server) override;
+    wl_global *global() const override;
+};
+
+WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/protocols/wrelativepointermanagerv1.cpp
+++ b/waylib/src/server/protocols/wrelativepointermanagerv1.cpp
@@ -1,0 +1,66 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "wrelativepointermanagerv1.h"
+
+#include "wseat.h"
+
+#include "private/wglobal_p.h"
+
+#include <qwdisplay.h>
+#include <qwrelativepointerv1.h>
+
+QW_USE_NAMESPACE
+WAYLIB_SERVER_BEGIN_NAMESPACE
+
+class Q_DECL_HIDDEN WRelativePointerManagerV1Private : public WObjectPrivate
+{
+public:
+    explicit WRelativePointerManagerV1Private(WRelativePointerManagerV1 *qq)
+        : WObjectPrivate(qq)
+    {
+    }
+};
+
+WRelativePointerManagerV1::WRelativePointerManagerV1()
+    : WObject(*new WRelativePointerManagerV1Private(this))
+{
+}
+
+qw_relative_pointer_manager_v1 *WRelativePointerManagerV1::handle() const
+{
+    return nativeInterface<qw_relative_pointer_manager_v1>();
+}
+
+void WRelativePointerManagerV1::sendRelativeMotion(WSeat *seat, uint32_t timeMsec,
+                                                   const QPointF &delta,
+                                                   const QPointF &unacceleratedDelta)
+{
+    if (!seat || !handle())
+        return;
+
+    handle()->send_relative_motion(seat->nativeHandle(), uint64_t(timeMsec) * 1000,
+                                   delta.x(), delta.y(),
+                                   unacceleratedDelta.x(), unacceleratedDelta.y());
+}
+
+QByteArrayView WRelativePointerManagerV1::interfaceName() const
+{
+    return "zwp_relative_pointer_manager_v1";
+}
+
+void WRelativePointerManagerV1::create(WServer *server)
+{
+    if (!m_handle)
+        m_handle = qw_relative_pointer_manager_v1::create(*server->handle());
+}
+
+wl_global *WRelativePointerManagerV1::global() const
+{
+    if (!handle())
+        return nullptr;
+
+    return handle()->handle()->global;
+}
+
+WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/protocols/wrelativepointermanagerv1.h
+++ b/waylib/src/server/protocols/wrelativepointermanagerv1.h
@@ -1,0 +1,38 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <WServer>
+
+#include <QObject>
+#include <QPointF>
+
+QW_BEGIN_NAMESPACE
+class qw_relative_pointer_manager_v1;
+QW_END_NAMESPACE
+
+WAYLIB_SERVER_BEGIN_NAMESPACE
+
+class WSeat;
+
+class WAYLIB_SERVER_EXPORT WRelativePointerManagerV1 : public QObject, public WObject, public WServerInterface
+{
+    Q_OBJECT
+
+public:
+    explicit WRelativePointerManagerV1();
+
+    QW_NAMESPACE::qw_relative_pointer_manager_v1 *handle() const;
+
+    void sendRelativeMotion(WSeat *seat, uint32_t timeMsec, const QPointF &delta,
+                            const QPointF &unacceleratedDelta);
+
+    QByteArrayView interfaceName() const override;
+
+protected:
+    void create(WServer *server) override;
+    wl_global *global() const override;
+};
+
+WAYLIB_SERVER_END_NAMESPACE


### PR DESCRIPTION
其实就是跑Minecraft Java Edition时会出现: 1. 永远只能看地面 2. 鼠标轻微移动视角就会看着地转好几圈 3. 鼠标向下移动太猛导致直接把光标直接移到了dde-shell上

该PR用于修复这个问题, 供给大佬们参考（

--

Add waylib wrappers for relative-pointer-v1 and pointer-constraints-v1, attach them during treeland startup, and route pointer motion through the seat so locked pointers receive relative motion without moving the compositor cursor.

This fixes Xwayland games such as Minecraft Java losing correct mouse input, spinning the camera, or letting the pointer escape while grabbed.