### PR TITLE
Revert "fix(personalization): connect windowRadiusChanged to surface …

### DIFF
--- a/misc/dconfig/org.deepin.dde.treeland.user.json
+++ b/misc/dconfig/org.deepin.dde.treeland.user.json
@@ -68,17 +68,6 @@
             "permissions": "readwrite",
             "visibility": "public"
         },
-        "popupRadius": {
-            "value": 8,
-            "serial": 0,
-            "flags": ["global"],
-            "name": "Popup Round Corner Radius",
-            "name[zh_CN]": "弹出窗口圆角大小",
-            "description": "Xdg Popup Corner Round Radius",
-            "description[zh_CN]": "设置弹出窗口圆角大小",
-            "permissions": "readwrite",
-            "visibility": "public"
-        },
         "preferDark": {
             "value": false,
             "serial": 0,

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1146,15 +1146,6 @@ void Helper::onSurfaceWrapperAdded(SurfaceWrapper *wrapper)
         };
         connect(attached, &Personalization::backgroundTypeChanged, this, updateBlur);
         updateBlur();
-
-        auto updateRadius = [attached] {
-            attached->surfaceWrapper()->setRadius(attached->cornerRadius());
-        };
-        connect(attached, &Personalization::cornerRadiusChanged, this, updateRadius);
-        updateRadius();
-
-        connect(Helper::instance()->config(), &TreelandUserConfig::windowRadiusChanged, wrapper, &SurfaceWrapper::radiusChanged);
-
         if (isLayer) {
             auto layer = qobject_cast<WLayerSurface *>(wrapper->shellSurface());
             if (isLaunchpad(layer))

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -1583,15 +1583,21 @@ void SurfaceWrapper::startShowDesktopAnimation(bool show)
 
 qreal SurfaceWrapper::radius() const
 {
-    if (m_radius > 1)
-        return m_radius;
-
-    if (m_type == Type::XdgToplevel)
-        return Helper::instance()->config()->windowRadius();
+    // TODO: move to dconfig
+    if (m_type == Type::InputPopup)
+        return 0;
     if (m_type == Type::XdgPopup)
-        return Helper::instance()->config()->popupRadius();
+        return 8;
 
-    return 0;
+    qreal radius = m_radius;
+
+    // TODO: Handle: XdgToplevel, popup, InputPopup, XWayland (bypass, window type:
+    // menu/normal/popup)
+    if (radius < 1 && m_type != Type::Layer) {
+        radius = Helper::instance()->config()->windowRadius();
+    }
+
+    return radius;
 }
 
 void SurfaceWrapper::setRadius(qreal newRadius)


### PR DESCRIPTION
…re-rendering"

This reverts commit 41272b8940a7eeeafa132e573dee4642562f8f2e.

## Summary by Sourcery

Enhancements:
- Adjust SurfaceWrapper radius calculation to provide fixed radii for popup/input surfaces and fall back to configured window radius only when no explicit radius is set.