### PR TITLE
fix(wallpaper):bump WallpaperShellInterfaceV1 version to 2

### DIFF
--- a/src/modules/wallpaper/wallpapershellinterfacev1.h
+++ b/src/modules/wallpaper/wallpapershellinterfacev1.h
@@ -24,7 +24,7 @@ public:
 
     QByteArrayView interfaceName() const override;
 
-    static constexpr int InterfaceVersion = 1;
+    static constexpr int InterfaceVersion = 2;
     QList<QString> producedWallpapers() const;
 
 Q_SIGNALS:


### PR DESCRIPTION
Bump interfaceversion to indicate protocol behavior changes.

Log: Bump WallpaperShellInterfaceV1 version
PMS: BUG-363035
Influence: Signals updated protocol to consumers of the wallpaper shell interface