### PR TITLE
fix(lockscreen): fix lockscreen display after TTY switch

### DIFF
--- a/src/core/lockscreen.cpp
+++ b/src/core/lockscreen.cpp
@@ -85,6 +85,8 @@ void LockScreen::switchUser()
 
 void LockScreen::addOutput(Output *output)
 {
+    qCDebug(treelandShell) << "Adding output to lock screen:" << output;
+
     SurfaceContainer::addOutput(output);
 #if EXT_SESSION_LOCK_V1
     auto outputItem = output->outputItem();
@@ -99,6 +101,7 @@ void LockScreen::addOutput(Output *output)
     }
 
     auto *item = m_impl->createLockScreen(output, this);
+    item->setProperty("primaryOutputName", m_primaryOutputName);
 
     connect(item, SIGNAL(animationPlayed()), this, SLOT(onAnimationPlayed()));
     connect(item, SIGNAL(animationPlayFinished()), this, SLOT(onAnimationPlayFinished()));
@@ -116,6 +119,8 @@ bool LockScreen::isLocked() const
 
 void LockScreen::removeOutput(Output *output)
 {
+    qCDebug(treelandShell) << "Removing output from lock screen:" << output;
+
     SurfaceContainer::removeOutput(output);
 #if EXT_SESSION_LOCK_V1
     auto outputItem = output->outputItem();
@@ -151,7 +156,10 @@ bool LockScreen::available() const
 
 void LockScreen::setPrimaryOutputName(const QString &primaryOutputName)
 {
-    for (const auto &[k, v] : m_components) {
+    qCDebug(treelandShell) << "Setting primary output name for lock screen:" << primaryOutputName;
+
+    m_primaryOutputName = primaryOutputName;
+    for (const auto &[k, v] : std::as_const(m_components)) {
         v->setProperty("primaryOutputName", primaryOutputName);
     }
 }

--- a/src/core/lockscreen.h
+++ b/src/core/lockscreen.h
@@ -80,4 +80,5 @@ private:
     std::map<WOutputItem *, std::unique_ptr<QQuickItem, std::function<void(QQuickItem*)>>> m_fallbackItems;
     WSessionLock* m_sessionLock{ nullptr };
 #endif
+    QString m_primaryOutputName;
 };

--- a/src/plugins/lockscreen/qml/LockView.qml
+++ b/src/plugins/lockscreen/qml/LockView.qml
@@ -15,6 +15,30 @@ FocusScope {
     /* Components */
     /**************/
 
+    function show() {
+        root.forceActiveFocus()
+        root.visible = true
+        root.state = LoginAnimation.Show
+        leftAnimation.item.start({x: root.x - quickAction.width, y: quickAction.y}, {x: quickAction.x, y: quickAction.y})
+        logoAnimation.item.start({x: root.x - logo.width, y: logo.y}, {x: logo.x, y: logo.y})
+        rightAnimation.item.start({x: root.width + userInput.width, y: userInput.y}, {x: userInput.x, y: userInput.y})
+        bottomAnimation.item.start({x: controlAction.x, y: controlAction.y + controlAction.height}, {x: controlAction.x, y: controlAction.y})
+    }
+
+    function hide() {
+        root.state = LoginAnimation.Hide
+        leftAnimation.item.start({x: quickAction.x, y: quickAction.y}, {x: root.x - quickAction.width, y: quickAction.y})
+        logoAnimation.item.start({x: logo.x, y: logo.y}, {x: root.x - logo.width, y: logo.y})
+        rightAnimation.item.start({x: userInput.x, y: userInput.y}, {x: root.width + userInput.width, y: userInput.y})
+        bottomAnimation.item.start({x: controlAction.x, y: controlAction.y}, {x: controlAction.x, y: controlAction.y + controlAction.height})
+    }
+
+    Component.onCompleted: {
+        if (GreeterProxy.isLocked) {
+            Qt.callLater(show)
+        }
+    }
+
     Loader {
         id: leftAnimation
         anchors.fill: parent
@@ -159,19 +183,9 @@ FocusScope {
         target: GreeterProxy
         function onLockChanged(isLocked) {
             if (isLocked) {
-                root.forceActiveFocus()
-                root.visible = true
-                root.state = LoginAnimation.Show
-                leftAnimation.item.start({x: root.x - quickAction.width, y: quickAction.y}, {x: quickAction.x, y: quickAction.y})
-                logoAnimation.item.start({x: root.x - logo.width, y: logo.y}, {x: logo.x, y: logo.y})
-                rightAnimation.item.start({x: root.width + userInput.width, y: userInput.y}, {x: userInput.x, y: userInput.y})
-                bottomAnimation.item.start({x: controlAction.x, y: controlAction.y + controlAction.height}, {x: controlAction.x, y: controlAction.y})
+                root.show()
             } else {
-                root.state = LoginAnimation.Hide
-                leftAnimation.item.start({x: quickAction.x, y: quickAction.y}, {x: root.x - quickAction.width, y: quickAction.y})
-                logoAnimation.item.start({x: logo.x, y: logo.y}, {x: root.x - logo.width, y: logo.y})
-                rightAnimation.item.start({x: userInput.x, y: userInput.y}, {x: root.width + userInput.width, y: userInput.y})
-                bottomAnimation.item.start({x: controlAction.x, y: controlAction.y}, {x: controlAction.x, y: controlAction.y + controlAction.height})
+                root.hide()
             }
         }
     }


### PR DESCRIPTION
Fixes issue where switching TTY and switching back only shows the wallpaper.

**Changes:**
- Store primaryOutputName and add debug logging for output management
- Add Component.onCompleted handler to properly show lock screen when switching back from TTY
- Refactor QML show/hide logic

**中文说明:**
修复切换TTY再切换回来后只显示壁纸的问题。

- 存储 primaryOutputName 并为输出管理添加调试日志
- 添加 Component.onCompleted 处理器，确保从 TTY 切换回来时正确显示锁屏
- 重构 QML 显示/隐藏逻辑