### PR TITLE
fix: avoid focus fallback for inactive surfaces

### DIFF
--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -794,7 +794,14 @@ void ShellHandler::setupSurfaceActiveWatcher(SurfaceWrapper *wrapper)
                 Helper::instance()->activateSurface(wrapper);
         });
 
-        connect(wrapper, &SurfaceWrapper::inactivationRequested, this, [this]() {
+        connect(wrapper, &SurfaceWrapper::inactivationRequested, this, [this, wrapper]() {
+            // Only the current keyboard focus owner should drive focus fallback.
+            // Closing an unfocused layer surface, such as a notification, must not
+            // move focus away from the current owner, which may be a layer-shell
+            // surface that does not participate in fallback history.
+            if (Helper::instance()->keyboardFocusSurface() != wrapper)
+                return;
+
             Helper::instance()->activateSurface(m_workspace->current()->latestActiveSurface());
         });
     } else { // Xdgtoplevel or X11 or Splash
@@ -807,6 +814,11 @@ void ShellHandler::setupSurfaceActiveWatcher(SurfaceWrapper *wrapper)
 
         connect(wrapper, &SurfaceWrapper::inactivationRequested, this, [this, wrapper]() {
             m_workspace->removeActivedSurface(wrapper);
+            // The window may already be inactive. Keep history cleanup above, but
+            // avoid changing focus unless this window still owns keyboard focus.
+            if (Helper::instance()->keyboardFocusSurface() != wrapper)
+                return;
+
             Helper::instance()->activateSurface(m_workspace->current()->latestActiveSurface());
         });
 

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -147,6 +147,7 @@ class Treeland;
 class Helper : public WSeatEventFilter
 {
     friend class RootSurfaceContainer;
+    friend class ShellHandler;
     friend class ShortcutRunner;
     Q_OBJECT
     Q_PROPERTY(RootSurfaceContainer* rootSurfaceContainer READ rootSurfaceContainer CONSTANT FINAL)


### PR DESCRIPTION
SurfaceWrapper::inactivationRequested can be emitted by a surface that is no longer the current keyboard focus surface. In that case Treeland should not fall back to the latest active surface, because doing so can steal focus from the window that currently owns keyboard focus.

Check the requesting wrapper against Helper::keyboardFocusSurface() before performing focus fallback for layer surfaces and regular toplevel/XWayland/splash surfaces. Regular surfaces are still removed from the active history before the check so stale entries are cleaned up without changing focus.

Grant ShellHandler friend access to Helper so the existing private keyboardFocusSurface() query can be reused without widening Helper's public API.

PMS: 345849
