### PR TITLE
refactor: unify treeland logging category system

### DIFF
--- a/src/common/treelandlogging.cpp
+++ b/src/common/treelandlogging.cpp
@@ -4,72 +4,83 @@
 #include "common/treelandlogging.h"
 
 // TreeLand logging category definitions
-// Naming convention: treeland.module_name.submodule_name
+// Naming convention: lcTl + PascalCase module name
+// String ID convention: treeland.<module>[.<submodule>]
 
 // Core modules
-Q_LOGGING_CATEGORY(treelandCore, "treeland.core")
-Q_LOGGING_CATEGORY(treelandServer, "treeland.server")
-Q_LOGGING_CATEGORY(treelandCompositor, "treeland.compositor")
-Q_LOGGING_CATEGORY(treelandShell, "treeland.shell")
+Q_LOGGING_CATEGORY(lcTlCore, "treeland.core", QtInfoMsg)
+Q_LOGGING_CATEGORY(lcTlServer, "treeland.server")
+Q_LOGGING_CATEGORY(lcTlCompositor, "treeland.compositor")
+Q_LOGGING_CATEGORY(lcTlShell, "treeland.shell")
+Q_LOGGING_CATEGORY(lcTlQml, "treeland.qml")
 
 // Input modules
-Q_LOGGING_CATEGORY(treelandInput, "treeland.input")
-Q_LOGGING_CATEGORY(treelandGestures, "treeland.gestures")
+Q_LOGGING_CATEGORY(lcTlInput, "treeland.input")
+Q_LOGGING_CATEGORY(lcTlInputManager, "treeland.input.manager")
+Q_LOGGING_CATEGORY(lcTlGestures, "treeland.input.gestures")
+Q_LOGGING_CATEGORY(lcTlKeyboardNotify, "treeland.input.keyboard.state.notify")
 
 // Seat management
-Q_LOGGING_CATEGORY(treelandSeat, "treeland.seat")
+Q_LOGGING_CATEGORY(lcTlSeat, "treeland.seat")
 
 // Output module
-Q_LOGGING_CATEGORY(treelandOutput, "treeland.output")
+Q_LOGGING_CATEGORY(lcTlOutput, "treeland.output", QtInfoMsg)
 
 // Window management
-Q_LOGGING_CATEGORY(treelandSurface, "treeland.surface")
-
-// Protocol module
-Q_LOGGING_CATEGORY(treelandProtocol, "treeland.protocol")
-
-// Plugin system
-Q_LOGGING_CATEGORY(treelandPlugin, "treeland.plugin")
-
-// Configuration management
-Q_LOGGING_CATEGORY(treelandConfig, "treeland.config")
+Q_LOGGING_CATEGORY(lcTlSurface, "treeland.surface")
 
 // Workspace management
-Q_LOGGING_CATEGORY(treelandWorkspace, "treeland.workspace")
+Q_LOGGING_CATEGORY(lcTlWorkspace, "treeland.workspace")
+
+// Protocol module
+Q_LOGGING_CATEGORY(lcTlProtocol, "treeland.protocol")
+
+// Plugin system
+Q_LOGGING_CATEGORY(lcTlPlugin, "treeland.plugin")
+
+// Configuration management
+Q_LOGGING_CATEGORY(lcTlConfig, "treeland.config")
 
 // Wallpaper system
-Q_LOGGING_CATEGORY(treelandWallpaper, "treeland.wallpaper")
+Q_LOGGING_CATEGORY(lcTlWallpaper, "treeland.wallpaper")
+Q_LOGGING_CATEGORY(lcTlWallpaperColor, "treeland.wallpaper.color")
 
 // Effects system
-Q_LOGGING_CATEGORY(treelandEffect, "treeland.effect")
+Q_LOGGING_CATEGORY(lcTlEffect, "treeland.effect")
 
 // Capture system
-Q_LOGGING_CATEGORY(treelandCapture, "treeland.capture")
+Q_LOGGING_CATEGORY(lcTlCapture, "treeland.capture")
 
 // DBus interface
-Q_LOGGING_CATEGORY(treelandDBus, "treeland.dbus")
+Q_LOGGING_CATEGORY(lcTlDBus, "treeland.dbus")
 
 // Utility classes
-Q_LOGGING_CATEGORY(treelandUtils, "treeland.utils")
+Q_LOGGING_CATEGORY(lcTlUtils, "treeland.utils")
+Q_LOGGING_CATEGORY(lcTlPropertyMonitor, "treeland.property.monitor")
 
 // Shortcut system
-Q_LOGGING_CATEGORY(treelandShortcut, "treeland.shortcut")
-
-// QML engine
-Q_LOGGING_CATEGORY(treelandQml, "treeland.qml")
+Q_LOGGING_CATEGORY(lcTlShortcut, "treeland.shortcut")
 
 // Greeter module
-Q_LOGGING_CATEGORY(treelandGreeter, "treeland.greeter")
+Q_LOGGING_CATEGORY(lcTlGreeter, "treeland.greeter")
 
 // FPS display
-Q_LOGGING_CATEGORY(treelandFpsDisplay, "treeland.fpsdisplay")
+Q_LOGGING_CATEGORY(lcTlFpsDisplay, "treeland.fps")
 
 // xsettings
-Q_LOGGING_CATEGORY(treelandXsettings, "treeland.xsettings")
+Q_LOGGING_CATEGORY(lcTlXsettings, "treeland.xsettings")
 
 // Activation module
-Q_LOGGING_CATEGORY(treelandActivation, "treeland.activation")
-// inputManager
-Q_LOGGING_CATEGORY(treelandInputManager, "treeland.input.manager")
-// key notify
-Q_LOGGING_CATEGORY(treelandKeyboardNotify, "treeland.keyboard.state.notify")
+Q_LOGGING_CATEGORY(lcTlActivation, "treeland.activation")
+
+// App ID resolver
+Q_LOGGING_CATEGORY(lcTlAppIdResolver, "treeland.appid.resolver", QtInfoMsg)
+
+// Prelaunch splash
+Q_LOGGING_CATEGORY(lcTlPrelaunchSplash, "treeland.prelaunch.splash", QtInfoMsg)
+
+// XWayland
+Q_LOGGING_CATEGORY(lcTlXwayland, "treeland.xwayland")
+
+// DDM integration
+Q_LOGGING_CATEGORY(lcTlDdm, "treeland.ddm")

--- a/src/common/treelandlogging.h
+++ b/src/common/treelandlogging.h
@@ -7,75 +7,85 @@
 #include <QLoggingCategory>
 
 // TreeLand Logging Categories
-// Naming convention: treeland.module_name.submodule_name
-// Use lowercase letters, separated by dots
+// Naming convention: lcTl + PascalCase module name
+// String ID convention: treeland.<module>[.<submodule>]
 
 // Core modules
-Q_DECLARE_LOGGING_CATEGORY(treelandCore)
-Q_DECLARE_LOGGING_CATEGORY(treelandServer)
-Q_DECLARE_LOGGING_CATEGORY(treelandCompositor)
-Q_DECLARE_LOGGING_CATEGORY(treelandShell)
+Q_DECLARE_LOGGING_CATEGORY(lcTlCore)
+Q_DECLARE_LOGGING_CATEGORY(lcTlServer)
+Q_DECLARE_LOGGING_CATEGORY(lcTlCompositor)
+Q_DECLARE_LOGGING_CATEGORY(lcTlShell)
+Q_DECLARE_LOGGING_CATEGORY(lcTlQml)
 
 // Input modules
-Q_DECLARE_LOGGING_CATEGORY(treelandInput)
-Q_DECLARE_LOGGING_CATEGORY(treelandGestures)
+Q_DECLARE_LOGGING_CATEGORY(lcTlInput)
+Q_DECLARE_LOGGING_CATEGORY(lcTlInputManager)
+Q_DECLARE_LOGGING_CATEGORY(lcTlGestures)
+Q_DECLARE_LOGGING_CATEGORY(lcTlKeyboardNotify)
 
 // Seat management
-Q_DECLARE_LOGGING_CATEGORY(treelandSeat)
+Q_DECLARE_LOGGING_CATEGORY(lcTlSeat)
 
 // Output module
-Q_DECLARE_LOGGING_CATEGORY(treelandOutput)
+Q_DECLARE_LOGGING_CATEGORY(lcTlOutput)
 
 // Window management
-Q_DECLARE_LOGGING_CATEGORY(treelandSurface)
-
-// Protocol module
-Q_DECLARE_LOGGING_CATEGORY(treelandProtocol)
-
-// Plugin system
-Q_DECLARE_LOGGING_CATEGORY(treelandPlugin)
-
-// Configuration management
-Q_DECLARE_LOGGING_CATEGORY(treelandConfig)
+Q_DECLARE_LOGGING_CATEGORY(lcTlSurface)
 
 // Workspace management
-Q_DECLARE_LOGGING_CATEGORY(treelandWorkspace)
+Q_DECLARE_LOGGING_CATEGORY(lcTlWorkspace)
+
+// Protocol module
+Q_DECLARE_LOGGING_CATEGORY(lcTlProtocol)
+
+// Plugin system
+Q_DECLARE_LOGGING_CATEGORY(lcTlPlugin)
+
+// Configuration management
+Q_DECLARE_LOGGING_CATEGORY(lcTlConfig)
 
 // Wallpaper system
-Q_DECLARE_LOGGING_CATEGORY(treelandWallpaper)
+Q_DECLARE_LOGGING_CATEGORY(lcTlWallpaper)
+Q_DECLARE_LOGGING_CATEGORY(lcTlWallpaperColor)
 
 // Effects system
-Q_DECLARE_LOGGING_CATEGORY(treelandEffect)
+Q_DECLARE_LOGGING_CATEGORY(lcTlEffect)
 
 // Capture system
-Q_DECLARE_LOGGING_CATEGORY(treelandCapture)
+Q_DECLARE_LOGGING_CATEGORY(lcTlCapture)
 
 // DBus interface
-Q_DECLARE_LOGGING_CATEGORY(treelandDBus)
+Q_DECLARE_LOGGING_CATEGORY(lcTlDBus)
 
 // Utility classes
-Q_DECLARE_LOGGING_CATEGORY(treelandUtils)
+Q_DECLARE_LOGGING_CATEGORY(lcTlUtils)
+Q_DECLARE_LOGGING_CATEGORY(lcTlPropertyMonitor)
 
 // Shortcut system
-Q_DECLARE_LOGGING_CATEGORY(treelandShortcut)
-
-// QML engine
-Q_DECLARE_LOGGING_CATEGORY(treelandQml)
+Q_DECLARE_LOGGING_CATEGORY(lcTlShortcut)
 
 // Greeter module
-Q_DECLARE_LOGGING_CATEGORY(treelandGreeter)
+Q_DECLARE_LOGGING_CATEGORY(lcTlGreeter)
 
 // FPS display
-Q_DECLARE_LOGGING_CATEGORY(treelandFpsDisplay)
+Q_DECLARE_LOGGING_CATEGORY(lcTlFpsDisplay)
 
 // xsettings
-Q_DECLARE_LOGGING_CATEGORY(treelandXsettings)
+Q_DECLARE_LOGGING_CATEGORY(lcTlXsettings)
 
 // Activation module
-Q_DECLARE_LOGGING_CATEGORY(treelandActivation)
-// inputManager
-Q_DECLARE_LOGGING_CATEGORY(treelandInputManager)
-// key notify
-Q_DECLARE_LOGGING_CATEGORY(treelandKeyboardNotify)
+Q_DECLARE_LOGGING_CATEGORY(lcTlActivation)
+
+// App ID resolver
+Q_DECLARE_LOGGING_CATEGORY(lcTlAppIdResolver)
+
+// Prelaunch splash
+Q_DECLARE_LOGGING_CATEGORY(lcTlPrelaunchSplash)
+
+// XWayland
+Q_DECLARE_LOGGING_CATEGORY(lcTlXwayland)
+
+// DDM integration
+Q_DECLARE_LOGGING_CATEGORY(lcTlDdm)
 
 #endif // TREELAND_LOGGING_H

--- a/src/core/layersurfacecontainer.cpp
+++ b/src/core/layersurfacecontainer.cpp
@@ -128,7 +128,7 @@ void LayerSurfaceContainer::addSurfaceToContainer(SurfaceWrapper *surface)
         : rootContainer()->primaryOutput() ? rootContainer()->primaryOutput()->output()
                                            : nullptr;
     if (!output) {
-        qCWarning(treelandShell) << "No output, will close layer surface!";
+        qCWarning(lcTlShell) << "No output, will close layer surface!";
         shell->closed();
         return;
     }

--- a/src/core/lockscreen.cpp
+++ b/src/core/lockscreen.cpp
@@ -50,7 +50,7 @@ void LockScreen::shutdown()
 {
     // ext_session_lock_v1 does not support shutdown
     if (!m_impl) {
-        qCWarning(treelandShell) << "Attempt to shutdown with no compatible lockscreen implementation!";
+        qCWarning(lcTlShell) << "Attempt to shutdown with no compatible lockscreen implementation!";
         emit unlock();
         return;
     }
@@ -69,7 +69,7 @@ void LockScreen::switchUser()
 {
     // ext_session_lock_v1 does not support user switching
     if (!m_impl) {
-        qCWarning(treelandShell) << "Attempt to switch user with no compatible lockscreen implementation!";
+        qCWarning(lcTlShell) << "Attempt to switch user with no compatible lockscreen implementation!";
         emit unlock();
         return;
     }
@@ -85,7 +85,7 @@ void LockScreen::switchUser()
 
 void LockScreen::addOutput(Output *output)
 {
-    qCDebug(treelandShell) << "Adding output to lock screen:" << output;
+    qCDebug(lcTlShell) << "Adding output to lock screen:" << output;
 
     SurfaceContainer::addOutput(output);
 #if EXT_SESSION_LOCK_V1
@@ -119,7 +119,7 @@ bool LockScreen::isLocked() const
 
 void LockScreen::removeOutput(Output *output)
 {
-    qCDebug(treelandShell) << "Removing output from lock screen:" << output;
+    qCDebug(lcTlShell) << "Removing output from lock screen:" << output;
 
     SurfaceContainer::removeOutput(output);
 #if EXT_SESSION_LOCK_V1
@@ -156,7 +156,7 @@ bool LockScreen::available() const
 
 void LockScreen::setPrimaryOutputName(const QString &primaryOutputName)
 {
-    qCDebug(treelandShell) << "Setting primary output name for lock screen:" << primaryOutputName;
+    qCDebug(lcTlShell) << "Setting primary output name for lock screen:" << primaryOutputName;
 
     m_primaryOutputName = primaryOutputName;
     for (const auto &[k, v] : std::as_const(m_components)) {
@@ -175,7 +175,7 @@ void LockScreen::doRemoveLockSurface(WSessionLockSurface *surface)
 
     auto wrapper = rootContainer()->getSurface(surface);
     if (!wrapper) {
-        qCWarning(treelandShell) << "Removing lock surface with no container attached";
+        qCWarning(lcTlShell) << "Removing lock surface with no container attached";
         return;
     }
     rootContainer()->destroyForSurface(wrapper);
@@ -190,7 +190,7 @@ void LockScreen::onLockSurfaceAdded(WSessionLockSurface *surface)
     auto output = Helper::instance()->getOutput(surface->output());
 
     if (!output) {
-        qCWarning(treelandShell) << "Lock surface added with no output!";
+        qCWarning(lcTlShell) << "Lock surface added with no output!";
         return;
     }
 
@@ -231,7 +231,7 @@ void LockScreen::onLockSurfaceRemoved(WSessionLockSurface *surface)
     }
     auto output = Helper::instance()->getOutput(surface->output());
     if (!output) {
-        qCWarning(treelandShell) << "removing lock surface with no output!";
+        qCWarning(lcTlShell) << "removing lock surface with no output!";
         return;
     }
 
@@ -283,7 +283,7 @@ void LockScreen::onExternalLock(WSessionLock *lock)
 
 void LockScreen::onExternalUnlock() {
     if (!m_sessionLock || !isLocked()) {
-        qCCritical(treelandShell) << "Session lock identified as unlocked but screen is not externally locked?";
+        qCCritical(lcTlShell) << "Session lock identified as unlocked but screen is not externally locked?";
         return;
     }
     setVisible(false);
@@ -300,11 +300,11 @@ void LockScreen::onExternalLockAbandoned() {
         return;
     }
     if (!isLocked()) {
-        qCCritical(treelandShell) << "Session lock identified as abandoned but screen is not locked?";
+        qCCritical(lcTlShell) << "Session lock identified as abandoned but screen is not locked?";
         return;
     }
 
-    qCWarning(treelandShell) << "locking client likely died";
+    qCWarning(lcTlShell) << "locking client likely died";
 
     m_sessionLock = nullptr;
 

--- a/src/core/popupsurfacecontainer.cpp
+++ b/src/core/popupsurfacecontainer.cpp
@@ -26,7 +26,7 @@ void PopupSurfaceContainer::mousePressEvent(QMouseEvent *event)
     }
 
     if (!xdgPopupSurfaces.isEmpty()) {
-        qCDebug(treelandShell) << "Intercepting mouse press event due to active popup surfaces";
+        qCDebug(lcTlShell) << "Intercepting mouse press event due to active popup surfaces";
         // If surfaces are not empty, intercept the mouse press event to prevent it from reaching
         // lower z-index components
         event->accept();
@@ -37,7 +37,7 @@ void PopupSurfaceContainer::mousePressEvent(QMouseEvent *event)
                 continue;
             }
             if (!surface->shellSurface()) {
-                qCCritical(treelandShell) << "Ignore invalid popup surface:" << surface;
+                qCCritical(lcTlShell) << "Ignore invalid popup surface:" << surface;
                 continue;
             }
             surface->closeSurface();

--- a/src/core/qmlengine.cpp
+++ b/src/core/qmlengine.cpp
@@ -15,8 +15,6 @@
 
 #include <QQuickItem>
 
-Q_LOGGING_CATEGORY(qLcQmlEngine, "treeland.qmlEngine")
-
 QmlEngine::QmlEngine(QObject *parent)
     : QQmlApplicationEngine(parent)
     , titleBarComponent(this, "Treeland", "TitleBar")
@@ -58,7 +56,7 @@ QQuickItem *QmlEngine::createComponent(QQmlComponent &component,
     }
     auto item = qobject_cast<QQuickItem *>(obj);
     if (!item) {
-        qCFatal(qLcQmlEngine) << "Can't create component:" << component.errorString();
+        qCFatal(lcTlQml) << "Can't create component:" << component.errorString();
     }
     QQmlEngine::setObjectOwnership(item, QQmlEngine::objectOwnership(parent));
     item->setParent(parent);
@@ -87,7 +85,7 @@ QObject *QmlEngine::createWindowMenu(QObject *parent)
     auto context = qmlContext(parent);
     auto obj = windowMenuComponent.beginCreate(context);
     if (!obj) {
-        qCFatal(qLcQmlEngine) << "Can't create WindowMenu:" << windowMenuComponent.errorString();
+        qCFatal(lcTlQml) << "Can't create WindowMenu:" << windowMenuComponent.errorString();
     }
     obj->setParent(parent);
     windowMenuComponent.completeCreate();

--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -533,7 +533,7 @@ void RootSurfaceContainer::setupSeatManagement()
 {
     auto *helper = Helper::instance();
     if (!helper || !helper->seatManager()) {
-        qCWarning(treelandCore) << "Helper or seatManager not available for seat management setup";
+        qCWarning(lcTlCore) << "Helper or seatManager not available for seat management setup";
         return;
     }
 
@@ -541,7 +541,7 @@ void RootSurfaceContainer::setupSeatManagement()
     const auto &seats = seatManager->seats();
 
     if (seats.isEmpty()) {
-        qCWarning(treelandCore) << "No seats available for seat management setup";
+        qCWarning(lcTlCore) << "No seats available for seat management setup";
         return;
     }
 
@@ -563,7 +563,7 @@ void RootSurfaceContainer::setupSurfaceRequestHandlers(SurfaceWrapper *surface)
         [this, surface]() {
             WSeat *requestingSeat = determineSeatForRequest(surface);
             if (!requestingSeat) {
-                qCWarning(treelandCore) << "No seat available for move request";
+                qCWarning(lcTlCore) << "No seat available for move request";
                 return;
             }
 
@@ -582,7 +582,7 @@ void RootSurfaceContainer::setupSurfaceRequestHandlers(SurfaceWrapper *surface)
         [this, surface](Qt::Edges edges) {
             WSeat *requestingSeat = determineSeatForRequest(surface);
             if (!requestingSeat) {
-                qCWarning(treelandCore) << "No seat available for resize request";
+                qCWarning(lcTlCore) << "No seat available for resize request";
                 return;
             }
 
@@ -637,7 +637,7 @@ void RootSurfaceContainer::onSeatRemoved(WSeat *seat)
 {
     auto *container = m_seatContainers.take(seat);
     if (container) {
-        qCDebug(treelandCore) << "Removing SeatContainer for seat:" << seat;
+        qCDebug(lcTlCore) << "Removing SeatContainer for seat:" << seat;
         container->deleteLater();
     }
 }
@@ -651,7 +651,7 @@ WSeat *RootSurfaceContainer::getDefaultSeat() const
 {
     auto *helper = Helper::instance();
     if (!helper || !helper->seatManager()) {
-        qCWarning(treelandCore) << "Helper or seatManager not available";
+        qCWarning(lcTlCore) << "Helper or seatManager not available";
         return nullptr;
     }
 
@@ -665,10 +665,10 @@ WSeat *RootSurfaceContainer::getDefaultSeat() const
     // Fallback: use first from list (QMap order, not predictable — warn)
     const auto &seats = seatManager->seats();
     if (seats.isEmpty()) {
-        qCCritical(treelandCore) << "No seats available - this should not happen in Wayland!";
+        qCCritical(lcTlCore) << "No seats available - this should not happen in Wayland!";
         return nullptr;
     }
-    qCWarning(treelandCore) << "fallbackSeat() is null, using first seat from seats() as default";
+    qCWarning(lcTlCore) << "fallbackSeat() is null, using first seat from seats() as default";
     return seats.first();
 }
 
@@ -677,14 +677,14 @@ SeatSurfaceManager *RootSurfaceContainer::getSeatContainerOrDefault(WSeat *seat)
     if (!seat) {
         seat = getDefaultSeat();
         if (!seat) {
-            qCCritical(treelandCore) << "Cannot get default seat";
+            qCCritical(lcTlCore) << "Cannot get default seat";
             return nullptr;
         }
     }
 
     auto *container = m_seatContainers.value(seat, nullptr);
     if (!container) {
-        qCWarning(treelandCore) << "No container for seat:" << seat;
+        qCWarning(lcTlCore) << "No container for seat:" << seat;
     }
 
     return container;

--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -205,7 +205,7 @@ void ShellHandler::createPrelaunchSplash(const QString &appId,
     qlonglong timeoutMs = Helper::instance()->globalConfig()->prelaunchSplashTimeoutMs();
     // Bounds: <=0 disables auto-destroy, >60000 clamps to 60000
     if (timeoutMs > 60000) {
-        qCWarning(treelandShell)
+        qCWarning(lcTlShell)
             << "Prelaunch splash timeout too long, clamping to 60000ms, requested:" << timeoutMs;
         timeoutMs = 60000;
     }
@@ -213,7 +213,7 @@ void ShellHandler::createPrelaunchSplash(const QString &appId,
     // Listen for splash close request
     connect(wrapper, &SurfaceWrapper::splashCloseRequested, this, [this, wrapper]() {
         const QString appId = wrapper->appId();
-        qCInfo(treelandShell) << "Splash close requested for appId=" << appId;
+        qCInfo(lcTlShell) << "Splash close requested for appId=" << appId;
 
         // Add to closed splash list
         if (!appId.isEmpty()) {
@@ -238,7 +238,7 @@ void ShellHandler::createPrelaunchSplash(const QString &appId,
                                if (idx < 0) {
                                    return; // Already matched or removed earlier
                                }
-                               qCDebug(treelandShell)
+                               qCDebug(lcTlShell)
                                    << "Prelaunch splash timeout, destroy wrapper appId="
                                    << wrapper->appId();
                                m_prelaunchWrappers.removeAt(idx);
@@ -258,7 +258,7 @@ void ShellHandler::handlePrelaunchSplashClosed(const QString &appId, const QStri
     for (int i = 0; i < m_prelaunchWrappers.size(); ++i) {
         auto *wrapper = m_prelaunchWrappers[i];
         if (wrapper->appId() == appId) {
-            qCDebug(treelandShell)
+            qCDebug(lcTlShell)
                 << "Client requested close_splash, destroy wrapper appId=" << appId;
             m_prelaunchWrappers.removeAt(i);
             m_rootSurfaceContainer->destroyForSurface(wrapper);
@@ -396,13 +396,13 @@ void ShellHandler::onXdgToplevelSurfaceAdded(WXdgToplevelSurface *surface)
                     m_pendingAppIdResolveToplevels.removeAt(idx);
                 });
             if (started) {
-                qCDebug(treelandShell) << "AppIdResolver request sent (callback) pidfd=" << pidfd;
+                qCDebug(lcTlShell) << "AppIdResolver request sent (callback) pidfd=" << pidfd;
                 return; // async path handles creation
             } else {
                 int idx = m_pendingAppIdResolveToplevels.indexOf(surface);
                 if (idx >= 0)
                     m_pendingAppIdResolveToplevels.removeAt(idx);
-                qCDebug(treelandShell)
+                qCDebug(lcTlShell)
                     << "AppIdResolverManager present but requestResolve failed pidfd=" << pidfd;
             }
         }
@@ -415,7 +415,7 @@ void ShellHandler::ensureXdgWrapper(WXdgToplevelSurface *surface, const QString 
 {
     // Check if this matches a closed splash screen
     if (!targetAppId.isEmpty() && m_closedSplashAppIds.contains(targetAppId)) {
-        qCInfo(treelandShell) << "XDG surface matches closed splash, closing immediately: appId="
+        qCInfo(lcTlShell) << "XDG surface matches closed splash, closing immediately: appId="
                               << targetAppId;
         m_closedSplashAppIds.remove(targetAppId);
         surface->close();
@@ -430,7 +430,7 @@ void ShellHandler::ensureXdgWrapper(WXdgToplevelSurface *surface, const QString 
         for (int i = 0; i < m_prelaunchWrappers.size(); ++i) {
             auto *candidate = m_prelaunchWrappers[i];
             if (candidate->appId() == targetAppId) {
-                qCDebug(treelandShell) << "match prelaunch xdg" << targetAppId;
+                qCDebug(lcTlShell) << "match prelaunch xdg" << targetAppId;
                 m_prelaunchWrappers.removeAt(i);
                 candidate->convertToNormalSurface(surface, SurfaceWrapper::Type::XdgToplevel);
                 wrapper = candidate;
@@ -479,7 +479,7 @@ void ShellHandler::onXdgToplevelSurfaceRemoved(WXdgToplevelSurface *surface)
     // never exposed this surface (from treeland's perspective).
     if (!wrapper) {
         if (!m_pendingAppIdResolveToplevels.removeOne(surface)) {
-            qCWarning(treelandShell)
+            qCWarning(lcTlShell)
                 << "onXdgToplevelSurfaceRemoved for unknown surface" << surface;
         }
         return;
@@ -575,14 +575,14 @@ void ShellHandler::onXWaylandSurfaceAdded(WXWaylandSurface *surface)
                                              m_pendingAppIdResolveToplevels.removeAt(idx);
                                          });
                                      if (started) {
-                                         qCDebug(treelandShell)
+                                         qCDebug(lcTlShell)
                                              << "(XWayland) AppIdResolver request sent (callback)";
                                          return; // async path
                                      } else {
                                          int idx = m_pendingAppIdResolveToplevels.indexOf(raw);
                                          if (idx >= 0)
                                              m_pendingAppIdResolveToplevels.removeAt(idx);
-                                         qCDebug(treelandShell)
+                                         qCDebug(lcTlShell)
                                              << "(XWayland) requestResolve failed pidfd=" << pidfd;
                                      }
                                  }
@@ -593,11 +593,11 @@ void ShellHandler::onXWaylandSurfaceAdded(WXWaylandSurface *surface)
                          });
     surface->safeConnect(&WXWaylandSurface::aboutToDissociate, this, [this, surface] {
         auto wrapper = m_rootSurfaceContainer->getSurface(surface);
-        qCDebug(treelandShell) << "WXWayland::aboutToDissociate" << surface << wrapper;
+        qCDebug(lcTlShell) << "WXWayland::aboutToDissociate" << surface << wrapper;
         // Cancel pending async resolve if still present. If wrapper never created, return.
         if (!wrapper) {
             if (!m_pendingAppIdResolveToplevels.removeOne(surface)) {
-                qCWarning(treelandShell)
+                qCWarning(lcTlShell)
                     << "WXWayland::aboutToDissociate for unknown surface" << surface;
             }
             return; // never created
@@ -622,7 +622,7 @@ void ShellHandler::ensureXwaylandWrapper(WXWaylandSurface *surface, const QStrin
 {
     // Check if this matches a closed splash screen
     if (!targetAppId.isEmpty() && m_closedSplashAppIds.contains(targetAppId)) {
-        qCDebug(treelandShell)
+        qCDebug(lcTlShell)
             << "XWayland surface matches closed splash, closing immediately: appId=" << targetAppId;
         m_closedSplashAppIds.remove(targetAppId);
         surface->close();
@@ -637,7 +637,7 @@ void ShellHandler::ensureXwaylandWrapper(WXWaylandSurface *surface, const QStrin
         for (int i = 0; i < m_prelaunchWrappers.size(); ++i) {
             auto *candidate = m_prelaunchWrappers[i];
             if (candidate->appId() == targetAppId) {
-                qCDebug(treelandShell) << "match prelaunch xwayland" << targetAppId;
+                qCDebug(lcTlShell) << "match prelaunch xwayland" << targetAppId;
                 m_prelaunchWrappers.removeAt(i);
                 candidate->convertToNormalSurface(surface, SurfaceWrapper::Type::XWayland);
                 wrapper = candidate;
@@ -758,11 +758,11 @@ void ShellHandler::setupSurfaceActiveWatcher(SurfaceWrapper *wrapper)
                 parent = parent->parentSurface();
             }
             if (!parent) {
-                qCCritical(treelandShell) << "A new popup without toplevel parent!";
+                qCCritical(lcTlShell) << "A new popup without toplevel parent!";
                 return;
             }
             if (!parent->showOnWorkspace(m_workspace->current()->id())) {
-                qCWarning(treelandShell)
+                qCWarning(lcTlShell)
                     << "A popup active, but it's parent not in current workspace!";
                 return;
             }
@@ -834,7 +834,7 @@ void ShellHandler::setupSurfaceActiveWatcher(SurfaceWrapper *wrapper)
 void ShellHandler::onLayerSurfaceAdded(WLayerSurface *surface)
 {
     if (!surface->output() && !m_rootSurfaceContainer->primaryOutput()) {
-        qCWarning(treelandShell) << "No output, will close layer surface!";
+        qCWarning(lcTlShell) << "No output, will close layer surface!";
         surface->closed();
         return;
     }
@@ -858,7 +858,7 @@ void ShellHandler::onLayerSurfaceRemoved(WLayerSurface *surface)
 {
     auto wrapper = m_rootSurfaceContainer->getSurface(surface->surface());
     if (!wrapper) {
-        qCWarning(treelandShell) << "A layerSurface that not in any Container is removing!";
+        qCWarning(lcTlShell) << "A layerSurface that not in any Container is removing!";
         return;
     }
     Q_EMIT surfaceWrapperAboutToRemove(wrapper);

--- a/src/core/treeland.cpp
+++ b/src/core/treeland.cpp
@@ -116,12 +116,12 @@ public:
             helper->qmlEngine()->singletonInstance<UserModel *>("Treeland", "UserModel");
         auto user = userModel->getUser(uid);
         if (!user) {
-            qCWarning(treelandDBus) << "user " << uid << " has been added but couldn't find it.";
+            qCWarning(lcTlDBus) << "user " << uid << " has been added but couldn't find it.";
             return;
         }
 
         auto locale = user->locale();
-        qCInfo(treelandDBus) << "current locale:" << locale.language();
+        qCInfo(lcTlDBus) << "current locale:" << locale.language();
 
         do {
             auto *newTrans = new QTranslator{ this };
@@ -137,7 +137,7 @@ public:
                 break;
             }
             newTrans->deleteLater();
-            qCWarning(treelandDBus) << "failed to load new translator";
+            qCWarning(lcTlDBus) << "failed to load new translator";
         } while (false);
     }
 
@@ -151,7 +151,7 @@ public:
         }
 
         auto locale = userModel->currentUser()->locale();
-        qCInfo(treelandDBus) << "current locale:" << locale.language();
+        qCInfo(lcTlDBus) << "current locale:" << locale.language();
         QTranslator *newTrans = new QTranslator;
 
         if (newTrans->load(locale, scope, ".", TREELAND_COMPONENTS_TRANSLATION_DIR, ".qm")) {
@@ -167,7 +167,7 @@ public:
             QCoreApplication::installTranslator(pluginTs[plugin]);
             qmlEngine->retranslate();
         } else {
-            qCWarning(treelandDBus) << "failed to load plugin translator: " << scope;
+            qCWarning(lcTlDBus) << "failed to load plugin translator: " << scope;
         }
     }
 #endif
@@ -185,22 +185,22 @@ public:
         const QStringList pluginFiles = pluginsDir.entryList(QDir::Files | QDir::NoDotAndDotDot);
         for (const QString &pluginFile : pluginFiles) {
             QString filePath = pluginsDir.absoluteFilePath(pluginFile);
-            qCDebug(treelandPlugin) << "Attempting to load plugin:" << filePath;
+            qCDebug(lcTlPlugin) << "Attempting to load plugin:" << filePath;
 
             QPluginLoader loader(filePath);
             QObject *pluginInstance = loader.instance();
 
             if (!pluginInstance) {
-                qCWarning(treelandPlugin) << "Failed to load plugin:" << loader.errorString();
+                qCWarning(lcTlPlugin) << "Failed to load plugin:" << loader.errorString();
                 continue;
             }
 
             PluginInterface *plugin = qobject_cast<PluginInterface *>(pluginInstance);
             if (!plugin) {
-                qCWarning(treelandPlugin) << "Plugin does not implement PluginInterface.";
+                qCWarning(lcTlPlugin) << "Plugin does not implement PluginInterface.";
             }
 
-            qCDebug(treelandPlugin) << "Loaded plugin: " << plugin->name()
+            qCDebug(lcTlPlugin) << "Loaded plugin: " << plugin->name()
                              << ", enabled: " << plugin->enabled()
                              << ", metadata: " << loader.metaData();
             // TODO: use scheduler to run
@@ -210,7 +210,7 @@ public:
             const QString scope{
                 loader.metaData().value("MetaData").toObject().value("translate").toString()
             };
-            qCDebug(treelandPlugin) << "Plugin translate scope:" << scope;
+            qCDebug(lcTlPlugin) << "Plugin translate scope:" << scope;
 
 #ifndef DISABLE_DDM
             connect(helper->qmlEngine()->singletonInstance<UserModel *>("Treeland", "UserModel"),
@@ -224,7 +224,7 @@ public:
 #endif
 
             if (auto *multitaskview = qobject_cast<IMultitaskView *>(pluginInstance)) {
-                qCDebug(treelandPlugin) << "Get MultitaskView Instance.";
+                qCDebug(lcTlPlugin) << "Get MultitaskView Instance.";
                 connect(pluginInstance, &QObject::destroyed, this, [this] {
                     helper->setMultitaskViewImpl(nullptr);
                 });
@@ -233,7 +233,7 @@ public:
 
 #if !defined(DISABLE_DDM) || defined(EXT_SESSION_LOCK_V1)
             if (auto *lockscreen = qobject_cast<ILockScreen *>(pluginInstance)) {
-                qCDebug(treelandPlugin) << "Get LockScreen Instance.";
+                qCDebug(lcTlPlugin) << "Get LockScreen Instance.";
                 connect(pluginInstance, &QObject::destroyed, this, [this] {
                     helper->setLockScreenImpl(nullptr);
                 });
@@ -318,7 +318,7 @@ Treeland::Treeland()
 
     if (CmdLine::ref().run().has_value()) {
         auto exec = [runCmd = CmdLine::ref().run().value(), d, globalSession] {
-            qCInfo(treelandDBus) << "run cmd:" << runCmd;
+            qCInfo(lcTlDBus) << "run cmd:" << runCmd;
             if (auto cmdline = CmdLine::ref().unescapeExecArgs(runCmd); cmdline) {
                 auto cmdArgs = cmdline.value();
 
@@ -367,7 +367,7 @@ Treeland::Treeland()
     if (dir.exists() && dir.isReadable()) {
         d->loadPlugin(QStringLiteral(TREELAND_PLUGINS_OUTPUT_PATH));
     } else {
-        qCInfo(treelandPlugin) << "The Treeland plugin build directory is inaccessible, "
+        qCInfo(lcTlPlugin) << "The Treeland plugin build directory is inaccessible, "
                                    "falling back to the installation directory";
         d->loadPlugin(QStringLiteral(TREELAND_PLUGINS_INSTALL_PATH));
     }

--- a/src/core/windowconfigstore.cpp
+++ b/src/core/windowconfigstore.cpp
@@ -33,18 +33,18 @@ AppConfig *WindowConfigStore::configForApp(const QString &appId) const
 void WindowConfigStore::saveLastSize(const QString &appId, const QSize &size)
 {
     if (appId.isEmpty() || !size.isValid()) {
-        qCWarning(treelandCore) << "WindowConfigStore: saveLastSize invalid parameters for" << appId
+        qCWarning(lcTlCore) << "WindowConfigStore: saveLastSize invalid parameters for" << appId
                                 << size;
         return;
     }
 
     auto *config = configForApp(appId);
     if (!config) {
-        qCWarning(treelandCore) << "WindowConfigStore: saveLastSize no config for" << appId;
+        qCWarning(lcTlCore) << "WindowConfigStore: saveLastSize no config for" << appId;
         return;
     }
 
-    qCDebug(treelandCore) << "WindowConfigStore: save size for" << appId << "as" << size;
+    qCDebug(lcTlCore) << "WindowConfigStore: save size for" << appId << "as" << size;
     config->setLastWindowWidth(size.width());
     config->setLastWindowHeight(size.height());
 }
@@ -59,7 +59,7 @@ void WindowConfigStore::withSplashConfigFor(const QString &appId,
 {
     Q_ASSERT_X(callback, Q_FUNC_INFO, "callback must be provided");
     Q_ASSERT_X(skipCallback, Q_FUNC_INFO, "skipCallback must be provided");
-    qCDebug(treelandCore) << "WindowConfigStore: withSplashConfigFor requested for" << appId;
+    qCDebug(lcTlCore) << "WindowConfigStore: withSplashConfigFor requested for" << appId;
     auto *config = configForApp(appId);
     if (!config) {
         skipCallback();
@@ -74,7 +74,7 @@ void WindowConfigStore::withSplashConfigFor(const QString &appId,
             skipCallback();
             return;
         }
-        qCDebug(treelandCore) << "WindowConfigStore: configInitializeSucceeded for" << appId
+        qCDebug(lcTlCore) << "WindowConfigStore: configInitializeSucceeded for" << appId
                               << config->lastWindowWidth() << config->lastWindowHeight();
         const QSize size(static_cast<int>(config->lastWindowWidth()),
                          static_cast<int>(config->lastWindowHeight()));
@@ -87,7 +87,7 @@ void WindowConfigStore::withSplashConfigFor(const QString &appId,
     }
 
     if (config->isInitializeFailed()) {
-        qCWarning(treelandCore) << "WindowConfigStore: configInitializeFailed for" << appId;
+        qCWarning(lcTlCore) << "WindowConfigStore: configInitializeFailed for" << appId;
         skipCallback();
         return;
     }
@@ -100,7 +100,7 @@ void WindowConfigStore::withSplashConfigFor(const QString &appId,
         ctx,
         [appId, callback, skipCallback, configGuard](DTK_CORE_NAMESPACE::DConfig *) {
             if (!configGuard) {
-                qCWarning(treelandCore)
+                qCWarning(lcTlCore)
                     << "WindowConfigStore: configInitializeSucceed but config deleted for" << appId;
                 skipCallback();
                 return;
@@ -111,7 +111,7 @@ void WindowConfigStore::withSplashConfigFor(const QString &appId,
                 return;
             }
 
-            qCDebug(treelandCore) << "WindowConfigStore: configInitializeSucceed for" << appId
+            qCDebug(lcTlCore) << "WindowConfigStore: configInitializeSucceed for" << appId
                                   << configGuard->lastWindowWidth()
                                   << configGuard->lastWindowHeight();
             const QSize size(static_cast<int>(configGuard->lastWindowWidth()),
@@ -128,7 +128,7 @@ void WindowConfigStore::withSplashConfigFor(const QString &appId,
         &AppConfig::configInitializeFailed,
         ctx,
         [skipCallback]() {
-            qCCritical(treelandCore) << "WindowConfigStore: configInitializeFailed callback";
+            qCCritical(lcTlCore) << "WindowConfigStore: configInitializeFailed callback";
             skipCallback();
         },
         Qt::SingleShotConnection);

--- a/src/effects/tquickradiuseffect.cpp
+++ b/src/effects/tquickradiuseffect.cpp
@@ -292,7 +292,7 @@ void TQuickRadiusEffect::setSourceItem(QQuickItem *item)
                     this,
                     SLOT(sourceItemDestroyed(QObject *)));
         } else {
-            qCWarning(treelandEffect) << "TRadiusEffect: sourceItem and TRadiusEffect must both be "
+            qCWarning(lcTlEffect) << "TRadiusEffect: sourceItem and TRadiusEffect must both be "
                                     "children of the "
                                     "same window.";
             d->sourceItem = nullptr;

--- a/src/greeter/greeterproxy.cpp
+++ b/src/greeter/greeterproxy.cpp
@@ -185,7 +185,7 @@ void GreeterProxy::hybridSleep()
 void GreeterProxy::login(const QString &user, const QString &password, const int sessionIndex)
 {
     if (!m_socket->isValid()) {
-        qCDebug(treelandGreeter) << "Socket is not valid. Local password check.";
+        qCDebug(lcTlGreeter) << "Socket is not valid. Local password check.";
         if (localValidation(user, password)) {
             setLock(false);
         } else {
@@ -201,7 +201,7 @@ void GreeterProxy::login(const QString &user, const QString &password, const int
     DDM::Session::Type type =
         static_cast<DDM::Session::Type>(sessionModel()->data(index, SessionModel::TypeRole).toInt());
     QString name = sessionModel()->data(index, SessionModel::FileRole).toString();
-    qCInfo(treelandGreeter) << "Logging user" << user << "in with" << type << "session" << name;
+    qCInfo(lcTlGreeter) << "Logging user" << user << "in with" << type << "session" << name;
     DDM::Session session(type, name);
     SocketWriter(m_socket) << quint32(GreeterMessages::Login) << user << password << session;
 }
@@ -209,7 +209,7 @@ void GreeterProxy::login(const QString &user, const QString &password, const int
 void GreeterProxy::unlock(const QString &user, const QString &password)
 {
     if (!m_socket->isValid()) {
-        qCDebug(treelandGreeter) << "Socket is not valid. Local password check.";
+        qCDebug(lcTlGreeter) << "Socket is not valid. Local password check.";
         if (localValidation(user, password)) {
             setLock(false);
         } else {
@@ -220,7 +220,7 @@ void GreeterProxy::unlock(const QString &user, const QString &password)
 
     auto userInfo = userModel()->get(user);
     if (userInfo.isValid()) {
-        qCInfo(treelandGreeter) << "Unlocking user" << user;
+        qCInfo(lcTlGreeter) << "Unlocking user" << user;
         SocketWriter(m_socket) << quint32(GreeterMessages::Unlock) << user << password;
     }
 }
@@ -228,7 +228,7 @@ void GreeterProxy::unlock(const QString &user, const QString &password)
 void GreeterProxy::logout()
 {
     auto session = Helper::instance()->sessionManager()->activeSession().lock();
-    qCInfo(treelandGreeter) << "Logging user" << session->username() << "out with session id" << session->id();
+    qCInfo(lcTlGreeter) << "Logging user" << session->username() << "out with session id" << session->id();
     SocketWriter(m_socket) << quint32(GreeterMessages::Logout) << session->id();
 }
 
@@ -236,11 +236,11 @@ void GreeterProxy::lock()
 {
     auto session = Helper::instance()->sessionManager()->activeSession().lock();
     if (!session || session->username() == "dde") {
-        qCInfo(treelandGreeter) << "Trying to lock when no user session active, show lockscreen directly.";
+        qCInfo(lcTlGreeter) << "Trying to lock when no user session active, show lockscreen directly.";
         setLock(true);
         return;
     }
-    qCInfo(treelandGreeter) << "Locking user" << session->username() << "with session id" << session->id();
+    qCInfo(lcTlGreeter) << "Locking user" << session->username() << "with session id" << session->id();
     SocketWriter(m_socket) << quint32(GreeterMessages::Lock) << session->id();
 }
 
@@ -261,17 +261,17 @@ void GreeterProxy::onSessionNew(const QString &id, [[maybe_unused]] const QDBusO
             free(service);
     });
     if (sd_session_get_username(session, &username) < 0) {
-        qCWarning(treelandGreeter) << "sd_session_get_username() failed for session id:" << id;
+        qCWarning(lcTlGreeter) << "sd_session_get_username() failed for session id:" << id;
         return;
     }
     if (sd_session_get_service(session, &service) < 0) {
-        qCWarning(treelandGreeter) << "sd_session_get_service() failed for session id:" << id;
+        qCWarning(lcTlGreeter) << "sd_session_get_service() failed for session id:" << id;
         return;
     }
 
     if (strcmp(service, "ddm") == 0) {
         QString user = QString::fromLocal8Bit(username);
-        qCInfo(treelandGreeter) << "New session added: id=" << id << ", user=" << user;
+        qCInfo(lcTlGreeter) << "New session added: id=" << id << ", user=" << user;
         userModel()->updateUserLoginState(user, true);
         // userLoggedIn signal is connected with Helper::updateActiveUserSession
         Q_EMIT userModel()->userLoggedIn(user, id.toInt());
@@ -320,7 +320,7 @@ void GreeterProxy::onSessionRemoved(const QString &id, [[maybe_unused]] const QD
     auto session = Helper::instance()->sessionManager()->sessionForId(id.toInt());
     if (session) {
         QString username = session->username();
-        qCInfo(treelandGreeter) << "Session removed: id=" << id << ", user=" << username;
+        qCInfo(lcTlGreeter) << "Session removed: id=" << id << ", user=" << username;
         if (Helper::instance()->sessionManager()->activeSession().lock() == session)
             setLock(true);
         userModel()->updateUserLoginState(username, false);
@@ -341,13 +341,13 @@ void GreeterProxy::onSessionLock()
                                                      path,
                                                      QDBusConnection::systemBus());
         int id = session.id().toInt();
-        qCInfo(treelandGreeter) << "Lock signal received for session id:" << id;
+        qCInfo(lcTlGreeter) << "Lock signal received for session id:" << id;
         auto activeSession = Helper::instance()->sessionManager()->activeSession().lock();
         if (!activeSession)
-            qCWarning(treelandGreeter)
+            qCWarning(lcTlGreeter)
                 << "Lock signal received for non-exist session id:" << id << ", ignore.";
         else if (activeSession->id() != id)
-            qCWarning(treelandGreeter)
+            qCWarning(lcTlGreeter)
                 << "Lock signal received for non-active session id:" << id << ", ignore.";
         else
             QMetaObject::invokeMethod(this, [this] {
@@ -365,13 +365,13 @@ void GreeterProxy::onSessionUnlock()
                                                      QDBusConnection::systemBus());
         int id = session.id().toInt();
         const QString username = session.name();
-        qCInfo(treelandGreeter) << "Unlock signal received for session id:" << id;
+        qCInfo(lcTlGreeter) << "Unlock signal received for session id:" << id;
         auto activeSession = Helper::instance()->sessionManager()->activeSession().lock();
         if (!activeSession) {
-            qCWarning(treelandGreeter)
+            qCWarning(lcTlGreeter)
                 << "Unlock signal received for non-exist session id:" << id << ", ignore.";
         } else if (activeSession->id() != id) {
-            qCWarning(treelandGreeter)
+            qCWarning(lcTlGreeter)
                 << "Unlock signal received for non-active session id:" << id << ", lock it back.";
             QMetaObject::invokeMethod(this, [this, id] {
                 SocketWriter(m_socket) << quint32(GreeterMessages::Lock) << QString::number(id);
@@ -395,7 +395,7 @@ bool GreeterProxy::isConnected() const
 
 void GreeterProxy::connected()
 {
-    qCInfo(treelandGreeter) << "Connected to the ddm";
+    qCInfo(lcTlGreeter) << "Connected to the ddm";
 
     SocketWriter(m_socket)
         << quint32(GreeterMessages::Connect)
@@ -404,14 +404,14 @@ void GreeterProxy::connected()
 
 void GreeterProxy::disconnected()
 {
-    qCWarning(treelandGreeter) << "Disconnected from the ddm";
+    qCWarning(lcTlGreeter) << "Disconnected from the ddm";
 
     Q_EMIT socketDisconnected();
 }
 
 void GreeterProxy::error()
 {
-    qCCritical(treelandGreeter) << "Socket error: " << m_socket->errorString();
+    qCCritical(lcTlGreeter) << "Socket error: " << m_socket->errorString();
 }
 
 void GreeterProxy::readyRead()
@@ -427,7 +427,7 @@ void GreeterProxy::readyRead()
         switch (DaemonMessages(message)) {
         case DaemonMessages::Capabilities: {
             // log message
-            qCDebug(treelandGreeter) << "Message received from daemon: Capabilities";
+            qCDebug(lcTlGreeter) << "Message received from daemon: Capabilities";
 
             // read capabilities
             quint32 capabilities;
@@ -448,7 +448,7 @@ void GreeterProxy::readyRead()
             Q_EMIT canHybridSleepChanged(m_canHybridSleep);
         } break;
         case DaemonMessages::HostName: {
-            qCDebug(treelandGreeter) << "Message received from daemon: HostName";
+            qCDebug(lcTlGreeter) << "Message received from daemon: HostName";
 
             // read host name
             input >> m_hostName;
@@ -460,7 +460,7 @@ void GreeterProxy::readyRead()
             QString user;
             input >> user;
 
-            qCDebug(treelandGreeter) << "Message received from daemon: LoginFailed" << user;
+            qCDebug(lcTlGreeter) << "Message received from daemon: LoginFailed" << user;
 
             Q_EMIT failedAttemptsChanged(++m_failedAttempts);
         } break;
@@ -468,11 +468,11 @@ void GreeterProxy::readyRead()
             QString message;
             input >> message;
 
-            qCDebug(treelandGreeter) << "Information Message received from daemon: " << message;
+            qCDebug(lcTlGreeter) << "Information Message received from daemon: " << message;
             Q_EMIT informationMessage(message);
         } break;
         case DaemonMessages::SwitchToGreeter: {
-            qCInfo(treelandGreeter) << "switch to greeter";
+            qCInfo(lcTlGreeter) << "switch to greeter";
             lock();
         } break;
         case DaemonMessages::UserActivateMessage: {
@@ -482,14 +482,14 @@ void GreeterProxy::readyRead()
 
             // NOTE: maybe DDM will active dde user.
             if (!userModel()->getUser(user)) {
-                qCInfo(treelandGreeter) << "activate user, but switch to greeter";
+                qCInfo(lcTlGreeter) << "activate user, but switch to greeter";
                 lock();
                 break;
             }
 
             userModel()->setCurrentUserName(user);
 
-            qCInfo(treelandGreeter) << "activate successfully: " << user << ", XDG_SESSION_ID: " << sessionId;
+            qCInfo(lcTlGreeter) << "activate successfully: " << user << ", XDG_SESSION_ID: " << sessionId;
         } break;
         case DaemonMessages::UserLoggedIn: {
             QString user;
@@ -497,7 +497,7 @@ void GreeterProxy::readyRead()
             input >> user >> sessionId;
 
             // This will happen after a crash recovery of treeland
-            qCInfo(treelandGreeter) << "User " << user << " is already logged in";
+            qCInfo(lcTlGreeter) << "User " << user << " is already logged in";
             auto userPtr = userModel()->getUser(user);
             if (userPtr) {
                 userModel()->updateUserLoginState(user, true);
@@ -511,7 +511,7 @@ void GreeterProxy::readyRead()
                     auto reply = manager.GetSession(QString::number(sessionId));
                     reply.waitForFinished();
                     if (!reply.isValid()) {
-                        qCWarning(treelandGreeter) << "Failed to get session path for session id:" << sessionId << ", error:" << reply.error().message();
+                        qCWarning(lcTlGreeter) << "Failed to get session path for session id:" << sessionId << ", error:" << reply.error().message();
                         return;
                     }
                     auto path = reply.value();
@@ -529,11 +529,11 @@ void GreeterProxy::readyRead()
                                  SLOT(onSessionUnlock()));
                 });
             } else {
-                qCWarning(treelandGreeter) << "User " << user << " logged in but not found";
+                qCWarning(lcTlGreeter) << "User " << user << " logged in but not found";
             }
         } break;
         default: {
-            qCWarning(treelandGreeter) << "Unknown message received from daemon." << message;
+            qCWarning(lcTlGreeter) << "Unknown message received from daemon." << message;
         }
         }
     }
@@ -548,7 +548,7 @@ void GreeterProxy::updateAuthSocket()
                                QDBusConnection::systemBus());
         QDBusReply<QString> reply = manager.call("AuthInfo");
         if (!reply.isValid()) {
-            qCWarning(treelandGreeter) << "Failed to get auth info from display manager:" << reply.error().message();
+            qCWarning(lcTlGreeter) << "Failed to get auth info from display manager:" << reply.error().message();
             return;
         }
         const QString &socket = reply.value();

--- a/src/greeter/user.cpp
+++ b/src/greeter/user.cpp
@@ -48,7 +48,7 @@ User::User(AccountsUserPtr ptr)
     d->inter = std::move(ptr);
 
     if (!d->inter) {
-        qCFatal(treelandGreeter) << "connect to AccountService Failed";
+        qCFatal(lcTlGreeter) << "connect to AccountService Failed";
     }
 
     connect(d->inter.data(), &DAccountsUser::userDataChanged, [this] {
@@ -162,7 +162,7 @@ QString User::toString(AccountTypes type) noexcept
     case AccountTypes::Default:
         return tr("Standard User");
     default:
-        qCWarning(treelandGreeter) << "ignore other types.";
+        qCWarning(lcTlGreeter) << "ignore other types.";
     }
 
     return {};

--- a/src/greeter/usermodel.cpp
+++ b/src/greeter/usermodel.cpp
@@ -64,12 +64,12 @@ UserModel::UserModel(QObject *parent)
     connect(this, &UserModel::currentUserNameChanged, [this] {
         auto user = getUser(d->currentUserName);
         if (!user) {
-            qCWarning(treelandGreeter) << "Couldn't find user:" << d->currentUserName;
+            qCWarning(lcTlGreeter) << "Couldn't find user:" << d->currentUserName;
             return;
         }
 
         auto locale = user->locale();
-        qCInfo(treelandGreeter) << "Current locale:" << locale.language();
+        qCInfo(lcTlGreeter) << "Current locale:" << locale.language();
         auto *newTrans = new QTranslator{ this };
         auto dirs = QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation);
         for (const auto &dir : dirs) {
@@ -88,7 +88,7 @@ UserModel::UserModel(QObject *parent)
         }
 
         newTrans->deleteLater();
-        qCWarning(treelandGreeter) << "Failed to load new translator under" << dirs.last();
+        qCWarning(lcTlGreeter) << "Failed to load new translator under" << dirs.last();
     });
 
     auto userList = d->manager.userList();
@@ -100,7 +100,7 @@ UserModel::UserModel(QObject *parent)
     for (auto uid : uids) {
         auto user = d->manager.findUserById(uid);
         if (!user) {
-            qCWarning(treelandGreeter) << "Failed to find user by ID:" << user.error();
+            qCWarning(lcTlGreeter) << "Failed to find user by ID:" << user.error();
             continue;
         }
 
@@ -125,7 +125,7 @@ UserModel::UserModel(QObject *parent)
     }
 
     if (d->currentUserName.isEmpty()) {
-        qCWarning(treelandGreeter) << "Couldn't find last user, using current running user as current user";
+        qCWarning(lcTlGreeter) << "Couldn't find last user, using current running user as current user";
         d->currentUserName = d->users.first()->userName();
     }
 }
@@ -329,7 +329,7 @@ void UserModel::onUserAdded(quint64 uid)
 {
     auto newUser = d->manager.findUserById(uid);
     if (!newUser) {
-        qCWarning(treelandGreeter) << "User" << uid << "has been added but couldn't find it.";
+        qCWarning(lcTlGreeter) << "User" << uid << "has been added but couldn't find it.";
         return;
     }
 
@@ -368,7 +368,7 @@ bool UserModel::tryAddNssUser(const QString &userName)
     bool found = std::any_of(d->users.cbegin(), d->users.cend(),
                              [&userName](const UserPtr &u) { return u->userName() == userName; });
     if (found) {
-        qCInfo(treelandGreeter) << "NSS user already in model:" << userName;
+        qCInfo(lcTlGreeter) << "NSS user already in model:" << userName;
         return true;
     }
 
@@ -376,14 +376,14 @@ bool UserModel::tryAddNssUser(const QString &userName)
     // consider moving to an async worker thread in a future iteration.
     struct passwd *pw = ::getpwnam(userName.toLocal8Bit().constData());
     if (!pw) {
-        qCInfo(treelandGreeter) << "NSS user not found:" << userName;
+        qCInfo(lcTlGreeter) << "NSS user not found:" << userName;
         return false;
     }
 
     // pw_gecos is comma-separated ("Full Name,Room,Work,Home,Other"); use only the first field.
     QString fullName = QString::fromLocal8Bit(pw->pw_gecos).section(QLatin1Char(','), 0, 0);
 
-    qCInfo(treelandGreeter) << "Adding NSS/LDAP user to model:" << userName;
+    qCInfo(lcTlGreeter) << "Adding NSS/LDAP user to model:" << userName;
     beginResetModel();
     d->users.emplace_back(std::make_unique<User>(
         userName,

--- a/src/input/gestures.cpp
+++ b/src/input/gestures.cpp
@@ -1,16 +1,13 @@
-// Copyright (C) 2024-2025 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "gestures.h"
 #include "common/treelandlogging.h"
 
-#include <QLoggingCategory>
 #include <QRect>
 
 // The minimum delta required to recognize a swipe gesture
 #define SWIPE_MINIMUM_DELTA 5
-
-Q_LOGGING_CATEGORY(qLcGestures, "treeland.gestures");
 
 Gesture::Gesture(QObject *parent)
     : QObject(parent)
@@ -245,7 +242,7 @@ void GestureRecognizer::updateSwipeGesture(const QPointF &delta)
         direction = m_currentDelta.x() < 0 ? SwipeGesture::Left : SwipeGesture::Right;
         break;
     default:
-        qCWarning(qLcGestures) << "Invalid swipe axis";
+        qCWarning(lcTlGestures) << "Invalid swipe axis";
         return;
     }
 
@@ -350,7 +347,7 @@ int GestureRecognizer::startSwipeGesture(uint fingerCount,
             }
             break;
         case SwipeGesture::Invalid:
-            qCWarning(qLcGestures) << "Invalid swipe direction";
+            qCWarning(lcTlGestures) << "Invalid swipe direction";
             continue;
         }
 

--- a/src/input/inputdevice.cpp
+++ b/src/input/inputdevice.cpp
@@ -20,7 +20,7 @@ QW_USE_NAMESPACE
 static bool ensureStatus(libinput_config_status status)
 {
     if (status != LIBINPUT_CONFIG_STATUS_SUCCESS) {
-        qCCritical(treelandInput) << "Failed to apply libinput config: "
+        qCCritical(lcTlInput) << "Failed to apply libinput config: "
                                 << libinput_config_status_to_str(status);
         return false;
     }
@@ -34,7 +34,7 @@ bool configSendEventsMode(libinput_device *device, uint32_t mode)
         return false;
     }
 
-    qCDebug(treelandInput) << "libinput_device_config_send_events_set_mode " << mode;
+    qCDebug(lcTlInput) << "libinput_device_config_send_events_set_mode " << mode;
     enum libinput_config_status status = libinput_device_config_send_events_set_mode(device, mode);
 
     return ensureStatus(status);
@@ -43,7 +43,7 @@ bool configSendEventsMode(libinput_device *device, uint32_t mode)
 bool configTapEnabled(libinput_device *device, libinput_config_tap_state tap)
 {
     if (libinput_device_config_tap_get_finger_count(device) <= 0) {
-        qCCritical(treelandInput) << "libinput_device_config_tap_set_enabled is invalid";
+        qCCritical(lcTlInput) << "libinput_device_config_tap_set_enabled is invalid";
 
         return false;
     }
@@ -52,7 +52,7 @@ bool configTapEnabled(libinput_device *device, libinput_config_tap_state tap)
         return false;
     }
 
-    qCDebug(treelandInput) << "libinput_device_config_tap_set_enabled: " << tap;
+    qCDebug(lcTlInput) << "libinput_device_config_tap_set_enabled: " << tap;
     enum libinput_config_status status = libinput_device_config_tap_set_enabled(device, tap);
 
     return ensureStatus(status);
@@ -61,7 +61,7 @@ bool configTapEnabled(libinput_device *device, libinput_config_tap_state tap)
 [[maybe_unused]] static bool configTapButtonMap(libinput_device *device, libinput_config_tap_button_map map)
 {
     if (libinput_device_config_tap_get_finger_count(device) <= 0) {
-        qCCritical(treelandInput) << "libinput_device_config_tap_set_button_map is invalid";
+        qCCritical(lcTlInput) << "libinput_device_config_tap_set_button_map is invalid";
 
         return false;
     }
@@ -70,7 +70,7 @@ bool configTapEnabled(libinput_device *device, libinput_config_tap_state tap)
         return false;
     }
 
-    qCDebug(treelandInput) << "libinput_device_config_tap_set_button_map: " << map;
+    qCDebug(lcTlInput) << "libinput_device_config_tap_set_button_map: " << map;
     enum libinput_config_status status = libinput_device_config_tap_set_button_map(device, map);
 
     return ensureStatus(status);
@@ -79,7 +79,7 @@ bool configTapEnabled(libinput_device *device, libinput_config_tap_state tap)
 [[maybe_unused]] static bool configTapDragEnabled(libinput_device *device, libinput_config_drag_state drag)
 {
     if (libinput_device_config_tap_get_finger_count(device) <= 0) {
-        qCCritical(treelandInput) << "libinput_device_config_tap_set_drag_enabled is invalid";
+        qCCritical(lcTlInput) << "libinput_device_config_tap_set_drag_enabled is invalid";
 
         return false;
     }
@@ -88,7 +88,7 @@ bool configTapEnabled(libinput_device *device, libinput_config_tap_state tap)
         return false;
     }
 
-    qCDebug(treelandInput) << "libinput_device_config_tap_set_drag_enabled: " << drag;
+    qCDebug(lcTlInput) << "libinput_device_config_tap_set_drag_enabled: " << drag;
     enum libinput_config_status status = libinput_device_config_tap_set_drag_enabled(device, drag);
 
     return ensureStatus(status);
@@ -97,7 +97,7 @@ bool configTapEnabled(libinput_device *device, libinput_config_tap_state tap)
 [[maybe_unused]] static bool configTapDragLockEnabled(libinput_device *device, libinput_config_drag_lock_state lock)
 {
     if (libinput_device_config_tap_get_finger_count(device) <= 0) {
-        qCCritical(treelandInput) << "libinput_device_config_tap_set_drag_enabled is invalid";
+        qCCritical(lcTlInput) << "libinput_device_config_tap_set_drag_enabled is invalid";
 
         return false;
     }
@@ -106,7 +106,7 @@ bool configTapEnabled(libinput_device *device, libinput_config_tap_state tap)
         return false;
     }
 
-    qCDebug(treelandInput) << "libinput_device_config_tap_set_drag_lock_enabled: " << lock;
+    qCDebug(lcTlInput) << "libinput_device_config_tap_set_drag_lock_enabled: " << lock;
     enum libinput_config_status status =
         libinput_device_config_tap_set_drag_lock_enabled(device, lock);
 
@@ -116,7 +116,7 @@ bool configTapEnabled(libinput_device *device, libinput_config_tap_state tap)
 bool configAccelSpeed(libinput_device *device, double speed)
 {
     if (!libinput_device_config_accel_is_available(device)) {
-        qCCritical(treelandInput) << "libinput_device_config_accel_set_speed is invalid";
+        qCCritical(lcTlInput) << "libinput_device_config_accel_set_speed is invalid";
 
         return false;
     }
@@ -125,7 +125,7 @@ bool configAccelSpeed(libinput_device *device, double speed)
         return false;
     }
 
-    qCDebug(treelandInput) << "libinput_device_config_accel_set_speed: " << speed;
+    qCDebug(lcTlInput) << "libinput_device_config_accel_set_speed: " << speed;
     enum libinput_config_status status = libinput_device_config_accel_set_speed(device, speed);
 
     return ensureStatus(status);
@@ -134,7 +134,7 @@ bool configAccelSpeed(libinput_device *device, double speed)
 [[maybe_unused]] static bool configRotationAngle(libinput_device *device, double angle)
 {
     if (!libinput_device_config_rotation_is_available(device)) {
-        qCCritical(treelandInput) << "libinput_device_config_rotation_set_angle is invalid";
+        qCCritical(lcTlInput) << "libinput_device_config_rotation_set_angle is invalid";
 
         return false;
     }
@@ -143,7 +143,7 @@ bool configAccelSpeed(libinput_device *device, double speed)
         return false;
     }
 
-    qCDebug(treelandInput) << "libinput_device_config_rotation_set_angle: " << angle;
+    qCDebug(lcTlInput) << "libinput_device_config_rotation_set_angle: " << angle;
     enum libinput_config_status status = libinput_device_config_rotation_set_angle(device, angle);
 
     return ensureStatus(status);
@@ -152,7 +152,7 @@ bool configAccelSpeed(libinput_device *device, double speed)
 bool configAccelProfile(libinput_device *device, libinput_config_accel_profile profile)
 {
     if (!libinput_device_config_accel_is_available(device)) {
-        qCCritical(treelandInput) << "libinput_device_config_accel_set_profile is invalid";
+        qCCritical(lcTlInput) << "libinput_device_config_accel_set_profile is invalid";
 
         return false;
     }
@@ -161,7 +161,7 @@ bool configAccelProfile(libinput_device *device, libinput_config_accel_profile p
         return false;
     }
 
-    qCDebug(treelandInput) << "libinput_device_config_accel_set_profile: " << profile;
+    qCDebug(lcTlInput) << "libinput_device_config_accel_set_profile: " << profile;
     enum libinput_config_status status = libinput_device_config_accel_set_profile(device, profile);
 
     return ensureStatus(status);
@@ -170,7 +170,7 @@ bool configAccelProfile(libinput_device *device, libinput_config_accel_profile p
 bool configNaturalScroll(libinput_device *device, bool natural)
 {
     if (!libinput_device_config_scroll_has_natural_scroll(device)) {
-        qCCritical(treelandInput) << "libinput_device_config_scroll_set_natural_scroll_enabled is invalid";
+        qCCritical(lcTlInput) << "libinput_device_config_scroll_set_natural_scroll_enabled is invalid";
 
         return false;
     }
@@ -179,7 +179,7 @@ bool configNaturalScroll(libinput_device *device, bool natural)
         return false;
     }
 
-    qCDebug(treelandInput) << "libinput_device_config_scroll_set_natural_scroll_enabled: " << natural;
+    qCDebug(lcTlInput) << "libinput_device_config_scroll_set_natural_scroll_enabled: " << natural;
     enum libinput_config_status status =
         libinput_device_config_scroll_set_natural_scroll_enabled(device, natural);
 
@@ -189,7 +189,7 @@ bool configNaturalScroll(libinput_device *device, bool natural)
 bool configLeftHanded(libinput_device *device, bool left)
 {
     if (!libinput_device_config_left_handed_is_available(device)) {
-        qCCritical(treelandInput) << "libinput_device_config_left_handed_set is invalid";
+        qCCritical(lcTlInput) << "libinput_device_config_left_handed_set is invalid";
 
         return false;
     }
@@ -198,7 +198,7 @@ bool configLeftHanded(libinput_device *device, bool left)
         return false;
     }
 
-    qCDebug(treelandInput) << "libinput_device_config_left_handed_set: " << left;
+    qCDebug(lcTlInput) << "libinput_device_config_left_handed_set: " << left;
     enum libinput_config_status status = libinput_device_config_left_handed_set(device, left);
 
     return ensureStatus(status);
@@ -212,7 +212,7 @@ bool configLeftHanded(libinput_device *device, bool left)
         return false;
     }
 
-    qCDebug(treelandInput) << "libinput_device_config_click_set_method: " << method;
+    qCDebug(lcTlInput) << "libinput_device_config_click_set_method: " << method;
     enum libinput_config_status status = libinput_device_config_click_set_method(device, method);
 
     return ensureStatus(status);
@@ -222,7 +222,7 @@ bool configLeftHanded(libinput_device *device, bool left)
                                   libinput_config_middle_emulation_state mid)
 {
     if (!libinput_device_config_middle_emulation_is_available(device)) {
-        qCCritical(treelandInput) << "libinput_device_config_middle_emulation_set_enabled is invalid";
+        qCCritical(lcTlInput) << "libinput_device_config_middle_emulation_set_enabled is invalid";
 
         return false;
     }
@@ -231,7 +231,7 @@ bool configLeftHanded(libinput_device *device, bool left)
         return false;
     }
 
-    qCDebug(treelandInput) << "libinput_device_config_middle_emulation_set_enabled: " << mid;
+    qCDebug(lcTlInput) << "libinput_device_config_middle_emulation_set_enabled: " << mid;
     enum libinput_config_status status =
         libinput_device_config_middle_emulation_set_enabled(device, mid);
 
@@ -246,7 +246,7 @@ bool configLeftHanded(libinput_device *device, bool left)
         return false;
     }
 
-    qCDebug(treelandInput) << "libinput_device_config_scroll_set_method: " << method;
+    qCDebug(lcTlInput) << "libinput_device_config_scroll_set_method: " << method;
     enum libinput_config_status status = libinput_device_config_scroll_set_method(device, method);
 
     return ensureStatus(status);
@@ -260,7 +260,7 @@ bool configLeftHanded(libinput_device *device, bool left)
         return false;
     }
 
-    qCDebug(treelandInput) << "libinput_device_config_scroll_set_button: " << button;
+    qCDebug(lcTlInput) << "libinput_device_config_scroll_set_button: " << button;
     enum libinput_config_status status = libinput_device_config_scroll_set_button(device, button);
 
     return ensureStatus(status);
@@ -275,7 +275,7 @@ bool configLeftHanded(libinput_device *device, bool left)
         return false;
     }
 
-    qCDebug(treelandInput) << "libinput_device_config_scroll_set_button: " << lock;
+    qCDebug(lcTlInput) << "libinput_device_config_scroll_set_button: " << lock;
     enum libinput_config_status status =
         libinput_device_config_scroll_set_button_lock(device, lock);
 
@@ -285,7 +285,7 @@ bool configLeftHanded(libinput_device *device, bool left)
 bool configDwtEnabled(libinput_device *device, enum libinput_config_dwt_state enable)
 {
     if (!libinput_device_config_dwt_is_available(device)) {
-        qCCritical(treelandInput) << "libinput_device_config_dwt_set_enabled is invalid";
+        qCCritical(lcTlInput) << "libinput_device_config_dwt_set_enabled is invalid";
 
         return false;
     }
@@ -293,7 +293,7 @@ bool configDwtEnabled(libinput_device *device, enum libinput_config_dwt_state en
         return false;
     }
 
-    qCDebug(treelandInput) << "libinput_device_config_dwt_set_enabled: " << enable;
+    qCDebug(lcTlInput) << "libinput_device_config_dwt_set_enabled: " << enable;
     enum libinput_config_status status = libinput_device_config_dwt_set_enabled(device, enable);
 
     return ensureStatus(status);
@@ -302,7 +302,7 @@ bool configDwtEnabled(libinput_device *device, enum libinput_config_dwt_state en
 [[maybe_unused]] static bool configDwtpEnabled(libinput_device *device, enum libinput_config_dwtp_state enable)
 {
     if (!libinput_device_config_dwtp_is_available(device)) {
-        qCCritical(treelandInput) << "libinput_device_config_dwtp_set_enabled is invalid";
+        qCCritical(lcTlInput) << "libinput_device_config_dwtp_set_enabled is invalid";
 
         return false;
     }
@@ -311,7 +311,7 @@ bool configDwtEnabled(libinput_device *device, enum libinput_config_dwt_state en
         return false;
     }
 
-    qCDebug(treelandInput) << "libinput_device_config_dwt_set_enabled: " << enable;
+    qCDebug(lcTlInput) << "libinput_device_config_dwt_set_enabled: " << enable;
     enum libinput_config_status status = libinput_device_config_dwtp_set_enabled(device, enable);
 
     return ensureStatus(status);
@@ -320,7 +320,7 @@ bool configDwtEnabled(libinput_device *device, enum libinput_config_dwt_state en
 [[maybe_unused]] static bool configCalibrationMatrix(libinput_device *device, float mat[])
 {
     if (!libinput_device_config_calibration_has_matrix(device)) {
-        qCCritical(treelandInput) << "setCalibrationMatrix mat is invalid";
+        qCCritical(lcTlInput) << "setCalibrationMatrix mat is invalid";
         return false;
     }
     bool changed = false;
@@ -334,7 +334,7 @@ bool configDwtEnabled(libinput_device *device, enum libinput_config_dwt_state en
         }
     }
     if (changed) {
-        qCDebug(treelandInput,
+        qCDebug(lcTlInput,
                 "libinput_device_config_calibration_set_matrix(%f, %f, %f, %f, "
                 "%f, %f)",
                 mat[0],

--- a/src/modules/activation/activationmanagerinterfacev1.cpp
+++ b/src/modules/activation/activationmanagerinterfacev1.cpp
@@ -135,7 +135,7 @@ public:
         const QString token = QUuid::createUuid().toString(QUuid::WithoutBraces);
         m_tokens.append(TokenInfo{ token, appId, client, serial, fromTrustedSurface,
                                    QDeadlineTimer(TokenLifetimeMs) });
-        qCDebug(treelandActivation) << "Registered activation token" << token.left(8) + u"..."_s
+        qCDebug(lcTlActivation) << "Registered activation token" << token.left(8) + u"..."_s
                                << "for app" << appId
                                << (fromTrustedSurface ? "" : "(inactive-surface-token-request)");
         return token;
@@ -151,7 +151,7 @@ public:
 protected:
     void destroy_global() override
     {
-        qCDebug(treelandActivation) << "treeland_activation_manager_v1 global destroyed";
+        qCDebug(lcTlActivation) << "treeland_activation_manager_v1 global destroyed";
     }
 
     void destroy(Resource *resource) override
@@ -181,18 +181,18 @@ protected:
 
         auto *wlrSurface = wlr_surface_from_resource(surface);
         if (!wlrSurface) {
-            qCWarning(treelandActivation) << "activate: invalid surface resource";
+            qCWarning(lcTlActivation) << "activate: invalid surface resource";
             return;
         }
 
         auto *wsurface = WSurface::fromHandle(wlrSurface);
         if (!wsurface) {
-            qCWarning(treelandActivation) << "activate: no WSurface for wlr_surface";
+            qCWarning(lcTlActivation) << "activate: no WSurface for wlr_surface";
             return;
         }
 
         auto disposition = dispositionForToken(token);
-        qCInfo(treelandActivation) << "activate: emitting activateRequested for token" << token.left(8) + u"..."_s
+        qCInfo(lcTlActivation) << "activate: emitting activateRequested for token" << token.left(8) + u"..."_s
                              << "with disposition" << disposition;
         // Keep token one-shot semantics; Helper performs the policy check.
         auto it = std::find_if(m_tokens.begin(), m_tokens.end(),
@@ -229,7 +229,7 @@ private:
         auto it = m_tokens.begin();
         while (it != m_tokens.end()) {
             if (it->expiry.hasExpired()) {
-                qCDebug(treelandActivation) << "Sweeping expired token for app" << it->appId;
+                qCDebug(lcTlActivation) << "Sweeping expired token for app" << it->appId;
                 it = m_tokens.erase(it);
             } else {
                 ++it;

--- a/src/modules/app-id-resolver/appidresolver.cpp
+++ b/src/modules/app-id-resolver/appidresolver.cpp
@@ -3,6 +3,7 @@
 
 #include "appidresolver.h"
 
+#include "common/treelandlogging.h"
 #include "qwayland-server-treeland-app-id-resolver-v1.h"
 
 #include <wserver.h>
@@ -10,13 +11,10 @@
 #include <qwdisplay.h>
 
 #include <QHash>
-#include <QLoggingCategory>
 
 #include <fcntl.h>
 #include <unistd.h>
 #include <utility>
-
-Q_LOGGING_CATEGORY(treelandAppIdResolver, "treeland.appid.resolver", QtInfoMsg)
 
 WAYLIB_SERVER_USE_NAMESPACE
 
@@ -135,7 +133,7 @@ private:
 protected:
     void destroy_global() override
     {
-        qCDebug(treelandAppIdResolver) << "AppIdResolverManager global destroyed";
+        qCDebug(lcTlAppIdResolver) << "AppIdResolverManager global destroyed";
     }
 
     void destroy(Resource *resource) override
@@ -145,7 +143,7 @@ protected:
 
     void get_resolver(Resource *resource, uint32_t id) override
     {
-        qCDebug(treelandAppIdResolver) << "get_resolver called (client id):" << id;
+        qCDebug(lcTlAppIdResolver) << "get_resolver called (client id):" << id;
         if (m_resolver) {
             wl_resource_post_error(resource->handle,
                                    WL_DISPLAY_ERROR_INVALID_OBJECT,
@@ -161,7 +159,7 @@ protected:
             resolverGone();
         };
         Q_EMIT q->availableChanged();
-        qCDebug(treelandAppIdResolver) << "Resolver bound";
+        qCDebug(lcTlAppIdResolver) << "Resolver bound";
     }
 };
 
@@ -181,13 +179,13 @@ bool AppIdResolverManager::resolvePidfd(int pidfd, std::function<void(const QStr
 void AppIdResolverManager::create(WServer *server)
 {
     d->init(*server->handle(), InterfaceVersion);
-    qCDebug(treelandAppIdResolver) << "AppIdResolverManager global created";
+    qCDebug(lcTlAppIdResolver) << "AppIdResolverManager global created";
 }
 
 void AppIdResolverManager::destroy([[maybe_unused]] WServer *server)
 {
     d->globalRemove();
-    qCDebug(treelandAppIdResolver) << "AppIdResolverManager global removal scheduled";
+    qCDebug(lcTlAppIdResolver) << "AppIdResolverManager global removal scheduled";
 }
 
 wl_global *AppIdResolverManager::global() const

--- a/src/modules/capture/capture.cpp
+++ b/src/modules/capture/capture.cpp
@@ -243,7 +243,7 @@ void CaptureContextV1::handleSessionStart()
                         &CaptureContextV1::handleRenderEnd,
                         Qt::AutoConnection);
     if (!conn) {
-        qCWarning(treelandCapture) << "Cannot connect to render end of output render window.";
+        qCWarning(lcTlCapture) << "Cannot connect to render end of output render window.";
     }
     if (!outputRenderWindow()->inRendering()) {
         QMetaObject::invokeMethod(this, &CaptureContextV1::handleRenderEnd, Qt::AutoConnection);
@@ -259,7 +259,7 @@ void CaptureContextV1::handleFrameDone(uint32_t tvSecHi, uint32_t tvSecLo, uint3
         // closed as soon as backing buffer is destroyed. We should not close fd here.
         m_currentFrameData.acked = true;
     } else {
-        qCWarning(treelandCapture)
+        qCWarning(lcTlCapture)
             << "Receive a frame done event that is not corresponding to current frame timestamp.";
     }
 }
@@ -287,7 +287,7 @@ void CaptureContextV1::handleRenderEnd()
     Q_ASSERT(source);
     auto dmabuf = source->sourceDMABuffer();
     if (!dmabuf) {
-        qCWarning(treelandCapture) << "Source has been invalid while connection still exists.";
+        qCWarning(lcTlCapture) << "Source has been invalid while connection still exists.";
         return;
     }
     m_currentFrameData = {};
@@ -304,8 +304,8 @@ void CaptureContextV1::handleRenderEnd()
         };
     } modifierUnion(m_currentFrameData.attribs.modifier);
 
-    qCInfo(treelandCapture) << "Session:" << session();
-    qCInfo(treelandCapture) << "Session resource:" << session()->resource;
+    qCInfo(lcTlCapture) << "Session:" << session();
+    qCInfo(lcTlCapture) << "Session resource:" << session()->resource;
     treeland_capture_session_v1_send_frame(session()->resource,
                                            source->cropRect().x(),
                                            source->cropRect().y(),
@@ -473,7 +473,7 @@ void CaptureManagerV1::freezeAllCapturedSurface(bool freeze, WSurface *mask)
                 if (auto wrapper = qobject_cast<SurfaceWrapper *>(parentItem)) {
                     if (qobject_cast<SurfaceProxy *>(wrapper->parent())) {
                         // This is m_proxySurface, skip it
-                        qCWarning(treelandCapture)
+                        qCWarning(lcTlCapture)
                             << "Surface capture/record window found in multitask view,"
                             << "protocol needs adjustment to filter it earlier";
                         continue;
@@ -776,7 +776,7 @@ qw_buffer *CaptureSourceSurface::internalBuffer()
             return m_surfaceItemContent->surface()->buffer();
         }
     } else {
-        qCWarning(treelandCapture) << "The first source has been invalidated";
+        qCWarning(lcTlCapture) << "The first source has been invalidated";
         return nullptr;
     }
 }
@@ -808,7 +808,7 @@ void CaptureSourceSelector::setSelectedSource(CaptureSource *newSelectedSource, 
 {
     if (m_selectedSource == newSelectedSource)
         return;
-    qCDebug(treelandCapture) << "Set selected source to" << newSelectedSource;
+    qCDebug(lcTlCapture) << "Set selected source to" << newSelectedSource;
     m_selectedSource = newSelectedSource;
     if (m_selectedSource) {
         m_captureManager->contextInSelection()->setSource(m_selectedSource, region);
@@ -923,7 +923,7 @@ void CaptureSource::createImage()
                 Q_EMIT imageReady();
             })
             .onFailed([](const std::exception &e) {
-                qCCritical(treelandCapture) << e.what();
+                qCCritical(lcTlCapture) << e.what();
             });
     } else {
         // TODO: support multiple sources
@@ -1087,7 +1087,7 @@ void CaptureSourceSelector::setSelectionMode(const SelectionMode &newSelectionMo
         || captureSourceHint().testAnyFlags(selectionModeHint(newSelectionMode))) {
         doSetSelectionMode(newSelectionMode);
     } else {
-        qCWarning(treelandCapture) << "Trying to set selection mode not support, discarded.";
+        qCWarning(lcTlCapture) << "Trying to set selection mode not support, discarded.";
     }
 }
 

--- a/src/modules/ddm/ddminterfacev1.cpp
+++ b/src/modules/ddm/ddminterfacev1.cpp
@@ -56,13 +56,13 @@ void DDMInterfaceV1Private::bind_resource(Resource *resource)
 
 void DDMInterfaceV1Private::switch_to_greeter([[maybe_unused]] Resource *resource)
 {
-    qCWarning(treelandCore) << "DDM protocol: switch_to_greeter";
+    qCWarning(lcTlCore) << "DDM protocol: switch_to_greeter";
     Helper::instance()->showLockScreen(false);
 }
 
 void DDMInterfaceV1Private::switch_to_user([[maybe_unused]] Resource *resource, const QString &username)
 {
-    qCWarning(treelandCore) << "DDM protocol: switch_to_user" << username;
+    qCWarning(lcTlCore) << "DDM protocol: switch_to_user" << username;
     auto helper = Helper::instance();
     if (username == "dde") {
         helper->showLockScreen(false);
@@ -74,19 +74,19 @@ void DDMInterfaceV1Private::switch_to_user([[maybe_unused]] Resource *resource, 
 
 void DDMInterfaceV1Private::activate_session([[maybe_unused]] Resource *resource)
 {
-    qCWarning(treelandCore) << "DDM protocol: activate_session";
+    qCWarning(lcTlCore) << "DDM protocol: activate_session";
     Helper::instance()->activateSession();
 }
 
 void DDMInterfaceV1Private::deactivate_session([[maybe_unused]] Resource *resource)
 {
-    qCWarning(treelandCore) << "DDM protocol: deactivate_session";
+    qCWarning(lcTlCore) << "DDM protocol: deactivate_session";
     Helper::instance()->deactivateSession();
 }
 
 void DDMInterfaceV1Private::enable_render([[maybe_unused]] Resource *resource)
 {
-    qCWarning(treelandCore) << "DDM protocol: enable_render";
+    qCWarning(lcTlCore) << "DDM protocol: enable_render";
     Helper::instance()->enableRender();
 }
 

--- a/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
+++ b/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
@@ -220,7 +220,7 @@ ForeignToplevelManagerInterfaceV1Private::createHandle(Resource *managerResource
                                                       wl_resource_get_version(managerResource->handle),
                                                       0);
     if (!resource) {
-        qCCritical(treelandProtocol) << "wl_resource_create failed!";
+        qCCritical(lcTlProtocol) << "wl_resource_create failed!";
         wl_client_post_no_memory(client);
         return nullptr;
     }
@@ -281,7 +281,7 @@ ForeignToplevelManagerInterfaceV1Private::findHandleForClient(SurfaceWrapper *wr
 void ForeignToplevelManagerInterfaceV1::addSurface(SurfaceWrapper *wrapper)
 {
     if (d->m_surfaces.contains(wrapper)) {
-        qCCritical(treelandProtocol)
+        qCCritical(lcTlProtocol)
         << wrapper << " has been add to foreign toplevel twice";
         return;
     }
@@ -304,7 +304,7 @@ void ForeignToplevelManagerInterfaceV1::removeSurface(SurfaceWrapper *wrapper)
 {
     auto it = d->m_surfaces.find(wrapper);
     if (it == d->m_surfaces.end()) {
-        qCCritical(treelandProtocol) << wrapper << " is not registered in foreign toplevel";
+        qCCritical(lcTlProtocol) << wrapper << " is not registered in foreign toplevel";
         return;
     }
 
@@ -402,7 +402,7 @@ void ForeignToplevelManagerInterfaceV1::initializeToplevelHandle(SurfaceWrapper 
     Q_ASSERT(wrapper->type() == SurfaceWrapper::Type::XdgToplevel
              || wrapper->type() == SurfaceWrapper::Type::XWayland);
     auto surface = wrapper->shellSurface();
-    qCInfo(treelandProtocol) << "Register surface to ForeignToplevelManagerInterfaceV1, appId=" << wrapper->appId()
+    qCInfo(lcTlProtocol) << "Register surface to ForeignToplevelManagerInterfaceV1, appId=" << wrapper->appId()
                              << wrapper->type() << wrapper->skipDockPreView();
 
     // initSurface
@@ -525,7 +525,7 @@ void ForeignToplevelManagerInterfaceV1::initializeToplevelHandle(SurfaceWrapper 
                     return;
                 }
             }
-            qCCritical(treelandProtocol)
+            qCCritical(lcTlProtocol)
                 << "Xdg toplevel surface " << xdgSurface
                 << "has set parent surface, but foreign_toplevel_handle for "
                    "parent surface not "
@@ -554,7 +554,7 @@ void ForeignToplevelManagerInterfaceV1::initializeToplevelHandle(SurfaceWrapper 
                     return;
                 }
             }
-            qCCritical(treelandProtocol)
+            qCCritical(lcTlProtocol)
                 << "X11 surface " << xwaylandSurface
                 << "has set parent surface, but foreign_toplevel_handle for "
                    "parent surface not "
@@ -565,7 +565,7 @@ void ForeignToplevelManagerInterfaceV1::initializeToplevelHandle(SurfaceWrapper 
                                      updateSurfaceParent);
         updateSurfaceParent();
     } else {
-        qCFatal(treelandProtocol)
+        qCFatal(lcTlProtocol)
         << "TreelandForeignToplevelManager only support WXdgSurface or "
            "WXWaylandSurface";
     }
@@ -662,7 +662,7 @@ void DockPreviewContextV1Private::show([[maybe_unused]] Resource *resource, wl_a
     }
 
     if (!surfaces->size)
-        qCCritical(treelandProtocol) << "Got empty surface list for dock preview!";
+        qCCritical(lcTlProtocol) << "Got empty surface list for dock preview!";
 
     Q_EMIT q->requestShow(QPoint(x, y),
                           static_cast<ForeignToplevelManagerInterfaceV1::PreviewDirection>(direction),

--- a/src/modules/input-manager/inputmanagerinterfacev1.cpp
+++ b/src/modules/input-manager/inputmanagerinterfacev1.cpp
@@ -374,7 +374,7 @@ void PointerDeviceConfigurationV1Private::set_handed_mode([[maybe_unused]] Resou
         handedMode = PointerDeviceConfigurationV1::Left;
         break;
     default:
-        qCCritical(treelandInputManager, "unknown mode in set_handed_mode request");
+        qCCritical(lcTlInputManager, "unknown mode in set_handed_mode request");
         return;
     }
     pendingChanges |= PointerDeviceConfigurationV1::HandedModeChanged;
@@ -391,7 +391,7 @@ void PointerDeviceConfigurationV1Private::set_acceleration_profile([[maybe_unuse
                                                                     uint32_t profile)
 {
     if (!treeland_pointer_device_configuration_v1_acceleration_profile_is_valid(profile, resource->version())) {
-        qCCritical(treelandInputManager, "unknown acceleration profile");
+        qCCritical(lcTlInputManager, "unknown acceleration profile");
         return;
     }
 
@@ -403,7 +403,7 @@ void PointerDeviceConfigurationV1Private::set_send_events_mode([[maybe_unused]] 
                                                                 uint32_t mode)
 {
     if (!treeland_pointer_device_configuration_v1_send_events_mode_is_valid(mode, resource->version())) {
-        qCCritical(treelandInputManager, "unknown send_events_mode");
+        qCCritical(lcTlInputManager, "unknown send_events_mode");
         return;
     }
 
@@ -422,7 +422,7 @@ void PointerDeviceConfigurationV1Private::set_natural_scroll([[maybe_unused]] Re
         naturalScroll = false;
         break;
     default:
-        qCCritical(treelandInputManager, "unknown state in set_natural_scroll request");
+        qCCritical(lcTlInputManager, "unknown state in set_natural_scroll request");
         return;
     }
     pendingChanges |= PointerDeviceConfigurationV1::NaturalScrollChanged;
@@ -439,7 +439,7 @@ void PointerDeviceConfigurationV1Private::set_disable_while_typing([[maybe_unuse
         disableWhileTyping = false;
         break;
     default:
-        qCCritical(treelandInputManager, "unknown state in set_disable_while_typing request");
+        qCCritical(lcTlInputManager, "unknown state in set_disable_while_typing request");
         return;
     }
     pendingChanges |= PointerDeviceConfigurationV1::DisableWhileTypingChanged;
@@ -456,7 +456,7 @@ void PointerDeviceConfigurationV1Private::set_tap_to_click([[maybe_unused]] Reso
         tapToClick = false;
         break;
     default:
-        qCCritical(treelandInputManager, "unknown state in set_tap_to_click request");
+        qCCritical(lcTlInputManager, "unknown state in set_tap_to_click request");
         return;
     }
     pendingChanges |= PointerDeviceConfigurationV1::TapToClickChanged;
@@ -888,7 +888,7 @@ void KeyboardSettingsInterfaceV1Private::set_num_lock([[maybe_unused]] Resource 
         numLock = false;
         break;
     default:
-        qCCritical(treelandInputManager, "unknown state in set_num_lock request");
+        qCCritical(lcTlInputManager, "unknown state in set_num_lock request");
         return;
     }
     pendingChanges |= KeyboardSettingsInterfaceV1::NumLockChanged;

--- a/src/modules/keyboard-state-notify/keyboardstatenotifymanagerinterfacev1.cpp
+++ b/src/modules/keyboard-state-notify/keyboardstatenotifymanagerinterfacev1.cpp
@@ -264,7 +264,7 @@ void KeyboardStateWatcherV1Private::destroy(Resource *resource)
 void KeyboardStateWatcherV1Private::set_modifiers(Resource *resource, uint32_t modifiers)
 {
     if (!treeland_keyboard_state_watcher_v1_modifier_is_valid(modifiers, resource->version())) {
-        qCCritical(treelandKeyboardNotify, "unknown modifiers");
+        qCCritical(lcTlKeyboardNotify, "unknown modifiers");
         return;
     }
 
@@ -274,7 +274,7 @@ void KeyboardStateWatcherV1Private::set_modifiers(Resource *resource, uint32_t m
 void KeyboardStateWatcherV1Private::set_flags(Resource *resource, uint32_t flags)
 {
     if (!treeland_keyboard_state_watcher_v1_watch_flag_is_valid(flags, resource->version())) {
-        qCCritical(treelandKeyboardNotify, "unknown watch flags");
+        qCCritical(lcTlKeyboardNotify, "unknown watch flags");
         return;
     }
 

--- a/src/modules/personalization/personalizationmanagerinterfacev1.cpp
+++ b/src/modules/personalization/personalizationmanagerinterfacev1.cpp
@@ -49,11 +49,11 @@ static std::optional<int32_t> protocolWindowThemeTypeToDConfig(uint32_t type)
     case TREELAND_PERSONALIZATION_APPEARANCE_CONTEXT_V1_THEME_TYPE_DARK:
         return 2;
     case TREELAND_PERSONALIZATION_APPEARANCE_CONTEXT_V1_THEME_TYPE_AUTO:
-        qCCritical(treelandConfig)
+        qCCritical(lcTlConfig)
             << "Protocol window theme type AUTO is not supported by dconfig.";
         return std::nullopt;
     default:
-        qCWarning(treelandConfig) << "Unknown protocol window theme type:" << type;
+        qCWarning(lcTlConfig) << "Unknown protocol window theme type:" << type;
         return std::nullopt;
     }
 }
@@ -66,7 +66,7 @@ static uint32_t dconfigWindowThemeTypeToProtocol(int32_t type)
     case 2:
         return TREELAND_PERSONALIZATION_APPEARANCE_CONTEXT_V1_THEME_TYPE_DARK;
     default:
-        qCWarning(treelandConfig)
+        qCWarning(lcTlConfig)
             << "Unknown dconfig windowThemeType:" << type << ", fallback to light.";
         return TREELAND_PERSONALIZATION_APPEARANCE_CONTEXT_V1_THEME_TYPE_LIGHT;
     }

--- a/src/modules/prelaunch-splash/prelaunchsplash.cpp
+++ b/src/modules/prelaunch-splash/prelaunchsplash.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 #include "prelaunchsplash.h"
 
+#include "common/treelandlogging.h"
 #include "qwayland-server-treeland-prelaunch-splash-v2.h"
 
 #include <wserver.h>
@@ -10,12 +11,9 @@
 #include <qwdisplay.h>
 
 #include <QByteArray>
-#include <QLoggingCategory>
 
 WAYLIB_SERVER_USE_NAMESPACE
 QW_USE_NAMESPACE
-
-Q_LOGGING_CATEGORY(prelaunchSplash, "treeland.prelaunchsplash", QtInfoMsg)
 
 class SplashResource : public QtWaylandServer::treeland_prelaunch_splash_v2
 {
@@ -44,7 +42,7 @@ public:
 protected:
     void destroy(Resource *resource) override
     {
-        qCInfo(prelaunchSplash) << "Client destroy splash appId=" << m_appId
+        qCInfo(lcTlPrelaunchSplash) << "Client destroy splash appId=" << m_appId
                                 << " instanceId=" << m_instanceId;
         wl_resource_destroy(resource->handle);
     }
@@ -79,7 +77,7 @@ public:
 protected:
     void destroy_global() override
     {
-        qCDebug(prelaunchSplash) << "PrelaunchSplash v2 global destroyed";
+        qCDebug(lcTlPrelaunchSplash) << "PrelaunchSplash v2 global destroyed";
     }
 
     void destroy(Resource *resource) override
@@ -94,7 +92,7 @@ protected:
                        const QString &sandboxEngineName,
                        struct ::wl_resource *icon_buffer) override
     {
-        qCInfo(prelaunchSplash) << "create_splash request sandbox=" << sandboxEngineName
+        qCInfo(lcTlPrelaunchSplash) << "create_splash request sandbox=" << sandboxEngineName
                                 << " app_id=" << app_id << " instance_id=" << instance_id;
 
         auto *splashResource = wl_resource_create(resource->client(),
@@ -128,13 +126,13 @@ PrelaunchSplash::~PrelaunchSplash() = default;
 void PrelaunchSplash::create(WAYLIB_SERVER_NAMESPACE::WServer *server)
 {
     d->init(*server->handle(), InterfaceVersion);
-    qCDebug(prelaunchSplash) << "PrelaunchSplash v2 global created";
+    qCDebug(lcTlPrelaunchSplash) << "PrelaunchSplash v2 global created";
 }
 
 void PrelaunchSplash::destroy([[maybe_unused]] WAYLIB_SERVER_NAMESPACE::WServer *server)
 {
     d->globalRemove();
-    qCDebug(prelaunchSplash) << "PrelaunchSplash v2 global removal scheduled";
+    qCDebug(lcTlPrelaunchSplash) << "PrelaunchSplash v2 global removal scheduled";
 }
 
 wl_global *PrelaunchSplash::global() const

--- a/src/modules/shortcut/shortcutcontroller.cpp
+++ b/src/modules/shortcut/shortcutcontroller.cpp
@@ -64,7 +64,7 @@ uint ShortcutController::registerKey(const QString &name, const QString& key, Sh
     if (entry.contains(action)) {
         const auto &[prevName, flags] = entry[action];
         m_deleters.remove(prevName);
-        qCInfo(treelandShortcut) << "Overriding existing key binding of"
+        qCInfo(lcTlShortcut) << "Overriding existing key binding of"
                                  << keySeq[0] << "for action" << static_cast<int>(action)
                                  << "by name" << prevName << "with new name" << name << "and flags" << keybindFlags;
     }

--- a/src/modules/shortcut/shortcutmanager.cpp
+++ b/src/modules/shortcut/shortcutmanager.cpp
@@ -730,7 +730,7 @@ void ShortcutManagerV2::onSessionChanged()
     if (d->m_shortcuts.contains(socket)) {
         uint status = d->updateShortcuts(d->m_shortcuts[socket], commitFailName);
         if (status) {
-            qCWarning(treelandShortcut) << "Failed to restore shortcuts" << commitFailName
+            qCWarning(lcTlShortcut) << "Failed to restore shortcuts" << commitFailName
                                         << "by reason" << status
                                         << "for session" << session->id()
                                         << "for user" << session->username();

--- a/src/modules/shortcut/shortcutrunner.cpp
+++ b/src/modules/shortcut/shortcutrunner.cpp
@@ -3,6 +3,7 @@
 
 #include "shortcutrunner.h"
 #include "seat/helper.h"
+#include "common/treelandlogging.h"
 #include "treelandconfig.hpp"
 #include "shortcutcontroller.h"
 #include "workspace/workspace.h"
@@ -397,7 +398,7 @@ void ShortcutRunner::taskswitchAction(bool isRepeat, bool isSameApp, bool isPrev
     } else {
         QMetaObject::invokeMethod(helper->m_taskSwitch, "next");
     }
-    qWarning() << "TaskSwitch: navigating in full task switcher";
+    qCWarning(lcTlShortcut) << "TaskSwitch: navigating in full task switcher";
 }
 
 void ShortcutRunner::onQuickSwitchTimeout()

--- a/src/modules/wallpaper-color/wallpapercolorinterfacev1.cpp
+++ b/src/modules/wallpaper-color/wallpapercolorinterfacev1.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wallpapercolorinterfacev1.h"
+#include "common/treelandlogging.h"
 #include "qwayland-server-treeland-wallpaper-color-v1.h"
 
 #include <woutput.h>
@@ -13,9 +14,6 @@
 #include <QDebug>
 #include <QQmlInfo>
 #include <QString>
-#include <QLoggingCategory>
-
-Q_LOGGING_CATEGORY(qlcWallpapercolor, "treeland.modules.wallpapercolor", QtWarningMsg)
 
 class WallpaperColorInterfaceV1Private : public QtWaylandServer::treeland_wallpaper_color_manager_v1
 {
@@ -57,7 +55,7 @@ void WallpaperColorInterfaceV1Private::destroy(Resource *resource) {
 void WallpaperColorInterfaceV1Private::watch(Resource *resource, const QString &output)
 {
     if (!color_map.contains(output)) {
-        qCWarning(qlcWallpapercolor)
+        qCWarning(lcTlWallpaperColor)
         << QString("Wallpaper info for output:(%1) never set, will ignore "
                    "this requset!")
                 .arg(output);
@@ -65,7 +63,7 @@ void WallpaperColorInterfaceV1Private::watch(Resource *resource, const QString &
     }
 
     auto isDark = color_map[output];
-    qCDebug(qlcWallpapercolor) << QString("New watch requset for output:(%1), it's wallpaper is %2")
+    qCDebug(lcTlWallpaperColor) << QString("New watch requset for output:(%1), it's wallpaper is %2")
                                       .arg(output, isDark ? "dark" : "light");
     send_output_color(resource->handle, output, isDark);
     watch_lists[resource->handle].append(output);
@@ -104,7 +102,7 @@ void WallpaperColorInterfaceV1::updateWallpaperColor(const QString &output, bool
         if (d->color_map[output] == isDarkType)
             return;
     }
-    qCDebug(qlcWallpapercolor)
+    qCDebug(lcTlWallpaperColor)
         << QString("Wallpaper info for output:(%1) changed, it's wallpaper is %2")
                .arg(output, isDarkType ? "dark" : "light");
 

--- a/src/modules/wine-window-management/winewindowmanagement.cpp
+++ b/src/modules/wine-window-management/winewindowmanagement.cpp
@@ -65,7 +65,7 @@ public:
 protected:
     void destroy_global() override
     {
-        qCDebug(treelandProtocol) << "WineWindowManager global destroyed";
+        qCDebug(lcTlProtocol) << "WineWindowManager global destroyed";
     }
 
     void destroy(Resource *resource) override
@@ -172,7 +172,7 @@ protected:
             return;
         }
 
-        qCDebug(treelandProtocol) << "set_position serial" << x << y << serial << "for window_id"
+        qCDebug(lcTlProtocol) << "set_position serial" << x << y << serial << "for window_id"
                                   << m_windowId;
 
         m_wrapper->setPositionAutomatic(false);
@@ -349,7 +349,7 @@ void WineWindowManagerPrivate::get_window_control(Resource *resource,
                                           id);
     registerControl(windowId, xdgToplevel, control);
 
-    qCDebug(treelandProtocol) << "Created WineWindowControl for toplevel, window_id =" << windowId;
+    qCDebug(lcTlProtocol) << "Created WineWindowControl for toplevel, window_id =" << windowId;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/modules/wine-window-state/winewindowstate.cpp
+++ b/src/modules/wine-window-state/winewindowstate.cpp
@@ -57,7 +57,7 @@ private:
 protected:
     void destroy_global() override
     {
-        qCDebug(treelandProtocol) << "WineWindowStateManager global destroyed";
+        qCDebug(lcTlProtocol) << "WineWindowStateManager global destroyed";
     }
 
     void destroy(Resource *resource) override

--- a/src/output/backlight.cpp
+++ b/src/output/backlight.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2025-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "backlight.h"
@@ -50,7 +50,7 @@ qreal Backlight::setBrightness(qreal brightness)
 
     QFile brightnessFile(QString("/sys/class/backlight/%1/brightness").arg(m_name));
     if (!brightnessFile.open(QIODevice::WriteOnly)) {
-        qCWarning(treelandOutput) << "Output" << m_name << ": Failed to open backlight brightness file for writing.";
+        qCWarning(lcTlOutput) << "Output" << m_name << ": Failed to open backlight brightness file for writing.";
         return this->brightness();
     }
 

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -59,7 +59,7 @@ Output *Output::create(WOutput *output, QQmlEngine *engine, QObject *parent)
             obj,
             [obj, output, isSoftwareCursor]() {
                 auto forceSoftwareCursor = isSoftwareCursor(output);
-                qCInfo(treelandOutput) << "forceSoftwareCursor changed to" << forceSoftwareCursor;
+                qCInfo(lcTlOutput) << "forceSoftwareCursor changed to" << forceSoftwareCursor;
                 obj->setProperty("forceSoftwareCursor", forceSoftwareCursor);
             });
 
@@ -392,7 +392,7 @@ void Output::enable()
         }
         newState.set_enabled(true);
         if (!qwoutput->commit_state(newState)) {
-            qCCritical(treelandCore, "commit failed on output %s", qwoutput->handle()->name);
+            qCCritical(lcTlCore, "commit failed on output %s", qwoutput->handle()->name);
         }
     }
 }
@@ -613,7 +613,7 @@ void Output::arrangeLayerSurface(SurfaceWrapper *surface)
             setExclusiveZone(Qt::RightEdge, layer, layer->exclusiveZone());
             break;
         default:
-            qCWarning(treelandOutput) << layer->appId()
+            qCWarning(lcTlOutput) << layer->appId()
                                  << " has set exclusive zone, but exclusive edge is invalid!";
             break;
         }
@@ -761,7 +761,7 @@ std::optional<QPointF> popupDPos(SurfaceWrapper *surface)
         }
     }
 
-    qCWarning(treelandOutput) << " Invalid popup surface type:" << surface->type();
+    qCWarning(lcTlOutput) << " Invalid popup surface type:" << surface->type();
     return std::nullopt;
 }
 } // namespace
@@ -770,7 +770,7 @@ QPointF Output::calculateBasePosition(SurfaceWrapper *surface, const QPointF &dP
 {
     auto parent = surface->parentSurface();
     if (!parent || !parent->surfaceItem()) {
-        qCWarning(treelandOutput) << " Invalid parent surface or surface item!";
+        qCWarning(lcTlOutput) << " Invalid parent surface or surface item!";
         return QPointF();
     }
 
@@ -802,7 +802,7 @@ void Output::adjustToOutputBounds(QPointF &pos, const QRectF &normalGeo, const Q
 void Output::handleLayerShellPopup(SurfaceWrapper *surface, const QRectF &normalGeo)
 {
     if (!surface->parentSurface() || !surface->parentSurface()->ownsOutput()) {
-        qCWarning(treelandOutput) << " Invalid LayerShell parent surface!";
+        qCWarning(lcTlOutput) << " Invalid LayerShell parent surface!";
         return;
     }
 
@@ -880,7 +880,7 @@ void Output::arrangePopupSurface(SurfaceWrapper *surface)
     if (!parentSurfaceWrapper) {
         //  When an input popup is still alive while its parent text-input client is being torn down, 
         //  arrangePopupSurface() can run in a transient state where parentSurface is temporarily unavailable.
-        qCWarning(treelandSurface) << "[popup] skip arrangePopupSurface: missing parent surface"
+        qCWarning(lcTlSurface) << "[popup] skip arrangePopupSurface: missing parent surface"
                                 << "surface=" << surface;
         return;
     }
@@ -901,7 +901,7 @@ void Output::arrangePopupSurface(SurfaceWrapper *surface)
     }
 
     if (!targetOutput) {
-        qCInfo(treelandSurface) << "[popup] skip arrangePopupSurface: missing target output"
+        qCInfo(lcTlSurface) << "[popup] skip arrangePopupSurface: missing target output"
                                 << "surface=" << surface
                                 << "parentSurface=" << parentSurfaceWrapper;
         return;
@@ -1047,7 +1047,7 @@ void Output::setOutputColor(qreal brightness,
     if (gammaSize == 0) {
         if (resultCallback)
             resultCallback(false);
-        qCWarning(treelandOutput) << " Output " << output()->name()
+        qCWarning(lcTlOutput) << " Output " << output()->name()
                              << " does not support gamma LUT! Brightness and color temperature adjustments through gamma will have no effect.";
         return;
     }
@@ -1079,14 +1079,14 @@ void Output::setOutputColor(qreal brightness,
             if (resultCallback)
                 resultCallback(success);
             if (!success) {
-                qCWarning(treelandOutput) << "Failed to apply brightness and color temperature settings to output"
+                qCWarning(lcTlOutput) << "Failed to apply brightness and color temperature settings to output"
                                           << output()->name();
             } else {
                 config()->setBrightness(brightness);
                 config()->setColorTemperature(colorTemperature);
             }
         } else {
-            qCWarning(treelandOutput) << "Commit callback received unexpected state pointer!"
+            qCWarning(lcTlOutput) << "Commit callback received unexpected state pointer!"
                                       << "Expected:" << newState.get()
                                       << "Got:" << state.get();
         }

--- a/src/plugins/multitaskview/multitaskview.cpp
+++ b/src/plugins/multitaskview/multitaskview.cpp
@@ -236,7 +236,7 @@ void MultitaskviewSurfaceModel::updateZOrder()
 uint MultitaskviewSurfaceModel::prevSameAppIndex(uint index)
 {
     if (index >= count()) {
-        qCWarning(treelandPlugin) << "prevSameAppIndex: invalid index" << index << "count:" << count();
+        qCWarning(lcTlPlugin) << "prevSameAppIndex: invalid index" << index << "count:" << count();
         return index;
     }
     auto circularPrev = [this](uint i) {
@@ -255,7 +255,7 @@ uint MultitaskviewSurfaceModel::prevSameAppIndex(uint index)
 uint MultitaskviewSurfaceModel::nextSameAppIndex(uint index)
 {
     if (index >= count()) {
-        qCWarning(treelandPlugin) << "nextSameAppIndex: invalid index" << index << "count:" << count();
+        qCWarning(lcTlPlugin) << "nextSameAppIndex: invalid index" << index << "count:" << count();
         return index;
     }
     auto circularNext = [this](uint i) {

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -284,9 +284,9 @@ Helper::Helper(QObject *parent)
     );
 
     if (!connected) {
-        qCWarning(treelandCore) << "Failed to connect to systemd-logind PrepareForSleep signal";
+        qCWarning(lcTlCore) << "Failed to connect to systemd-logind PrepareForSleep signal";
     } else {
-        qCInfo(treelandCore) << "Successfully connected to systemd-logind PrepareForSleep signal";
+        qCInfo(lcTlCore) << "Successfully connected to systemd-logind PrepareForSleep signal";
     }
 
     // Also connect to SessionNew signal for logging purposes
@@ -343,12 +343,12 @@ void Helper::syncPaletteTypeWithWindowThemeType(int32_t themeType)
 {
     auto *guiHelper = DTK_GUI_NAMESPACE::DGuiApplicationHelper::instance();
     if (!guiHelper) {
-        qCCritical(treelandConfig) << "DGuiApplicationHelper instance not available, cannot sync "
+        qCCritical(lcTlConfig) << "DGuiApplicationHelper instance not available, cannot sync "
                                       "palette type with window theme type.";
         return;
     }
 
-    qCDebug(treelandConfig) << "Syncing palette type with window theme type:" << themeType;
+    qCDebug(lcTlConfig) << "Syncing palette type with window theme type:" << themeType;
 
     switch (themeType) {
     case 2:
@@ -358,7 +358,7 @@ void Helper::syncPaletteTypeWithWindowThemeType(int32_t themeType)
         guiHelper->setPaletteType(Dtk::Gui::DGuiApplicationHelper::LightType);
         break;
     default:
-        qCWarning(treelandConfig) << "Unknown windowThemeType:" << themeType
+        qCWarning(lcTlConfig) << "Unknown windowThemeType:" << themeType
                                   << ", fallback to light.";
         guiHelper->setPaletteType(Dtk::Gui::DGuiApplicationHelper::LightType);
         break;
@@ -382,7 +382,7 @@ bool Helper::isNvidiaCardPresent()
         return false;
 
     QString deviceName = rhi->driverInfo().deviceName;
-    qCDebug(treelandCore) << "Graphics Device:" << deviceName;
+    qCDebug(lcTlCore) << "Graphics Device:" << deviceName;
 
     return deviceName.contains("NVIDIA", Qt::CaseInsensitive);
 }
@@ -462,7 +462,7 @@ void Helper::onOutputAdded(WOutput *output)
     if (shouldRestoreCopyMode) {
         Output *primaryOutput = m_rootSurfaceContainer->primaryOutput();
         if (!primaryOutput) {
-            qCWarning(treelandCore) << "Cannot restore Copy Mode: no primary output available";
+            qCWarning(lcTlCore) << "Cannot restore Copy Mode: no primary output available";
             o = createNormalOutput(output);
         } else {
             const auto &allSurfaces = getWorkspaceSurfaces();
@@ -515,7 +515,7 @@ void Helper::onOutputAdded(WOutput *output)
         newState.set_transform(static_cast<wl_output_transform>(settings.value("transform").toInt()));
         newState.set_scale(settings.value("scale").toFloat());
         if (!output->handle()->commit_state(newState)) {
-            qCCritical(treelandCore) << "commit failed on output" << output->name();
+            qCCritical(lcTlCore) << "commit failed on output" << output->name();
         }
     }
     settings.endGroup();
@@ -624,8 +624,8 @@ void Helper::setGamma(struct wlr_gamma_control_manager_v1_set_gamma_event *event
     qw_output_state newState;
     newState.set_gamma_lut(ramp_size, r, g, b);
     if (!qwOutput->commit_state(newState)) {
-        qCCritical(treelandCore, "commit failed on output  %s", qwOutput->handle()->name);
-        qCWarning(treelandCore) << "Failed to set gamma lut!";
+        qCCritical(lcTlCore, "commit failed on output  %s", qwOutput->handle()->name);
+        qCWarning(lcTlCore) << "Failed to set gamma lut!";
         // TODO: use software impl it.
         qw_gamma_control_v1::from(gamma_control)->send_failed_and_destroy();
     }
@@ -635,7 +635,7 @@ void Helper::handleCopyModeOutputDisable(Output *affectedOutput)
 {
     int affectedIndex = m_outputList.indexOf(affectedOutput);
     if (affectedIndex < 0) {
-        qCWarning(treelandCore) << "Disabled output not found in m_outputList";
+        qCWarning(lcTlCore) << "Disabled output not found in m_outputList";
         return;
     }
 
@@ -773,7 +773,7 @@ void Helper::onOutputTestOrApply(qw_output_configuration_v1 *config, bool onlyTe
 
         WOutputRenderWindow *renderWindow = viewport->outputRenderWindow();
         if (!renderWindow) {
-            qCWarning(treelandCore) << "No renderWindow for output" << state.output->name();
+            qCWarning(lcTlCore) << "No renderWindow for output" << state.output->name();
             m_outputManager->sendResult(config, false);
             m_pendingOutputConfig = {};
             return;
@@ -788,7 +788,7 @@ void Helper::onOutputTestOrApply(qw_output_configuration_v1 *config, bool onlyTe
 
         auto outputHelper = renderWindow->getOutputHelper(viewport);
         if (!outputHelper) {
-            qCWarning(treelandCore) << "No output helper for viewport" << viewport;
+            qCWarning(lcTlCore) << "No output helper for viewport" << viewport;
             m_outputManager->sendResult(config, false);
             m_pendingOutputConfig = {};
             return;
@@ -824,7 +824,7 @@ void Helper::onOutputTestOrApply(qw_output_configuration_v1 *config, bool onlyTe
         }
 
         if (!outputHelper->setExtraState(extraState)) {
-            qCWarning(treelandCore) << "Failed to set extra state for output" << state.output->name();
+            qCWarning(lcTlCore) << "Failed to set extra state for output" << state.output->name();
             m_outputManager->sendResult(config, false);
             m_pendingOutputConfig = {};
             return;
@@ -851,7 +851,7 @@ void Helper::onOutputTestOrApply(qw_output_configuration_v1 *config, bool onlyTe
                         }
                     }
                 } else {
-                    qCWarning(treelandCore) << "Commit callback received unexpected state pointer!"
+                    qCWarning(lcTlCore) << "Commit callback received unexpected state pointer!"
                                             << "Expected:" << extraState.get()
                                             << "Got:" << committedState.get();
                     self->onOutputCommitFinished(config, false);
@@ -898,7 +898,7 @@ void Helper::onOutputCommitFinished(qw_output_configuration_v1 *config, bool suc
                 // Reason: When disabled, mode/scale/transform are not committed to wlroots,
                 // so we should not save uncommitted values
                 if (!state.enabled) {
-                    qCDebug(treelandCore) << "Skipping config save for disabled output:" << state.output->name();
+                    qCDebug(lcTlCore) << "Skipping config save for disabled output:" << state.output->name();
                     continue;
                 }
 
@@ -929,7 +929,7 @@ void Helper::onSetOutputPowerMode(wlr_output_power_v1_set_mode_event *event)
         }
         newState.set_enabled(false);
         if (!output->commit_state(newState)) {
-            qCCritical(treelandCore, "commit failed on output %s", output->handle()->name);
+            qCCritical(lcTlCore, "commit failed on output %s", output->handle()->name);
         }
         break;
     case ZWLR_OUTPUT_POWER_V1_MODE_ON:
@@ -938,7 +938,7 @@ void Helper::onSetOutputPowerMode(wlr_output_power_v1_set_mode_event *event)
         }
         newState.set_enabled(true);
         if (!output->commit_state(newState)) {
-            qCCritical(treelandCore, "commit failed on output %s", output->handle()->name);
+            qCCritical(lcTlCore, "commit failed on output %s", output->handle()->name);
         }
         break;
     }
@@ -947,13 +947,13 @@ void Helper::onSetOutputPowerMode(wlr_output_power_v1_set_mode_event *event)
 void Helper::onNewIdleInhibitor(wlr_idle_inhibitor_v1 *wlr_inhibitor)
 {
     if (!wlr_inhibitor->surface) {
-        qCInfo(treelandCore) << "Ignoring idle inhibitor with null surface";
+        qCInfo(lcTlCore) << "Ignoring idle inhibitor with null surface";
         return;
     }
 
     auto wsurface = WSurface::fromHandle(wlr_inhibitor->surface);
     if (!wsurface) {
-        qCWarning(treelandCore) << "No WSurface found for idle inhibitor surface"
+        qCWarning(lcTlCore) << "No WSurface found for idle inhibitor surface"
                                 << wlr_inhibitor->surface;
         return;
     }
@@ -1461,7 +1461,7 @@ void Helper::init(Treeland::Treeland *treeland)
     // Initialize seats from configuration
     m_seat = m_seatManager->initializeFromConfig("/etc/deepin/treeland/seats.json", m_server);
     if (!m_seat) {
-        qCCritical(treelandCore) << "Failed to initialize seats!";
+        qCCritical(lcTlCore) << "Failed to initialize seats!";
         return;
     }
 
@@ -1495,7 +1495,7 @@ void Helper::init(Treeland::Treeland *treeland)
     }
 
     if (!m_seat) {
-        qCCritical(treelandCore) << "No seat available after initialization, cannot continue";
+        qCCritical(lcTlCore) << "No seat available after initialization, cannot continue";
         return;
     }
     m_shellHandler->init(m_server, m_seat);
@@ -1506,7 +1506,7 @@ void Helper::init(Treeland::Treeland *treeland)
 
     m_renderer = WRenderHelper::createRenderer(m_backend->handle());
     if (!m_renderer) {
-        qCFatal(treelandCore) << "Failed to create renderer";
+        qCFatal(lcTlCore) << "Failed to create renderer";
     }
 
     m_allocator = qw_allocator::autocreate(*m_backend->handle(), *m_renderer);
@@ -1600,11 +1600,11 @@ void Helper::init(Treeland::Treeland *treeland)
             [this](ActivationManagerInterfaceV1::TokenDisposition disposition, WSurface *wsurface) {
                 auto wrapper = m_rootSurfaceContainer->getSurface(wsurface);
                 if (!wrapper) {
-                    qCWarning(treelandCore) << "Activation request for unknown surface!";
+                    qCWarning(lcTlCore) << "Activation request for unknown surface!";
                     return;
                 }
                 if (!wsurface->mapped()) {
-                    qCWarning(treelandCore) << "Activation request for unmapped surface!";
+                    qCWarning(lcTlCore) << "Activation request for unmapped surface!";
                     return;
                 }
                 switch (disposition) {
@@ -1729,7 +1729,7 @@ void Helper::activateSurface(SurfaceWrapper *wrapper, Qt::FocusReason reason)
             if (wrapper->hasActiveCapability()) {
                 setActivatedSurface(wrapper);
             } else {
-                qCCritical(treelandShell) << "Trying to activate a surface which doesn't have ActiveCapability!";
+                qCCritical(lcTlShell) << "Trying to activate a surface which doesn't have ActiveCapability!";
             }
         }
     }
@@ -1765,11 +1765,11 @@ void Helper::activateSurface(SurfaceWrapper *wrapper, Qt::FocusReason reason)
 void Helper::forceActivateSurface(SurfaceWrapper *wrapper, Qt::FocusReason reason)
 {
     if (!wrapper) {
-        qCCritical(treelandShell) << "Don't force activate to empty surface! do you want `Helper::activeSurface(nullptr)`?";
+        qCCritical(lcTlShell) << "Don't force activate to empty surface! do you want `Helper::activeSurface(nullptr)`?";
         return;
     }
     if (!wrapper->shellSurface()) {
-        qCWarning(treelandShell) << "Try to force activate a destroyed surface!";
+        qCWarning(lcTlShell) << "Try to force activate a destroyed surface!";
         return;
     }
 
@@ -1781,7 +1781,7 @@ void Helper::forceActivateSurface(SurfaceWrapper *wrapper, Qt::FocusReason reaso
     }
 
     if (!wrapper->surface()->mapped()) {
-        qCWarning(treelandShell) << "Can't activate unmapped surface: " << wrapper;
+        qCWarning(lcTlShell) << "Can't activate unmapped surface: " << wrapper;
         return;
     }
 
@@ -1826,13 +1826,13 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *targetWindow, QInputEvent 
             if (key >= Qt::Key_F1 && key <= Qt::Key_F12) {
                 const int vtnr = key - Qt::Key_F1 + 1;
                 const bool sessionActive = m_backend->isSessionActive();
-                qCWarning(treelandCore) << "Ctrl+Alt+Fn VT shortcut received"
+                qCWarning(lcTlCore) << "Ctrl+Alt+Fn VT shortcut received"
                                         << vtnr << "sessionActive" << sessionActive;
                 if (!sessionActive) {
                     return true;
                 }
 
-                qCWarning(treelandCore) << "Ctrl+Alt+Fn VT shortcut requested" << vtnr;
+                qCWarning(lcTlCore) << "Ctrl+Alt+Fn VT shortcut requested" << vtnr;
                 m_backend->session()->change_vt(vtnr);
                 return true;
             }
@@ -1845,7 +1845,7 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *targetWindow, QInputEvent 
         if (device) {
             targetSeat = m_seatManager->getSeatForDevice(device);
             if (!targetSeat) {
-                qCWarning(treelandCore) << "Device has no associated seat, using default seat";
+                qCWarning(lcTlCore) << "Device has no associated seat, using default seat";
                 targetSeat = seat;
             }
         }
@@ -2145,13 +2145,13 @@ WOutputViewport *Helper::getOwnOutputViewport(WOutput *output)
     // but we need the OutputViewport that is a direct child of the OutputItem
     Output *outputObj = getOutput(output);
     if (!outputObj || !outputObj->outputItem()) {
-        qCWarning(treelandCore) << "Invalid output object for" << output->name();
+        qCWarning(lcTlCore) << "Invalid output object for" << output->name();
         return nullptr;
     }
 
     WOutputViewport *viewport = outputObj->outputItem()->findChild<WOutputViewport *>({}, Qt::FindDirectChildrenOnly);
     if (!viewport) {
-        qCWarning(treelandCore) << "No viewport found for output" << output->name()
+        qCWarning(lcTlCore) << "No viewport found for output" << output->name()
                                 << "- OutputItem may not have been fully initialized";
     }
     return viewport;
@@ -2295,7 +2295,7 @@ void Helper::handleLockScreen(LockScreenInterface *lockScreen)
 void Helper::onSessionNew(const QString &sessionId, const QDBusObjectPath &sessionPath)
 {
     const auto path = sessionPath.path();
-    qCDebug(treelandCore) << "Session new, sessionId:" << sessionId << ", sessionPath:" << path;
+    qCDebug(lcTlCore) << "Session new, sessionId:" << sessionId << ", sessionPath:" << path;
     QDBusConnection::systemBus().connect("org.freedesktop.login1", path, "org.freedesktop.login1.Session", "Lock", this, SLOT(onSessionLock()));
     QDBusConnection::systemBus().connect("org.freedesktop.login1", path, "org.freedesktop.login1.Session", "Unlock", this, SLOT(onSessionUnlock()));
 }
@@ -2359,7 +2359,7 @@ void Helper::allowNonDrmOutputAutoChangeMode(WOutput *output)
                             if (newState->state->committed & WLR_OUTPUT_STATE_MODE) {
                                 auto output = qobject_cast<qw_output *>(sender());
                                 if (!output->commit_state(newState->state)) {
-                                    qCCritical(treelandCore, "commit failed on output %s",
+                                    qCCritical(lcTlCore, "commit failed on output %s",
                                                output->handle()->name);
                                 }
                             }
@@ -2696,43 +2696,43 @@ Output *Helper::getOutputAtCursor() const
 void Helper::handleNewForeignToplevelCaptureRequest(wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request *request)
 {
     if (!request || !request->toplevel_handle) {
-        qCWarning(treelandCapture) << "Invalid capture request or toplevel handle";
+        qCWarning(lcTlCapture) << "Invalid capture request or toplevel handle";
         return;
     }
 
     auto *qw_handle = qw_ext_foreign_toplevel_handle_v1::from(request->toplevel_handle);
     WToplevelSurface *toplevelSurface = m_extForeignToplevelListV1->findSurfaceByHandle(qw_handle);
     if (!toplevelSurface) {
-        qCWarning(treelandCapture) << "Could not find toplevel surface for handle";
+        qCWarning(lcTlCapture) << "Could not find toplevel surface for handle";
         return;
     }
 
     SurfaceWrapper *surfaceWrapper = m_rootSurfaceContainer->getSurface(toplevelSurface);
     if (!surfaceWrapper) {
-        qCWarning(treelandCapture) << "Could not find SurfaceWrapper for toplevel surface";
+        qCWarning(lcTlCapture) << "Could not find SurfaceWrapper for toplevel surface";
         return;
     }
 
     WSurfaceItem *surfaceItem = surfaceWrapper->surfaceItem();
     if (!surfaceItem) {
-        qCWarning(treelandCapture) << "Could not get WSurfaceItem from SurfaceWrapper";
+        qCWarning(lcTlCapture) << "Could not get WSurfaceItem from SurfaceWrapper";
         return;
     }
 
     WSurfaceItemContent *surfaceContent = surfaceItem->findItemContent();
     if (!surfaceContent) {
-        qCWarning(treelandCapture) << "Could not find WSurfaceItemContent";
+        qCWarning(lcTlCapture) << "Could not find WSurfaceItemContent";
         return;
     }
 
-    qCDebug(treelandCapture) << "Found WSurfaceItemContent for capture:"
+    qCDebug(lcTlCapture) << "Found WSurfaceItemContent for capture:"
              << "size=" << surfaceContent->size()
              << "implicitSize=" << QSizeF(surfaceContent->implicitWidth(), surfaceContent->implicitHeight())
              << "isTextureProvider=" << surfaceContent->isTextureProvider();
 
     auto *output = surfaceWrapper->ownsOutput()->output();
     if (!output) {
-        qCWarning(treelandCapture) << "Could not get WOutput from SurfaceWrapper";
+        qCWarning(lcTlCapture) << "Could not get WOutput from SurfaceWrapper";
         return;
     }
 
@@ -2742,7 +2742,7 @@ void Helper::handleNewForeignToplevelCaptureRequest(wlr_ext_foreign_toplevel_ima
         request, *imageCaptureSource);
 
     if (!success) {
-        qCWarning(treelandCapture) << "Failed to accept foreign toplevel image capture request";
+        qCWarning(lcTlCapture) << "Failed to accept foreign toplevel image capture request";
         delete imageCaptureSource;
     }
 }
@@ -2750,11 +2750,11 @@ void Helper::handleNewForeignToplevelCaptureRequest(wlr_ext_foreign_toplevel_ima
 void Helper::onPrepareForSleep(bool sleep)
 {
     if (sleep) {
-        qCInfo(treelandCore) << "Rendering black frames to all outputs before hibernate";
+        qCInfo(lcTlCore) << "Rendering black frames to all outputs before hibernate";
         disableRender();
         // TODO：should we disable output？
     } else {
-        qCInfo(treelandCore) << "Re-enabled rendering after hibernate";
+        qCInfo(lcTlCore) << "Re-enabled rendering after hibernate";
         enableRender();
     }
 }
@@ -2852,7 +2852,7 @@ void Helper::restoreCopyMode()
 {
     Output *primaryOutput = m_rootSurfaceContainer->primaryOutput();
     if (!primaryOutput) {
-        qCWarning(treelandCore) << "Cannot restore Copy Mode: no primary output available";
+        qCWarning(lcTlCore) << "Cannot restore Copy Mode: no primary output available";
         return;
     }
 
@@ -2873,7 +2873,7 @@ bool Helper::setXWindowPositionRelative(uint wid, WSurface *anchor, wl_fixed_t d
 {
     SurfaceWrapper *ach = m_rootSurfaceContainer->getSurface(anchor);
     if (!ach) {
-        qCWarning(treelandCore) << "setXWindowPositionRelative: Failed to get SurfaceWrapper from WSurface";
+        qCWarning(lcTlCore) << "setXWindowPositionRelative: Failed to get SurfaceWrapper from WSurface";
         return false;
     }
 
@@ -2889,7 +2889,7 @@ bool Helper::setXWindowPositionRelative(uint wid, WSurface *anchor, wl_fixed_t d
         }
     }
     if (!target) {
-        qCWarning(treelandCore) << "setXWindowPositionRelative: XWayland surface corresponding to WID" << wid << "not found!";
+        qCWarning(lcTlCore) << "setXWindowPositionRelative: XWayland surface corresponding to WID" << wid << "not found!";
         return false;
     }
 

--- a/src/seat/seatsmanager.cpp
+++ b/src/seat/seatsmanager.cpp
@@ -41,7 +41,7 @@ SeatsManager::~SeatsManager()
 WSeat *SeatsManager::createSeat(const QString &name, bool isFallback)
 {
     if (m_seats.contains(name)) {
-        qCDebug(treelandSeat) << "Seat" << name << "already exists";
+        qCDebug(lcTlSeat) << "Seat" << name << "already exists";
         return m_seats[name];
     }
 
@@ -54,7 +54,7 @@ WSeat *SeatsManager::createSeat(const QString &name, bool isFallback)
 
 
     Q_EMIT seatAdded(seat);
-    qCDebug(treelandSeat) << "Created seat:" << name << "fallback:" << isFallback;
+    qCDebug(lcTlSeat) << "Created seat:" << name << "fallback:" << isFallback;
     
     return seat;
 }
@@ -62,7 +62,7 @@ WSeat *SeatsManager::createSeat(const QString &name, bool isFallback)
 void SeatsManager::removeSeat(const QString &name)
 {
     if (!m_seats.contains(name)) {
-        qCWarning(treelandSeat) << "Cannot remove non-existent seat:" << name;
+        qCWarning(lcTlSeat) << "Cannot remove non-existent seat:" << name;
         return;
     }
 
@@ -70,10 +70,10 @@ void SeatsManager::removeSeat(const QString &name)
 
     if (m_defaultSeat == seat && !m_seats.isEmpty()) {
         m_defaultSeat = m_seats.begin().value();
-        qCDebug(treelandSeat) << "Fallback seat changed to:" << m_defaultSeat->name();
+        qCDebug(lcTlSeat) << "Fallback seat changed to:" << m_defaultSeat->name();
     } else if (m_defaultSeat == seat) {
         m_defaultSeat = nullptr;
-        qCDebug(treelandSeat) << "No fallback seat available";
+        qCDebug(lcTlSeat) << "No fallback seat available";
     }
 
     QList<WInputDevice*> devices = seat->deviceList();
@@ -87,7 +87,7 @@ void SeatsManager::removeSeat(const QString &name)
             if (newSeat) {
                 Q_EMIT deviceReassigned(device, seat, newSeat);
             } else {
-                qCWarning(treelandSeat) << "Failed to reassign device after seat removal:" << device->name();
+                qCWarning(lcTlSeat) << "Failed to reassign device after seat removal:" << device->name();
             }
         }
     }
@@ -97,7 +97,7 @@ void SeatsManager::removeSeat(const QString &name)
     }
 
     Q_EMIT seatRemoved(seat);
-    qCDebug(treelandSeat) << "Removed seat:" << name;
+    qCDebug(lcTlSeat) << "Removed seat:" << name;
 
     delete seat;
 
@@ -120,7 +120,7 @@ void SeatsManager::removeSeat(WSeat *seat)
     if (!seatName.isEmpty()) {
         removeSeat(seatName);
     } else {
-        qCWarning(treelandSeat) << "Attempted to remove a seat that is not managed by SeatsManager";
+        qCWarning(lcTlSeat) << "Attempted to remove a seat that is not managed by SeatsManager";
     }
 }
 
@@ -142,44 +142,44 @@ WSeat *SeatsManager::fallbackSeat() const
 void SeatsManager::assignDeviceToSeat(WInputDevice *device, const QString &seatName)
 {
     if (!device) {
-        qCWarning(treelandSeat) << "Cannot assign null device to seat";
+        qCWarning(lcTlSeat) << "Cannot assign null device to seat";
         return;
     }
 
     for (auto seat : std::as_const(m_seats)) {
         if (seat->deviceList().contains(device)) {
             if (seat->name() == seatName) {
-                qCDebug(treelandSeat) << "Device" << device->name() << "already assigned to seat" << seatName;
+                qCDebug(lcTlSeat) << "Device" << device->name() << "already assigned to seat" << seatName;
                 return;
             }
 
             seat->detachInputDevice(device);
-            qCDebug(treelandSeat) << "Device" << device->name() << "detached from seat" << seat->name();
+            qCDebug(lcTlSeat) << "Device" << device->name() << "detached from seat" << seat->name();
             break;
         }
     }
 
     if (m_seats.contains(seatName)) {
         m_seats[seatName]->attachInputDevice(device);
-        qCDebug(treelandSeat) << "Device" << device->name() << "assigned to seat" << seatName;
+        qCDebug(lcTlSeat) << "Device" << device->name() << "assigned to seat" << seatName;
     } else if (fallbackSeat()) {
         fallbackSeat()->attachInputDevice(device);
-        qCDebug(treelandSeat) << "Device" << device->name() << "assigned to fallback seat";
+        qCDebug(lcTlSeat) << "Device" << device->name() << "assigned to fallback seat";
     } else {
-        qCWarning(treelandSeat) << "Cannot assign device" << device->name() << "- no seats available";
+        qCWarning(lcTlSeat) << "Cannot assign device" << device->name() << "- no seats available";
     }
 }
 
 WSeat *SeatsManager::autoAssignDevice(WInputDevice *device)
 {
     if (!device) {
-        qCWarning(treelandSeat) << "Cannot auto-assign null device";
+        qCWarning(lcTlSeat) << "Cannot auto-assign null device";
         return nullptr;
     }
 
     for (auto seat : std::as_const(m_seats)) {
         if (seat->deviceList().contains(device)) {
-            qCDebug(treelandSeat) << "Device" << device->name() << "already assigned to seat" << seat->name();
+            qCDebug(lcTlSeat) << "Device" << device->name() << "already assigned to seat" << seat->name();
             return seat;
         }
     }
@@ -188,38 +188,38 @@ WSeat *SeatsManager::autoAssignDevice(WInputDevice *device)
 
     if (targetSeat) {
         targetSeat->attachInputDevice(device);
-        qCDebug(treelandSeat) << "Device" << device->name() << "auto-assigned to seat" << targetSeat->name();
+        qCDebug(lcTlSeat) << "Device" << device->name() << "auto-assigned to seat" << targetSeat->name();
         return targetSeat;
     } else if (fallbackSeat()) {
         fallbackSeat()->attachInputDevice(device);
-        qCDebug(treelandSeat) << "Device" << device->name() << "auto-assigned to fallback seat";
+        qCDebug(lcTlSeat) << "Device" << device->name() << "auto-assigned to fallback seat";
         return fallbackSeat();
     }
 
-    qCWarning(treelandSeat) << "Failed to auto-assign device" << device->name();
+    qCWarning(lcTlSeat) << "Failed to auto-assign device" << device->name();
     return nullptr;
 }
 
 void SeatsManager::addDeviceRule(const QString &seatName, const QString &rule)
 {
     if (seatName.isEmpty()) {
-        qCWarning(treelandSeat) << "Cannot add device rule for seat with empty name";
+        qCWarning(lcTlSeat) << "Cannot add device rule for seat with empty name";
         return;
     }
 
     if (rule.isEmpty()) {
-        qCWarning(treelandSeat) << "Cannot add empty device rule";
+        qCWarning(lcTlSeat) << "Cannot add empty device rule";
         return;
     }
 
     if (!m_seats.contains(seatName)) {
-        qCWarning(treelandSeat) << "Cannot add device rule for non-existent seat:" << seatName;
+        qCWarning(lcTlSeat) << "Cannot add device rule for non-existent seat:" << seatName;
         return;
     }
 
     QRegularExpression regex(rule);
     if (!regex.isValid()) {
-        qCWarning(treelandSeat) << "Invalid regex pattern for device rule:" << rule << "Error:" << regex.errorString();
+        qCWarning(lcTlSeat) << "Invalid regex pattern for device rule:" << rule << "Error:" << regex.errorString();
         return;
     }
 
@@ -230,25 +230,25 @@ void SeatsManager::addDeviceRule(const QString &seatName, const QString &rule)
     // Check for duplicate rules
     for (const auto &existingRule : std::as_const(m_deviceRules[seatName])) {
         if (existingRule.pattern() == rule) {
-            qCDebug(treelandSeat) << "Device rule already exists for seat" << seatName << ":" << rule;
+            qCDebug(lcTlSeat) << "Device rule already exists for seat" << seatName << ":" << rule;
             return;
         }
     }
 
     m_deviceRules[seatName].append(regex);
-    qCDebug(treelandSeat) << "Added device rule for seat" << seatName << ":" << rule;
+    qCDebug(lcTlSeat) << "Added device rule for seat" << seatName << ":" << rule;
 }
 
 void SeatsManager::removeDeviceRule(const QString &seatName, const QString &rule)
 {
     if (!m_deviceRules.contains(seatName)) {
-        qCDebug(treelandSeat) << "No device rules for seat:" << seatName;
+        qCDebug(lcTlSeat) << "No device rules for seat:" << seatName;
         return;
     }
 
     QRegularExpression regex(rule);
     if (!regex.isValid()) {
-        qCWarning(treelandSeat) << "Invalid regex pattern:" << rule;
+        qCWarning(lcTlSeat) << "Invalid regex pattern:" << rule;
         return;
     }
 
@@ -256,14 +256,14 @@ void SeatsManager::removeDeviceRule(const QString &seatName, const QString &rule
     for (int i = 0; i < rules.size(); i++) {
         if (rules[i].pattern() == regex.pattern()) {
             rules.removeAt(i);
-            qCDebug(treelandSeat) << "Removed device rule from seat" << seatName << ":" << rule;
+            qCDebug(lcTlSeat) << "Removed device rule from seat" << seatName << ":" << rule;
             break;
         }
     }
 
     if (rules.isEmpty()) {
         m_deviceRules.remove(seatName);
-        qCDebug(treelandSeat) << "All device rules removed for seat:" << seatName;
+        qCDebug(lcTlSeat) << "All device rules removed for seat:" << seatName;
     }
 }
 
@@ -283,7 +283,7 @@ QStringList SeatsManager::deviceRules(const QString &seatName) const
 
 void SeatsManager::loadConfig(const QJsonObject &config)
 {
-    qCDebug(treelandSeat) << "Loading seat configuration";
+    qCDebug(lcTlSeat) << "Loading seat configuration";
 
     QMap<QString, WSeat*> seatsToDelete;
     seatsToDelete.swap(m_seats);
@@ -314,35 +314,35 @@ void SeatsManager::loadConfig(const QJsonObject &config)
     }
 
     if (m_seats.isEmpty()) {
-        qCDebug(treelandSeat) << "No seats in config, creating default seat0";
+        qCDebug(lcTlSeat) << "No seats in config, creating default seat0";
         createSeat("seat0", true);
     }
 
     if (!m_defaultSeat && !m_seats.isEmpty()) {
         m_defaultSeat = m_seats.begin().value();
-        qCDebug(treelandSeat) << "Set fallback seat to:" << m_defaultSeat->name();
+        qCDebug(lcTlSeat) << "Set fallback seat to:" << m_defaultSeat->name();
     }
 
-    qCDebug(treelandSeat) << "Loaded" << m_seats.size() << "seats";
+    qCDebug(lcTlSeat) << "Loaded" << m_seats.size() << "seats";
 }
 
 bool SeatsManager::loadConfigFromFile(const QString &filePath)
 {
     QFile file(filePath);
     if (!file.open(QIODevice::ReadOnly)) {
-        qCDebug(treelandSeat) << "Config file not found:" << filePath;
+        qCDebug(lcTlSeat) << "Config file not found:" << filePath;
         return false;
     }
 
     QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
     if (doc.isNull() || !doc.isObject()) {
-        qCWarning(treelandSeat) << "Invalid JSON in config file:" << filePath;
+        qCWarning(lcTlSeat) << "Invalid JSON in config file:" << filePath;
         return false;
     }
 
     QJsonObject config = doc.object();
     if (!validateConfig(config)) {
-        qCWarning(treelandSeat) << "Invalid seat configuration in:" << filePath;
+        qCWarning(lcTlSeat) << "Invalid seat configuration in:" << filePath;
         return false;
     }
 
@@ -357,12 +357,12 @@ bool SeatsManager::saveConfigToFile(const QString &filePath) const
 
     QFile file(filePath);
     if (!file.open(QIODevice::WriteOnly)) {
-        qCWarning(treelandSeat) << "Cannot write config file:" << filePath;
+        qCWarning(lcTlSeat) << "Cannot write config file:" << filePath;
         return false;
     }
 
     file.write(doc.toJson(QJsonDocument::Indented));
-    qCDebug(treelandSeat) << "Saved configuration to:" << filePath;
+    qCDebug(lcTlSeat) << "Saved configuration to:" << filePath;
     return true;
 }
 
@@ -387,7 +387,7 @@ bool SeatsManager::validateConfig(const QJsonObject &config) const
 
         if (seatObj.contains("fallback") && seatObj["fallback"].toBool()) {
             if (hasFallback) {
-                qCWarning(treelandSeat) << "Multiple fallback seats found in configuration";
+                qCWarning(lcTlSeat) << "Multiple fallback seats found in configuration";
                 return false;
             }
             hasFallback = true;
@@ -404,19 +404,19 @@ bool SeatsManager::validateConfig(const QJsonObject &config) const
 void SeatsManager::initializeDefaultSeat()
 {
     if (!m_seats.isEmpty()) {
-        qCDebug(treelandSeat) << "Seats already initialized";
+        qCDebug(lcTlSeat) << "Seats already initialized";
         return;
     }
 
     WSeat *defaultSeat = createSeat("seat0", true);
     if (!defaultSeat) {
-        qCCritical(treelandSeat) << "Failed to create default seat!";
+        qCCritical(lcTlSeat) << "Failed to create default seat!";
         return;
     }
 
     ensureDefaultDeviceRules("seat0");
 
-    qCDebug(treelandSeat) << "Initialized default seat: seat0";
+    qCDebug(lcTlSeat) << "Initialized default seat: seat0";
 }
 
 void SeatsManager::ensureDefaultDeviceRules(const QString &seatName)
@@ -425,7 +425,7 @@ void SeatsManager::ensureDefaultDeviceRules(const QString &seatName)
         addDeviceRule(seatName, QString("%1:.*").arg(static_cast<int>(WInputDevice::Type::Keyboard)));
         addDeviceRule(seatName, QString("%1:.*").arg(static_cast<int>(WInputDevice::Type::Pointer)));
         addDeviceRule(seatName, QString("%1:.*").arg(static_cast<int>(WInputDevice::Type::Touch)));
-        qCDebug(treelandSeat) << "Added default device rules for seat:" << seatName;
+        qCDebug(lcTlSeat) << "Added default device rules for seat:" << seatName;
     }
 }
 
@@ -433,7 +433,7 @@ WSeat *SeatsManager::initializeFromConfig(const QString &configPath, WServer *se
 {
     // Try to load config from file
     if (!loadConfigFromFile(configPath)) {
-        qCDebug(treelandSeat) << "No valid seat config found at:" << configPath;
+        qCDebug(lcTlSeat) << "No valid seat config found at:" << configPath;
     }
 
     // Ensure at least one seat exists
@@ -448,7 +448,7 @@ WSeat *SeatsManager::initializeFromConfig(const QString &configPath, WServer *se
     }
 
     if (!primarySeat) {
-        qCCritical(treelandSeat) << "No seat available after initialization!";
+        qCCritical(lcTlSeat) << "No seat available after initialization!";
         return nullptr;
     }
 
@@ -464,7 +464,7 @@ WSeat *SeatsManager::initializeFromConfig(const QString &configPath, WServer *se
         }
     }
 
-    qCDebug(treelandSeat) << "Seat initialization complete. Primary seat:" << primarySeat->name();
+    qCDebug(lcTlSeat) << "Seat initialization complete. Primary seat:" << primarySeat->name();
     return primarySeat;
 }
 
@@ -492,7 +492,7 @@ QJsonObject SeatsManager::saveConfig() const
     }
     
     config["seats"] = seatsArray;
-    qCDebug(treelandSeat) << "Saved configuration for" << m_seats.size() << "seats";
+    qCDebug(lcTlSeat) << "Saved configuration for" << m_seats.size() << "seats";
     return config;
 }
 
@@ -580,7 +580,7 @@ void SeatsManager::setupAllSeats(QQuickWindow *renderWindow,
 {
     for (auto *seat : std::as_const(m_seats)) {
         if (!seat->nativeHandle()) {
-            qCWarning(treelandSeat) << "Seat" << seat->name() << "has no native handle, skipping configuration";
+            qCWarning(lcTlSeat) << "Seat" << seat->name() << "has no native handle, skipping configuration";
             continue;
         }
 
@@ -609,7 +609,7 @@ void SeatsManager::setupAllSeats(QQuickWindow *renderWindow,
 void SeatsManager::connectBackendSignals(WBackend *backend)
 {
     if (!backend) {
-        qCWarning(treelandSeat) << "Cannot connect signals for null backend";
+        qCWarning(lcTlSeat) << "Cannot connect signals for null backend";
         return;
     }
 
@@ -626,7 +626,7 @@ void SeatsManager::connectBackendSignals(WBackend *backend)
             for (auto *seat : std::as_const(m_seats)) {
                 if (seat->deviceList().contains(device)) {
                     seat->detachInputDevice(device);
-                    qCDebug(treelandSeat) << "Device" << device->name() << "removed from seat" << seat->name();
+                    qCDebug(lcTlSeat) << "Device" << device->name() << "removed from seat" << seat->name();
                     break;
                 }
             }
@@ -640,7 +640,7 @@ void SeatsManager::connectBackendSignals(WBackend *backend)
 void SeatsManager::assignExistingDevices(WBackend *backend)
 {
     if (!backend) {
-        qCWarning(treelandSeat) << "Cannot assign devices from null backend";
+        qCWarning(lcTlSeat) << "Cannot assign devices from null backend";
         return;
     }
 
@@ -658,7 +658,7 @@ void SeatsManager::assignDevice(WInputDevice *device,
                                 WSeat *fallbackSeat)
 {
     if (!device) {
-        qCWarning(treelandSeat) << "Cannot assign null device";
+        qCWarning(lcTlSeat) << "Cannot assign null device";
         return;
     }
 
@@ -667,13 +667,13 @@ void SeatsManager::assignDevice(WInputDevice *device,
 
     // Filter out mismatched device types
     if (deviceType == WInputDevice::Type::Pointer && deviceName.contains("Keyboard", Qt::CaseInsensitive)) {
-        qCWarning(treelandSeat) << "Device type mismatch - ignoring:" << deviceName;
+        qCWarning(lcTlSeat) << "Device type mismatch - ignoring:" << deviceName;
         return;
     }
 
     if (deviceType == WInputDevice::Type::Keyboard &&
         (deviceName.contains("Mouse", Qt::CaseInsensitive) || deviceName.contains("Touchpad", Qt::CaseInsensitive))) {
-        qCWarning(treelandSeat) << "Device type mismatch - ignoring:" << deviceName;
+        qCWarning(lcTlSeat) << "Device type mismatch - ignoring:" << deviceName;
         return;
     }
 
@@ -689,11 +689,11 @@ void SeatsManager::assignDevice(WInputDevice *device,
     if (!assignedSeat && fallbackSeat && fallbackSeat->nativeHandle()) {
         fallbackSeat->attachInputDevice(device);
         assignedSeat = fallbackSeat;
-        qCDebug(treelandSeat) << "Device" << deviceName << "assigned to fallback seat";
+        qCDebug(lcTlSeat) << "Device" << deviceName << "assigned to fallback seat";
     }
 
     if (!assignedSeat) {
-        qCWarning(treelandSeat) << "Failed to assign device:" << deviceName;
+        qCWarning(lcTlSeat) << "Failed to assign device:" << deviceName;
         return;
     }
 
@@ -736,7 +736,7 @@ WSeat *SeatsManager::getSeatForDevice(WInputDevice *device) const
 WSeat *SeatsManager::getSeatForEvent(QInputEvent *event) const
 {
     if (!event) {
-        qCWarning(treelandSeat) << "getSeatForEvent called with null event";
+        qCWarning(lcTlSeat) << "getSeatForEvent called with null event";
         return nullptr;
     }
 

--- a/src/session/session.cpp
+++ b/src/session/session.cpp
@@ -23,7 +23,7 @@
 static void applyCursorSettings(SettingManager *settingManager, const QString &theme, qreal size)
 {
     if (!settingManager) {
-        qCDebug(treelandXsettings) << "Skip cursor settings sync: no SettingManager";
+        qCDebug(lcTlXsettings) << "Skip cursor settings sync: no SettingManager";
         return;
     }
 
@@ -36,7 +36,7 @@ static void applyCursorSettings(SettingManager *settingManager, const QString &t
         },
         Qt::QueuedConnection);
     if (!queued) {
-        qCWarning(treelandXsettings) << "Failed to queue cursor settings sync"
+        qCWarning(lcTlXsettings) << "Failed to queue cursor settings sync"
                                      << "theme:" << theme << "size:" << size;
     }
 }
@@ -60,7 +60,7 @@ static xcb_atom_t internAtom(xcb_connection_t *connection, const char *name, boo
 
 Session::~Session()
 {
-    qCDebug(treelandCore) << "Deleting session for uid:" << m_uid << m_socket;
+    qCDebug(lcTlCore) << "Deleting session for uid:" << m_uid << m_socket;
     Q_EMIT aboutToBeDestroyed();
 
     if (m_settingManagerThread) {
@@ -180,7 +180,7 @@ void SessionManager::setActiveSocketEnabled(bool newEnabled)
     if (ptr && ptr->m_socket)
         ptr->m_socket->setEnabled(newEnabled, globalSession()->socket());
     else
-        qCWarning(treelandCore) << "Can't set enabled for empty socket!";
+        qCWarning(lcTlCore) << "Can't set enabled for empty socket!";
 }
 
 /**
@@ -221,7 +221,7 @@ std::shared_ptr<Session> SessionManager::ensureSession(int id, QString username)
         // Create WSocket
         auto socket = new WSocket(true, nullptr);
         if (!socket->autoCreate()) {
-            qCCritical(treelandCore) << "Failed to create Wayland socket";
+            qCCritical(lcTlCore) << "Failed to create Wayland socket";
             delete socket;
             return static_cast<WSocket *>(nullptr);
         }
@@ -238,7 +238,7 @@ std::shared_ptr<Session> SessionManager::ensureSession(int id, QString username)
         // Create xwayland
         auto *xwayland = Helper::instance()->createXWayland();
         if (!xwayland) {
-            qCCritical(treelandCore) << "Failed to create XWayland instance";
+            qCCritical(lcTlCore) << "Failed to create XWayland instance";
             return static_cast<WXWayland *>(nullptr);
         }
         // Bind xwayland to socket
@@ -249,7 +249,7 @@ std::shared_ptr<Session> SessionManager::ensureSession(int id, QString username)
                 session->m_noTitlebarAtom =
                     internAtom(session->m_xwayland->xcbConnection(), _DEEPIN_NO_TITLEBAR, false);
                 if (!session->m_noTitlebarAtom) {
-                    qCWarning(treelandInput) << "Failed to intern atom:" << _DEEPIN_NO_TITLEBAR;
+                    qCWarning(lcTlInput) << "Failed to intern atom:" << _DEEPIN_NO_TITLEBAR;
                 }
                 session->m_settingManager = new SettingManager(session->m_xwayland->xcbConnection());
                 session->m_settingManagerThread = new QThread();
@@ -265,7 +265,7 @@ std::shared_ptr<Session> SessionManager::ensureSession(int id, QString username)
                          scale,
                          renderWindow] {
                             if (!settingManager) {
-                                qCDebug(treelandXsettings)
+                                qCDebug(lcTlXsettings)
                                     << "Skip initial XSettings sync: no SettingManager";
                                 return;
                             }
@@ -285,7 +285,7 @@ std::shared_ptr<Session> SessionManager::ensureSession(int id, QString username)
                                 },
                                 Qt::QueuedConnection);
                             if (!queued) {
-                                qCWarning(treelandXsettings)
+                                qCWarning(lcTlXsettings)
                                     << "Failed to queue initial XSettings sync"
                                     << "cursorTheme:" << cursorTheme << "cursorSize:" << cursorSize
                                     << "scale:" << scale;
@@ -334,7 +334,7 @@ std::shared_ptr<Session> SessionManager::ensureSession(int id, QString username)
     // Session does not exist, create new session with deleter
     auto passwd = getpwnam(username.toLocal8Bit().data());
     if (!passwd) {
-        qCWarning(treelandCore) << "Failed to get passwd entry for user:" << username;
+        qCWarning(lcTlCore) << "Failed to get passwd entry for user:" << username;
         return nullptr;
     }
     auto session = std::make_shared<Session>();
@@ -445,12 +445,12 @@ void SessionManager::syncActiveSessionCursorSettings()
 {
     const auto session = m_activeSession.lock();
     if (!session) {
-        qCDebug(treelandXsettings) << "Skip cursor settings sync: no active session";
+        qCDebug(lcTlXsettings) << "Skip cursor settings sync: no active session";
         return;
     }
 
     if (!session->m_settingManager) {
-        qCDebug(treelandXsettings)
+        qCDebug(lcTlXsettings)
             << "Skip cursor settings sync: no SettingManager for session" << session->username();
         return;
     }
@@ -460,7 +460,7 @@ void SessionManager::syncActiveSessionCursorSettings()
 
     const auto *config = helper->config();
     if (!config) {
-        qCWarning(treelandXsettings) << "Cannot sync cursor settings: user config is unavailable";
+        qCWarning(lcTlXsettings) << "Cannot sync cursor settings: user config is unavailable";
         return;
     }
 
@@ -481,7 +481,7 @@ void SessionManager::updateActiveUserSession(const QString &username, int id)
     // Get new session for uid, creating if necessary
     auto session = ensureSession(id, username);
     if (!session) {
-        qCWarning(treelandInput) << "Failed to ensure session for user" << username;
+        qCWarning(lcTlInput) << "Failed to ensure session for user" << username;
         return;
     }
     if (previous != session) {
@@ -498,6 +498,6 @@ void SessionManager::updateActiveUserSession(const QString &username, int id)
         // Notify session changed through DBus, treeland-sd will listen it to update envs
         Q_EMIT sessionChanged();
     }
-    qCInfo(treelandCore) << "Listening on:" << session->m_socket->fullServerName();
+    qCInfo(lcTlCore) << "Listening on:" << session->m_socket->fullServerName();
     syncActiveSessionCursorSettings();
 }

--- a/src/surface/surfacecontainer.cpp
+++ b/src/surface/surfacecontainer.cpp
@@ -133,7 +133,7 @@ SurfaceContainer::SurfaceContainer(SurfaceContainer *parent)
 SurfaceContainer::~SurfaceContainer()
 {
     if (!m_model->surfaces().isEmpty()) {
-        qCCritical(treelandSurface)
+        qCCritical(lcTlSurface)
             << "SurfaceContainer destroyed with surfaces still attached:" << m_model->surfaces();
     }
 }
@@ -226,7 +226,7 @@ bool SurfaceContainer::doAddSurface(SurfaceWrapper *surface, bool setContainer)
 
     if (setContainer) {
         if (surface->parent()) {
-            qCWarning(treelandSurface)
+            qCWarning(lcTlSurface)
                 << "Surface already has QObject parent, changing parent:" << surface
                 << "from:" << surface->parent() << "to:" << this;
         }

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -174,7 +174,7 @@ SurfaceWrapper::SurfaceWrapper(QmlEngine *qmlEngine,
     if (initialSize.isValid() && initialSize.width() > 0 && initialSize.height() > 0) {
         // Also set implicit size to keep QML layout consistent
         setImplicitSize(initialSize.width(), initialSize.height());
-        qCDebug(treelandSurface) << "Prelaunch Splash: set initial size to" << initialSize;
+        qCDebug(lcTlSurface) << "Prelaunch Splash: set initial size to" << initialSize;
     } else {
         setImplicitSize(800, 600);
     }
@@ -219,7 +219,7 @@ SurfaceWrapper::~SurfaceWrapper()
 {
     if (!m_wrapperAboutToRemove) {
         if (isWindowAnimationRunning()) {
-            qCWarning(treelandSurface)
+            qCWarning(lcTlSurface)
                 << "SurfaceWrapper is being destroyed without destroy(); expected external"
                    " destroy() rather than QObject parent-child destruction";
         }
@@ -459,7 +459,7 @@ void SurfaceWrapper::convertToNormalSurface(WToplevelSurface *shellSurface, Type
 {
     // Conversion only allowed from prelaunch (SplashScreen) state
     if (m_type != Type::SplashScreen || m_shellSurface != nullptr) {
-        qCCritical(treelandSurface)
+        qCCritical(lcTlSurface)
             << "convertToNormalSurface can only be called on prelaunch surfaces";
         return;
     }
@@ -510,11 +510,11 @@ void SurfaceWrapper::setActivate(bool activate)
 void SurfaceWrapper::updateActiveState()
 {
     if (!m_shellSurface) {
-        qCCritical(treelandSurface) << "updateActiveState called without a valid shellSurface";
+        qCCritical(lcTlSurface) << "updateActiveState called without a valid shellSurface";
         return;
     }
     if (!m_shellSurface->isInitialized()) {
-        qCWarning(treelandSurface)
+        qCWarning(lcTlSurface)
             << "updateActiveState called with shellSurface not yet initialized";
         return;
     }
@@ -556,14 +556,14 @@ void SurfaceWrapper::startPrelaunchSplashHideSequence()
 {
     Q_ASSERT(m_surfaceItem != nullptr);
     if (m_windowAnimation) {
-        qCDebug(treelandSurface) << "prelaunch splash transition is starting while window "
+        qCDebug(lcTlSurface) << "prelaunch splash transition is starting while window "
                                     "animation is still running,"
                                     "this may cause visual glitches, will delay the transition "
                                     "until window animation finishes";
         return;
     }
     if (m_geometryAnimation) {
-        qCDebug(treelandSurface) << "prelaunch splash transition already prepared or running, skip";
+        qCDebug(lcTlSurface) << "prelaunch splash transition already prepared or running, skip";
         return;
     }
 
@@ -586,7 +586,7 @@ void SurfaceWrapper::startPrelaunchSplashHideSequence()
     const bool hasValidTargetImplicitSize =
         targetImplicitSize.width() > 0 && targetImplicitSize.height() > 0;
     if (!hasValidTargetImplicitSize) {
-        qCCritical(treelandSurface) << "Invalid target implicit size, skip transition animation"
+        qCCritical(lcTlSurface) << "Invalid target implicit size, skip transition animation"
                                     << "targetImplicit=" << targetImplicitSize;
     }
 
@@ -921,7 +921,7 @@ void SurfaceWrapper::setOutputs(const QList<WOutput *> &outputs)
         return;
     }
     if (!surface()) {
-        qCDebug(treelandSurface) << "SurfaceWrapper::setOutputs called but surface() is null!";
+        qCDebug(lcTlSurface) << "SurfaceWrapper::setOutputs called but surface() is null!";
         return;
     }
     const auto oldOutputs = surface()->outputs();
@@ -1077,7 +1077,7 @@ bool SurfaceWrapper::setAttention(bool attention)
     if (m_attention == attention)
         return true;
     if (attention && m_isActivated) {
-        qCWarning(treelandSurface) << "setAttention(true) ignored: surface is already activated";
+        qCWarning(lcTlSurface) << "setAttention(true) ignored: surface is already activated";
         return false;
     }
     m_attention = attention;
@@ -2178,7 +2178,7 @@ bool SurfaceWrapper::skipDockPreView() const
 void SurfaceWrapper::setSkipDockPreView(bool skip)
 {
     if (!skip && (m_type != Type::XdgToplevel && m_type != Type::XWayland)) {
-        qCWarning(treelandSurface) << "Only XdgToplevel or XWayland surfaces are allowed to set "
+        qCWarning(lcTlSurface) << "Only XdgToplevel or XWayland surfaces are allowed to set "
                                       "`skipDockPreView` to false.";
         return;
     }

--- a/src/systemd-socket.cpp
+++ b/src/systemd-socket.cpp
@@ -15,12 +15,16 @@
 #include <QDebug>
 #include <QDir>
 #include <QFile>
+#include <QLoggingCategory>
 #include <QTemporaryFile>
 #include <QtEnvironmentVariables>
 
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
+
+Q_DECLARE_LOGGING_CATEGORY(lcSdSocket)
+Q_LOGGING_CATEGORY(lcSdSocket, "treeland.systemd.socket")
 
 typedef QMap<QString, QString> StringMap;
 Q_DECLARE_METATYPE(StringMap)
@@ -106,7 +110,7 @@ int main(int argc, char *argv[])
                     if (reply.type() == QDBusMessage::ReplyMessage) {
                         QVariantList values = reply.arguments();
                         if (values.size() < 2) {
-                            qWarning() << "Invalid XWaylandName reply";
+                            qCWarning(lcSdSocket) << "Invalid XWaylandName reply";
                             return;
                         }
                         QString xwaylandName = values.at(0).toString();
@@ -118,7 +122,7 @@ int main(int argc, char *argv[])
                         QTemporaryFile *authFile = new QTemporaryFile();
                         authFile->setFileTemplate(QStringLiteral("%1/.xauth_XXXXXX").arg(runtimeDir));
                         if (!authFile->open()) {
-                            qWarning() << "Failed to create temporary xauth file";
+                            qCWarning(lcSdSocket) << "Failed to create temporary xauth file";
                             return;
                         }
                         QString authFileName = authFile->fileName();

--- a/src/treeland-shortcut/shortcut.cpp
+++ b/src/treeland-shortcut/shortcut.cpp
@@ -15,7 +15,7 @@
 #include <QRegularExpression>
 #include <QStandardPaths>
 
-Q_LOGGING_CATEGORY(treelandShortcut, "daemon.shortcut", QtDebugMsg);
+Q_LOGGING_CATEGORY(lcShortcutDaemon, "treeland.shortcut.daemon", QtDebugMsg);
 
 static const QMap<QString, ShortcutV2::action> ActionMap = {
     {"Notify", ShortcutV2::action_notify},
@@ -156,7 +156,7 @@ void ShortcutV2::treeland_shortcut_manager_v2_commit_success()
 
 void ShortcutV2::treeland_shortcut_manager_v2_commit_failure(const QString &name, uint32_t error)
 {
-    qCWarning(treelandShortcut) << "Commit failure for shortcut:" << name << ", error code:" << error;
+    qCWarning(lcShortcutDaemon) << "Commit failure for shortcut:" << name << ", error code:" << error;
     Q_EMIT commitStatus(false);
 }
 
@@ -169,7 +169,7 @@ ShortcutV2::ShortcutV2()
     : QWaylandClientExtensionTemplate<ShortcutV2>(1)
 {
     connect(this, &ShortcutV2::activeChanged, this, [this] {
-        qCDebug(treelandShortcut) << "isActive:" << isActive();
+        qCDebug(lcShortcutDaemon) << "isActive:" << isActive();
 
         if (isActive()) {
             acquire();
@@ -192,7 +192,7 @@ void ShortcutV2::registerAllShortcuts()
     QDir dir(TREELAND_DATA_DIR "/shortcuts");
     const auto entries = dir.entryInfoList(QDir::Filter::Files);
     for (auto d : entries) {
-        qCInfo(treelandShortcut) << "Load shortcut:" << d.filePath();
+        qCInfo(lcShortcutDaemon) << "Load shortcut:" << d.filePath();
         auto shortcut = new Shortcut(d.filePath(), d.fileName());
         shortcut->registerForManager(this);
         m_shortcuts.append(shortcut);
@@ -254,7 +254,7 @@ void Shortcut::registerForManager(ShortcutV2 *manager)
         if (ActionMap.contains(actionStr)) {
             action = ActionMap.value(actionStr);
         } else {
-            qCWarning(treelandShortcut) << "Unknown action:" << actionStr
+            qCWarning(lcShortcutDaemon) << "Unknown action:" << actionStr
                                         << "for shortcut:" << m_shortcutName
                                         << ", shortcut registration skipped.";
             return;
@@ -285,7 +285,7 @@ void Shortcut::registerForManager(ShortcutV2 *manager)
         static const QRegularExpression regex(QStringLiteral("^(\\d+)Finger(.+)$"));
         const auto match = regex.match(gestureStr);
         if (!match.hasMatch()) {
-            qCWarning(treelandShortcut) << "Invalid gesture format:" << gestureStr;
+            qCWarning(lcShortcutDaemon) << "Invalid gesture format:" << gestureStr;
             break;
         }
 
@@ -293,7 +293,7 @@ void Shortcut::registerForManager(ShortcutV2 *manager)
         const QString movement = match.captured(2);
         if (fingerCount < 2 || fingerCount > 4) {
             // unsupported by libinput
-            qCWarning(treelandShortcut) << "Unsupported finger count:" << fingerCount
+            qCWarning(lcShortcutDaemon) << "Unsupported finger count:" << fingerCount
                                         << "for gesture:" << gestureStr;
             break;
         }
@@ -301,7 +301,7 @@ void Shortcut::registerForManager(ShortcutV2 *manager)
             manager->bind_hold_gesture(gestureName, fingerCount, action);
         } else {
             if (!GestureDirectionMap.contains(movement)) {
-                qCWarning(treelandShortcut) << "Unknown gesture movement:" << movement
+                qCWarning(lcShortcutDaemon) << "Unknown gesture movement:" << movement
                                             << "for gesture:" << gestureStr;
                 break;
             }
@@ -314,7 +314,7 @@ void Shortcut::registerForManager(ShortcutV2 *manager)
     QObject::connect(manager, &ShortcutV2::commitStatus, this, [this, manager, type, &loop](bool success) {
         loop.quit();
         if (!success) {
-            qCWarning(treelandShortcut) << "Shortcut commit failed for shortcut:" << m_shortcutName;
+            qCWarning(lcShortcutDaemon) << "Shortcut commit failed for shortcut:" << m_shortcutName;
             m_registeredBindings.clear();
         } else {
             // unbind on destroy

--- a/src/utils/cmdline.cpp
+++ b/src/utils/cmdline.cpp
@@ -77,7 +77,7 @@ std::optional<QStringList> CmdLine::unescapeExecArgs(const QString &str) noexcep
 {
     auto unescapedStr = unescape(str);
     if (unescapedStr.isEmpty()) {
-        qCWarning(treelandUtils) << "unescape Exec failed.";
+        qCWarning(lcTlUtils) << "unescape Exec failed.";
         return std::nullopt;
     }
 
@@ -110,7 +110,7 @@ std::optional<QStringList> CmdLine::unescapeExecArgs(const QString &str) noexcep
         default:
             errMessage = "unknown";
         }
-        qCWarning(treelandUtils) << "wordexp error: " << errMessage;
+        qCWarning(lcTlUtils) << "wordexp error: " << errMessage;
         return std::nullopt;
     }
 

--- a/src/utils/loginddbustypes.cpp
+++ b/src/utils/loginddbustypes.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "loginddbustypes.h"
@@ -51,7 +51,7 @@ LogindPathInternal::LogindPathInternal()
 
     if (QDBusConnection::systemBus().interface()->isServiceRegistered(
             QStringLiteral("org.freedesktop.login1"))) {
-        qCDebug(treelandDBus) << "Logind interface found";
+        qCDebug(lcTlDBus) << "Logind interface found";
         available = true;
         serviceName = QStringLiteral("org.freedesktop.login1");
         managerPath = QStringLiteral("/org/freedesktop/login1");
@@ -64,7 +64,7 @@ LogindPathInternal::LogindPathInternal()
 
     if (QDBusConnection::systemBus().interface()->isServiceRegistered(
             QStringLiteral("org.freedesktop.ConsoleKit"))) {
-        qCDebug(treelandDBus) << "Console kit interface found";
+        qCDebug(lcTlDBus) << "Console kit interface found";
         available = true;
         serviceName = QStringLiteral("org.freedesktop.ConsoleKit");
         managerPath = QStringLiteral("/org/freedesktop/ConsoleKit/Manager");
@@ -75,7 +75,7 @@ LogindPathInternal::LogindPathInternal()
         userIfaceName = QStringLiteral("org.freedesktop.ConsoleKit.User");
         return;
     }
-    qCDebug(treelandDBus) << "No session manager found";
+    qCDebug(lcTlDBus) << "No session manager found";
 }
 
 Q_GLOBAL_STATIC(LogindPathInternal, s_instance);

--- a/src/utils/propertymonitor.cpp
+++ b/src/utils/propertymonitor.cpp
@@ -1,12 +1,9 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 #include "propertymonitor.h"
 #include "common/treelandlogging.h"
 
 #include <QEvent>
-#include <QLoggingCategory>
-
-Q_LOGGING_CATEGORY(qLcMonitor, "treeland.property.monitor")
 
 PropertyMonitor::PropertyMonitor(QObject *parent)
     : QObject(parent)
@@ -49,7 +46,7 @@ void PropertyMonitor::handlePropertyChanged()
     auto index = senderSignalIndex();
     for (const auto &mProp : std::as_const(m_metaProps)) {
         if (mProp.hasNotifySignal() && mProp.notifySignalIndex() == index) {
-            qCDebug(qLcMonitor) << m_target << mProp.name() << mProp.read(m_target);
+            qCDebug(lcTlPropertyMonitor) << m_target << mProp.name() << mProp.read(m_target);
             break;
         }
     }

--- a/src/wallpaper/wallpaperlauncher.cpp
+++ b/src/wallpaper/wallpaperlauncher.cpp
@@ -62,7 +62,7 @@ void WallpaperLauncher::onSetDisplayNameRequested(const QString &displayName)
 void WallpaperLauncher::onStartRequested()
 {
     if (m_wallpaperProcess) {
-        qCDebug(treelandWallpaper) << "Wallpaper already running or start requested.";
+        qCDebug(lcTlWallpaper) << "Wallpaper already running or start requested.";
         return;
     }
 
@@ -87,7 +87,7 @@ void WallpaperLauncher::onStartRequested()
 void WallpaperLauncher::onStopRequested()
 {
     if (!m_wallpaperProcess) {
-        qCDebug(treelandWallpaper) << "Wallpaper not running or stop already requested.";
+        qCDebug(lcTlWallpaper) << "Wallpaper not running or stop already requested.";
         return;
     }
 
@@ -111,20 +111,20 @@ void WallpaperLauncher::handleWallpaperError(QProcess::ProcessError error)
 {
     switch (error) {
     case QProcess::FailedToStart:
-        qCCritical(treelandWallpaper) << "Wallpaper process failed to start";
+        qCCritical(lcTlWallpaper) << "Wallpaper process failed to start";
         break;
     case QProcess::Crashed:
-        qCCritical(treelandWallpaper) << "Wallpaper process crashed";
+        qCCritical(lcTlWallpaper) << "Wallpaper process crashed";
         break;
     case QProcess::Timedout:
-        qCCritical(treelandWallpaper) << "Wallpaper operation timed out";
+        qCCritical(lcTlWallpaper) << "Wallpaper operation timed out";
         break;
     case QProcess::WriteError:
     case QProcess::ReadError:
-        qCCritical(treelandWallpaper) << "An error occurred while communicating with Wallpaper";
+        qCCritical(lcTlWallpaper) << "An error occurred while communicating with Wallpaper";
         break;
     case QProcess::UnknownError:
-        qCCritical(treelandWallpaper) << "An unknown error has occurred in Wallpaper";
+        qCCritical(lcTlWallpaper) << "An unknown error has occurred in Wallpaper";
         break;
     }
 

--- a/src/wallpaper/wallpapermanager.cpp
+++ b/src/wallpaper/wallpapermanager.cpp
@@ -94,7 +94,7 @@ void WallpaperManager::updateWallpaperConfig()
                 m_wallpaperConfig.append(WallpaperOutputConfig::fromJson(obj));
             }
         } else {
-            qCCritical(treelandWallpaper) << "wallpapers config value error: Expected a JSON array, but got something else.";
+            qCCritical(lcTlWallpaper) << "wallpapers config value error: Expected a JSON array, but got something else.";
         }
     } else {
         defaultWallpaperConfig();
@@ -353,7 +353,7 @@ TreelandWallpaperInterfaceV1::WallpaperType WallpaperManager::getWallpaperType(c
         }
     }
 
-    qCCritical(treelandWallpaper) << "Failed find wallpaper type for" << wallpaper;
+    qCCritical(lcTlWallpaper) << "Failed find wallpaper type for" << wallpaper;
     return TreelandWallpaperInterfaceV1::Image;
 }
 

--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -360,7 +360,7 @@ void Workspace::stopPreviewing()
 void Workspace::pushActivedSurface(SurfaceWrapper *surface)
 {
     if (surface->type() == SurfaceWrapper::Type::XdgPopup) {
-        qWarning(treelandWorkspace) << "XdgPopup can't participate in focus fallback!";
+        qCWarning(lcTlWorkspace) << "XdgPopup can't participate in focus fallback!";
         return;
     }
     if (surface->showOnAllWorkspace()) [[unlikely]] {

--- a/src/xsettings/xresource.cpp
+++ b/src/xsettings/xresource.cpp
@@ -151,7 +151,7 @@ void XResource::reload()
     xcb_get_property_reply_t *reply =
         xcb_get_property_reply(m_connection, cookie, nullptr);
     if (!reply) {
-        qCCritical(treelandXsettings) << "xcb_intern_atom_reply returned nullptr, atom:" << XRESOURCE_ATOM_NAME;
+        qCCritical(lcTlXsettings) << "xcb_intern_atom_reply returned nullptr, atom:" << XRESOURCE_ATOM_NAME;
         return;
     }
 

--- a/src/xsettings/xsettings.cpp
+++ b/src/xsettings/xsettings.cpp
@@ -363,7 +363,7 @@ bool XSettings::initX11(int screen, bool replace) {
     xcb_intern_atom_reply_t *atomReply = xcb_intern_atom_reply(m_connection, atomCookie, nullptr);
 
     if (!atomReply) {
-        qCCritical(treelandXsettings) << "xcb_intern_atom_reply return nullptr for" << XSETTINGS_ATOM_NAME;
+        qCCritical(lcTlXsettings) << "xcb_intern_atom_reply return nullptr for" << XSETTINGS_ATOM_NAME;
         return false;
     }
 
@@ -376,7 +376,7 @@ bool XSettings::initX11(int screen, bool replace) {
     xcb_intern_atom_reply_t *notifyAtomReply = xcb_intern_atom_reply(m_connection, notifyAtomCookie, nullptr);
 
     if (!notifyAtomReply) {
-        qCCritical(treelandXsettings) << "xcb_intern_atom_reply return nullptr for" << XSETTINGS_NOTIFY_ATOM_NAME;
+        qCCritical(lcTlXsettings) << "xcb_intern_atom_reply return nullptr for" << XSETTINGS_NOTIFY_ATOM_NAME;
         return false;
     }
 
@@ -389,7 +389,7 @@ bool XSettings::initX11(int screen, bool replace) {
     xcb_intern_atom_reply_t *signalAtomReply = xcb_intern_atom_reply(m_connection, signalAtomCookie, nullptr);
 
     if (!signalAtomReply) {
-        qCCritical(treelandXsettings) << "xcb_intern_atom_reply return nullptr for" << XSETTINGS_SIGNAL_ATOM_NAME;
+        qCCritical(lcTlXsettings) << "xcb_intern_atom_reply return nullptr for" << XSETTINGS_SIGNAL_ATOM_NAME;
         return false;
     }
 
@@ -412,7 +412,7 @@ bool XSettings::initX11(int screen, bool replace) {
         xcb_window_t win;
         xcb_timestamp_t timestamp;
         if (!createWindow(s, &win, &timestamp)) {
-            qCCritical(treelandXsettings) << "xsettingsd Unable to create window on screen" << s;
+            qCCritical(lcTlXsettings) << "xsettingsd Unable to create window on screen" << s;
             return false;
         }
 
@@ -428,7 +428,7 @@ bool XSettings::initX11(int screen, bool replace) {
             return false;
 
         m_windows.push_back(win);
-        qCDebug(treelandXsettings) << "XSettings: registered window" << win << "for screen" << s;
+        qCDebug(lcTlXsettings) << "XSettings: registered window" << win << "for screen" << s;
     }
 
     xcb_flush(m_connection);
@@ -443,7 +443,7 @@ bool XSettings::createWindow(int screen, xcb_window_t *out_win, xcb_timestamp_t 
 
     xcb_screen_t *scr = it.data;
     if (!scr) {
-        qCCritical(treelandXsettings) << "xcb_setup_roots_iterator failed";
+        qCCritical(lcTlXsettings) << "xcb_setup_roots_iterator failed";
         return false;
     }
 
@@ -473,7 +473,7 @@ bool XSettings::createWindow(int screen, xcb_window_t *out_win, xcb_timestamp_t 
     *out_win = win;
     *out_time = XCB_CURRENT_TIME;
 
-    qCDebug(treelandXsettings) << "Created XSETTINGS window" << win << "named" << name;
+    qCDebug(lcTlXsettings) << "Created XSETTINGS window" << win << "named" << name;
 
     return true;
 }
@@ -486,7 +486,7 @@ bool XSettings::manageScreen(int screen, xcb_window_t win, xcb_timestamp_t times
         xcb_intern_atom(m_connection, 0, strlen(sel_name), sel_name);
     xcb_intern_atom_reply_t *sel_reply = xcb_intern_atom_reply(m_connection, sel_cookie, nullptr);
     if (!sel_reply) {
-        qCCritical(treelandXsettings)
+        qCCritical(lcTlXsettings)
         << "xcb_intern_atom_reply return nullptr for"
         << QString("_XSETTINGS_S%1").arg(screen);
 
@@ -507,7 +507,7 @@ bool XSettings::manageScreen(int screen, xcb_window_t win, xcb_timestamp_t times
 
     if (owner != XCB_NONE && !replace) {
         xcb_ungrab_server(m_connection);
-        qCCritical(treelandXsettings)
+        qCCritical(lcTlXsettings)
             << "xsettings: Another XSETTINGS manager exists for screen"
             << screen
             << "owner window" << owner;
@@ -525,7 +525,7 @@ bool XSettings::manageScreen(int screen, xcb_window_t win, xcb_timestamp_t times
     xcb_ungrab_server(m_connection);
 
     if (!ok) {
-        qCCritical(treelandXsettings) << "xsettingsd: Failed to acquire ownership of" << sel_name;
+        qCCritical(lcTlXsettings) << "xsettingsd: Failed to acquire ownership of" << sel_name;
         return false;
     }
 
@@ -539,7 +539,7 @@ bool XSettings::manageScreen(int screen, xcb_window_t win, xcb_timestamp_t times
     xcb_intern_atom_reply_t *man_reply =
         xcb_intern_atom_reply(m_connection, man_cookie, nullptr);
     if (!man_reply) {
-        qCCritical(treelandXsettings) << "Failed to intern MANAGER atom";
+        qCCritical(lcTlXsettings) << "Failed to intern MANAGER atom";
         return false;
     }
 

--- a/src/xwayland.cpp
+++ b/src/xwayland.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2025-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 /**
@@ -7,7 +7,7 @@
  * (dde)   treeland -> wlroots -> treeland-xwayland (this) -> Xwayland
  *            ^ |                         |
  *            | |                         +-> /tmp/.xauth_:X (dde, 0600)
- *       XwaylandName()                              |
+ *       XWaylandName()                              |
  *            | |------------------<-----------------+
  *            | |               content
  *            | v
@@ -17,6 +17,7 @@
 
 #include <QByteArray>
 #include <QDebug>
+#include <QLoggingCategory>
 #include <QString>
 #include <QTemporaryFile>
 #include <random>
@@ -24,10 +25,13 @@
 #include <unistd.h>
 #include <X11/Xauth.h>
 
+Q_DECLARE_LOGGING_CATEGORY(lcXwaylandHelper)
+Q_LOGGING_CATEGORY(lcXwaylandHelper, "treeland.xwayland.helper")
+
 int main(int argc, char *argv[])
 {
     if (argc < 2) {
-        qCritical() << "Usage: treeland-xwayland <display> [args]";
+        qCCritical(lcXwaylandHelper) << "Usage: treeland-xwayland <display> [args]";
         return 1;
     }
     // Generate cookie
@@ -97,6 +101,6 @@ int main(int argc, char *argv[])
     args[argc + 1] = const_cast<char *>(fileName);
     args[argc + 2] = nullptr;
     execvp("Xwayland", args);
-    qWarning() << "execvp() returned";
+    qCWarning(lcXwaylandHelper) << "execvp() returned";
     return 1;
 }


### PR DESCRIPTION
## Summary

Unify treeland logging category system following Qt convention.

### Changes
1. Rename category variables from `treelandXxx` to `lcTlXxx` following Qt convention
2. Reorganize string IDs under `treeland.*` hierarchy (e.g. `treeland.core`, `treeland.input`)
3. Move scattered `Q_LOGGING_CATEGORY` definitions into `treelandlogging.h/cpp`
4. Migrate raw `qDebug`/`qWarning`/`qCritical` calls to categorized `qCDebug`/`qCWarning`/`qCCritical`
5. Remove duplicate category in `gestures.cpp` (`qLcGestures` merged into `lcTlGestures`)
6. Fix inconsistent string IDs (`daemon.shortcut` -> `treeland.shortcut.daemon`)

### Testing
- Verify logging output still works correctly with existing category filters
- Test that `QT_LOGGING_RULES` environment variable filters work as expected
- Verify no regression in debug/warning/critical message output

Related: linuxdeepin/treeland#990