### PR TITLE
fix: remove invalid minimize request connection

### DIFF
--- a/src/core/lockscreen.cpp
+++ b/src/core/lockscreen.cpp
@@ -219,7 +219,7 @@ void LockScreen::onLockSurfaceAdded(WSessionLockSurface *surface)
 
     wrapper->setHasInitializeContainer(true);
 
-    connect(wrapper, &SurfaceWrapper::requestActive, this, [wrapper] {
+    connect(wrapper, &SurfaceWrapper::activationRequested, this, [wrapper] {
         Helper::instance()->activateSurface(wrapper);
     });
 }

--- a/src/core/popupsurfacecontainer.cpp
+++ b/src/core/popupsurfacecontainer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2025-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "popupsurfacecontainer.h"
@@ -40,7 +40,7 @@ void PopupSurfaceContainer::mousePressEvent(QMouseEvent *event)
                 qCCritical(treelandShell) << "Ignore invalid popup surface:" << surface;
                 continue;
             }
-            surface->requestClose();
+            surface->closeSurface();
         }
         return;
     }

--- a/src/core/qml/Decoration.qml
+++ b/src/core/qml/Decoration.qml
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import QtQuick
@@ -60,7 +60,7 @@ Item {
             // Maybe missing onPositionChanged when use touchscreen
             edges = WaylibHelper.getEdges(Qt.rect(0, 0, width, height), Qt.point(event.x, event.y), 10)
             if (edges)
-                surface.requestResize(edges)
+                surface.resizeRequested(edges)
         }
     }
 

--- a/src/core/qml/TaskBar.qml
+++ b/src/core/qml/TaskBar.qml
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import QtQuick
@@ -34,7 +34,7 @@ ListView {
 
         MouseArea {
             anchors.fill: parent
-            onClicked: parent.surface.requestCancelMinimize()
+            onClicked: parent.surface.restoreFromMinimized()
         }
     }
 

--- a/src/core/qml/TitleBar.qml
+++ b/src/core/qml/TitleBar.qml
@@ -48,11 +48,11 @@ Control {
         }
         onPressedChanged: {
             if (pressed)
-                surface.requestMove()
+                surface.moveRequested()
         }
         onDoubleTapped: {
             if (root.canToggleMaximize)
-                surface.requestToggleMaximize()
+                surface.toggleMaximized()
         }
     }
 
@@ -60,7 +60,7 @@ Control {
     TapHandler {
         acceptedButtons: Qt.RightButton
         onTapped: {
-            surface.requestShowWindowMenu(eventPoint.position)
+            surface.windowMenuRequested(eventPoint.position)
         }
     }
 
@@ -70,9 +70,9 @@ Control {
         acceptedDevices: PointerDevice.TouchScreen
         onDoubleTapped: {
             if (root.canToggleMaximize)
-                surface.requestToggleMaximize()
+                surface.toggleMaximized()
         }
-        onLongPressed: surface.requestShowWindowMenu(point.position)
+        onLongPressed: surface.windowMenuRequested(point.position)
     }
 
     Rectangle {
@@ -115,7 +115,7 @@ Control {
                     D.ColorSelector.inactived: !surface.isActivated
 
                     onClicked: {
-                        surface.requestMinimize()
+                        surface.minimize()
                     }
                 }
             }
@@ -133,7 +133,7 @@ Control {
 
                     onClicked: {
                         Helper.activateSurface(surface)
-                        surface.requestToggleMaximize()
+                        surface.toggleMaximized()
                     }
                 }
             }
@@ -156,7 +156,7 @@ Control {
                         D.ColorSelector.inactived: !surface.isActivated
 
                         onClicked: {
-                            surface.requestClose()
+                            surface.closeSurface()
                         }
                     }
                 }

--- a/src/core/qml/WindowMenu.qml
+++ b/src/core/qml/WindowMenu.qml
@@ -31,18 +31,18 @@ D.Menu {
 
     D.MenuItem {
         text: qsTr("Minimize")
-        onTriggered: surface.requestMinimize()
+        onTriggered: surface.minimize()
     }
 
     D.MenuItem {
         text: surface?.surfaceState === SurfaceWrapper.State.Maximized ? qsTr("Unmaximize") : qsTr("Maximize")
         enabled: menu.canToggleMaximize
-        onTriggered: surface.requestToggleMaximize()
+        onTriggered: surface.toggleMaximized()
     }
 
     D.MenuItem {
         text: qsTr("Move")
-        onTriggered: surface.requestMove()
+        onTriggered: surface.moveRequested()
     }
 
     D.MenuItem {

--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -585,29 +585,6 @@ void RootSurfaceContainer::setupSurfaceRequestHandlers(SurfaceWrapper *surface)
         }
     }, Qt::DirectConnection);
 
-    bool isXdgToplevel = surface->type() == SurfaceWrapper::Type::XdgToplevel;
-    bool isXwayland = surface->type() == SurfaceWrapper::Type::XWayland;
-
-    if (isXdgToplevel || isXwayland) {
-        connect(surface, &SurfaceWrapper::requestMinimize, this, [surface]() {
-            auto *helper = Helper::instance();
-            if (!helper)
-                return;
-
-            if (helper->blockActivateSurface())
-                return;
-
-            if (helper->currentMode() == Helper::CurrentMode::Normal) {
-                if (surface->surfaceState() == SurfaceWrapper::State::Minimized)
-                    return;
-
-                auto container = surface->container();
-                if (container) {
-                    container->removeSurface(surface);
-                }
-            }
-        });
-    }
 }
 
 WSeat *RootSurfaceContainer::determineSeatForRequest(SurfaceWrapper *surface)

--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -554,37 +554,46 @@ void RootSurfaceContainer::setupSeatManagement()
 
 void RootSurfaceContainer::setupSurfaceRequestHandlers(SurfaceWrapper *surface)
 {
-    connect(surface, &SurfaceWrapper::requestMove, this, [this, surface]() {
-        WSeat *requestingSeat = determineSeatForRequest(surface);
-        if (!requestingSeat) {
-            qCWarning(treelandCore) << "No seat available for move request";
-            return;
-        }
+    connect(
+        surface,
+        &SurfaceWrapper::moveRequested,
+        this,
+        [this, surface]() {
+            WSeat *requestingSeat = determineSeatForRequest(surface);
+            if (!requestingSeat) {
+                qCWarning(treelandCore) << "No seat available for move request";
+                return;
+            }
 
-        beginMoveResizeForSeat(requestingSeat, surface, Qt::Edges{});
-        auto *helper = Helper::instance();
-        if (helper) {
-            helper->activateSurface(surface);
-        }
-    }, Qt::DirectConnection);
+            beginMoveResizeForSeat(requestingSeat, surface, Qt::Edges{});
+            auto *helper = Helper::instance();
+            if (helper) {
+                helper->activateSurface(surface);
+            }
+        },
+        Qt::DirectConnection);
 
-    connect(surface, &SurfaceWrapper::requestResize, this, [this, surface](Qt::Edges edges) {
-        WSeat *requestingSeat = determineSeatForRequest(surface);
-        if (!requestingSeat) {
-            qCWarning(treelandCore) << "No seat available for resize request";
-            return;
-        }
+    connect(
+        surface,
+        &SurfaceWrapper::resizeRequested,
+        this,
+        [this, surface](Qt::Edges edges) {
+            WSeat *requestingSeat = determineSeatForRequest(surface);
+            if (!requestingSeat) {
+                qCWarning(treelandCore) << "No seat available for resize request";
+                return;
+            }
 
-        beginMoveResizeForSeat(requestingSeat, surface, edges);
-        if (auto *sh = surface->shellSurface()) {
-            sh->setResizeing(true);
-        }
-        auto *helper = Helper::instance();
-        if (helper) {
-            helper->activateSurface(surface);
-        }
-    }, Qt::DirectConnection);
-
+            beginMoveResizeForSeat(requestingSeat, surface, edges);
+            if (auto *sh = surface->shellSurface()) {
+                sh->setResizeing(true);
+            }
+            auto *helper = Helper::instance();
+            if (helper) {
+                helper->activateSurface(surface);
+            }
+        },
+        Qt::DirectConnection);
 }
 
 WSeat *RootSurfaceContainer::determineSeatForRequest(SurfaceWrapper *surface)

--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -211,7 +211,7 @@ void ShellHandler::createPrelaunchSplash(const QString &appId,
     }
 
     // Listen for splash close request
-    connect(wrapper, &SurfaceWrapper::requestCloseSplash, this, [this, wrapper]() {
+    connect(wrapper, &SurfaceWrapper::splashCloseRequested, this, [this, wrapper]() {
         const QString appId = wrapper->appId();
         qCInfo(treelandShell) << "Splash close requested for appId=" << appId;
 
@@ -752,7 +752,7 @@ void ShellHandler::setupSurfaceActiveWatcher(SurfaceWrapper *wrapper)
     Q_ASSERT_X(wrapper->container(), Q_FUNC_INFO, "Must setContainer at first!");
 
     if (wrapper->type() == SurfaceWrapper::Type::XdgPopup) {
-        connect(wrapper, &SurfaceWrapper::requestActive, this, [this, wrapper]() {
+        connect(wrapper, &SurfaceWrapper::activationRequested, this, [this, wrapper]() {
             auto parent = wrapper->parentSurface();
             while (parent->type() == SurfaceWrapper::Type::XdgPopup) {
                 parent = parent->parentSurface();
@@ -770,7 +770,7 @@ void ShellHandler::setupSurfaceActiveWatcher(SurfaceWrapper *wrapper)
         });
 
         /*
-        connect(wrapper, &SurfaceWrapper::requestInactive, this, [this, wrapper]() {
+        connect(wrapper, &SurfaceWrapper::inactivationRequested, this, [this, wrapper]() {
             auto parent = wrapper->parentSurface();
             if (!parent || parent->type() == SurfaceWrapper::Type::XdgPopup)
                 return;
@@ -778,7 +778,7 @@ void ShellHandler::setupSurfaceActiveWatcher(SurfaceWrapper *wrapper)
         });
         */
     } else if (wrapper->type() == SurfaceWrapper::Type::Layer) {
-        connect(wrapper, &SurfaceWrapper::requestActive, this, [wrapper]() {
+        connect(wrapper, &SurfaceWrapper::activationRequested, this, [wrapper]() {
             auto layerSurface = qobject_cast<WLayerSurface *>(wrapper->shellSurface());
             if (layerSurface->keyboardInteractivity() == WLayerSurface::KeyboardInteractivity::None)
                 return;
@@ -794,18 +794,18 @@ void ShellHandler::setupSurfaceActiveWatcher(SurfaceWrapper *wrapper)
                 Helper::instance()->activateSurface(wrapper);
         });
 
-        connect(wrapper, &SurfaceWrapper::requestInactive, this, [this]() {
+        connect(wrapper, &SurfaceWrapper::inactivationRequested, this, [this]() {
             Helper::instance()->activateSurface(m_workspace->current()->latestActiveSurface());
         });
     } else { // Xdgtoplevel or X11 or Splash
-        connect(wrapper, &SurfaceWrapper::requestActive, this, [this, wrapper]() {
+        connect(wrapper, &SurfaceWrapper::activationRequested, this, [this, wrapper]() {
             if (wrapper->showOnWorkspace(m_workspace->current()->id()))
                 Helper::instance()->activateSurface(wrapper);
             else
                 m_workspace->pushActivedSurface(wrapper);
         });
 
-        connect(wrapper, &SurfaceWrapper::requestInactive, this, [this, wrapper]() {
+        connect(wrapper, &SurfaceWrapper::inactivationRequested, this, [this, wrapper]() {
             m_workspace->removeActivedSurface(wrapper);
             Helper::instance()->activateSurface(m_workspace->current()->latestActiveSurface());
         });
@@ -908,7 +908,7 @@ void ShellHandler::setupSurfaceWindowMenu(SurfaceWrapper *wrapper)
 {
     Q_ASSERT(m_windowMenu);
     connect(wrapper,
-            &SurfaceWrapper::requestShowWindowMenu,
+            &SurfaceWrapper::windowMenuRequested,
             m_windowMenu,
             [this, wrapper](QPointF pos) {
                 QMetaObject::invokeMethod(m_windowMenu,

--- a/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
+++ b/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
@@ -460,9 +460,9 @@ void ForeignToplevelManagerInterfaceV1::initializeToplevelHandle(SurfaceWrapper 
             wrapper,
             [wrapper](bool maximized) {
                 if (maximized)
-                    wrapper->requestMaximize();
+                    wrapper->maximize();
                 else
-                    wrapper->requestCancelMaximize();
+                    wrapper->unmaximize();
             });
 
     connect(handle,
@@ -476,9 +476,9 @@ void ForeignToplevelManagerInterfaceV1::initializeToplevelHandle(SurfaceWrapper 
                 }
 
                 if (minimized)
-                    wrapper->requestMinimize();
+                    wrapper->minimize();
                 else
-                    wrapper->requestCancelMinimize();
+                    wrapper->restoreFromMinimized();
             });
 
     connect(handle,
@@ -487,9 +487,9 @@ void ForeignToplevelManagerInterfaceV1::initializeToplevelHandle(SurfaceWrapper 
             [wrapper](bool fullscreen, WOutput *output) {
                 Q_UNUSED(output);
                 if (fullscreen)
-                    wrapper->requestFullscreen();
+                    wrapper->enterFullscreen();
                 else
-                    wrapper->requestCancelFullscreen();
+                    wrapper->leaveFullscreen();
             });
 
     connect(handle,

--- a/src/modules/shortcut/shortcutrunner.cpp
+++ b/src/modules/shortcut/shortcutrunner.cpp
@@ -101,34 +101,34 @@ void ShortcutRunner::onActionTrigger(ShortcutAction action, const QString &name,
     case ShortcutAction::Maximize: {
         auto surface = helper->activatedSurface();
         if (surface && surface->isMaximizable()) {
-            surface->requestMaximize();
+            surface->maximize();
         }
         break;
     }
     case ShortcutAction::CancelMaximize: {
         auto surface = helper->activatedSurface();
         if (surface) {
-            surface->requestCancelMaximize();
+            surface->unmaximize();
         }
         break;
     }
     case ShortcutAction::MoveWindow: {
         auto surface = helper->activatedSurface();
         if (surface) {
-            surface->requestMove();
+            Q_EMIT surface->moveRequested();
         }
         break;
     }
     case ShortcutAction::CloseWindow: {
         auto surface = helper->activatedSurface();
         if (surface) {
-            surface->requestClose();
+            surface->closeSurface();
         }
         break;
     }
     case ShortcutAction::ShowWindowMenu:
         if (helper->m_activatedSurface) {
-            Q_EMIT helper->m_activatedSurface->requestShowWindowMenu({0, 0});
+            Q_EMIT helper->m_activatedSurface->windowMenuRequested({ 0, 0 });
         }
         break;
     case ShortcutAction::OpenMultiTaskView:

--- a/src/modules/wine-window-state/winewindowstate.cpp
+++ b/src/modules/wine-window-state/winewindowstate.cpp
@@ -128,7 +128,7 @@ protected:
         if (!m_wrapper)
             return;
         if (m_wrapper->isMinimized())
-            m_wrapper->requestCancelMinimize();
+            m_wrapper->restoreFromMinimized();
     }
 
     void activate([[maybe_unused]] Resource *resource,

--- a/src/plugins/multitaskview/qml/WindowSelectionGrid.qml
+++ b/src/plugins/multitaskview/qml/WindowSelectionGrid.qml
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import QtQuick
@@ -326,7 +326,7 @@ Item {
                         }
                         onClicked: {
                             surfaceItemDelegate.visible = false
-                            surfaceItemDelegate.wrapper.requestClose()
+                            surfaceItemDelegate.wrapper.closeSurface()
                         }
                     }
                     Keys.onPressed: function (event) {
@@ -334,7 +334,7 @@ Item {
                             if (event.key === Qt.Key_Enter || event.key === Qt.Key_Return) {
                                 multitaskview.exit(wrapper)
                             } else if (event.key === Qt.Key_Delete) {
-                                wrapper.requestClose()
+                                wrapper.closeSurface()
                             }
                         } else if (event.modifiers === (Qt.MetaModifier | Qt.ShiftModifier)) {
                             const workspaceNumKeys = [Qt.Key_1, Qt.Key_2, Qt.Key_3, Qt.Key_4, Qt.Key_5, Qt.Key_6]

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1097,8 +1097,10 @@ void Helper::onSurfaceWrapperAdded(SurfaceWrapper *wrapper)
     bool isXwayland = wrapper->type() == SurfaceWrapper::Type::XWayland;
     bool isLayer = wrapper->type() == SurfaceWrapper::Type::Layer;
 
-    connect(m_sessionManager->activeSession().lock().get(), &Session::aboutToBeDestroyed,
-            wrapper, &SurfaceWrapper::requestClose);
+    connect(m_sessionManager->activeSession().lock().get(),
+            &Session::aboutToBeDestroyed,
+            wrapper,
+            &SurfaceWrapper::closeSurface);
 
     if (isXdgToplevel || isXdgPopup || isLayer) {
         auto *attached =
@@ -1771,7 +1773,7 @@ void Helper::forceActivateSurface(SurfaceWrapper *wrapper, Qt::FocusReason reaso
     restoreFromShowDesktop(wrapper);
 
     if (wrapper->isMinimized()) {
-        wrapper->requestCancelMinimize(
+        wrapper->restoreFromMinimized(
             !(reason == Qt::TabFocusReason || reason == Qt::BacktabFocusReason));
     }
 
@@ -1795,7 +1797,7 @@ void Helper::fakePressSurfaceBottomRightToReszie(SurfaceWrapper *surface)
     auto position = surface->geometry().bottomRight();
     m_fakelastPressedPosition = position;
     m_seat->setCursorPosition(position);
-    Q_EMIT surface->requestResize(Qt::BottomEdge | Qt::RightEdge);
+    Q_EMIT surface->resizeRequested(Qt::BottomEdge | Qt::RightEdge);
 }
 
 bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *targetWindow, QInputEvent *event)
@@ -2661,7 +2663,7 @@ void Helper::restoreFromShowDesktop(SurfaceWrapper *activeSurface)
         m_showDesktop = WindowManagementInterfaceV1::DesktopState::Normal;
         m_windowManagementInterfaceV1->setDesktopState(WindowManagementInterfaceV1::DesktopState::Normal);
         if (activeSurface) {
-            activeSurface->requestCancelMinimize();
+            activeSurface->restoreFromMinimized();
         }
         const auto &surfaces = getWorkspaceSurfaces();
         for (auto &surface : surfaces) {

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -295,37 +295,37 @@ void SurfaceWrapper::setup()
 
     if (!m_isProxy) {
         m_shellSurface->safeConnect(&WToplevelSurface::requestMinimize, this, [this]() {
-            requestMinimize();
+            minimize();
         });
         m_shellSurface->safeConnect(&WToplevelSurface::requestCancelMinimize, this, [this]() {
-            requestCancelMinimize();
+            restoreFromMinimized();
         });
         m_shellSurface->safeConnect(&WToplevelSurface::requestMaximize,
                                     this,
-                                    &SurfaceWrapper::requestMaximize);
+                                    &SurfaceWrapper::maximize);
         m_shellSurface->safeConnect(&WToplevelSurface::requestCancelMaximize,
                                     this,
-                                    &SurfaceWrapper::requestCancelMaximize);
-        m_shellSurface->safeConnect(&WToplevelSurface::requestMove,
-                                    this,
-                                    &SurfaceWrapper::requestMove);
+                                    &SurfaceWrapper::unmaximize);
+        m_shellSurface->safeConnect(&WToplevelSurface::requestMove, this, [this]() {
+            Q_EMIT moveRequested();
+        });
         m_shellSurface->safeConnect(&WToplevelSurface::requestResize,
                                     this,
                                     [this](WSeat *, Qt::Edges edge, quint32) {
-                                        Q_EMIT requestResize(edge);
+                                        Q_EMIT resizeRequested(edge);
                                     });
         m_shellSurface->safeConnect(&WToplevelSurface::requestFullscreen,
                                     this,
-                                    &SurfaceWrapper::requestFullscreen);
+                                    &SurfaceWrapper::enterFullscreen);
         m_shellSurface->safeConnect(&WToplevelSurface::requestCancelFullscreen,
                                     this,
-                                    &SurfaceWrapper::requestCancelFullscreen);
+                                    &SurfaceWrapper::leaveFullscreen);
 
         if (m_type == Type::XdgToplevel) {
             m_shellSurface->safeConnect(&WToplevelSurface::requestShowWindowMenu,
                                         this,
                                         [this](WSeat *, QPoint pos, quint32) {
-                                            Q_EMIT requestShowWindowMenu(
+                                            Q_EMIT windowMenuRequested(
                                                 m_surfaceItem->mapFromSurface(pos).toPoint());
                                         });
         }
@@ -727,7 +727,7 @@ void SurfaceWrapper::close()
 {
     if (m_type == Type::SplashScreen) {
         // For splash screens, emit a signal to request closure
-        Q_EMIT requestCloseSplash();
+        Q_EMIT splashCloseRequested();
     } else if (m_shellSurface) {
         // For normal surfaces, call the shell surface's close method
         m_shellSurface->close();
@@ -1608,7 +1608,7 @@ void SurfaceWrapper::setRadius(qreal newRadius)
     Q_EMIT radiusChanged();
 }
 
-void SurfaceWrapper::requestMinimize(bool onAnimation)
+void SurfaceWrapper::minimize(bool onAnimation)
 {
     if (m_surfaceState == State::Minimized)
         return;
@@ -1617,7 +1617,7 @@ void SurfaceWrapper::requestMinimize(bool onAnimation)
         startMinimizeAnimation(iconGeometry(), CLOSE_ANIMATION);
 }
 
-void SurfaceWrapper::requestCancelMinimize(bool onAnimation)
+void SurfaceWrapper::restoreFromMinimized(bool onAnimation)
 {
     if (m_surfaceState != State::Minimized && m_hideByshowDesk)
         return;
@@ -1629,7 +1629,7 @@ void SurfaceWrapper::requestCancelMinimize(bool onAnimation)
         startMinimizeAnimation(iconGeometry(), OPEN_ANIMATION);
 }
 
-void SurfaceWrapper::requestMaximize()
+void SurfaceWrapper::maximize()
 {
     if (m_surfaceState == State::Minimized || m_surfaceState == State::Fullscreen
         || !isMaximizable())
@@ -1638,7 +1638,7 @@ void SurfaceWrapper::requestMaximize()
     setSurfaceState(State::Maximized);
 }
 
-void SurfaceWrapper::requestCancelMaximize()
+void SurfaceWrapper::unmaximize()
 {
     if (m_surfaceState != State::Maximized)
         return;
@@ -1646,15 +1646,15 @@ void SurfaceWrapper::requestCancelMaximize()
     setSurfaceState(State::Normal);
 }
 
-void SurfaceWrapper::requestToggleMaximize()
+void SurfaceWrapper::toggleMaximized()
 {
     if (m_surfaceState == State::Maximized)
-        requestCancelMaximize();
+        unmaximize();
     else
-        requestMaximize();
+        maximize();
 }
 
-void SurfaceWrapper::requestFullscreen()
+void SurfaceWrapper::enterFullscreen()
 {
     if (m_surfaceState == State::Minimized)
         return;
@@ -1662,7 +1662,7 @@ void SurfaceWrapper::requestFullscreen()
     setSurfaceState(State::Fullscreen);
 }
 
-void SurfaceWrapper::requestCancelFullscreen()
+void SurfaceWrapper::leaveFullscreen()
 {
     if (m_surfaceState != State::Fullscreen)
         return;
@@ -1670,7 +1670,7 @@ void SurfaceWrapper::requestCancelFullscreen()
     setSurfaceState(m_previousSurfaceState);
 }
 
-void SurfaceWrapper::requestClose()
+void SurfaceWrapper::closeSurface()
 {
     // No shellSurface in prelaunch mode -> early return
     if (!m_shellSurface)
@@ -2133,9 +2133,9 @@ void SurfaceWrapper::updateHasActiveCapability(ActiveControlState state, bool va
     m_hasActiveCapability.setFlag(state, value);
     if (oldValue != hasActiveCapability()) {
         if (hasActiveCapability())
-            Q_EMIT requestActive();
+            Q_EMIT activationRequested();
         else
-            Q_EMIT requestInactive();
+            Q_EMIT inactivationRequested();
     }
 }
 

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -289,15 +289,14 @@ public:
     bool setAttention(bool attention);
 
 public Q_SLOTS:
-    // for titlebar
-    void requestMinimize(bool onAnimation = true);
-    void requestCancelMinimize(bool onAnimation = true);
-    void requestMaximize();
-    void requestCancelMaximize();
-    void requestToggleMaximize();
-    void requestFullscreen();
-    void requestCancelFullscreen();
-    void requestClose();
+    void minimize(bool onAnimation = true);
+    void restoreFromMinimized(bool onAnimation = true);
+    void maximize();
+    void unmaximize();
+    void toggleMaximized();
+    void enterFullscreen();
+    void leaveFullscreen();
+    void closeSurface();
     void onMappedChanged();
     void onSocketEnabledChanged();
 
@@ -320,9 +319,9 @@ Q_SIGNALS:
     void previousSurfaceStateChanged();
     void surfaceStateChanged();
     void radiusChanged();
-    void requestMove(); // for titlebar
-    void requestResize(Qt::Edges edges);
-    void requestShowWindowMenu(QPointF pos);
+    void moveRequested();
+    void resizeRequested(Qt::Edges edges);
+    void windowMenuRequested(QPointF pos);
     void geometryChanged();
     void containerChanged();
     void visibleDecorationChanged();
@@ -334,9 +333,9 @@ Q_SIGNALS:
     void workspaceIdChanged();
     void alwaysOnTopChanged();
     void showOnAllWorkspaceChanged();
-    void requestActive();
-    void requestInactive();
-    void requestCloseSplash();
+    void activationRequested();
+    void inactivationRequested();
+    void splashCloseRequested();
     void skipSwitcherChanged();
     void skipDockPreViewChanged();
     void skipMutiTaskViewChanged();


### PR DESCRIPTION
SurfaceWrapper::requestMinimize is a slot with implementation, not a signal. Connecting it as a sender signal fails at runtime and logs "QObject::connect: signal not found in SurfaceWrapper" when a new surface is added.\n\nRemove the dead handler instead of keeping a connection that never succeeds.