### PR TITLE
fix(wallpaper): bump WallpaperProduceV1 version to 2

### DIFF
--- a/wallpaper-factory/qwaylandwallpapershellintegration.cpp
+++ b/wallpaper-factory/qwaylandwallpapershellintegration.cpp
@@ -9,7 +9,7 @@
 
 #include <private/qquickanimatedimage_p.h>
 
-#define TREELAND_WALLPAPER_PRODUCE_V1_VERSION 1
+#define TREELAND_WALLPAPER_PRODUCE_V1_VERSION 2
 
 QWaylandWallpaperShellIntegration::QWaylandWallpaperShellIntegration()
     : QWaylandShellIntegrationTemplate<QWaylandWallpaperShellIntegration>(TREELAND_WALLPAPER_PRODUCE_V1_VERSION)


### PR DESCRIPTION
Bump client-side TREELAND_WALLPAPER_PRODUCE_V1_VERSION to match the protocol version bump on the server side.

Log: bump WallpaperProduceV1 version to2
PMS: BUG-363035
Influence: