### PR TITLE
fix(foreign-toplevel): remove redundant output_leave connection on output destroy

### DIFF
--- a/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
+++ b/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
@@ -931,9 +931,6 @@ void ForeignToplevelHandleV1::output_enter(WOutput *output)
         }
     });
 
-    connect(qwOutput, &qw_output::before_destroy, this, [toplevel_output]() {
-        toplevel_output.toplevel->output_leave(toplevel_output.output);
-    });
     send_output(output, true);
 }
 


### PR DESCRIPTION
WSurface::outputLeave 信号已正常处理 output leave 通知，无需在
before_destroy 中重复调用。旧代码在 output 销毁时错误地再次调用
output_leave → send_output，但此时 WOutput 的 nativeHandle() 已
因内部 QPointer 数据被清除而返回 nullptr，解引用空指针导致 SIGSEGV。
此外，客户端通过 wl_output global 移除即可感知 output 销毁，无需
foreign-toplevel 协议额外发送 leave 事件。

Log: 移除 output 销毁时重复调用 output_leave 的冗余连接，修复空指针解引用崩溃
PMS: BUG-365301
Influence: 修复了 output 销毁时因访问已释放的 nativeHandle() 导致的段错误，消除重复 leave 通知