### PR TITLE
chore(deps): bump treeland-protocols dependency to >= 0.5.9

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -34,7 +34,7 @@ Build-Depends: cmake (>= 3.25.0),
                qt6-remoteobjects-dev,
                wayland-protocols,
                wlr-protocols,
-               treeland-protocols (>= 0.5.7),
+               treeland-protocols (>= 0.5.9),
                libpam0g-dev,
                libmpv-dev,
 Standards-Version: 4.6.0


### PR DESCRIPTION
Update the build dependency to match the latest
treeland-protocolsrelease with breaking changes.

Log: bump treeland-protocolsdependencyversionto0.5.9 PMS:BUG-364795
Influence:BreakingAPIchangesintreeland-protocols0.5.9,bumprequiredversion

## Summary by Sourcery

Build:
- Bump treeland-protocols build dependency in Debian control file to version 0.5.9 or later.