### PR TITLE
fix: input guard seat access when applying device config

### DIFF
--- a/src/input/inputmanager.cpp
+++ b/src/input/inputmanager.cpp
@@ -552,7 +552,8 @@ void InputManager::onInputAdded(WInputDevice *input)
         return;
     }
 
-    auto *cursor = input->seat()->cursor();
+    auto *seat = input->seat();
+    auto *cursor = seat ? seat->cursor() : nullptr;
     if (cursor) {
         cursor->setScrollFactor(m_seatDConfig->pointerScrollFactor());
     }


### PR DESCRIPTION
该PR用于修复由 #955 导致的以DRM直接启动treeland时崩溃的问题

InputManager can see libinput devices that were not assigned to a seat, for example devices filtered by SeatsManager. Avoid dereferencing a null seat when syncing the cursor scroll factor, while keeping the rest of the device configuration path unchanged.

## Summary by Sourcery

Bug Fixes:
- Prevent crashes when syncing cursor scroll factor for input devices that are not associated with any seat.