### PR TITLE
fix(qtquick): create RHI textures from DRM formats

### DIFF
--- a/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
+++ b/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
@@ -62,8 +62,9 @@ QByteArray encodeStates(ForeignToplevelHandleV1::States states)
 }
 }
 
-struct SurfaceEntry
+class SurfaceEntry
 {
+public:
     SurfaceWrapper *wrapper = nullptr;
     QList<ForeignToplevelHandleV1 *> handles;
 };

--- a/waylib/src/server/qtquick/private/wrenderbuffernode.cpp
+++ b/waylib/src/server/qtquick/private/wrenderbuffernode.cpp
@@ -3,11 +3,14 @@
 
 #include <QDebug>
 
+#include "wrenderhelper.h"
 #include "wrenderbuffernode_p.h"
 #include "wbufferrenderer_p.h"
 #include "wqmlhelper_p.h"
 #include "platformplugin/types.h"
 #include "private/wprivateaccessor_p.h"
+
+#include <qwtexture.h>
 
 #include <QQuickItem>
 #include <QRunnable>
@@ -202,7 +205,7 @@ public:
         return owner->findChild<Derive*>({}, Qt::FindDirectChildrenOnly);
     }
 
-    static DataManagerPointer<Derive> resolve(const DataManagerPointer<Derive> &other, QQuickWindow *owner) {
+    static DataManagerPointer<Derive> resolveByOwner(const DataManagerPointer<Derive> &other, QQuickWindow *owner) {
         static_assert(QtPrivate::HasQ_OBJECT_Macro<Derive>::Value, "Derive must have Q_OBJECT macro");
         Q_ASSERT(owner);
         if (other && other->owner() == owner)
@@ -234,7 +237,7 @@ public:
         {
             auto d = data.lock();
             if (d && dataList.contains(d)) {
-                if (get()->check(d->data, keys...)) {
+                if (get()->check(d->data, std::forward<DataKeys>(keys)...)) {
                     d->released = 0;
                     return data;
                 }
@@ -243,7 +246,7 @@ public:
         }
 
         for (auto data : std::as_const(dataList)) {
-            if (get()->check(data->data, keys...)) {
+            if (get()->check(data->data, std::forward<DataKeys>(keys)...)) {
                 data->released = 0;
                 return data;
             }
@@ -342,33 +345,51 @@ protected:
     QRunnable *cleanJob = nullptr;
 };
 
-class Q_DECL_HIDDEN RhiTextureManager : public DataManager<RhiTextureManager, QRhiTexture, QRhiTexture::Format, const QSize&>
+struct WlrAndRhiTexture {
+    struct wlr_buffer *buffer = nullptr;
+    qw_texture *wlrTexture = nullptr;
+    QRhiTexture *rhiTexture = nullptr;
+};
+
+class Q_DECL_HIDDEN RhiTextureManager : public DataManager<RhiTextureManager, WlrAndRhiTexture, QRhiTexture::Format, uint32_t, uint64_t, const QSize&>
 {
     Q_OBJECT
 
     friend class DataManager;
 
     RhiTextureManager(QQuickWindow *owner)
-        : DataManager<RhiTextureManager, QRhiTexture, QRhiTexture::Format, const QSize&>(owner) {
+        : DataManager<RhiTextureManager, WlrAndRhiTexture, QRhiTexture::Format, uint32_t, uint64_t, const QSize&>(owner) {
         Q_ASSERT(owner->findChildren<RhiTextureManager*>(Qt::FindDirectChildrenOnly).size() == 1);
     }
 
-    static bool check(QRhiTexture *texture, QRhiTexture::Format format, const QSize &size) {
-        return texture->format() == format && texture->pixelSize() == size;
-    }
-
-    QRhiTexture *create(QRhiTexture::Format format, const QSize &size) {
-        auto texture = owner()->rhi()->newTexture(format, size, 1, QRhiTexture::RenderTarget);
-        if  (!texture->create()) {
-            delete texture;
-            return nullptr;
+    static bool check(WlrAndRhiTexture *texture, QRhiTexture::Format, uint32_t drmFormat, uint64_t drmModifier, const QSize &size) {
+        auto buffer = texture->buffer;
+        wlr_dmabuf_attributes attribs;
+        if (!wlr_buffer_get_dmabuf(buffer, &attribs)) {
+            qWarning() << "Failed to get dmabuf attributes for texture" << texture << "with buffer" << buffer
+                       << ", Can't check texture without dmabuf attributes";
+            return false;
         }
-
-        return texture;
+        return attribs.format == drmFormat && attribs.modifier == drmModifier && texture->rhiTexture->pixelSize() == size;
     }
 
-    static void destroy(QRhiTexture *texture) {
-        texture->deleteLater();
+    WlrAndRhiTexture *create(QRhiTexture::Format format, uint32_t drmFormat, uint64_t drmModifier, const QSize &size) {
+        auto ow = qobject_cast<WOutputRenderWindow*>(owner());
+        auto texture = WRenderHelper::newTexture(ow->allocator(), ow->renderer(),
+                                                 drmFormat, drmModifier, owner()->rhi(),
+                                                 size, format, QRhiTexture::RenderTarget);
+        if (!texture.rhiTexture)
+            return nullptr;
+
+        return new WlrAndRhiTexture{texture.buffer, texture.texture, texture.rhiTexture};
+    }
+
+    static void destroy(WlrAndRhiTexture *texture) {
+        delete texture->rhiTexture;
+        delete texture->wlrTexture;
+        if (texture->buffer)
+            wlr_buffer_drop(texture->buffer);
+        delete texture;
     }
 };
 
@@ -698,6 +719,18 @@ public:
             return;
         }
 
+        auto buffer = WRenderHelper::lookupBuffer(ct);
+        if (!buffer) {
+            reset();
+            return;
+        }
+
+        wlr_dmabuf_attributes attribs;
+        if (!buffer->get_dmabuf(&attribs)) {
+            reset();
+            return;
+        }
+
         const auto currentRenderer = maybeBufferRenderer();
         // TODO: Apple viewport to matrix, needs get QSGRenderer
         renderMatrix = currentRenderer
@@ -705,7 +738,7 @@ public:
                            : *this->matrix();
         devicePixelRatio = effectiveDevicePixelRatio();
         const auto oldManager = manager;
-        manager = RhiTextureManager::resolve(manager, window);
+        manager = RhiTextureManager::resolveByOwner(manager, window);
 
         if (oldManager != manager) {
             sgTexture()->setTexture(nullptr);
@@ -715,7 +748,7 @@ public:
         }
 
         Q_ASSERT(ct->rhi() == window->rhi());
-        rhi = rhi->resolve(rhi, window);
+        rhi = rhi->resolveByOwner(rhi, window);
         Q_ASSERT(rhi);
 
         const bool hasRotation = renderMatrix.flags().testAnyFlags(QMatrix4x4::Rotation2D | QMatrix4x4::Rotation);
@@ -752,7 +785,11 @@ public:
             pixelSize = size.toSize();
         }
 
-        texture = manager->resolve(texture, ct->format(), pixelSize);
+        {
+            auto format = attribs.format;
+            auto modifier = attribs.modifier;
+            texture = manager->resolve(texture, ct->format(), std::move(format), std::move(modifier), pixelSize);
+        }
         if (Q_UNLIKELY(texture.expired())) {
             reset();
             return;
@@ -761,8 +798,8 @@ public:
         Q_ASSERT(texture->data);
 
         if (renderData) {
-            if (!renderData->rt || sgTexture()->rhiTexture() != texture->data) {
-                QRhiTextureRenderTargetDescription rtDesc(texture->data);
+            if (!renderData->rt || sgTexture()->rhiTexture() != texture->data->rhiTexture) {
+                QRhiTextureRenderTargetDescription rtDesc(texture->data->rhiTexture);
                 const auto flags = QRhiTextureRenderTarget::PreserveColorContents
                     | QRhiTextureRenderTarget::PreserveDepthStencilContents;
                 auto newRT = rhi->rhi()->newTextureRenderTarget(rtDesc, flags);
@@ -785,10 +822,10 @@ public:
     }
 
     void render([[maybe_unused]] const RenderState *state) override {
-
         auto texture = this->texture.lock();
         if (Q_UNLIKELY(!texture))
             return;
+        auto rhiTexture = texture->data->rhiTexture;
 
         auto ct = currentRenderTexture();
         Q_ASSERT(ct);
@@ -800,13 +837,13 @@ public:
             const QPointF sourcePos = renderMatrix.map(m_rect.topLeft());
             renderData->imageNode->setRect(QRectF(-(devicePixelRatio - 1) * sourcePos, ct->pixelSize()));
 
-            rhi->sync(texture->data->pixelSize(), &renderData->rootNode, renderMatrix.inverted(), {}, nullptr,
-                      {texture->data->pixelSize().width() / float(m_rect.width() * devicePixelRatio),
-                       texture->data->pixelSize().height() / float(m_rect.height() * devicePixelRatio)});
+            rhi->sync(rhiTexture->pixelSize(), &renderData->rootNode, renderMatrix.inverted(), {}, nullptr,
+                      {rhiTexture->pixelSize().width() / float(m_rect.width() * devicePixelRatio),
+                       rhiTexture->pixelSize().height() / float(m_rect.height() * devicePixelRatio)});
             rhi->render(renderData->rt.get());
         } else {
             const QPoint sourcePos = (renderMatrix.map(m_rect.topLeft()) * devicePixelRatio).toPoint();
-            const QRect sourceTextureRect(sourcePos, texture->data->pixelSize());
+            const QRect sourceTextureRect(sourcePos, rhiTexture->pixelSize());
             const QRect renderTargetRect(QPoint(0, 0), ct->pixelSize());
             const QRect copySourceRect = sourceTextureRect.intersected(renderTargetRect);
             if (copySourceRect.isEmpty())
@@ -818,7 +855,7 @@ public:
             desc.setPixelSize(copySourceRect.size());
             desc.setSourceTopLeft(copySourceRect.topLeft());
             desc.setDestinationTopLeft(copySourceRect.topLeft() - sourcePos);
-            rub->copyTexture(texture->data, ct, desc);
+            rub->copyTexture(rhiTexture, ct, desc);
 
             QRhiCommandBuffer *cb = nullptr;
             if (rhi->beginOffscreenFrame(&cb) != QRhi::FrameOpSuccess)
@@ -830,8 +867,8 @@ public:
             rhi->endOffscreenFrame();
         }
 
-        if (sgTexture()->rhiTexture() != texture->data)
-            sgTexture()->setTexture(texture->data);
+        if (sgTexture()->rhiTexture() != rhiTexture)
+            sgTexture()->setTexture(rhiTexture);
         doNotifyTextureChanged();
 
         if (contentNode) {
@@ -1085,7 +1122,7 @@ public:
         const auto matrix = /*(sgRenderer && sgRenderer->renderTarget().paintDevice == p->device())
             ? currentRenderer->currentWorldTransform() * (*this->matrix()) :*/ *this->matrix();
         const auto oldManager = manager;
-        manager = QImageManager::resolve(manager, window);
+        manager = QImageManager::resolveByOwner(manager, window);
 
         if (oldManager != manager) {
             texture()->setTexture(nullptr);

--- a/waylib/src/server/qtquick/wrenderhelper.cpp
+++ b/waylib/src/server/qtquick/wrenderhelper.cpp
@@ -25,6 +25,7 @@
 #include <private/qsgplaintexture_p.h>
 #include <private/qsgadaptationlayer_p.h>
 #include <private/qsgsoftwarepixmaptexture_p.h>
+#include <private/qsgrhisupport_p.h>
 
 extern "C" {
 #define static
@@ -40,6 +41,14 @@ extern "C" {
 
 QW_USE_NAMESPACE
 WAYLIB_SERVER_BEGIN_NAMESPACE
+
+struct Q_DECL_HIDDEN RhiRenderEntry {
+    const QRhiRenderTarget *renderTarget;
+    const QRhiTexture *texture;
+    QPointer<qw_buffer> buffer;
+};
+
+Q_GLOBAL_STATIC(QVector<RhiRenderEntry>, s_rhiRenderBuffers)
 
 struct Q_DECL_HIDDEN BufferData {
     BufferData() {
@@ -58,6 +67,17 @@ struct Q_DECL_HIDDEN BufferData {
 
     inline void resetWindowRenderTarget() {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+        {
+            auto it = s_rhiRenderBuffers->begin();
+            while (it != s_rhiRenderBuffers->end()) {
+                if (windowRenderTarget.rt.renderTarget == it->renderTarget) {
+                    it = s_rhiRenderBuffers->erase(it);
+                    break;
+                }
+                ++it;
+            }
+        }
+
         if (windowRenderTarget.rt.owns)
             delete windowRenderTarget.rt.renderTarget;
 
@@ -79,6 +99,17 @@ struct Q_DECL_HIDDEN BufferData {
 
         windowRenderTarget.sw = {};
 #else
+        {
+            auto it = s_rhiRenderBuffers->begin();
+            while (it != s_rhiRenderBuffers->end()) {
+                if (windowRenderTarget.renderTarget == it->renderTarget) {
+                    it = s_rhiRenderBuffers->erase(it);
+                    break;
+                }
+                ++it;
+            }
+        }
+
         if (windowRenderTarget.owns) {
             delete windowRenderTarget.renderTarget;
             delete windowRenderTarget.rpDesc;
@@ -123,6 +154,7 @@ static bool createRhiRenderTarget(const QRhiColorAttachment &colorAttachment,
         return false;
     }
 
+    rt->setName(QByteArrayLiteral("WaylibTextureRenderTarget"));
 #if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
     dst.rt.renderTarget = rt.release();
     dst.res.rpDesc = rp.release();
@@ -153,6 +185,7 @@ bool createRhiRenderTarget(QRhi *rhi, const QQuickRenderTarget &source, QQuickWi
 #endif
                                                                           );
         std::unique_ptr<QRhiTexture> texture(rhi->newTexture(format, rtd->pixelSize, rtd->sampleCount, flags));
+        texture->setName(QByteArrayLiteral("WaylibTexture"));
 #if QT_VERSION < QT_VERSION_CHECK(6, 6, 0)
         if (!texture->createFrom({ rtd->u.nativeTexture.object, rtd->u.nativeTexture.layout }))
 #else
@@ -178,6 +211,7 @@ bool createRhiRenderTarget(QRhi *rhi, const QQuickRenderTarget &source, QQuickWi
         QRhiColorAttachment att(renderbuffer.get());
         if (!createRhiRenderTarget(att, rtd->pixelSize, rtd->sampleCount, rhi, dst))
             return false;
+        renderbuffer->setName(QByteArrayLiteral("WaylibRenderBuffer"));
 #if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
         dst.res.renderBuffer = renderbuffer.release();
 #else
@@ -557,6 +591,11 @@ QQuickRenderTarget WRenderHelper::acquireRenderTarget(QQuickRenderControl *rc, q
 
         if (bufferData->renderTarget.isNull())
             return {};
+
+        if (auto texture = bufferData->windowRenderTarget.res.texture) {
+            s_rhiRenderBuffers->append({ bufferData->windowRenderTarget.rt.renderTarget,
+                                         texture, bufferData->buffer });
+        }
     }
 
     connect(buffer, SIGNAL(before_destroy()),
@@ -804,6 +843,116 @@ bool WRenderHelper::makeTexture(QRhi *rhi, qw_texture *handle, QSGPlainTexture *
         return false;
     updateTexture(rhi, handle, texture);
     return true;
+}
+
+WRenderHelper::TextureEntry
+WRenderHelper::newTexture(qw_allocator *allocator, qw_renderer *renderer,
+                          uint32_t drmFormat, uint64_t drmModifier,
+                          QRhi *rhi, const QSize &size,
+                          int rhiFormat, int rhiFlags)
+{
+    uint64_t modifiers[] = {drmModifier};
+    wlr_drm_format format {
+        .format = drmFormat,
+        .len = 1,
+        .capacity = 1,
+        .modifiers = modifiers
+    };
+
+    wlr_buffer *buffer = allocator->create_buffer(size.width(), size.height(), &format);
+    if (!buffer) {
+        qCritical() << "Failed to create qw_buffer from allocator";
+        return {};
+    }
+
+    std::unique_ptr<qw_texture> texture(qw_texture::from_buffer(*renderer, buffer));
+    if (!texture) {
+        qCritical() << "Failed to create qw_texture from buffer";
+        wlr_buffer_drop(buffer);
+        return {};
+    }
+
+    const auto qformat = static_cast<QRhiTexture::Format>(rhiFormat);
+    const auto qflags = QRhiTexture::Flags(rhiFlags);
+    std::unique_ptr<QRhiTexture> rhiTexture(rhi->newTexture(qformat, size, 1, qflags));
+
+    if (wlr_texture_is_gles2(*texture.get())) {
+        if (rhi->backend() != QRhi::OpenGLES2) {
+            qFatal("The current QRhi backend doesn't support creating texture from GLES2 texture");
+        }
+
+        wlr_gles2_texture_attribs attribs;
+        wlr_gles2_texture_get_attribs(*texture.get(), &attribs);
+
+        if (!rhiTexture->createFrom({attribs.tex, 0})) {
+            qCritical("Failed to create QRhiTexture from GLES2 texture");
+            wlr_buffer_drop(buffer);
+            return {};
+        }
+    }
+#ifdef ENABLE_VULKAN_RENDER
+    else if (wlr_texture_is_vk(*texture.get())) {
+        if (rhi->backend() != QRhi::Vulkan) {
+            qFatal("The current QRhi backend doesn't support creating texture from Vulkan image");
+        }
+
+        wlr_vk_image_attribs attribs;
+        wlr_vk_texture_get_image_attribs(*texture.get(), &attribs);
+
+        if (!rhiTexture->createFrom({vkimage_cast(attribs.image), attribs.layout})) {
+            qCritical("Failed to create QRhiTexture from Vulkan image");
+            wlr_buffer_drop(buffer);
+            return {};
+        }
+    }
+#endif
+    else if (wlr_texture_is_pixman(*texture.get())) {
+        qFatal("Creating QRhiTexture from Pixman image is not supported");
+    } else {
+        qFatal("Unknown texture type");
+    }
+
+    rhiTexture->setName("WaylibTexture");
+
+    return {buffer, texture.release(), rhiTexture.release()};
+}
+
+WRenderHelper::TextureEntry
+WRenderHelper::newTextureLike(QW_NAMESPACE::qw_allocator *allocator,
+                              QW_NAMESPACE::qw_renderer *renderer,
+                              QRhiTexture *texture, QRhi *rhi,
+                              int rhiFlags)
+{
+    auto buffer = lookupBuffer(texture);
+    if (!buffer)
+        return {};
+
+    wlr_dmabuf_attributes attribs;
+    if (!buffer->get_dmabuf(&attribs))
+        return {};
+
+    return newTexture(allocator, renderer, attribs.format, attribs.modifier,
+                      rhi, texture->pixelSize(), texture->format(), rhiFlags);
+}
+
+QW_NAMESPACE::qw_buffer *WRenderHelper::lookupBuffer(const QRhiRenderTarget *rt)
+{
+    for (const auto &entry : std::as_const(*s_rhiRenderBuffers)) {
+        if (entry.renderTarget == rt)
+            return entry.buffer;
+    }
+
+    return nullptr;
+}
+
+QW_NAMESPACE::qw_buffer *WRenderHelper::lookupBuffer(const QRhiTexture *texture)
+{
+    for (const auto &entry : std::as_const(*s_rhiRenderBuffers)) {
+        if (entry.texture == texture)
+            return entry.buffer;
+    }
+
+    return nullptr;
 }
 
 WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/qtquick/wrenderhelper.h
+++ b/waylib/src/server/qtquick/wrenderhelper.h
@@ -19,10 +19,13 @@ QT_END_NAMESPACE
 
 QW_BEGIN_NAMESPACE
 class qw_renderer;
+class qw_allocator;
 class qw_backend;
 class qw_buffer;
 class qw_texture;
 QW_END_NAMESPACE
+
+struct wlr_buffer;
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
@@ -53,6 +56,22 @@ public:
     static QSGRendererInterface::GraphicsApi probe(QW_NAMESPACE::qw_backend *testBackend, const QList<QSGRendererInterface::GraphicsApi> &apiList);
 
     static bool makeTexture(QRhi *rhi, QW_NAMESPACE::qw_texture *handle, QSGPlainTexture *texture);
+
+    struct TextureEntry {
+        wlr_buffer *buffer;
+        QW_NAMESPACE::qw_texture *texture;
+        QRhiTexture *rhiTexture;
+    };
+    static TextureEntry newTexture(QW_NAMESPACE::qw_allocator *allocator,
+                                   QW_NAMESPACE::qw_renderer *renderer,
+                                   uint32_t drmFormat, uint64_t drmModifier,
+                                   QRhi *rhi, const QSize &size,
+                                   int rhiFormat, int rhiFlags);
+    static TextureEntry newTextureLike(QW_NAMESPACE::qw_allocator *allocator,
+                                       QW_NAMESPACE::qw_renderer *renderer,
+                                       QRhiTexture *texture, QRhi *rhi, int rhiFlags);
+    static QW_NAMESPACE::qw_buffer *lookupBuffer(const QRhiRenderTarget *rt);
+    static QW_NAMESPACE::qw_buffer *lookupBuffer(const QRhiTexture *texture);
 
 Q_SIGNALS:
     void sizeChanged();


### PR DESCRIPTION
## Summary
- Add WRenderHelper APIs to allocate QRhiTexture objects from DRM formats via the wlroots allocator.
- Expose the allocator-backed texture factories through WOutputRenderWindow for render nodes.
- Update WRenderBufferNode to copy into textures created from the source render target DRM format.

## Test Plan
- cmake --build build --target waylibserver
- cmake --build build --target treeland
- /usr/bin/ctest --test-dir build/waylib/tests/unit_tests --output-on-failure