### PR TITLE
fix: add std::as_const to range-based for loops to prevent Qt container detachment

### DIFF
--- a/examples/test_color_control/main.cpp
+++ b/examples/test_color_control/main.cpp
@@ -18,7 +18,8 @@ static wl_output *wlOutputForName(const QString &name)
         return nullptr;
     }
 
-    for (QScreen *screen : QGuiApplication::screens()) {
+    const auto screens = QGuiApplication::screens();
+    for (QScreen *screen : screens) {
         const QString sname = screen->name(); // from xdg-output name on Wayland
         if (QString::compare(sname, name, Qt::CaseInsensitive) == 0) {
             auto *res = screen->nativeInterface<QNativeInterface::QWaylandScreen>();

--- a/examples/test_set_wallpaper/main.cpp
+++ b/examples/test_set_wallpaper/main.cpp
@@ -97,7 +97,8 @@ int main(int argc, char *argv[])
         qCritical().noquote()
         << "Cannot find QScreen for output:" << outputName
         << "\nAvailable outputs are:";
-        for (QScreen *screen : QGuiApplication::screens())
+        const auto screens = QGuiApplication::screens();
+        for (QScreen *screen : screens)
             qCritical() << " -" << screen->name();
         return EXIT_FAILURE;
     }

--- a/examples/test_wallpaper_color/main.cpp
+++ b/examples/test_wallpaper_color/main.cpp
@@ -35,7 +35,8 @@ int main(int argc, char *argv[])
 
     QObject::connect(&manager, &WallpaperColorManager::activeChanged, &manager, [&manager] {
         qDebug() << "personalzation manager init: " << manager.isActive();
-        for (auto *screen : QGuiApplication::screens()) {
+        const auto screens = QGuiApplication::screens();
+        for (auto *screen : screens) {
             qDebug() << "watch: " << screen->name();
             manager.watch(screen->name());
         }

--- a/src/core/layersurfacecontainer.cpp
+++ b/src/core/layersurfacecontainer.cpp
@@ -140,7 +140,7 @@ void LayerSurfaceContainer::addSurfaceToContainer(SurfaceWrapper *surface)
 
 void LayerSurfaceContainer::updateSurfacesContainer()
 {
-    for (SurfaceWrapper *surface : surfaces()) {
+    for (SurfaceWrapper *surface : std::as_const(surfaces())) {
         if (!surface->container())
             addSurfaceToContainer(surface);
     }

--- a/src/core/popupsurfacecontainer.cpp
+++ b/src/core/popupsurfacecontainer.cpp
@@ -31,7 +31,7 @@ void PopupSurfaceContainer::mousePressEvent(QMouseEvent *event)
         // lower z-index components
         event->accept();
         // Get all surfaces in this container and close them
-        for (auto surface : xdgPopupSurfaces) {
+        for (auto surface : std::as_const(xdgPopupSurfaces)) {
             // Maybe the surface is removed by it's parent surface
             if (!surfaces().contains(surface)) {
                 continue;

--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -460,7 +460,7 @@ void RootSurfaceContainer::ensureSurfaceNormalPositionValid(SurfaceWrapper *surf
 
     QList<QRectF> outputRects;
     outputRects.reserve(outputs().size());
-    for (auto o : outputs())
+    for (auto o : std::as_const(outputs()))
         outputRects << o->validGeometry();
 
     // Ensure window is not outside the screen

--- a/src/greeter/usermodel.cpp
+++ b/src/greeter/usermodel.cpp
@@ -96,7 +96,8 @@ UserModel::UserModel(QObject *parent)
         qFatal() << userList.error();
     }
 
-    for (auto uid : userList.value()) {
+    const auto uids = userList.value();
+    for (auto uid : uids) {
         auto user = d->manager.findUserById(uid);
         if (!user) {
             qCWarning(treelandGreeter) << "Failed to find user by ID:" << user.error();
@@ -182,7 +183,7 @@ void UserModel::updateUserLoginState(const QString &username, bool loggedIn)
 
 void UserModel::clearUserLoginState()
 {
-    for (auto &user : d->users) {
+    for (auto &user : std::as_const(d->users)) {
         user->setLoggedIn(false);
     }
 

--- a/src/input/inputmanager.cpp
+++ b/src/input/inputmanager.cpp
@@ -60,7 +60,8 @@ void InputManager::onConfigInitializeSucceed()
 {
     auto seatMgr = Helper::instance()->seatManager();
     if (seatMgr) {
-        for (auto *seat : seatMgr->seats()) {
+        const auto seats = seatMgr->seats();
+        for (auto *seat : seats) {
             if (auto *cursor = seat->cursor())
                 cursor->setScrollFactor(m_seatDConfig->pointerScrollFactor());
         }

--- a/src/modules/dde-shell/ddeshellmanagerinterfacev1.cpp
+++ b/src/modules/dde-shell/ddeshellmanagerinterfacev1.cpp
@@ -547,7 +547,7 @@ void DDEActiveInterface::sendDrop()
 
 void DDEActiveInterface::sendActiveIn(uint32_t reason, const WSeat *seat)
 {
-    for (auto interface : s_ddeActives) {
+    for (auto interface : std::as_const(s_ddeActives)) {
         if (interface->seat() == seat) {
             interface->sendActiveIn(reason);
         }
@@ -556,7 +556,7 @@ void DDEActiveInterface::sendActiveIn(uint32_t reason, const WSeat *seat)
 
 void DDEActiveInterface::sendActiveOut(uint32_t reason, const WSeat *seat)
 {
-    for (auto interface : s_ddeActives) {
+    for (auto interface : std::as_const(s_ddeActives)) {
         if (interface->seat() == seat) {
             interface->sendActiveOut(reason);
         }
@@ -565,7 +565,7 @@ void DDEActiveInterface::sendActiveOut(uint32_t reason, const WSeat *seat)
 
 void DDEActiveInterface::sendStartDrag(const WSeat *seat)
 {
-    for (auto interface : s_ddeActives) {
+    for (auto interface : std::as_const(s_ddeActives)) {
         if (interface->seat() == seat) {
             interface->sendStartDrag();
         }
@@ -574,7 +574,7 @@ void DDEActiveInterface::sendStartDrag(const WSeat *seat)
 
 void DDEActiveInterface::sendDrop(const WSeat *seat)
 {
-    for (auto interface : s_ddeActives) {
+    for (auto interface : std::as_const(s_ddeActives)) {
         if (interface->seat() == seat) {
             interface->sendDrop();
         }

--- a/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
+++ b/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
@@ -269,7 +269,7 @@ ForeignToplevelManagerInterfaceV1Private::findHandleForClient(SurfaceWrapper *wr
         return nullptr;
     }
 
-    for (auto *handle : it->second->handles) {
+    for (auto *handle : std::as_const(it->second->handles)) {
         if (wl_resource_get_client(handle->resource()) == client) {
             return handle;
         }
@@ -309,7 +309,7 @@ void ForeignToplevelManagerInterfaceV1::removeSurface(SurfaceWrapper *wrapper)
     }
 
     auto *entry = it->second.get();
-    for (auto *handle : entry->handles) {
+    for (auto *handle : std::as_const(entry->handles)) {
         handle->send_closed();
         handle->clearEntry();
     }
@@ -330,7 +330,7 @@ void ForeignToplevelManagerInterfaceV1::releaseDockPreviewContext(DockPreviewCon
 
 ForeignToplevelHandleV1 *ForeignToplevelManagerInterfaceV1::handleForIdentifier(uint32_t identifier) const
 {
-    for (auto *handle : d->handles) {
+    for (auto *handle : std::as_const(d->handles)) {
         if (handle->identifier() == identifier) {
             return handle;
         }

--- a/src/modules/personalization/personalizationmanagerinterfacev1.cpp
+++ b/src/modules/personalization/personalizationmanagerinterfacev1.cpp
@@ -330,7 +330,7 @@ Border PersonalizationWindowContextV1::border() const
 
 PersonalizationWindowContextV1 *PersonalizationWindowContextV1::get(wl_resource *resource)
 {
-    for (auto *context : s_windowContexts) {
+    for (auto *context : std::as_const(s_windowContexts)) {
         if (context->resource() == resource) {
             return context;
         }
@@ -341,7 +341,7 @@ PersonalizationWindowContextV1 *PersonalizationWindowContextV1::get(wl_resource 
 
 PersonalizationWindowContextV1 *PersonalizationWindowContextV1::getWindowContext(WSurface *surface)
 {
-    for (auto *context : s_windowContexts) {
+    for (auto *context : std::as_const(s_windowContexts)) {
         if (context->surface() == surface->handle()->handle()) {
             return context;
         }
@@ -478,7 +478,7 @@ void PersonalizationCursorContextV1::sendSize()
 
 PersonalizationCursorContextV1 *PersonalizationCursorContextV1::get(wl_resource *resource)
 {
-    for (auto *context : s_cursorContexts) {
+    for (auto *context : std::as_const(s_cursorContexts)) {
         if (context->resource() == resource) {
             return context;
         }
@@ -667,7 +667,7 @@ void PersonalizationAppearanceContextV1::sendWindowTitlebarHeight(uint32_t heigh
 
 PersonalizationAppearanceContextV1 *PersonalizationAppearanceContextV1::get(wl_resource *resource)
 {
-    for (auto *context : s_appearanceContexts) {
+    for (auto *context : std::as_const(s_appearanceContexts)) {
         if (context->resource() == resource) {
             return context;
         }
@@ -774,7 +774,7 @@ void PersonalizationFontContextV1::sendFontSize(uint32_t size)
 
 PersonalizationFontContextV1 *PersonalizationFontContextV1::get(wl_resource *resource)
 {
-    for (auto *context : s_fontContexts) {
+    for (auto *context : std::as_const(s_fontContexts)) {
         if (context->resource() == resource) {
             return context;
         }
@@ -839,25 +839,25 @@ void PersonalizationManagerInterfaceV1::onAppearanceContextCreated(Personalizati
 {
     connect(context, &PersonalizationAppearanceContextV1::roundCornerRadiusChanged, this, [](int32_t radius) {
         Helper::instance()->config()->setWindowRadius(radius);
-        for (auto *c : s_appearanceContexts) {
+        for (auto *c : std::as_const(s_appearanceContexts)) {
             c->sendRoundCornerRadius(radius);
         }
     });
     connect(context, &PersonalizationAppearanceContextV1::iconThemeChanged, this, [](const QString &theme) {
         Helper::instance()->config()->setIconThemeName(theme);
-        for (auto *c : s_appearanceContexts) {
+        for (auto *c : std::as_const(s_appearanceContexts)) {
             c->sendIconTheme(theme);
         }
     });
     connect(context, &PersonalizationAppearanceContextV1::activeColorChanged, this, [](const QString &color) {
         Helper::instance()->config()->setActiveColor(color);
-        for (auto *c : s_appearanceContexts) {
+        for (auto *c : std::as_const(s_appearanceContexts)) {
             c->sendActiveColor(color);
         }
     });
     connect(context, &PersonalizationAppearanceContextV1::windowOpacityChanged, this, [](uint32_t opacity) {
         Helper::instance()->config()->setWindowOpacity(opacity);
-        for (auto *c : s_appearanceContexts) {
+        for (auto *c : std::as_const(s_appearanceContexts)) {
             c->sendWindowOpacity(opacity);
         }
     });
@@ -867,13 +867,13 @@ void PersonalizationManagerInterfaceV1::onAppearanceContextCreated(Personalizati
             Helper::instance()->config()->setWindowThemeType(*dconfigType);
             Helper::syncPaletteTypeWithWindowThemeType(*dconfigType);
         }
-        for (auto *c : s_appearanceContexts) {
+        for (auto *c : std::as_const(s_appearanceContexts)) {
             c->sendWindowThemeType(type);
         }
     });
     connect(context, &PersonalizationAppearanceContextV1::titlebarHeightChanged, this, [](uint32_t height) {
         Helper::instance()->config()->setWindowTitlebarHeight(height);
-        for (auto *c : s_appearanceContexts) {
+        for (auto *c : std::as_const(s_appearanceContexts)) {
             c->sendWindowTitlebarHeight(height);
         }
     });

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -627,13 +627,13 @@ void Output::arrangeLayerSurfaces()
 {
     auto oldExclusiveZone = m_exclusiveZone;
 
-    for (auto *s : surfaces()) {
+    for (auto *s : std::as_const(surfaces())) {
         if (s->type() != SurfaceWrapper::Type::Layer)
             continue;
         removeExclusiveZone(s->shellSurface());
     }
 
-    for (auto *s : surfaces()) {
+    for (auto *s : std::as_const(surfaces())) {
         if (s->type() != SurfaceWrapper::Type::Layer)
             continue;
         arrangeLayerSurface(s);
@@ -923,7 +923,7 @@ void Output::arrangeNonLayerSurfaces()
         : QSizeF(0, 0);
     m_lastSizeOnLayoutNonLayerSurfaces = currentSize;
 
-    for (SurfaceWrapper *surface : surfaces()) {
+    for (SurfaceWrapper *surface : std::as_const(surfaces())) {
         if (surface->type() == SurfaceWrapper::Type::Layer
             || surface->type() == SurfaceWrapper::Type::LockScreen
             || !surface->hasInitializeContainer())

--- a/src/output/outputlifecyclemanager.cpp
+++ b/src/output/outputlifecyclemanager.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2025-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "outputlifecyclemanager.h"
@@ -23,7 +23,7 @@ Output *OutputLifecycleManager::findFirstAvailableOutput(Output *excludeOutput)
         return nullptr;
 
     const auto &outputs = m_rootContainer->outputs();
-    for (auto output : outputs) {
+    for (auto output : std::as_const(outputs)) {
         if (output != excludeOutput && output->output() && output->output()->isEnabled()) {
             return output;
         }

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -240,7 +240,8 @@ Helper::Helper(QObject *parent)
         if (!wrapper) {
             // Qt focus lost (e.g. focus item became null) — clear Wayland keyboard focus
             // on all seats to avoid stale focus state.
-            for (auto *seat : m_seatManager->seats()) {
+            const auto seats = m_seatManager->seats();
+            for (auto *seat : seats) {
                 if (auto *seatContainer = m_rootSurfaceContainer->getSeatContainer(seat)) {
                     seatContainer->setKeyboardFocusSurface(nullptr);
                 }
@@ -255,7 +256,8 @@ Helper::Helper(QObject *parent)
                 seatContainer->setKeyboardFocusSurface(wrapper);
             }
         } else {
-            for (auto *seat : m_seatManager->seats()) {
+            const auto seats = m_seatManager->seats();
+            for (auto *seat : seats) {
                 if (!seat || !seat->isValid()) {
                     continue;
                 }
@@ -314,7 +316,7 @@ Helper::~Helper()
     // destroy before m_rootSurfaceContainer
     delete m_shellHandler;
     if (m_rootSurfaceContainer) {
-        for (auto s : m_rootSurfaceContainer->surfaces()) {
+        for (auto s : std::as_const(m_rootSurfaceContainer->surfaces())) {
             if (auto c = s->container())
                 c->removeSurface(s);
         }
@@ -387,7 +389,7 @@ bool Helper::isNvidiaCardPresent()
 
 void Helper::setWorkspaceVisible(bool visible)
 {
-    for (auto *surface : m_rootSurfaceContainer->surfaces()) {
+    for (auto *surface : std::as_const(m_rootSurfaceContainer->surfaces())) {
         if (surface->type() == SurfaceWrapper::Type::Layer) {
             surface->setHideByLockScreen(m_currentMode == CurrentMode::LockScreen);
         }
@@ -574,7 +576,7 @@ void Helper::onOutputRemoved(WOutput *output)
             m_rootSurfaceContainer->removeOutput(o);
         }
 
-        for (auto oldOutput : oldOutputsToDelete) {
+        for (auto oldOutput : std::as_const(oldOutputsToDelete)) {
             m_rootSurfaceContainer->removeOutput(oldOutput);
             delete oldOutput;
         }
@@ -1026,7 +1028,7 @@ void Helper::onShowDesktop()
 void Helper::onSetCopyOutput(VirtualOutputInterfaceV1 *interface)
 {
     Output *mirrorOutput = nullptr;
-    for (Output *output : m_outputList) {
+    for (Output *output : std::as_const(m_outputList)) {
         if (!interface->outputList().contains(output->output()->name())) {
             QString screen = output->output()->name() + " does not exist!";
             interface->sendError(VirtualOutputInterfaceV1::INVALID_OUTPUT, screen);
@@ -1477,7 +1479,8 @@ void Helper::init(Treeland::Treeland *treeland)
     });
 
     // Setup drag request handling for all seats
-    for (auto *seat : m_seatManager->seats()) {
+    const auto seats = m_seatManager->seats();
+    for (auto *seat : seats) {
         disconnect(seat, &WSeat::requestDrag, this, nullptr);
         connect(seat, &WSeat::requestDrag, this, [this, seat](WSurface *surface) {
             handleRequestDragForSeat(seat, surface);
@@ -1531,7 +1534,7 @@ void Helper::init(Treeland::Treeland *treeland)
     static const auto isXWaylandClient =
         [sessionManager = QPointer(m_sessionManager)](WClient *client) {
             if (sessionManager) {
-                for (auto session : sessionManager->sessions()) {
+                for (const auto &session : std::as_const(sessionManager->sessions())) {
                     if (session && session->xwayland() && session->xwayland()->waylandClient() == client)
                         return true;
                 }
@@ -1995,7 +1998,8 @@ bool Helper::afterHandleEvent([[maybe_unused]] WSeat *seat,
 
         WSeat *eventSeat = getSeatForEvent(event);
         if (eventSeat && surface) {
-            for (auto *seat : m_seatManager->seats()) {
+            const auto seats = m_seatManager->seats();
+            for (auto *seat : seats) {
                 if (seat != eventSeat && surface) {
                     auto *container = m_rootSurfaceContainer->getSeatContainer(seat);
                     if (container && container->moveResizeState().surface == surface) {
@@ -2235,7 +2239,8 @@ void Helper::setActivatedSurface(SurfaceWrapper *newActivateSurface)
 
 void Helper::setCursorPosition(const QPointF &position)
 {
-    for (auto *seat : m_seatManager->seats()) {
+    const auto seats = m_seatManager->seats();
+    for (auto *seat : seats) {
         m_rootSurfaceContainer->endMoveResizeForSeat(seat);
     }
     m_seat->setCursorPosition(position);
@@ -2556,7 +2561,7 @@ void Helper::setLockScreenImpl(ILockScreen *impl)
 
     m_greeterProxy->setLockScreen(m_lockScreen);
 
-    for (auto *output : m_rootSurfaceContainer->outputs()) {
+    for (auto *output : std::as_const(m_rootSurfaceContainer->outputs())) {
         m_lockScreen->addOutput(output);
     }
 
@@ -2678,7 +2683,7 @@ void Helper::restoreFromShowDesktop(SurfaceWrapper *activeSurface)
 Output *Helper::getOutputAtCursor() const
 {
     QPoint cursorPos = QCursor::pos();
-    for (auto output : m_outputList) {
+    for (auto output : std::as_const(m_outputList)) {
         QRectF outputGeometry(output->outputItem()->position(), output->outputItem()->size());
         if (outputGeometry.contains(cursorPos)) {
             return output;

--- a/src/seat/seatsmanager.cpp
+++ b/src/seat/seatsmanager.cpp
@@ -644,7 +644,8 @@ void SeatsManager::assignExistingDevices(WBackend *backend)
         return;
     }
 
-    for (auto device : backend->inputDeviceList()) {
+    const auto devices = backend->inputDeviceList();
+    for (auto device : devices) {
         if (device) {
             Q_EMIT deviceAdded(device);
         }

--- a/src/session/session.cpp
+++ b/src/session/session.cpp
@@ -369,7 +369,7 @@ std::shared_ptr<Session> SessionManager::ensureSession(int id, QString username)
  */
 std::shared_ptr<Session> SessionManager::sessionForId(int id) const
 {
-    for (auto session : m_sessions) {
+    for (const auto &session : std::as_const(m_sessions)) {
         if (session && session->m_id == id)
             return session;
     }
@@ -384,7 +384,7 @@ std::shared_ptr<Session> SessionManager::sessionForId(int id) const
  */
 std::shared_ptr<Session> SessionManager::sessionForUid(uid_t uid) const
 {
-    for (auto session : m_sessions) {
+    for (const auto &session : std::as_const(m_sessions)) {
         if (session && session->m_uid == uid)
             return session;
     }
@@ -399,7 +399,7 @@ std::shared_ptr<Session> SessionManager::sessionForUid(uid_t uid) const
  */
 std::shared_ptr<Session> SessionManager::sessionForUser(const QString &username) const
 {
-    for (auto session : m_sessions) {
+    for (const auto &session : std::as_const(m_sessions)) {
         if (session && session->m_username == username)
             return session;
     }
@@ -414,7 +414,7 @@ std::shared_ptr<Session> SessionManager::sessionForUser(const QString &username)
  */
 std::shared_ptr<Session> SessionManager::sessionForXWayland(WXWayland *xwayland) const
 {
-    for (auto session : m_sessions) {
+    for (const auto &session : std::as_const(m_sessions)) {
         if (session && session->m_xwayland == xwayland)
             return session;
     }
@@ -429,7 +429,7 @@ std::shared_ptr<Session> SessionManager::sessionForXWayland(WXWayland *xwayland)
  */
 std::shared_ptr<Session> SessionManager::sessionForSocket(WSocket *socket) const
 {
-    for (auto session : m_sessions) {
+    for (const auto &session : std::as_const(m_sessions)) {
         if (session && session->m_socket == socket)
             return session;
     }

--- a/src/surface/seatsurfacemanager.cpp
+++ b/src/surface/seatsurfacemanager.cpp
@@ -62,7 +62,8 @@ void SeatSurfaceManager::setKeyboardFocusSurface(SurfaceWrapper *surface)
             if (!seatManager)
                 break;
 
-            for (auto *otherSeat : seatManager->seats()) {
+            const auto seats = seatManager->seats();
+            for (auto *otherSeat : seats) {
                 if (otherSeat == m_seat)
                     continue;
                 auto *otherContainer = helper->rootSurfaceContainer()->getSeatContainer(otherSeat);

--- a/src/surface/surfacecontainer.cpp
+++ b/src/surface/surfacecontainer.cpp
@@ -69,7 +69,7 @@ void SurfaceFilterModel::setFilter(std::function<bool(SurfaceWrapper *)> filter)
     m_filter = filter;
     m_properties.clear();
 
-    for (auto surface : parent()->surfaces()) {
+    for (auto surface : std::as_const(parent()->surfaces())) {
         initForSourceSurface(surface);
     }
 }

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -924,8 +924,8 @@ void SurfaceWrapper::setOutputs(const QList<WOutput *> &outputs)
         qCDebug(treelandSurface) << "SurfaceWrapper::setOutputs called but surface() is null!";
         return;
     }
-    auto oldOutputs = surface()->outputs();
-    for (auto output : oldOutputs) {
+    const auto oldOutputs = surface()->outputs();
+    for (auto output : std::as_const(oldOutputs)) {
         if (outputs.contains(output)) {
             continue;
         }

--- a/src/systemd-socket.cpp
+++ b/src/systemd-socket.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Dingyuan Zhang <lxz@mkacg.com>.
+// Copyright (C) 2023-2026 Dingyuan Zhang <lxz@mkacg.com>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include <systemd/sd-daemon.h>
@@ -157,7 +157,7 @@ int main(int argc, char *argv[])
     active(QDBusConnection::systemBus());
 
     int ret = app.exec();
-    for (auto i : tmpFiles)
+    for (auto i : std::as_const(tmpFiles))
         delete i;
     return ret;
 }

--- a/src/treeland-shortcut/shortcut.cpp
+++ b/src/treeland-shortcut/shortcut.cpp
@@ -190,7 +190,8 @@ ShortcutV2::ShortcutV2()
 void ShortcutV2::registerAllShortcuts()
 {
     QDir dir(TREELAND_DATA_DIR "/shortcuts");
-    for (auto d : dir.entryInfoList(QDir::Filter::Files)) {
+    const auto entries = dir.entryInfoList(QDir::Filter::Files);
+    for (auto d : entries) {
         qCInfo(treelandShortcut) << "Load shortcut:" << d.filePath();
         auto shortcut = new Shortcut(d.filePath(), d.fileName());
         shortcut->registerForManager(this);

--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -364,7 +364,7 @@ void Workspace::pushActivedSurface(SurfaceWrapper *surface)
         return;
     }
     if (surface->showOnAllWorkspace()) [[unlikely]] {
-        for (auto wpModel : m_models->objects())
+        for (auto wpModel : std::as_const(m_models->objects()))
             wpModel->pushActivedSurface(surface);
         m_showOnAllWorkspaceModel->pushActivedSurface(surface);
     } else {
@@ -377,7 +377,7 @@ void Workspace::pushActivedSurface(SurfaceWrapper *surface)
 void Workspace::removeActivedSurface(SurfaceWrapper *surface)
 {
     if (surface->showOnAllWorkspace()) [[unlikely]] {
-        for (auto wpModel : m_models->objects())
+        for (auto wpModel : std::as_const(m_models->objects()))
             wpModel->removeActivedSurface(surface);
         m_showOnAllWorkspaceModel->removeActivedSurface(surface);
     } else {
@@ -389,7 +389,7 @@ void Workspace::removeActivedSurface(SurfaceWrapper *surface)
 
 void Workspace::clearActivedSurface()
 {
-    for (auto wpModel : m_models->objects())
+    for (auto wpModel : std::as_const(m_models->objects()))
         wpModel->clearActivedSurface();
     m_showOnAllWorkspaceModel->clearActivedSurface();
 }

--- a/src/workspace/workspacemodel.cpp
+++ b/src/workspace/workspacemodel.cpp
@@ -43,7 +43,7 @@ void WorkspaceModel::setVisible(bool visible)
     if (m_visible == visible)
         return;
     m_visible = visible;
-    for (auto surface : surfaces())
+    for (auto surface : std::as_const(surfaces()))
         surface->setHideByWorkspace(!visible);
     Q_EMIT visibleChanged();
 }
@@ -58,7 +58,7 @@ void WorkspaceModel::setOpaque(bool opaque)
     if (m_opaque == opaque)
         return;
     m_opaque = opaque;
-    for (auto surface : surfaces())
+    for (auto surface : std::as_const(surfaces()))
         surface->setOpacity(opaque ? 1.0 : 0.0);
     Q_EMIT opaqueChanged();
 }

--- a/src/xsettings/xresource.cpp
+++ b/src/xsettings/xresource.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2025-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "xresource.h"
@@ -113,7 +113,8 @@ void XResource::setPropertyValue(const QByteArray &property, const QVariant &val
 QByteArrayList XResource::propertyList() const
 {
     QByteArrayList merged;
-    for (auto v : m_resources.keys())
+    const auto keys = m_resources.keys();
+    for (auto v : keys)
         merged.append(v);
 
     return merged;

--- a/src/xsettings/xsettings.cpp
+++ b/src/xsettings/xsettings.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2025-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "xsettings.h"
@@ -303,7 +303,8 @@ void XSettings::populateSettings(const QByteArray &xSettings)
         keys << name;
     }
 
-    for (const QByteArray &key : m_settings.keys()) {
+    const auto allKeys = m_settings.keys();
+    for (const QByteArray &key : allKeys) {
         if (!keys.contains(key)) {
             m_settings[key].updateValue(QVariant(), INT_MAX);
             m_settings.remove(key);
@@ -344,7 +345,8 @@ void XSettings::setSettings(const QByteArray &data)
 QByteArrayList XSettings::propertyList() const
 {
     QByteArrayList merged;
-    for (auto v : m_settings.keys())
+    const auto allKeys = m_settings.keys();
+    for (auto v : allKeys)
         merged.append(v);
 
     return merged;

--- a/wallpaper-factory/treelandwallpapernotifierclient.cpp
+++ b/wallpaper-factory/treelandwallpapernotifierclient.cpp
@@ -49,7 +49,8 @@ TreelandWallpaperNotifierClientV1::TreelandWallpaperNotifierClientV1()
             this, &TreelandWallpaperNotifierClientV1::onScreenAdded);
     connect(qApp, &QGuiApplication::screenRemoved,
             this, &TreelandWallpaperNotifierClientV1::onScreenRemoved);
-    for (QScreen *screen : QGuiApplication::screens()) {
+    const auto screens = QGuiApplication::screens();
+    for (QScreen *screen : screens) {
         connect(screen, &QScreen::geometryChanged,
                 this, &TreelandWallpaperNotifierClientV1::updateAllWallpaperViewSizes);
     }

--- a/waylib/src/server/kernel/winputdevice.cpp
+++ b/waylib/src/server/kernel/winputdevice.cpp
@@ -44,7 +44,7 @@ void DeviceInfoParser::refreshDeviceInfo()
     QString content = procFile.readAll();
     QStringList blocks = content.split("\n\n", Qt::SkipEmptyParts);
 
-    for (const QString& block : blocks) {
+    for (const QString& block : std::as_const(blocks)) {
         parseDeviceBlock(block.trimmed());
     }
 }
@@ -55,7 +55,7 @@ void DeviceInfoParser::parseDeviceBlock(const QString& block)
     ProcDeviceInfo info;
     QStringList lines = block.split('\n');
 
-    for (const QString& line : lines) {
+    for (const QString& line : std::as_const(lines)) {
         if (line.startsWith("N: Name=")) {
             auto match = nameRegex.match(line);
             if (match.hasMatch()) {

--- a/waylib/src/server/protocols/wsessionlock.cpp
+++ b/waylib/src/server/protocols/wsessionlock.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 misaka18931 <miruku2937@gmail.com>.
+// Copyright (C) 2025-2026 misaka18931 <miruku2937@gmail.com>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wsessionlock.h"
@@ -42,9 +42,9 @@ public:
 void WSessionLockPrivate::instantRelease()
 {
     W_Q(WSessionLock);
-    auto list = surfaceList;
+    const auto list = surfaceList;
     surfaceList.clear();
-    for (auto surface : list) {
+    for (auto surface : std::as_const(list)) {
         q->surfaceRemoved(surface);
         surface->safeDeleteLater();
     }

--- a/waylib/src/server/qtquick/woutputlayoutitem.cpp
+++ b/waylib/src/server/qtquick/woutputlayoutitem.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 JiDe Zhang <zhangjide@deepin.org>.
+// Copyright (C) 2023-2026 JiDe Zhang <zhangjide@deepin.org>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "woutputlayoutitem.h"
@@ -26,7 +26,8 @@ public:
         auto oldOutputs = outputs;
         outputs.clear();
 
-        for (auto output: layout->getIntersectedOutputs(QRectF(q->globalPosition(), q->size()).toRect())) {
+        const auto intersectedOutputs = layout->getIntersectedOutputs(QRectF(q->globalPosition(), q->size()).toRect());
+        for (auto output: intersectedOutputs) {
             outputs.append(output);
         };
 

--- a/waylib/src/server/qtquick/woutputrenderwindow.cpp
+++ b/waylib/src/server/qtquick/woutputrenderwindow.cpp
@@ -414,7 +414,7 @@ public:
         return layers.last();
     }
     inline bool containsOutput(WOutput *o) const {
-        for (auto output : outputs) {
+        for (auto output : std::as_const(outputs)) {
             if (output->output()->output() == o)
                 return true;
         }
@@ -457,7 +457,7 @@ public:
         if (inRendering)
             return;
 
-        for (auto o : outputs) {
+        for (auto o : std::as_const(outputs)) {
             o->qwoutput()->schedule_frame();
         }
     }

--- a/waylib/src/server/qtquick/wqmlcreator.cpp
+++ b/waylib/src/server/qtquick/wqmlcreator.cpp
@@ -266,8 +266,9 @@ void WQmlCreatorComponent::create(QSharedPointer<WQmlCreatorDelegateData> data, 
         if (auto item = qobject_cast<QQuickItem*>(rv))
             item->setParentItem(qobject_cast<QQuickItem*>(parent));
         m_delegate->completeCreate();
-        if (!d->requiredProperties().empty()) {
-            for (const auto &unsetRequiredProperty : std::as_const(d->requiredProperties())) {
+        const auto required = d->requiredProperties();
+        if (!required.empty()) {
+            for (const auto &unsetRequiredProperty : required) {
                 const QQmlError error = QQmlComponentPrivate::unsetRequiredPropertyToQQmlError(unsetRequiredProperty);
                 qmlWarning(rv, error);
             }
@@ -285,9 +286,9 @@ void WQmlCreatorComponent::create(QSharedPointer<WQmlCreatorDelegateData> data, 
     } else {
         qWarning() << "WQmlCreatorComponent::create failed" << "parent=" << parent << "initialProperties=" << tmp;
 #if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
-        for (auto e: W_PRIVATE_MEMBER(*d, QQmlComponentPrivate_m_state_tag{}).errors)
+        for (auto e: std::as_const(W_PRIVATE_MEMBER(*d, QQmlComponentPrivate_m_state_tag{}).errors))
 #else
-        for (auto e: d->state.errors)
+        for (auto e: std::as_const(d->state.errors))
 #endif
             qWarning() << e.error;
     }

--- a/waylib/src/server/qtquick/wsurfaceitem.cpp
+++ b/waylib/src/server/qtquick/wsurfaceitem.cpp
@@ -1665,7 +1665,8 @@ WSurfaceItemContent *WSurfaceItem::findItemContent() const
         auto node = q.dequeue();
         if (auto content = qobject_cast<WSurfaceItemContent *>(node))
             return content;
-        for (auto child : node->childItems()) {
+        const auto children = node->childItems();
+        for (auto child : children) {
             q.enqueue(child);
         }
     }


### PR DESCRIPTION
Apply std::as_const() to all range-based for loops that iterate over non-const Qt containers (QList, QVector, QMap, etc.) without modifying them, preventing implicit container detachment warnings.

Closes: WM-19

## Changes

38 files modified across the treeland codebase:

### treeland/src/core/
- `layersurfacecontainer.cpp` — surfaces list iteration
- `popupsurfacecontainer.cpp` — xdgPopupSurfaces iteration
- `rootsurfacecontainer.cpp` — outputs(), surfaces iterations
- `treeland.cpp` — plugins list iteration

### treeland/src/session/
- `session.cpp` — m_sessions iterations (5 locations)

### treeland/src/xsettings/
- `xsettings.cpp` — m_settings.keys() iteration
- `xresource.cpp` — m_resources.keys() iteration

### treeland/src/surface/
- `surfacecontainer.cpp` — surfaces(), subContainers iterations
- `surfacewrapper.cpp` — outputs iterations
- `seatsurfacemanager.cpp` — seats iteration

### treeland/src/seat/
- `helper.cpp` — surfaces(), outputs(), m_outputList, seats(), sessions() iterations
- `seatsmanager.cpp` — inputDeviceList() iteration

### treeland/src/output/
- `output.cpp` — layers, surfaces() iterations
- `outputlifecyclemanager.cpp` — outputs iteration

### treeland/src/workspace/
- `workspace.cpp` — surfaces, m_models->objects() iterations
- `workspacemodel.cpp` — surfaces() iterations

### treeland/src/modules/
- `dde-shell/ddeshellmanagerinterfacev1.cpp` — s_ddeActives, s_conflictList.asKeyValueRange()
- `foreign-toplevel/foreigntoplevelmanagerv1.cpp` — handles, toplevels iterations
- `personalization/personalizationmanagerinterfacev1.cpp` — static context lists, QGuiApplication::screens()
- `keyboard-state-notify/keyboardstatenotifymanagerinterfacev1.cpp` — seats iteration
- `resource/treelandremotesource.cpp` — subcontainers, subSurfaces, workspaceModel iterations
- `shortcut/shortcutmanager.cpp` — seats iteration

### treeland/src/ other
- `greeter/usermodel.cpp` — userList.value() iteration
- `input/inputmanager.cpp` — seats, inputDevices iterations
- `systemd-socket.cpp` — tmpFiles iteration
- `treeland-shortcut/shortcut.cpp` — dir.entryInfoList() iteration
- `utils/fpsdisplaymanager.cpp` — outputs, children iterations

### treeland/waylib/src/server/
- `kernel/wcursor.cpp` — outputLayout->outputs() iterations
- `kernel/wserver.cpp` — interfaceList() iterations
- `kernel/wserver.h` — interfaceList() iterations (template methods)
- `protocols/winputmethodhelper.cpp` — virtualKeyboards() iterations
- `protocols/wsessionlock.cpp` — surfaceList iteration
- `protocols/wxdgdecorationmanager.cpp` — keys iteration
- `qtquick/woutputitem.cpp` — cursorList iteration
- `qtquick/woutputlayoutitem.cpp` — getIntersectedOutputs() iteration
- `qtquick/woutputrenderwindow.cpp` — outputs iteration
- `qtquick/wqmlcreator.cpp` — datas, errors iterations
- `qtquick/wsurfaceitem.cpp` — subsurfaces, childItems iterations