### PR TITLE
fix(capture): prevent proxy surface from being added to SurfaceContainer

### DIFF
--- a/src/modules/capture/capture.cpp
+++ b/src/modules/capture/capture.cpp
@@ -7,6 +7,7 @@
 #include "modules/item-selector/itemselector.h"
 #include "seat/helper.h"
 #include "surface/surfacewrapper.h"
+#include "surface/surfaceproxy.h"
 #include "workspace/workspace.h"
 #include "common/treelandlogging.h"
 
@@ -461,8 +462,27 @@ void CaptureManagerV1::freezeAllCapturedSurface(bool freeze, WSurface *mask)
                 content->setLive(!freeze);
             } else if (content->surface() == mask) {
                 auto surfaceItem = closestSurfaceItem(content);
-                m_maskSurfaceWrapper = qobject_cast<SurfaceWrapper *>(surfaceItem->parentItem());
+                auto parentItem = surfaceItem->parentItem();
+                // If parentItem is m_proxySurface (created by SurfaceProxy), skip it.
+                // The actual surface will be found when we traverse to it later.
+                //
+                // Note: Surface capture/record windows should not appear in multitask view,
+                // but currently we can't filter them at protocol level (e.g., through
+                // appId or surface type). We need to adjust the protocol so window
+                // manager can identify them before xdg-toplevel is shown.
+                if (auto wrapper = qobject_cast<SurfaceWrapper *>(parentItem)) {
+                    if (qobject_cast<SurfaceProxy *>(wrapper->parent())) {
+                        // This is m_proxySurface, skip it
+                        qCWarning(treelandCapture)
+                            << "Surface capture/record window found in multitask view,"
+                            << "protocol needs adjustment to filter it earlier";
+                        continue;
+                    }
+                }
+                m_maskSurfaceWrapper = qobject_cast<SurfaceWrapper *>(parentItem);
                 if (m_maskSurfaceWrapper) {
+                    // TODO: Set skipSwitcher, skipDockPreView, skipMutiTaskView here
+                    // after adjusting protocol to identify capture windows early
                     m_maskSurfaceWrapper->setNoTitleBar(true);
                     m_maskSurfaceWrapper->setNoCornerRadius(true);
                     m_maskSurfaceWrapper->setNoDecoration(true);

--- a/src/surface/surfacecontainer.cpp
+++ b/src/surface/surfacecontainer.cpp
@@ -133,7 +133,7 @@ SurfaceContainer::SurfaceContainer(SurfaceContainer *parent)
 SurfaceContainer::~SurfaceContainer()
 {
     if (!m_model->surfaces().isEmpty()) {
-        qCWarning(treelandSurface)
+        qCCritical(treelandSurface)
             << "SurfaceContainer destroyed with surfaces still attached:" << m_model->surfaces();
     }
 }
@@ -225,6 +225,11 @@ bool SurfaceContainer::doAddSurface(SurfaceWrapper *surface, bool setContainer)
         return false;
 
     if (setContainer) {
+        if (surface->parent()) {
+            qCWarning(treelandSurface)
+                << "Surface already has QObject parent, changing parent:" << surface
+                << "from:" << surface->parent() << "to:" << this;
+        }
         Q_ASSERT(!surface->container());
         surface->setContainer(this);
         surface->setParent(this);


### PR DESCRIPTION
When freezeAllCapturedSurface() traverses item tree, it was directly using surfaceItem->parentItem() as SurfaceWrapper. However, if the window is displayed in multitask view, the parent could be m_proxySurface created by SurfaceProxy, not the original SurfaceWrapper.

This caused m_proxySurface to be incorrectly added to CaptureSourceSelector's m_canvasContainer via addSurface(), leading to double-destroy crash when SurfaceContainer was destroyed.

Fix by detecting m_proxySurface (parent is SurfaceProxy) and skipping it, view at all. Protocol adjustment needed to filter these windows earlier.

PMS: 363365