### PR TITLE
chore: add TREELAND_INPUT_ENHANCE environment variable

### DIFF
--- a/misc/systemd/treeland.service.in
+++ b/misc/systemd/treeland.service.in
@@ -18,6 +18,7 @@ Environment=ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
 # For Debug: if enable asan, you can't get it's log from journalctl, so ensure the log to a file
 Environment=ASAN_OPTIONS=log_path=/tmp/treeland-asan:detect_leaks=0:abort_on_error=1:symbolize=1
 Environment=DDM_DISPLAY_MANAGER=1
+Environment=TREELAND_INPUT_ENHANCE=1
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/treeland.sh --lockscreen
 Restart=on-failure
 RestartSec=1s


### PR DESCRIPTION
Add TREELAND_INPUT_ENHANCE=1 to systemd service configuration to enable input enhancement feature.

Log: 添加 INPUT_ENHANCE 环境变量
Influence: 启用 treeland 输入增强功能的环境变量配置。

## Summary by Sourcery

Build:
- Add TREELAND_INPUT_ENHANCE environment variable to the Treeland systemd service configuration.