### PR TITLE
修复光标显示相关的两个问题

### DIFF
--- a/src/core/qml/PrimaryOutput.qml
+++ b/src/core/qml/PrimaryOutput.qml
@@ -42,8 +42,7 @@ OutputItem {
         OutputLayer.cursorHotSpot: hotSpot
 
         themeName: Helper.config.cursorThemeName
-        // Scale-aware cursor size: automatically updates when output scale changes
-        sourceSize: Qt.size(Helper.config.cursorSize * effectiveScale, Helper.config.cursorSize * effectiveScale)
+        sourceSize: Qt.size(Helper.config.cursorSize, Helper.config.cursorSize)
     }
 
     OutputViewport {

--- a/waylib/src/server/qtquick/woutputrenderwindow.cpp
+++ b/waylib/src/server/qtquick/woutputrenderwindow.cpp
@@ -1117,23 +1117,51 @@ bool OutputHelper::tryToHardwareCursor(const LayerData *layer)
         auto get_cursor_formsts = qwoutput()->handle()->impl->get_cursor_formats;
         bool needsRepaintCursor = get_cursor_sizes && get_cursor_formsts;
 
+        if (Q_UNLIKELY(wlcRenderer().isDebugEnabled()))
+            qCDebug(wlcRenderer) << "Request cursor buffer size:" << pixelSize;
+
         if (get_cursor_sizes) {
+            if (Q_UNLIKELY(wlcRenderer().isDebugEnabled()))
+                qCDebug(wlcRenderer) << "Supported cursor sizes for output" << output() << ":";
+
             bool foundTargetSize = false;
             size_t sizes_len = 0;
             const auto sizes = get_cursor_sizes(qwoutput()->handle(), &sizes_len);
             for (size_t i = 0; i < sizes_len; ++i) {
+                if (Q_UNLIKELY(wlcRenderer().isDebugEnabled()))
+                     qCDebug(wlcRenderer) << "    " << sizes[i].width << "x" << sizes[i].height;
+
                 if (sizes[i].width == pixelSize.width()
                     && sizes[i].height == pixelSize.height()) {
                     foundTargetSize = true;
-                    break;
+                    if (Q_UNLIKELY(wlcRenderer().isDebugEnabled()))
+                        qCDebug(wlcRenderer) << "    " << sizes[i].width << "x" << sizes[i].height << "(matched)";
+                    else
+                        break; //need continue to print other sizes when find matched size
                 }
             }
 
             if (!foundTargetSize && sizes_len > 0) {
-                // Use the request size wlroots's backend to render the cursor
-                pixelSize.rwidth() = sizes[0].width;
-                pixelSize.rheight() = sizes[0].height;
-                needsRepaintCursor = true;
+                // Use the wlroots's backend supported size to re-render the cursor
+                for (size_t i = 0; i < sizes_len; ++i) {
+                    if (sizes[i].width > pixelSize.width()
+                        && sizes[i].height > pixelSize.height()) {
+                        pixelSize.rwidth() = sizes[i].width;
+                        pixelSize.rheight() = sizes[i].height;
+                        if (Q_UNLIKELY(wlcRenderer().isDebugEnabled()))
+                            qCDebug(wlcRenderer) << "Re-render cursor with size" << pixelSize
+                                                 << "because the original cursor size"
+                                                 << QSize(buffer->width, buffer->height)
+                                                 << "is not supported by wlroots backend";
+                        needsRepaintCursor = true;
+                        break;
+                    }
+                }
+
+                if (Q_UNLIKELY(!needsRepaintCursor)) {
+                    qCWarning(wlcRenderer) << "Can't find suitable cursor size for" << pixelSize;
+                    return false;
+                }
             } else {
                 needsRepaintCursor = false;
             }


### PR DESCRIPTION
## Summary by Sourcery

Improve cursor rendering compatibility with wlroots backends and adjust cursor sizing behavior in the primary output view.

Bug Fixes:
- Select a backend-supported hardware cursor size larger than the requested size and fail early when no suitable size is available to avoid incorrect cursor rendering.
- Make the cursor QML source size independent of output scale to prevent cursor size mis-scaling on scaled outputs.

Enhancements:
- Add detailed debug logging and warnings for hardware cursor size negotiation with wlroots backends.