### PR TITLE
[backup] [codex/zccrs] chore: raise treeland service priority and add SEATD_SOCK

### DIFF
--- a/misc/systemd/treeland.service.in
+++ b/misc/systemd/treeland.service.in
@@ -13,6 +13,7 @@ RuntimeDirectory=treeland
 RuntimeDirectoryMode=0700
 Environment="XDG_RUNTIME_DIR=%t/treeland"
 Environment=LIBSEAT_BACKEND=seatd
+Environment=SEATD_SOCK=/run/dde-seatd.sock
 Environment=DSG_APP_ID=org.deepin.dde.treeland
 Environment=ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
 # For Debug: if enable asan, you can't get it's log from journalctl, so ensure the log to a file
@@ -27,8 +28,14 @@ StandardOutput=null
 StandardError=null
 
 NoNewPrivileges=true
-OOMScoreAdjust=-300
-Nice=-15
+OOMScoreAdjust=-1000
+Nice=-20
+CPUWeight=10000
+CPUSchedulingPolicy=rr
+CPUSchedulingPriority=20
+IOWeight=10000
+IOSchedulingClass=realtime
+IOSchedulingPriority=0
 
 # Enable MemoryDenyWriteExecute will cause Treeland crash in certain
 # condition (observed on arm64 virtual machine). The coredump indicate


### PR DESCRIPTION
这个PR将treeland设置为最高优先级的同时, 增加SEATD_SOCK环境变量设定让DDM能正常进入treeland会话

raise treeland service priority

Keep the compositor responsive under CPU, I/O, and memory pressure by giving the critical display and input path realtime round-robin scheduling. Own the dde-seatd socket setting in Treeland so it no longer depends on a DDM-installed drop-in.

## Summary by Sourcery

Raise treeland systemd service priority and configure its display/input scheduling for improved responsiveness under system load.

Enhancements:
- Set treeland service to highest priority with realtime round-robin scheduling to keep the compositor responsive under CPU, I/O, and memory pressure.
- Configure the dde-seatd socket (SEATD_SOCK environment variable) directly in the treeland service to remove dependence on an external DDM drop-in.