### PR TITLE
fix: 窗口移动到左边缘弹出的窗口大小不正确，dock位置改变窗口乱动

### DIFF
--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -459,31 +459,33 @@ void RootSurfaceContainer::ensureSurfaceNormalPositionValid(SurfaceWrapper *surf
         return;
 
     QList<QRectF> outputRects;
+    qreal minScreenX = std::numeric_limits<qreal>::max();
     outputRects.reserve(outputs().size());
-    for (auto o : std::as_const(outputs()))
+    for (auto o : std::as_const(outputs())) {
         outputRects << o->validGeometry();
+        minScreenX = qMin(minScreenX, o->validGeometry().left());
+    }
 
     // Ensure window is not outside the screen
-    const QPointF mustVisiblePosOfSurface(qMin(normalGeo.right(), normalGeo.x() + 20),
-                                          qMin(normalGeo.bottom(), normalGeo.y() + 20));
+    QPointF mustVisiblePosOfSurface(qMin(normalGeo.right(), normalGeo.x() + 20),
+                                    qMin(normalGeo.bottom(), normalGeo.y() + 20));
+
+    if (normalGeo.x() < minScreenX) {
+        mustVisiblePosOfSurface.setX(qMax(normalGeo.left(), normalGeo.right() - 20));
+    }
+
     normalGeo = adjustRectToMakePointVisible(normalGeo, mustVisiblePosOfSurface, outputRects);
 
-    // Ensure titlebar is not outside the screen
+    // Ensure titlebar is not above the screen
     const auto titlebarGeometry = surface->titlebarGeometry().translated(normalGeo.topLeft());
     if (titlebarGeometry.isValid()) {
-        bool titlebarGeometryAdjusted = false;
         for (auto r : std::as_const(outputRects)) {
             if ((r & titlebarGeometry).isEmpty())
                 continue;
             if (titlebarGeometry.top() < r.top()) {
                 normalGeo.moveTop(normalGeo.top() + r.top() - titlebarGeometry.top());
-                titlebarGeometryAdjusted = true;
+                break; // Only need to adjust once based on the intersected output
             }
-        }
-
-        if (!titlebarGeometryAdjusted) {
-            normalGeo =
-                adjustRectToMakePointVisible(normalGeo, titlebarGeometry.topLeft(), outputRects);
         }
     }
 

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -917,7 +917,7 @@ void Output::arrangePopupSurface(SurfaceWrapper *surface)
 
 void Output::arrangeNonLayerSurfaces()
 {
-    const auto currentSize = validRect().size();
+    const auto currentSize = geometry().size();
     const auto sizeDiff = m_lastSizeOnLayoutNonLayerSurfaces.isValid()
         ? currentSize - m_lastSizeOnLayoutNonLayerSurfaces
         : QSizeF(0, 0);


### PR DESCRIPTION
修复左侧防丢逻辑：通过基于最左侧屏幕边界动态调整可见点（即我们加的 `minScreenX` 和 `qMax` 逻辑），解决窗口向左移出受限的问题
修复dock 位置修改导致的没有遮盖的窗口位置发生了变动