### PR TITLE
[codex] raise Treeland service resource priority

### DIFF
--- a/misc/systemd/treeland.service.in
+++ b/misc/systemd/treeland.service.in
@@ -13,6 +13,7 @@ RuntimeDirectory=treeland
 RuntimeDirectoryMode=0700
 Environment="XDG_RUNTIME_DIR=%t/treeland"
 Environment=LIBSEAT_BACKEND=seatd
+Environment=SEATD_SOCK=/run/dde-seatd.sock
 Environment=DSG_APP_ID=org.deepin.dde.treeland
 Environment=ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
 # For Debug: if enable asan, you can't get it's log from journalctl, so ensure the log to a file
@@ -27,8 +28,14 @@ StandardOutput=null
 StandardError=null
 
 NoNewPrivileges=true
-OOMScoreAdjust=-300
-Nice=-15
+OOMScoreAdjust=-1000
+Nice=-20
+CPUWeight=10000
+CPUSchedulingPolicy=rr
+CPUSchedulingPriority=20
+IOWeight=10000
+IOSchedulingClass=realtime
+IOSchedulingPriority=0
 
 # Enable MemoryDenyWriteExecute will cause Treeland crash in certain
 # condition (observed on arm64 virtual machine). The coredump indicate


### PR DESCRIPTION
Raise Treeland DDM-mode systemd service to highest normal CPU, I/O, and OOM-protection priorities. Move dde-seatd socket environment ownership to treeland.service.

**Changes:**

- Add `Environment=SEATD_SOCK=/run/dde-seatd.sock` to own the seatd socket configuration
- Change `OOMScoreAdjust=-300` to `OOMScoreAdjust=-1000` (maximum protection)
- Change `Nice=-15` to `Nice=-20` (highest nice priority)
- Add `CPUWeight=10000` (high CPU weight)
- Add `CPUSchedulingPolicy=rr` (round-robin realtime scheduling)
- Add `CPUSchedulingPriority=20` (realtime priority level)
- Add `IOWeight=10000` (high I/O weight)
- Add `IOSchedulingClass=realtime` (realtime I/O scheduling)
- Add `IOSchedulingPriority=0` (highest I/O priority)

This PR replaces closed PR #932 which was targeting the old/master branch.

## Summary by Sourcery

Increase Treeland systemd service runtime priority and assume ownership of seatd socket configuration.

Enhancements:
- Raise Treeland service CPU, I/O, and OOM-protection priorities to highest normal levels in its systemd unit.
- Configure the Treeland service to own the SEATD_SOCK environment for the dde-seatd socket.