### PR TITLE
fix(input): allow layer shell windows to receive keyboard focus on click

### DIFF
--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -782,12 +782,13 @@ void ShellHandler::setupSurfaceActiveWatcher(SurfaceWrapper *wrapper)
             auto layerSurface = qobject_cast<WLayerSurface *>(wrapper->shellSurface());
             if (layerSurface->keyboardInteractivity() == WLayerSurface::KeyboardInteractivity::None)
                 return;
+
             /*
-             * if LayerSurface's keyboardInteractivity is `OnDemand`, only allow `Overlay` layer
-             * surface get keyboard focus, to avoid dock/dde-desktop grab keyboard focus When they
-             * restart
+             * For OnDemand keyboardInteractivity, only allow surfaces with z-order above
+             * normal windows (Top/Overlay) to receive keyboard focus, to avoid dock/dde-desktop
+             * grabbing focus when they restart.
              */
-            if (layerSurface->layer() == WLayerSurface::LayerType::Overlay
+            if (layerSurface->layer() >= WLayerSurface::LayerType::Top
                 || layerSurface->keyboardInteractivity()
                     == WLayerSurface::KeyboardInteractivity::Exclusive)
                 Helper::instance()->activateSurface(wrapper);

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2004,11 +2004,6 @@ bool Helper::afterHandleEvent([[maybe_unused]] WSeat *seat,
 
         WSeat *eventSeat = getSeatForEvent(event);
         if (eventSeat && surface) {
-            // LayerSurface cannot be activated, nor should it be activated.
-            if (surface->type() == SurfaceWrapper::Type::Layer) {
-                return false;
-            }
-
             for (auto *seat : m_seatManager->seats()) {
                 if (seat != eventSeat && surface) {
                     auto *container = m_rootSurfaceContainer->getSeatContainer(seat);
@@ -2019,7 +2014,10 @@ bool Helper::afterHandleEvent([[maybe_unused]] WSeat *seat,
                 }
             }
 
-            m_rootSurfaceContainer->setActivatedSurfaceForSeat(eventSeat, surface, Qt::MouseFocusReason);
+            if (surface->shellSurface()->hasCapability(WToplevelSurface::Capability::Activate))
+                m_rootSurfaceContainer->setActivatedSurfaceForSeat(eventSeat,
+                                                                   surface,
+                                                                   Qt::MouseFocusReason);
 
             if (surface->shellSurface()->hasCapability(WToplevelSurface::Capability::Focus)
                 && surface->acceptKeyboardFocus()) {


### PR DESCRIPTION
Remove the early return for LayerSurface in afterHandleEvent, since layer shell windows can receive keyboard focus based on their keyboardInteractivity setting even though they cannot be "activated".

Also change the condition from `layer == Overlay` to `layer >= Top` to allow all surfaces with z-order above normal windows (Top/Overlay) to receive keyboard focus automatically on request.

PMS: 363911