### PR TITLE
fix(qtquick): disconnect positionChanged before cursor cleanup

### DIFF
--- a/waylib/src/server/qtquick/woutputitem.cpp
+++ b/waylib/src/server/qtquick/woutputitem.cpp
@@ -53,6 +53,7 @@ public:
     }
 
     void clearCursors();
+    void destroyCursor(const std::pair<WCursor *, WOutputCursor *> &i);
     void updateCursors();
     void updateCursorsVisible();
     void updateCursorVisible(WOutputCursor *cursor);
@@ -100,12 +101,18 @@ void WOutputItemPrivate::initForOutput()
     }
 }
 
+void WOutputItemPrivate::destroyCursor(const std::pair<WCursor *, WOutputCursor *> &i)
+{
+    W_Q(WOutputItem);
+    QObject::disconnect(i.first, nullptr, q, nullptr);
+    i.second->invalidate();
+    i.second->deleteLater();
+}
+
 void WOutputItemPrivate::clearCursors()
 {
-    for (auto i : std::as_const(cursors)) {
-        i.second->invalidate();
-        i.second->deleteLater();
-    }
+    for (auto i : std::as_const(cursors))
+        destroyCursor(i);
     cursors.clear();
 }
 
@@ -164,8 +171,7 @@ void WOutputItemPrivate::updateCursors()
     for (auto i : std::as_const(tmpCursors)) {
         if (cursors.contains(i))
             continue;
-        i.second->invalidate();
-        i.second->deleteLater();
+        destroyCursor(i);
         cursorsChanged = true;
     }
 


### PR DESCRIPTION
Disconnect the positionChanged signal before invalidating WOutputCursor to prevent SIGSEGV from stale signal delivery after m_cursor is cleared.

在销毁WOutputCursor前断开positionChanged信号连接，避免信号触发
时访问已清空的m_cursor指针导致SIGSEGV崩溃。

Log: 修复光标销毁时信号未断开导致的空指针崩溃
PMS: BUG-366603
Influence: 修复了WOutputCursor销毁时positionChanged信号连接未断开，在WOutput移除后触发信号导致SIGSEGV的问题，提升光标管理稳定性。