### PR TITLE
feat(input): distinguishing between libinput mouse and touchpad funct…

### DIFF
--- a/waylib/src/server/kernel/winputdevice.cpp
+++ b/waylib/src/server/kernel/winputdevice.cpp
@@ -245,6 +245,26 @@ bool WInputDevice::isVirtual() const
     return d->isVirtual;
 }
 
+WInputDevice::LibinputPointerType WInputDevice::libinputPointerType() const
+{
+    if (!handle()->is_libinput()) {
+        return LibinputPointerType::Unknown;
+    }
+
+    struct libinput_device *inputDevice = wlr_libinput_get_device_handle(handle()->handle());
+    struct udev_device *udevDevice = libinput_device_get_udev_device(inputDevice);
+
+    if (udev_device_get_property_value(udevDevice, "ID_INPUT_MOUSE")) {
+        return LibinputPointerType::Mouse;
+    }
+
+    if (udev_device_get_property_value(udevDevice, "ID_INPUT_TOUCHPAD")) {
+        return LibinputPointerType::TouchPad;
+    }
+
+    return LibinputPointerType::Unknown;
+}
+
 void WInputDevice::setExclusiveGrabber(QObject *grabber)
 {
     W_D(WInputDevice);

--- a/waylib/src/server/kernel/winputdevice.h
+++ b/waylib/src/server/kernel/winputdevice.h
@@ -62,6 +62,13 @@ public:
     };
     Q_ENUM(Type)
 
+    enum class LibinputPointerType {
+        Unknown,
+        Mouse,
+        TouchPad,
+    };
+    Q_ENUM(LibinputPointerType)
+
     WInputDevice(QW_NAMESPACE::qw_input_device *handle, bool isVirtual = false);
 
     QW_NAMESPACE::qw_input_device *handle() const;
@@ -82,6 +89,8 @@ public:
     QString devicePath() const;
 
     bool isVirtual() const;
+
+    LibinputPointerType libinputPointerType() const;
 
 private:
     friend class QWlrootsIntegration;


### PR DESCRIPTION
…ions

Determine whether a device is a mouse or a touchpad by checking the udev device attribute ID_INPUT_XXXX.

Log: distinguishing between libinput mouse and touchpad functions

PMS: TASK-389477

Influence:

## Summary by Sourcery

New Features:
- Expose APIs on WInputDevice to detect whether a libinput pointer device is a mouse or a touchpad based on udev attributes.