### PR TITLE
fix(foreign-toplevel): crash when disconnecting HDMI from extended sc…

### DIFF
--- a/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
+++ b/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
@@ -931,8 +931,10 @@ void ForeignToplevelHandleV1::output_enter(WOutput *output)
         }
     });
 
-    connect(qwOutput, &qw_output::before_destroy, this, [toplevel_output]() {
-        toplevel_output.toplevel->output_leave(toplevel_output.output);
+    connect(qwOutput, &qw_output::before_destroy, this, [this, output]() {
+        d->outputs.removeIf([output](const foreign_toplevel_output &handle_output) {
+            return handle_output.output == output;
+        });
     });
     send_output(output, true);
 }
@@ -1026,6 +1028,10 @@ void ForeignToplevelHandleV1::send_state()
 void ForeignToplevelHandleV1::send_output(WOutput *output, bool enter)
 {
     if (!output) {
+        return;
+    }
+
+    if (!output->handle()) {
         return;
     }
 


### PR DESCRIPTION
…reen

When an output is destroyed (e.g. HDMI unplugged), WBackend's before_destroy handler runs first (connected earlier) and calls safeDeleteLater() which invalidates WOutput by clearing m_handle. ForeignToplevelHandleV1's before_destroy handler runs second and previously called output_leave() -> send_output() -> nativeHandle(), dereferencing the now-null m_handle and crashing.

Fix by cleaning up internal state directly in the before_destroy lambda instead of calling output_leave()/send_output(), since clients will receive wl_registry::global_remove anyway. Add a null-guard in send_output() as defense-in-depth.

Log: 拔掉扩展屏HDMI线时触发的before_destroy信号中，WBackend先于ForeignToplevelHandleV1执行，将WOutput的m_handle置空，导致后续send_output()访问空指针崩溃
Influence: 修复拔掉扩展屏HDMI时compositor的崩溃问题

```
 13 #0  0x00007f60ad07de65 in ForeignToplevelHandleV1::send_output (this=0x55693fdb8f90, output=0x55693f64c570, enter=false)                                                 
 14     at /home/uos/Downloads/work/treeland/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp:1035                                                                                                          
 15 #1  0x00007f60ad07df8f in ForeignToplevelHandleV1::output_leave (this=0x55693fdb8f90, output=0x55693f64c570)                                                                                                     
 16     at /home/uos/Downloads/work/treeland/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp:950                                                                                                           
 17 #2  0x00007f60ad08357c in ForeignToplevelHandleV1::output_enter(Waylib::Server::WOutput*)::$_2::operator()() const (this=0x55693fc53ea0)                                                                         
 18     at /home/uos/Downloads/work/treeland/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp:935                                                                                                           
 19 #3  0x00007f60ad083558 in QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, ForeignToplevelHandleV1::output_enter(Waylib::Server::WOutput*)::$_2>::call(ForeignToplevelHandleV1::output_\
    enter(Waylib::Server::WOutput*)::$_2&, void**)::{lambda()#1}::operator()() const (this=0x7ffcb83ba4d8) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:141                                        
 20 #4  0x00007f60ad083539 in QtPrivate::FunctorCallBase::call_internal<void, QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, ForeignToplevelHandleV1::output_enter(Waylib::Server::WOutpu\
    t*)::$_2>::call(ForeignToplevelHandleV1::output_enter(Waylib::Server::WOutput*)::$_2&, void**)::{lambda()#1}>(void**, QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, ForeignToplevelH\
    andleV1::output_enter(Waylib::Server::WOutput*)::$_2>::call(ForeignToplevelHandleV1::output_enter(Waylib::Server::WOutput*)::$_2&, void**)::{lambda()#1}&&)                                                      
 21     (args=0x7ffcb83ba608, fn=...) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:65                                                                                                              
 22 #5  0x00007f60ad083515 in QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, ForeignToplevelHandleV1::output_enter(Waylib::Server::WOutput*)::$_2>::call(ForeignToplevelHandleV1::output_\
    enter(Waylib::Server::WOutput*)::$_2&, void**) (f=..., arg=0x7ffcb83ba608) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:140                                                                    
 23 #6  0x00007f60ad0834d1 in QtPrivate::FunctorCallable<ForeignToplevelHandleV1::output_enter(Waylib::Server::WOutput*)::$_2>::call<QtPrivate::List<>, void>(ForeignToplevelHandleV1::output_enter(Waylib::Server::\
    WOutput*)::$_2&, void*, void**) (f=..., arg=0x7ffcb83ba608) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:362                                                                                   
 24 #7  0x00007f60ad08346e in QtPrivate::QCallableObject<ForeignToplevelHandleV1::output_enter(Waylib::Server::WOutput*)::$_2, QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bo\
    ol*) (which=1, this_=0x55693fc53e90, r=0x55693fdb8f90, a=0x7ffcb83ba608, ret=0x0) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qobjectdefs_impl.h:572                                                             
 25 #8  0x00007f60aae6046c in ??? () at /usr/bin/../lib/x86_64-linux-gnu/libQt6Core.so.6                                                                                                                             
 26 #9  0x00007f60abaede42 in qw_object_basic::before_destroy (this=0x55693f24e330) at waylib/qwlroots/src/qwlroots_autogen/EWIEGA46WW/moc_qwobject.cpp:139                                                          
 27 #10 0x00007f60acd8bcb2 in qw_object<wlr_output, qw_output>::on_destroy (this=0x55693f24e330) at /home/uos/Downloads/work/treeland/qwlroots/src/qwobject.h:187                                                    
 28 #11 0x00007f60acd8f22a in qw_signal_connector::connect<qw_object<wlr_output, qw_output>, qw_object<wlr_output, qw_output> >(wl_signal*, qw_object<wlr_output, qw_output>*, void (qw_object<wlr_output, qw_output\
    >::*)())::{lambda(void*, void*)#1}::operator()(void*, void*) const (this=0x55693f71d1c0) at /home/uos/Downloads/work/treeland/qwlroots/src/util/qwsignalconnector.h:125                                          
 29 #12 0x00007f60acd8f1ab in std::__invoke_impl<void, qw_signal_connector::connect<qw_object<wlr_output, qw_output>, qw_object<wlr_output, qw_output> >(wl_signal*, qw_object<wlr_output, qw_output>*, void (qw_obj\
    ect<wlr_output, qw_output>::*)())::{lambda(void*, void*)#1}&, void*, void*>(std::__invoke_other, qw_signal_connector::connect<qw_object<wlr_output, qw_output>, qw_object<wlr_output, qw_output> >(wl_signal*, q\
    w_object<wlr_output, qw_output>*, void (qw_object<wlr_output, qw_output>::*)())::{lambda(void*, void*)#1}&, void*&&, void*&&)                                                                                    
 30     (__f=..., __args=@0x7ffcb83ba780: 0x55693d6b06f0, __args=@0x7ffcb83ba778: 0x0) at /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:61                                        
 31 #13 0x00007f60acd8f155 in std::__invoke_r<void, qw_signal_connector::connect<qw_object<wlr_output, qw_output>, qw_object<wlr_output, qw_output> >(wl_signal*, qw_object<wlr_output, qw_output>*, void (qw_object\
    <wlr_output, qw_output>::*)())::{lambda(void*, void*)#1}&, void*, void*>(qw_signal_connector::connect<qw_object<wlr_output, qw_output>, qw_object<wlr_output, qw_output> >(wl_signal*, qw_object<wlr_output, qw_\
    output>*, void (qw_object<wlr_output, qw_output>::*)())::{lambda(void*, void*)#1}&, void*&&, void*&&)                                                                                                            
 32     (__fn=..., __args=@0x7ffcb83ba780: 0x55693d6b06f0, __args=@0x7ffcb83ba778: 0x0) at /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:111                                      
 33 #14 0x00007f60acd8f01d in std::_Function_handler<void (void*, void*), qw_signal_connector::connect<qw_object<wlr_output, qw_output>, qw_object<wlr_output, qw_output> >(wl_signal*, qw_object<wlr_output, qw_out\
    put>*, void (qw_object<wlr_output, qw_output>::*)())::{lambda(void*, void*)#1}>::_M_invoke(std::_Any_data const&, void*&&, void*&&)                                                                              
 34     (__functor=..., __args=@0x7ffcb83ba780: 0x55693d6b06f0, __args=@0x7ffcb83ba778: 0x0) at /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:290      
```