### PR TITLE
fix(keyboard-state-notify): prevent crash when seat has no keyboard

### DIFF
--- a/src/modules/keyboard-state-notify/keyboardstatenotifymanagerinterfacev1.cpp
+++ b/src/modules/keyboard-state-notify/keyboardstatenotifymanagerinterfacev1.cpp
@@ -303,7 +303,8 @@ void KeyboardStateWatcherV1Private::apply([[maybe_unused]] Resource *resource)
     }
 
     for (auto *seat : std::as_const(seats)) {
-        qw_keyboard *keyboard = qobject_cast<qw_keyboard*>(seat->keyboard()->handle());
+        qw_keyboard *keyboard =
+            qobject_cast<qw_keyboard *>(seat->keyboardGroupKeyboard()->handle());
         if (!keyboard || !keyboard->handle()->xkb_state)
             continue;
 


### PR DESCRIPTION
In KeyboardStateWatcherV1Private::apply(), add null-check for seat->keyboard() before dereferencing it, matching the defensive pattern already used in onModifiersEvent(). This fixes a crash when the Wayland client sends an apply request while the seat has no keyboard device attached yet.

Log: 修复键盘状态监听在seat无键盘时崩溃
PMS: BUG-346031
Influence: 修复后键盘状态通知模块在seat尚未关联键盘时不会触发SIGSEGV崩溃。

## Summary by Sourcery

Bug Fixes:
- Avoid dereferencing a null keyboard device when applying keyboard state for a seat that has no keyboard attached, preventing SIGSEGV crashes in the keyboard state notification module.