### PR TITLE
fix: apply cursor settings without restart

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1368,6 +1368,14 @@ void Helper::init(Treeland::Treeland *treeland)
         m_config.reset(TreelandUserConfig::createByName("org.deepin.dde.treeland.user",
                                                   "org.deepin.dde.treeland",
                                                   "/" + m_userModel->currentUserName()));
+        connect(m_config.get(),
+                &TreelandUserConfig::cursorThemeNameChanged,
+                m_sessionManager,
+                &SessionManager::syncActiveSessionCursorSettings);
+        connect(m_config.get(),
+                &TreelandUserConfig::cursorSizeChanged,
+                m_sessionManager,
+                &SessionManager::syncActiveSessionCursorSettings);
         auto user = m_userModel->currentUser();
         m_personalizationInterfaceV1->setUserId(user ? user->UID() : getuid());
         // TODO(YaoBing Xiao): remove "dde"
@@ -1376,27 +1384,24 @@ void Helper::init(Treeland::Treeland *treeland)
         }
 
         m_inputManager->setupSeatUserConfig(m_userModel->currentUserName());
+        auto onConfigInitialized = [this] {
+            m_sessionManager->syncActiveSessionCursorSettings();
+            syncPaletteTypeWithWindowThemeType(m_config->windowThemeType());
+            m_wallpaperManager->updateWallpaperConfig();
+            tryInitRemoteSource();
+        };
         // TODO(YaoBing Xiao): pre-initialize dconfig, remove isInitializeSucceeded
 #if TREELANDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
         if (m_config->isInitializeSucceeded()) {
 #else
         if (m_config->isInitializeSucceed()) {
 #endif
-            syncPaletteTypeWithWindowThemeType(m_config->windowThemeType());
-            m_wallpaperManager->updateWallpaperConfig();
-            tryInitRemoteSource();
+            onConfigInitialized();
         } else {
             connect(m_config.get(),
                     &TreelandUserConfig::configInitializeSucceed,
-                    m_wallpaperManager,
-                    &WallpaperManager::updateWallpaperConfig);
-            connect(m_config.get(), &TreelandUserConfig::configInitializeSucceed, this, [this] {
-                syncPaletteTypeWithWindowThemeType(m_config->windowThemeType());
-            });
-            connect(m_config.get(),
-                    &TreelandUserConfig::configInitializeSucceed,
                     this,
-                    &Helper::tryInitRemoteSource);
+                    onConfigInitialized);
         }
     };
     connect(m_userModel, &UserModel::currentUserNameChanged, this, updateCurrentUser);

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1368,6 +1368,9 @@ void Helper::init(Treeland::Treeland *treeland)
         m_config.reset(TreelandUserConfig::createByName("org.deepin.dde.treeland.user",
                                                   "org.deepin.dde.treeland",
                                                   "/" + m_userModel->currentUserName()));
+        // Notify QML that the config pointer has changed so bindings (e.g. sourceSize
+        // on WQuickCursor) reconnect their notifiers to the new TreelandUserConfig object.
+        Q_EMIT configChanged();
         connect(m_config.get(),
                 &TreelandUserConfig::cursorThemeNameChanged,
                 m_sessionManager,

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -154,7 +154,7 @@ class Helper : public WSeatEventFilter
     Q_PROPERTY(OutputMode outputMode READ outputMode WRITE setOutputMode NOTIFY outputModeChanged FINAL)
     Q_PROPERTY(SurfaceWrapper* activatedSurface READ activatedSurface NOTIFY activatedSurfaceChanged FINAL)
     Q_PROPERTY(Workspace* workspace READ workspace CONSTANT FINAL)
-    Q_PROPERTY(TreelandUserConfig* config READ config CONSTANT FINAL)
+    Q_PROPERTY(TreelandUserConfig* config READ config NOTIFY configChanged FINAL)
     Q_PROPERTY(TreelandConfig* globalConfig READ globalConfig CONSTANT FINAL)
     Q_PROPERTY(bool blockActivateSurface READ blockActivateSurface WRITE setBlockActivateSurface NOTIFY blockActivateSurfaceChanged FINAL)
     Q_PROPERTY(bool noAnimation READ noAnimation WRITE setNoAnimation NOTIFY noAnimationChanged FINAL)
@@ -274,6 +274,7 @@ public Q_SLOTS:
     bool surfaceBelongsToCurrentSession(SurfaceWrapper *wrapper);
 
 Q_SIGNALS:
+    void configChanged();
     void primaryOutputChanged();
     void activatedSurfaceChanged();
 

--- a/src/session/session.cpp
+++ b/src/session/session.cpp
@@ -7,9 +7,10 @@
 #include "core/rootsurfacecontainer.h"
 #include "core/shellhandler.h"
 #include "seat/helper.h"
+#include "treelanduserconfig.hpp"
+#include "wallpaper/wallpaperlauncher.h"
 #include "workspace/workspace.h"
 #include "xsettings/settingmanager.h"
-#include "wallpaper/wallpaperlauncher.h"
 
 #include <woutputrenderwindow.h>
 #include <wsocket.h>
@@ -18,6 +19,27 @@
 #include <pwd.h>
 
 #define _DEEPIN_NO_TITLEBAR "_DEEPIN_NO_TITLEBAR"
+
+static void applyCursorSettings(SettingManager *settingManager, const QString &theme, qreal size)
+{
+    if (!settingManager) {
+        qCDebug(treelandXsettings) << "Skip cursor settings sync: no SettingManager";
+        return;
+    }
+
+    const bool queued = QMetaObject::invokeMethod(
+        settingManager,
+        [settingManager, theme, size]() {
+            settingManager->setCursorTheme(theme);
+            settingManager->setCursorSize(size);
+            settingManager->apply();
+        },
+        Qt::QueuedConnection);
+    if (!queued) {
+        qCWarning(treelandXsettings) << "Failed to queue cursor settings sync"
+                                     << "theme:" << theme << "size:" << size;
+    }
+}
 
 static xcb_atom_t internAtom(xcb_connection_t *connection, const char *name, bool onlyIfExists)
 {
@@ -236,17 +258,38 @@ std::shared_ptr<Session> SessionManager::ensureSession(int id, QString username)
 
                 const qreal scale = Helper::instance()->rootSurfaceContainer()->window()->effectiveDevicePixelRatio();
                 const auto renderWindow = Helper::instance()->window();
-                connect(session->m_settingManagerThread, &QThread::started,
+                connect(session->m_settingManagerThread,
+                        &QThread::started,
                         this,
                         [settingManager = QPointer(session->m_settingManager),
-                         scale, renderWindow] {
-                            QMetaObject::invokeMethod(
+                         scale,
+                         renderWindow] {
+                            if (!settingManager) {
+                                qCDebug(treelandXsettings)
+                                    << "Skip initial XSettings sync: no SettingManager";
+                                return;
+                            }
+
+                            const auto *config = Helper::instance()->config();
+                            const QString cursorTheme =
+                                config ? config->cursorThemeName() : QString();
+                            const qreal cursorSize = config ? config->cursorSize() : 24;
+
+                            const bool queued = QMetaObject::invokeMethod(
                                 settingManager,
-                                [settingManager, scale]() {
+                                [settingManager, scale, cursorTheme, cursorSize]() {
                                     settingManager->setGlobalScale(scale);
+                                    settingManager->setCursorTheme(cursorTheme);
+                                    settingManager->setCursorSize(cursorSize);
                                     settingManager->apply();
                                 },
                                 Qt::QueuedConnection);
+                            if (!queued) {
+                                qCWarning(treelandXsettings)
+                                    << "Failed to queue initial XSettings sync"
+                                    << "cursorTheme:" << cursorTheme << "cursorSize:" << cursorSize
+                                    << "scale:" << scale;
+                            }
                             QObject::connect(
                                 renderWindow,
                                 &WOutputRenderWindow::effectiveDevicePixelRatioChanged,
@@ -256,7 +299,7 @@ std::shared_ptr<Session> SessionManager::ensureSession(int id, QString username)
                                     settingManager->apply();
                                 },
                                 Qt::QueuedConnection);
-                });
+                        });
                 connect(session->m_settingManagerThread, &QThread::finished, session->m_settingManagerThread, &QThread::deleteLater);
                 session->m_settingManagerThread->start();
             }
@@ -398,6 +441,32 @@ bool SessionManager::isDDEUserClient(WClient *client)
     return client->socket() == globalSession()->socket();
 }
 
+void SessionManager::syncActiveSessionCursorSettings()
+{
+    const auto session = m_activeSession.lock();
+    if (!session) {
+        qCDebug(treelandXsettings) << "Skip cursor settings sync: no active session";
+        return;
+    }
+
+    if (!session->m_settingManager) {
+        qCDebug(treelandXsettings)
+            << "Skip cursor settings sync: no SettingManager for session" << session->username();
+        return;
+    }
+
+    auto *helper = Helper::instance();
+    Q_ASSERT(helper);
+
+    const auto *config = helper->config();
+    if (!config) {
+        qCWarning(treelandXsettings) << "Cannot sync cursor settings: user config is unavailable";
+        return;
+    }
+
+    applyCursorSettings(session->m_settingManager, config->cursorThemeName(), config->cursorSize());
+}
+
 /**
  * Update the active session to the given uid, creating it if necessary.
  * This will update XWayland visibility and emit socketFileChanged if the
@@ -430,4 +499,5 @@ void SessionManager::updateActiveUserSession(const QString &username, int id)
         Q_EMIT sessionChanged();
     }
     qCInfo(treelandCore) << "Listening on:" << session->m_socket->fullServerName();
+    syncActiveSessionCursorSettings();
 }

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -70,6 +70,7 @@ public:
     std::shared_ptr<Session> sessionForXWayland(WXWayland *xwayland) const;
     std::shared_ptr<Session> sessionForSocket(WSocket *socket) const;
     bool isDDEUserClient(WClient *client);
+    void syncActiveSessionCursorSettings();
 
 Q_SIGNALS:
     void socketFileChanged();

--- a/src/xsettings/settingmanager.cpp
+++ b/src/xsettings/settingmanager.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2025-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "settingmanager.h"
@@ -65,23 +65,40 @@ QString SettingManager::soundTheme() const
 void SettingManager::setCursorTheme(const QString &theme)
 {
     m_resource->setPropertyValue(XResource::toByteArray(XResource::Gtk_CursorThemeName), theme);
+    m_resource->setPropertyValue(XResource::toByteArray(XResource::Xcursor_Theme), theme);
     m_settings->setPropertyValue(XSettings::toByteArray(XSettings::Gtk_CursorThemeName), theme);
+    m_settings->setPropertyValue(XSettings::toByteArray(XSettings::Xcursor_Theme), theme);
 }
 
 QString SettingManager::cursorTheme() const
 {
-    return m_settings->getPropertyValue(XSettings::toByteArray(XSettings::Gtk_CursorThemeName)).toString();
+    const auto theme =
+        m_settings->getPropertyValue(XSettings::toByteArray(XSettings::Gtk_CursorThemeName));
+    if (theme.isValid()) {
+        return theme.toString();
+    }
+
+    return m_settings->getPropertyValue(XSettings::toByteArray(XSettings::Xcursor_Theme))
+        .toString();
 }
 
 void SettingManager::setCursorSize(qreal value)
 {
     m_resource->setPropertyValue(XResource::toByteArray(XResource::Xcursor_Size), value);
+    m_resource->setPropertyValue(XResource::toByteArray(XResource::Gtk_CursorThemeSize), value);
     m_settings->setPropertyValue(XSettings::toByteArray(XSettings::Xcursor_Size), value);
+    m_settings->setPropertyValue(XSettings::toByteArray(XSettings::Gtk_CursorThemeSize), value);
 }
 
 qreal SettingManager::cursorSize() const
 {
-    return m_settings->getPropertyValue(XSettings::toByteArray(XSettings::Xcursor_Size)).toReal();
+    const auto size = m_settings->getPropertyValue(XSettings::toByteArray(XSettings::Xcursor_Size));
+    if (size.isValid()) {
+        return size.toReal();
+    }
+
+    return m_settings->getPropertyValue(XSettings::toByteArray(XSettings::Gtk_CursorThemeSize))
+        .toReal();
 }
 
 void SettingManager::setDoubleClickInterval(int interval)

--- a/waylib/src/server/qtquick/wquickcursor.cpp
+++ b/waylib/src/server/qtquick/wquickcursor.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 JiDe Zhang <zhangjide@deepin.org>.
+// Copyright (C) 2023-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wquickcursor.h"
@@ -453,6 +453,7 @@ void WQuickCursor::setThemeName(const QString &name)
     if (d->xcursorThemeName == name)
         return;
     d->xcursorThemeName = name;
+    Q_EMIT themeNameChanged();
     if (isComponentComplete())
         QMetaObject::invokeMethod(this, "updateXCursorManager", Qt::QueuedConnection);
 }
@@ -470,6 +471,7 @@ void WQuickCursor::setSourceSize(const QSize &size)
     if (d->cursorSize == size)
         return;
     d->cursorSize = size;
+    Q_EMIT sourceSizeChanged();
     if (isComponentComplete())
         QMetaObject::invokeMethod(this, "updateXCursorManager", Qt::QueuedConnection);
 }


### PR DESCRIPTION
Synchronize cursor theme and size changes from TreelandUserConfig to the active XWayland session at runtime, so clients can observe updates without restarting treeland.

Update SettingManager to publish both GTK and Xcursor keys for cursor theme and size. Also emit WQuickCursor property notifications so the compositor cursor image reloads when QML-bound theme or source size changes.

Log failed queued XSettings updates while keeping expected startup timing gaps at debug level.