### PR TITLE
feat: use DRM format for texture creation

### DIFF
--- a/waylib/src/server/qtquick/private/wrenderbuffernode.cpp
+++ b/waylib/src/server/qtquick/private/wrenderbuffernode.cpp
@@ -8,6 +8,8 @@
 #include "wqmlhelper_p.h"
 #include "platformplugin/types.h"
 #include "private/wprivateaccessor_p.h"
+#include "woutputrenderwindow.h"
+#include "wrenderhelper.h"
 
 #include <QQuickItem>
 #include <QRunnable>
@@ -752,12 +754,23 @@ public:
             pixelSize = size.toSize();
         }
 
+
+        // Try DRM format-driven texture creation via window convenience method
+        auto outputWindow = qobject_cast<WOutputRenderWindow*>(window);
+        if (outputWindow && outputWindow->allocator() && outputWindow->renderer()) {
+            auto drmTexture = outputWindow->createMatchingTexture(sgTexture());
+            if (drmTexture) {
+                sgTexture()->setTexture(drmTexture);
+                return;
+            }
+        }
+        
+        // Fallback to original Qt RHI format approach
         texture = manager->resolve(texture, ct->format(), pixelSize);
         if (Q_UNLIKELY(texture.expired())) {
             reset();
             return;
         }
-        auto texture = this->texture.lock();
         Q_ASSERT(texture->data);
 
         if (renderData) {

--- a/waylib/src/server/qtquick/woutputrenderwindow.cpp
+++ b/waylib/src/server/qtquick/woutputrenderwindow.cpp
@@ -1866,18 +1866,6 @@ qw_allocator *WOutputRenderWindow::allocator() const
 }
 
 
-::wlr_egl *WOutputRenderWindow::egl() const
-{
-    Q_D(const WOutputRenderWindow);
-    if (!d->m_renderer)
-        return nullptr;
-    
-    if (!wlr_renderer_is_gles2(d->m_renderer->handle()))
-        return nullptr;
-    
-    return wlr_gles2_renderer_get_egl(d->m_renderer->handle());
-}
-
 QRhiTexture *WOutputRenderWindow::createTextureFromDRMFormat(uint32_t drmFormat, const QSize &size)
 {
     return WRenderHelper::createTextureFromDRMFormat(rhi(), allocator(), renderer(), drmFormat, size);

--- a/waylib/src/server/qtquick/woutputrenderwindow.cpp
+++ b/waylib/src/server/qtquick/woutputrenderwindow.cpp
@@ -1887,6 +1887,8 @@ QRhiTexture *WOutputRenderWindow::createMatchingTexture(QSGTexture *sourceTextur
 {
     return WRenderHelper::createMatchingTexture(rhi(), allocator(), renderer(), sourceTexture);
 }
+WBufferRenderer *WOutputRenderWindow::currentRenderer() const
+{
     Q_D(const WOutputRenderWindow);
     return d->rendererList.isEmpty() ? nullptr : d->rendererList.top();
 }

--- a/waylib/src/server/qtquick/woutputrenderwindow.cpp
+++ b/waylib/src/server/qtquick/woutputrenderwindow.cpp
@@ -1866,7 +1866,7 @@ qw_allocator *WOutputRenderWindow::allocator() const
 }
 
 
-wlr_egl *WOutputRenderWindow::egl() const
+::wlr_egl *WOutputRenderWindow::egl() const
 {
     Q_D(const WOutputRenderWindow);
     if (!d->m_renderer)

--- a/waylib/src/server/qtquick/woutputrenderwindow.cpp
+++ b/waylib/src/server/qtquick/woutputrenderwindow.cpp
@@ -1865,8 +1865,28 @@ qw_allocator *WOutputRenderWindow::allocator() const
     return d->m_allocator;
 }
 
-WBufferRenderer *WOutputRenderWindow::currentRenderer() const
+
+wlr_egl *WOutputRenderWindow::egl() const
 {
+    Q_D(const WOutputRenderWindow);
+    if (!d->m_renderer)
+        return nullptr;
+    
+    if (!wlr_renderer_is_gles2(d->m_renderer->handle()))
+        return nullptr;
+    
+    return wlr_gles2_renderer_get_egl(d->m_renderer->handle());
+}
+
+QRhiTexture *WOutputRenderWindow::createTextureFromDRMFormat(uint32_t drmFormat, const QSize &size)
+{
+    return WRenderHelper::createTextureFromDRMFormat(rhi(), allocator(), renderer(), drmFormat, size);
+}
+
+QRhiTexture *WOutputRenderWindow::createMatchingTexture(QSGTexture *sourceTexture)
+{
+    return WRenderHelper::createMatchingTexture(rhi(), allocator(), renderer(), sourceTexture);
+}
     Q_D(const WOutputRenderWindow);
     return d->rendererList.isEmpty() ? nullptr : d->rendererList.top();
 }

--- a/waylib/src/server/qtquick/woutputrenderwindow.h
+++ b/waylib/src/server/qtquick/woutputrenderwindow.h
@@ -54,6 +54,11 @@ public:
     QW_NAMESPACE::qw_renderer *renderer() const;
     QW_NAMESPACE::qw_allocator *allocator() const;
 
+    // Convenience methods for DRM format texture creation
+    wlr_egl *egl() const;
+    QRhiTexture *createTextureFromDRMFormat(uint32_t drmFormat, const QSize &size);
+    QRhiTexture *createMatchingTexture(QSGTexture *sourceTexture);
+
     qreal width() const;
     qreal height() const;
     WBufferRenderer *currentRenderer() const;

--- a/waylib/src/server/qtquick/woutputrenderwindow.h
+++ b/waylib/src/server/qtquick/woutputrenderwindow.h
@@ -14,6 +14,8 @@ Q_MOC_INCLUDE(<wquickoutputlayout.h>)
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
+
+struct wlr_egl;
 class WOutputViewport;
 class WOutputLayer;
 class WBufferRenderer;

--- a/waylib/src/server/qtquick/woutputrenderwindow.h
+++ b/waylib/src/server/qtquick/woutputrenderwindow.h
@@ -56,7 +56,6 @@ public:
     QW_NAMESPACE::qw_allocator *allocator() const;
 
     // Convenience methods for DRM format texture creation
-    ::wlr_egl *egl() const;
     QRhiTexture *createTextureFromDRMFormat(uint32_t drmFormat, const QSize &size);
     QRhiTexture *createMatchingTexture(QSGTexture *sourceTexture);
 

--- a/waylib/src/server/qtquick/woutputrenderwindow.h
+++ b/waylib/src/server/qtquick/woutputrenderwindow.h
@@ -14,7 +14,6 @@ Q_MOC_INCLUDE(<wquickoutputlayout.h>)
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
-
 struct wlr_egl;
 class WOutputViewport;
 class WOutputLayer;
@@ -57,7 +56,7 @@ public:
     QW_NAMESPACE::qw_allocator *allocator() const;
 
     // Convenience methods for DRM format texture creation
-    wlr_egl *egl() const;
+    ::wlr_egl *egl() const;
     QRhiTexture *createTextureFromDRMFormat(uint32_t drmFormat, const QSize &size);
     QRhiTexture *createMatchingTexture(QSGTexture *sourceTexture);
 

--- a/waylib/src/server/qtquick/wrenderhelper.cpp
+++ b/waylib/src/server/qtquick/wrenderhelper.cpp
@@ -797,6 +797,233 @@ static UpdateTextureFunction getUpdateTextFunction(qw_texture *handle)
     return nullptr;
 }
 
+
+// DRM format to QRhiTexture::Format mapping
+static QRhiTexture::Format drmFormatToRhiFormat(uint32_t drmFormat)
+{
+    switch (drmFormat) {
+    case DRM_FORMAT_ARGB8888:
+    case DRM_FORMAT_XRGB8888:
+    case DRM_FORMAT_ABGR8888:
+    case DRM_FORMAT_XBGR8888:
+    case DRM_FORMAT_RGBA8888:
+    case DRM_FORMAT_RGBX8888:
+        return QRhiTexture::RGBA8;
+    case DRM_FORMAT_BGRA8888:
+    case DRM_FORMAT_BGRX8888:
+        return QRhiTexture::BGRA8;
+    case DRM_FORMAT_RGB565:
+        return QRhiTexture::R16;
+    case DRM_FORMAT_RGBA4444:
+    case DRM_FORMAT_RGBX4444:
+    case DRM_FORMAT_RGBA5551:
+    case DRM_FORMAT_RGBX5551:
+        return QRhiTexture::RGBA16;
+    case DRM_FORMAT_ARGB2101010:
+    case DRM_FORMAT_XRGB2101010:
+    case DRM_FORMAT_ABGR2101010:
+    case DRM_FORMAT_XBGR2101010:
+    case DRM_FORMAT_RGBA1010102:
+    case DRM_FORMAT_RGBX1010102:
+    case DRM_FORMAT_BGRA1010102:
+    case DRM_FORMAT_BGRX1010102:
+        return QRhiTexture::RGB10A2;
+    default:
+        return QRhiTexture::RGBA8;
+    }
+}
+
+// Resource structure for DRM format textures
+// NOTE: This static mapping table is only safe to use on Qt Quick scene graph render thread.
+// All operations (create/register/unregister) must happen on the same thread to avoid race conditions.
+struct TextureResources {
+    qw_swapchain *swapchain = nullptr;
+    qw_buffer *buffer = nullptr;
+    qw_texture *texture = nullptr;
+};
+
+// Static texture-to-resources mapping (render thread only)
+static QHash<QRhiTexture*, TextureResources> s_textureResources;
+
+// Get DRM format from texture via EGL
+static uint32_t getDRMFormatFromTexture(QRhiTexture *rhiTexture, wlr_egl *egl)
+{
+    if (!rhiTexture || !egl)
+        return DRM_FORMAT_INVALID;
+
+    auto display = wlr_egl_get_display(egl);
+    auto context = wlr_egl_get_context(egl);
+
+    EGLImage image = eglCreateImage(display, context,
+                                    EGL_GL_TEXTURE_2D,
+                                    reinterpret_cast<EGLClientBuffer>(rhiTexture->nativeTexture().object),
+                                    nullptr);
+
+    if (image == EGL_NO_IMAGE)
+        return DRM_FORMAT_INVALID;
+
+    static auto eglExportDMABUFImageQueryMESA =
+        reinterpret_cast<PFNEGLEXPORTDMABUFIMAGEQUERYMESAPROC>(eglGetProcAddress("eglExportDMABUFImageQueryMESA"));
+    static auto eglDestroyImageKHR =
+        reinterpret_cast<PFNEGLDESTROYIMAGEKHRPROC>(eglGetProcAddress("eglDestroyImageKHR"));
+
+    if (!eglExportDMABUFImageQueryMESA) {
+        if (eglDestroyImageKHR)
+            eglDestroyImageKHR(display, image);
+        return DRM_FORMAT_INVALID;
+    }
+
+    uint32_t format = DRM_FORMAT_INVALID;
+    int n_planes = 0;
+    uint64_t modifier = 0;
+    bool ok = eglExportDMABUFImageQueryMESA(display, image,
+                                           reinterpret_cast<int*>(&format),
+                                           &n_planes, &modifier);
+
+    // Destroy EGLImage to prevent resource leak
+    if (eglDestroyImageKHR)
+        eglDestroyImageKHR(display, image);
+
+    if (!ok)
+        return DRM_FORMAT_INVALID;
+
+    return format;
+}
+
+// Pick format from renderer's supported formats
+static const wlr_drm_format *pickRenderFormat(qw_renderer *renderer, uint32_t format)
+{
+    auto r = renderer->handle();
+    if (!r->impl->get_render_formats)
+        return nullptr;
+        
+    const wlr_drm_format_set *format_set = r->impl->get_render_formats(r);
+    if (!format_set)
+        return nullptr;
+
+    return wlr_drm_format_set_get(format_set, format);
+}
+
+QRhiTexture *WRenderHelper::createTextureFromDRMFormat(QRhi *rhi, qw_allocator *allocator,
+                                                        qw_renderer *renderer,
+                                                        uint32_t drmFormat, const QSize &size)
+{
+    if (!allocator || !renderer || !rhi)
+        return nullptr;
+    // Only support OpenGL backend for now
+    if (!wlr_renderer_is_gles2(renderer->handle()))
+        return nullptr;
+
+
+    auto format = pickRenderFormat(renderer, drmFormat);
+    if (!format)
+        return nullptr;
+
+    auto swapchain = qw_swapchain::create(allocator->handle(), size.width(), size.height(), format);
+    if (!swapchain)
+        return nullptr;
+
+    auto wbuffer = swapchain->acquire();
+    if (!wbuffer) {
+        delete swapchain;
+        return nullptr;
+    }
+
+    auto buffer = qw_buffer::from(wbuffer);
+    auto texture = qw_texture::from_buffer(*renderer, *buffer);
+    if (!texture) {
+        buffer->unref();
+        delete swapchain;
+        return nullptr;
+    }
+
+    wlr_gles2_texture_attribs attribs;
+    wlr_gles2_texture_get_attribs(texture->handle(), &attribs);
+
+    QRhiTexture *rhiTexture = rhi->newTexture(drmFormatToRhiFormat(drmFormat), size, 1, QRhiTexture::RenderTarget);
+    if (!rhiTexture || !rhiTexture->createFrom({attribs.tex, 0})) {
+        delete rhiTexture;
+        buffer->unref();
+        delete swapchain;
+        return nullptr;
+    }
+
+    // Store complete resources for cleanup
+    TextureResources resources;
+    resources.swapchain = swapchain;
+    resources.buffer = buffer;
+    resources.texture = texture;
+    s_textureResources[rhiTexture] = resources;
+    
+    return rhiTexture;
+}
+
+QRhiTexture *WRenderHelper::createMatchingTexture(QRhi *rhi, qw_allocator *allocator,
+                                                   qw_renderer *renderer,
+                                                   QSGTexture *sourceTexture)
+{
+    if (!sourceTexture || !rhi)
+        return nullptr;
+
+    auto rhiTexture = sourceTexture->rhiTexture();
+    if (!rhiTexture)
+        return nullptr;
+
+    // Get DRM format from source texture
+    if (!wlr_renderer_is_gles2(renderer->handle()))
+        return nullptr;
+
+    auto egl = wlr_gles2_renderer_get_egl(renderer->handle());
+    uint32_t drmFormat = getDRMFormatFromTexture(rhiTexture, egl);
+    
+    if (drmFormat == DRM_FORMAT_INVALID)
+        return nullptr;
+
+    return createTextureFromDRMFormat(rhi, allocator, renderer, drmFormat, rhiTexture->pixelSize());
+}
+
+qw_buffer *WRenderHelper::getBufferFromTexture(QRhiTexture *texture)
+{
+    if (!s_textureResources.contains(texture))
+        return nullptr;
+    return s_textureResources[texture].buffer;
+}
+
+void WRenderHelper::registerTextureBuffer(QRhiTexture *texture, qw_buffer *buffer)
+{
+    if (!texture || !buffer)
+        return;
+    
+    // Only register if not already created via DRM format path
+    if (!s_textureResources.contains(texture)) {
+        TextureResources resources;
+        resources.buffer = buffer;
+        s_textureResources[texture] = resources;
+    }
+}
+
+void WRenderHelper::unregisterTexture(QRhiTexture *texture)
+{
+    if (!s_textureResources.contains(texture))
+        return;
+        
+    auto &resources = s_textureResources[texture];
+    
+    // Clean up all resources in reverse creation order
+    if (resources.buffer) {
+        resources.buffer->unref();
+    }
+    
+    if (resources.texture) {
+        delete resources.texture;
+    }
+    
+    if (resources.swapchain) {
+        delete resources.swapchain;
+    }
+    
+    s_textureResources.remove(texture);
+}
 bool WRenderHelper::makeTexture(QRhi *rhi, qw_texture *handle, QSGPlainTexture *texture)
 {
     auto updateTexture = getUpdateTextFunction(handle);

--- a/waylib/src/server/qtquick/wrenderhelper.cpp
+++ b/waylib/src/server/qtquick/wrenderhelper.cpp
@@ -814,11 +814,6 @@ static QRhiTexture::Format drmFormatToRhiFormat(uint32_t drmFormat)
         return QRhiTexture::BGRA8;
     case DRM_FORMAT_RGB565:
         return QRhiTexture::R16;
-    case DRM_FORMAT_RGBA4444:
-    case DRM_FORMAT_RGBX4444:
-    case DRM_FORMAT_RGBA5551:
-    case DRM_FORMAT_RGBX5551:
-        return QRhiTexture::RGBA16;
     case DRM_FORMAT_ARGB2101010:
     case DRM_FORMAT_XRGB2101010:
     case DRM_FORMAT_ABGR2101010:
@@ -832,13 +827,11 @@ static QRhiTexture::Format drmFormatToRhiFormat(uint32_t drmFormat)
         return QRhiTexture::RGBA8;
     }
 }
-
 // Resource structure for DRM format textures
 // NOTE: This static mapping table is only safe to use on Qt Quick scene graph render thread.
 // All operations (create/register/unregister) must happen on the same thread to avoid race conditions.
 struct TextureResources {
     qw_swapchain *swapchain = nullptr;
-    qw_buffer *buffer = nullptr;
     qw_texture *texture = nullptr;
 };
 
@@ -910,10 +903,6 @@ QRhiTexture *WRenderHelper::createTextureFromDRMFormat(QRhi *rhi, qw_allocator *
 {
     if (!allocator || !renderer || !rhi)
         return nullptr;
-    // Only support OpenGL backend for now
-    if (!wlr_renderer_is_gles2(renderer->handle()))
-        return nullptr;
-
 
     auto format = pickRenderFormat(renderer, drmFormat);
     if (!format)
@@ -932,7 +921,12 @@ QRhiTexture *WRenderHelper::createTextureFromDRMFormat(QRhi *rhi, qw_allocator *
     auto buffer = qw_buffer::from(wbuffer);
     auto texture = qw_texture::from_buffer(*renderer, *buffer);
     if (!texture) {
-        buffer->unref();
+        delete swapchain;
+        return nullptr;
+    }
+
+    // Only support OpenGL backend for now
+    if (!wlr_renderer_is_gles2(renderer->handle())) {
         delete swapchain;
         return nullptr;
     }
@@ -943,21 +937,19 @@ QRhiTexture *WRenderHelper::createTextureFromDRMFormat(QRhi *rhi, qw_allocator *
     QRhiTexture *rhiTexture = rhi->newTexture(drmFormatToRhiFormat(drmFormat), size, 1, QRhiTexture::RenderTarget);
     if (!rhiTexture || !rhiTexture->createFrom({attribs.tex, 0})) {
         delete rhiTexture;
-        buffer->unref();
         delete swapchain;
         return nullptr;
     }
 
     // Store complete resources for cleanup
+    // Note: buffer lifecycle is managed by swapchain, no need to store separately
     TextureResources resources;
     resources.swapchain = swapchain;
-    resources.buffer = buffer;
     resources.texture = texture;
     s_textureResources[rhiTexture] = resources;
     
     return rhiTexture;
 }
-
 QRhiTexture *WRenderHelper::createMatchingTexture(QRhi *rhi, qw_allocator *allocator,
                                                    qw_renderer *renderer,
                                                    QSGTexture *sourceTexture)
@@ -982,24 +974,6 @@ QRhiTexture *WRenderHelper::createMatchingTexture(QRhi *rhi, qw_allocator *alloc
     return createTextureFromDRMFormat(rhi, allocator, renderer, drmFormat, rhiTexture->pixelSize());
 }
 
-qw_buffer *WRenderHelper::getBufferFromTexture(QRhiTexture *texture)
-{
-    if (!s_textureResources.contains(texture))
-        return nullptr;
-    return s_textureResources[texture].buffer;
-}
-
-void WRenderHelper::registerTextureBuffer(QRhiTexture *texture, qw_buffer *buffer)
-{
-    if (!texture || !buffer)
-        return;
-    
-    // Only register if not already created via DRM format path
-    if (!s_textureResources.contains(texture)) {
-        TextureResources resources;
-        resources.buffer = buffer;
-        s_textureResources[texture] = resources;
-    }
 }
 
 void WRenderHelper::unregisterTexture(QRhiTexture *texture)
@@ -1011,10 +985,6 @@ void WRenderHelper::unregisterTexture(QRhiTexture *texture)
     
     // Clean up all resources in reverse creation order
     if (resources.buffer) {
-        resources.buffer->unref();
-    }
-    
-    if (resources.texture) {
         delete resources.texture;
     }
     

--- a/waylib/src/server/qtquick/wrenderhelper.h
+++ b/waylib/src/server/qtquick/wrenderhelper.h
@@ -54,6 +54,22 @@ public:
 
     static bool makeTexture(QRhi *rhi, QW_NAMESPACE::qw_texture *handle, QSGPlainTexture *texture);
 
+    // DRM format-driven texture creation
+    // NOTE: All these methods must be called on Qt Quick scene graph render thread only
+    static QRhiTexture *createTextureFromDRMFormat(QRhi *rhi, QW_NAMESPACE::qw_allocator *allocator,
+                                                    QW_NAMESPACE::qw_renderer *renderer,
+                                                    uint32_t drmFormat, const QSize &size);
+    static QRhiTexture *createMatchingTexture(QRhi *rhi, QW_NAMESPACE::qw_allocator *allocator,
+                                               QW_NAMESPACE::qw_renderer *renderer,
+                                               QSGTexture *sourceTexture);
+    
+    // Get buffer from texture (requires prior registration)
+    static QW_NAMESPACE::qw_buffer *getBufferFromTexture(QRhiTexture *texture);
+    
+    // Resource management (called internally, render thread only)
+    static void registerTextureBuffer(QRhiTexture *texture, QW_NAMESPACE::qw_buffer *buffer);
+    static void unregisterTexture(QRhiTexture *texture);
+
 Q_SIGNALS:
     void sizeChanged();
 

--- a/waylib/src/server/qtquick/wrenderhelper.h
+++ b/waylib/src/server/qtquick/wrenderhelper.h
@@ -63,12 +63,6 @@ public:
                                                QW_NAMESPACE::qw_renderer *renderer,
                                                QSGTexture *sourceTexture);
     
-    // Get buffer from texture (requires prior registration)
-    static QW_NAMESPACE::qw_buffer *getBufferFromTexture(QRhiTexture *texture);
-    
-    // Resource management (called internally, render thread only)
-    static void registerTextureBuffer(QRhiTexture *texture, QW_NAMESPACE::qw_buffer *buffer);
-    static void unregisterTexture(QRhiTexture *texture);
 
 Q_SIGNALS:
     void sizeChanged();

--- a/waylib/src/server/qtquick/wrenderhelper.h
+++ b/waylib/src/server/qtquick/wrenderhelper.h
@@ -22,6 +22,7 @@ class qw_renderer;
 class qw_backend;
 class qw_buffer;
 class qw_texture;
+class qw_allocator;
 QW_END_NAMESPACE
 
 WAYLIB_SERVER_BEGIN_NAMESPACE


### PR DESCRIPTION
Implement DRM format-driven texture creation in WRenderBufferNode with fallback to Qt RHI format.

**Changes:**
- waylib/src/server/qtquick/wrenderhelper.h
- waylib/src/server/qtquick/wrenderhelper.cpp
- waylib/src/server/qtquick/woutputrenderwindow.h
- waylib/src/server/qtquick/woutputrenderwindow.cpp
- waylib/src/server/qtquick/private/wrenderbuffernode.cpp

**Fixes:**
- Add OpenGL backend check in createTextureFromDRMFormat
- Use Q_D macro for private member access

Related: [WM-8](https://pms.uniontech.com/task-view-22306589.html)