### PR TITLE
fix: add idle event dispatch to resolve lock screen time refresh issue

### DIFF
--- a/waylib/src/server/kernel/private/wserver_p.h
+++ b/waylib/src/server/kernel/private/wserver_p.h
@@ -28,6 +28,9 @@ public:
     void stop();
 
     void initSocket(WSocket *socketServer);
+    void processWaylandEvents();
+    void onAboutToBlock();
+    void onAwake();
 
     W_DECLARE_PUBLIC(WServer)
     std::unique_ptr<QSocketNotifier> sockNot;

--- a/waylib/src/server/kernel/wserver.cpp
+++ b/waylib/src/server/kernel/wserver.cpp
@@ -106,25 +106,16 @@ void WServerPrivate::init()
     int fd = wl_event_loop_get_fd(loop);
 
     sockNot.reset(new QSocketNotifier(fd, QSocketNotifier::Read));
-    QObject::connect(sockNot.get(), &QSocketNotifier::activated, q, [this] {
-        if (isProcessingEvents)
-            return;
-
-        QScopedValueRollback<bool> guard(isProcessingEvents, true);
-
-        int ret = wl_event_loop_dispatch(loop, 0);
-        if (ret)
-            fprintf(stderr, "wl_event_loop_dispatch error: %d\n", ret);
-    });
+    bool ok = QObject::connect(sockNot.get(), SIGNAL(activated(QSocketDescriptor,QSocketNotifier::Type)),
+                               q, SLOT(processWaylandEvents()));
+    Q_ASSERT(ok);
 
     // Match upstream wl_display_run order: flush before dispatch.
     QAbstractEventDispatcher *dispatcher = QThread::currentThread()->eventDispatcher();
-    QObject::connect(dispatcher, &QAbstractEventDispatcher::aboutToBlock, q, [this] {
-        if (isProcessingEvents)
-            return;
-
-        safeFlushClients();
-    });
+    ok = QObject::connect(dispatcher, SIGNAL(aboutToBlock()), q, SLOT(onAboutToBlock()));
+    Q_ASSERT(ok);
+    ok = QObject::connect(dispatcher, SIGNAL(awake()), q, SLOT(onAwake()));
+    Q_ASSERT(ok);
 
     for (auto socket : std::as_const(sockets))
         initSocket(socket);
@@ -174,6 +165,157 @@ void WServerPrivate::initSocket(WSocket *socketServer)
 {
     bool ok = socketServer->listen(display->handle());
     Q_ASSERT(ok);
+}
+
+void WServerPrivate::processWaylandEvents()
+{
+    if (isProcessingEvents)
+        return;
+
+    QScopedValueRollback<bool> guard(isProcessingEvents, true);
+
+    int ret = wl_event_loop_dispatch(loop, 0);
+    if (ret)
+        fprintf(stderr, "wl_event_loop_dispatch error: %d\n", ret);
+}
+
+/*
+ * NOTE: Wayland idle dispatch integration (Qt + wlroots hybrid loop)
+ *
+ * In a native wlroots/libwayland architecture, wl_event_loop_dispatch()
+ * is continuously driven by wl_display_run(), which guarantees a strict
+ * event-loop ordering:
+ *
+ *   1. poll()/epoll_wait() for fd activity
+ *   2. dispatch fd/timer/signal sources
+ *   3. dispatch idle sources (wl_event_loop_dispatch_idle)
+ *   4. return immediately into the next loop iteration
+ *
+ * In that model, idle callbacks are always executed within the same
+ * dispatch cycle in which they become pending, and newly scheduled idle
+ * tasks (e.g. from wlroots such as wlr_output_schedule_frame()) are
+ * guaranteed to be picked up in a timely next iteration.
+ *
+ * ---------------------------------------------------------------------
+ * Qt integration problem
+ * ---------------------------------------------------------------------
+ *
+ * In this architecture, Qt owns the main event loop, and Wayland is
+ * driven manually via QSocketNotifier on wl_display_get_fd().
+ *
+ * This changes the execution model fundamentally:
+ *
+ *   Qt Event Loop:
+ *     -> processes Qt events
+ *     -> enters aboutToBlock()
+ *     -> waits (epoll/poll)
+ *
+ *   Wayland:
+ *     -> only progresses when Qt triggers wl_event_loop_dispatch()
+ *        due to fd readability
+ *
+ * Therefore, wl_event_loop_dispatch(loop, 0) is NOT continuously running
+ * like wl_display_run(), but only executed opportunistically.
+ *
+ * ---------------------------------------------------------------------
+ * The critical correctness issue (idle starvation)
+ * ---------------------------------------------------------------------
+ *
+ * When wl_event_loop_dispatch(loop, 0) is executed:
+ *
+ *   - all currently pending Wayland fd/timer/signal events are processed
+ *   - wl_event_loop_dispatch_idle(loop) runs
+ *   - at this point, ALL idle callbacks existing at that moment are executed
+ *
+ * However, after this point, control returns to Qt immediately.
+ *
+ * During subsequent Qt event processing, it is possible that:
+ *
+ *   - Qt handlers trigger wlroots logic
+ *   - wlroots schedules deferred work via wl_event_loop_add_idle()
+ *     (e.g. wlr_output_schedule_frame, commit batching, repaint deferral)
+ *
+ * These newly added idle callbacks are NOT associated with any fd activity.
+ *
+ * As a result:
+ *
+ *   - wl_display fd remains inactive
+ *   - QSocketNotifier is not triggered
+ *   - wl_event_loop_dispatch(loop, 0) is not called again
+ *   - idle callbacks remain pending indefinitely
+ *
+ * They will only be executed later when some unrelated Wayland fd event
+ * occurs, causing wl_event_loop_dispatch() to run again — by which time
+ * the intended scheduling point (frame timing / batching window) is already
+ * delayed and incorrect relative to wlroots expectations.
+ *
+ * ---------------------------------------------------------------------
+ * Why aboutToBlock fixes this
+ * ---------------------------------------------------------------------
+ *
+ * QAbstractEventDispatcher::aboutToBlock() is emitted at a key semantic
+ * boundary in Qt:
+ *
+ *   - all Qt events have been processed
+ *   - no more Qt event handlers are running
+ *   - the event loop is about to enter a blocking wait
+ *
+ * This makes it equivalent to the "end of event-loop iteration" point.
+ *
+ * By invoking wl_event_loop_dispatch_idle(loop) here, we effectively:
+ *
+ *   - emulate wl_display_run() idle phase
+ *   - ensure all pending Wayland idle callbacks are executed
+ *   - drain idle tasks that were scheduled during Qt event processing
+ *
+ * This also covers the second critical case:
+ *
+ *   Qt wake-up cycle:
+ *     Qt processes events
+ *     -> wlroots schedules new idle work
+ *     -> Qt may not hit a new Wayland fd event immediately
+ *     -> idle would otherwise be delayed
+ *
+ * Therefore, we must also process idle:
+ *
+ *   - right before Qt sleeps (aboutToBlock)
+ *   - and effectively on each Qt iteration boundary
+ *
+ * to preserve wl_display_run() semantics.
+ *
+ * ---------------------------------------------------------------------
+ * Summary
+ * ---------------------------------------------------------------------
+ *
+ * This manual call to wl_event_loop_dispatch_idle(loop) is required to
+ * restore the implicit guarantees provided by wl_display_run():
+ *
+ *   - idle callbacks are executed within the same logical iteration
+ *     in which they are scheduled
+ *   - wlroots frame scheduling (e.g. wlr_output_schedule_frame) is not
+ *     delayed until the next unrelated Wayland fd event
+ *
+ * Without this, idle work can be starved indefinitely in a Qt-driven
+ * event loop where no Wayland fd activity occurs.
+ *
+ * This is a deliberate synchronization point between Qt's event loop
+ * lifecycle and Wayland's idle scheduling model.
+ */
+void WServerPrivate::onAboutToBlock()
+{
+    if (isProcessingEvents)
+        return;
+
+    wl_event_loop_dispatch_idle(loop);
+    safeFlushClients();
+}
+
+void WServerPrivate::onAwake()
+{
+    if (isProcessingEvents)
+        return;
+
+    wl_event_loop_dispatch_idle(loop);
 }
 
 WServer::WServer(QObject *parent)

--- a/waylib/src/server/kernel/wserver.h
+++ b/waylib/src/server/kernel/wserver.h
@@ -24,6 +24,7 @@ QW_END_NAMESPACE
 
 struct wl_global;
 
+Q_MOC_INCLUDE("private/wserver_p.h")
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
 typedef bool (*GlobalFilterFunc)(const wl_client *client,
@@ -153,6 +154,11 @@ Q_SIGNALS:
 
 protected:
     WServer(WServerPrivate &dd, QObject *parent = nullptr);
+
+private:
+    W_PRIVATE_SLOT(void processWaylandEvents())
+    W_PRIVATE_SLOT(void onAboutToBlock())
+    W_PRIVATE_SLOT(void onAwake())
 };
 
 WAYLIB_SERVER_END_NAMESPACE


### PR DESCRIPTION
1. Extract Wayland event processing into separate method processWaylandEvents()
2. Add wl_event_loop_dispatch_idle() calls in onAboutToBlock() and onAwake() handlers
3. Convert lambda connections to Q_PRIVATE_SLOT for better event loop integration
4. Process idle events when event dispatcher is about to block or awakens

The root cause was that when the screen is locked, the main event loop enters a blocking state waiting for user input. Without processing idle events during this time, scheduled timer callbacks (like time updates) were not being executed. By adding wl_event_loop_dispatch_idle() calls in both aboutToBlock and awake signals, we ensure that idle sources (including timers) are properly dispatched even when the application is in a waiting state.

Technical details:
- wl_event_loop_dispatch_idle() processes all idle sources in the Wayland event loop
- aboutToBlock: called before event loop blocks, ensures idle events run before sleeping
- awake: called when event loop wakes up, ensures idle events run immediately after

Log: Fixed lock screen time not refreshing automatically

Influence:
1. Test time display updates during lock screen state
2. Verify timer-based UI updates continue when screen is locked
3. Test event processing under various system load conditions
4. Verify no performance regression during normal operation
5. Test rapid lock/unlock cycles to ensure stable event handling
6. Verify other idle-scheduled operations work correctly during blocking states

fix: 添加空闲事件调度以解决锁屏时间刷新问题

1. 将 Wayland 事件处理提取为独立方法 processWaylandEvents()
2. 在 onAboutToBlock() 和 onAwake() 处理器中添加 wl_event_loop_dispatch_idle() 调用
3. 将 lambda 连接转换为 Q_PRIVATE_SLOT 以更好地集成事件循环
4. 在事件调度器即将阻塞或唤醒时处理空闲事件

根本原因是当屏幕锁定时，主事件循环进入阻塞状态等待用户输入。在此期间
如果不处理空闲事件，计划的定时器回调（如时间更新）就不会被执行。通过在
aboutToBlock 和 awake 信号中添加 wl_event_loop_dispatch_idle() 调用，我 们确保即使应用程序处于等待状态，空闲源（包括定时器）也能被正确调度。

技术细节：
- wl_event_loop_dispatch_idle() 处理 Wayland 事件循环中的所有空闲源
- aboutToBlock：在事件循环阻塞前调用，确保睡眠前运行空闲事件
- awake：在事件循环唤醒时调用，确保唤醒后立即运行空闲事件

Log: 修复锁屏时时间不会自动刷新问题

Influence:
1. 测试锁屏状态下时间显示的更新情况
2. 验证屏幕锁定时基于定时器的 UI 更新是否继续工作
3. 测试不同系统负载条件下的事件处理
4. 验证正常操作期间没有性能回退
5. 测试快速锁定/解锁循环以确保事件处理稳定
6. 验证其他空闲调度操作在阻塞状态下是否正常工作

## Summary by Sourcery

Ensure Wayland idle events are dispatched around the Qt event loop blocking to keep timers and lock-screen time updates responsive.

Bug Fixes:
- Fix lock screen time and other timer-based UI updates not refreshing while the main event loop is blocked waiting for input.

Enhancements:
- Extract Wayland event processing into a dedicated method and connect it via private slots for better integration with the Qt event dispatcher.