### PR TITLE
fix(personalization): connect windowRadiusChanged to surface re-rende…

### DIFF
--- a/misc/dconfig/org.deepin.dde.treeland.user.json
+++ b/misc/dconfig/org.deepin.dde.treeland.user.json
@@ -68,6 +68,17 @@
             "permissions": "readwrite",
             "visibility": "public"
         },
+        "popupRadius": {
+            "value": 8,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Popup Round Corner Radius",
+            "name[zh_CN]": "弹出窗口圆角大小",
+            "description": "Xdg Popup Corner Round Radius",
+            "description[zh_CN]": "设置弹出窗口圆角大小",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
         "preferDark": {
             "value": false,
             "serial": 0,

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1117,6 +1117,15 @@ void Helper::onSurfaceWrapperAdded(SurfaceWrapper *wrapper)
         };
         connect(attached, &Personalization::backgroundTypeChanged, this, updateBlur);
         updateBlur();
+
+        auto updateRadius = [attached] {
+            attached->surfaceWrapper()->setRadius(attached->cornerRadius());
+        };
+        connect(attached, &Personalization::cornerRadiusChanged, this, updateRadius);
+        updateRadius();
+
+        connect(Helper::instance()->config(), &TreelandUserConfig::windowRadiusChanged, wrapper, &SurfaceWrapper::radiusChanged);
+
         if (isLayer) {
             auto layer = qobject_cast<WLayerSurface *>(wrapper->shellSurface());
             if (isLaunchpad(layer))

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -1560,21 +1560,15 @@ void SurfaceWrapper::startShowDesktopAnimation(bool show)
 
 qreal SurfaceWrapper::radius() const
 {
-    // TODO: move to dconfig
-    if (m_type == Type::InputPopup)
-        return 0;
+    if (m_radius > 1)
+        return m_radius;
+
+    if (m_type == Type::XdgToplevel)
+        return Helper::instance()->config()->windowRadius();
     if (m_type == Type::XdgPopup)
-        return 8;
+        return Helper::instance()->config()->popupRadius();
 
-    qreal radius = m_radius;
-
-    // TODO: Handle: XdgToplevel, popup, InputPopup, XWayland (bypass, window type:
-    // menu/normal/popup)
-    if (radius < 1 && m_type != Type::Layer) {
-        radius = Helper::instance()->config()->windowRadius();
-    }
-
-    return radius;
+    return 0;
 }
 
 void SurfaceWrapper::setRadius(qreal newRadius)


### PR DESCRIPTION
…ring

Log: TreelandUserConfig::windowRadiusChanged had no listener. AppearanceContext updates were written to config but surfaces never re-rendered with the new radius. Connect config signal to SurfaceWrapper::radiusChanged in helper.cpp.

PMS: BUG-340399
Influence: SurfaceWrapper corner radius updates when global windowRadius changes.

## Summary by Sourcery

Bug Fixes:
- Ensure surface wrappers receive and apply window radius updates when TreelandUserConfig::windowRadiusChanged is emitted.