### PR TITLE
refactor: unify waylib logging category system

### DIFF
--- a/waylib/src/server/CMakeLists.txt
+++ b/waylib/src/server/CMakeLists.txt
@@ -102,6 +102,8 @@ ws_generate(
 )
 
 set(SOURCES
+    wayliblogging.cpp
+
     kernel/wbackend.cpp
     kernel/wcursor.cpp
     kernel/winputdevice.cpp
@@ -203,6 +205,8 @@ set(SOURCES
 )
 
 set(HEADERS
+    wayliblogging.h
+
     kernel/wglobal.h
     kernel/wbackend.h
     kernel/wcursor.h
@@ -419,6 +423,7 @@ target_include_directories(${TARGET}
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/protocols/private>
         $<INSTALL_INTERFACE:${WAYLIB_INCLUDE_INSTALL_DIR}>
     PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         ${Qt6Gui_PRIVATE_INCLUDE_DIRS}
         ${Qt6Quick_PRIVATE_INCLUDE_DIRS}
         ${Qt6EglSupport_PRIVATE_INCLUDE_DIRS}

--- a/waylib/src/server/kernel/wcursor.cpp
+++ b/waylib/src/server/kernel/wcursor.cpp
@@ -12,6 +12,7 @@
 #include "wseat.h"
 #include "woutput.h"
 #include "woutputlayout.h"
+#include "wayliblogging.h"
 
 #include <qwbuffer.h>
 #include <qwcompositor.h>
@@ -27,22 +28,12 @@
 #include <QPixmap>
 #include <QCoreApplication>
 #include <QQuickWindow>
-#include <QLoggingCategory>
 #include <private/qcursor_p.h>
 
 W_DECLARE_PRIVATE_MEMBER(QCursor_d_tag, QCursor, d, QCursorData*);
 
 QW_USE_NAMESPACE
 WAYLIB_SERVER_BEGIN_NAMESPACE
-
-// Cursor management and movement
-Q_LOGGING_CATEGORY(waylibCursor, "waylib.server.cursor", QtInfoMsg)
-// Cursor input events (motion, buttons, etc.)
-Q_LOGGING_CATEGORY(waylibCursorInput, "waylib.server.cursor.input", QtInfoMsg)
-// Cursor gesture events (pinch, swipe, etc.)
-Q_LOGGING_CATEGORY(waylibCursorGesture, "waylib.server.cursor.gesture", QtDebugMsg)
-// Cursor touch events
-Q_LOGGING_CATEGORY(waylibCursorTouch, "waylib.server.cursor.touch", QtInfoMsg)
 
 WCursorPrivate::WCursorPrivate(WCursor *qq)
     : WWrapObjectPrivate(qq)
@@ -58,15 +49,15 @@ WCursorPrivate::~WCursorPrivate()
 
 void WCursorPrivate::instantRelease()
 {
-    qCDebug(waylibCursor) << "Releasing cursor" << q_func();
+    qCDebug(lcWlCursor) << "Releasing cursor" << q_func();
 
     if (seat) {
-        qCDebug(waylibCursor) << "Detaching cursor from seat:" << seat->name();
+        qCDebug(lcWlCursor) << "Detaching cursor from seat:" << seat->name();
         seat->setCursor(nullptr);
     }
 
     if (outputLayout) {
-        qCDebug(waylibCursor) << "Removing cursor from" << outputLayout->outputs().size() << "outputs";
+        qCDebug(lcWlCursor) << "Removing cursor from" << outputLayout->outputs().size() << "outputs";
         for (auto o : outputLayout->outputs())
             o->removeCursor(q_func());
     }
@@ -111,7 +102,7 @@ void WCursorPrivate::on_button(wlr_pointer_button_event *event)
     button = WCursor::fromNativeButton(event->button);
 
     QString stateStr = (event->state == WL_POINTER_BUTTON_STATE_RELEASED) ? "released" : "pressed";
-    qCDebug(waylibCursorInput) << "Button" << static_cast<int>(button) << stateStr
+    qCDebug(lcWlPointer) << "Button" << static_cast<int>(button) << stateStr
                               << "at position:" << q_func()->position();
 
     if (event->state == WL_POINTER_BUTTON_STATE_RELEASED) {
@@ -338,7 +329,7 @@ void WCursorPrivate::processCursorMotion(qw_pointer *device, uint32_t time)
 {
     W_Q(WCursor);
 
-    qCDebug(waylibCursorInput) << "Processing cursor motion at" << q->position()
+    qCDebug(lcWlPointer) << "Processing cursor motion at" << q->position()
                               << "time:" << time;
 
     if (auto inputDevice = WInputDevice::fromHandle(device)) {
@@ -360,7 +351,7 @@ void WCursor::move(qw_input_device *device, const QPointF &delta)
     d_func()->handle()->move(*device, delta.x(), delta.y());
 
     if (oldPos != position()) {
-        qCDebug(waylibCursor) << "Cursor moved from" << oldPos << "to" << position()
+        qCDebug(lcWlCursor) << "Cursor moved from" << oldPos << "to" << position()
                              << "delta:" << delta;
         Q_EMIT positionChanged();
     }
@@ -435,7 +426,7 @@ Qt::MouseButton WCursor::fromNativeButton(uint32_t code)
     case 0x11e: qt_button = Qt::ExtraButton12; break;
     case 0x11f: qt_button = Qt::ExtraButton13; break;
     default: 
-        qCWarning(waylibCursorInput) << "Invalid button code:" << QString("0x%1").arg(code, 0, 16)
+        qCWarning(lcWlPointer) << "Invalid button code:" << QString("0x%1").arg(code, 0, 16)
                                     << "- not mappable to Qt button";
     }
 
@@ -462,7 +453,7 @@ uint32_t WCursor::toNativeButton(Qt::MouseButton button)
     case Qt::ExtraButton12: return 0x11e;
     case Qt::ExtraButton13: return 0x11f;
     default:
-        qCWarning(waylibCursorInput) << "Invalid Qt button:" << button 
+        qCWarning(lcWlPointer) << "Invalid Qt button:" << button 
                                     << "- cannot be mapped to native button code";
     }
 
@@ -605,14 +596,14 @@ bool WCursor::attachInputDevice(WInputDevice *device)
     if (device->type() != WInputDevice::Type::Pointer
             && device->type() != WInputDevice::Type::Touch
             && device->type() != WInputDevice::Type::Tablet) {
-        qCDebug(waylibCursor) << "Cannot attach device type" << static_cast<int>(device->type())
+        qCDebug(lcWlCursor) << "Cannot attach device type" << static_cast<int>(device->type())
                              << "to cursor - not a pointing device";
         return false;
     }
 
     W_D(WCursor);
     Q_ASSERT(!d->deviceList.contains(device));
-    qCDebug(waylibCursor) << "Attaching input device" << device->qtDevice()->name() 
+    qCDebug(lcWlCursor) << "Attaching input device" << device->qtDevice()->name() 
                          << "of type" << static_cast<int>(device->type()) << "to cursor";
     d->handle()->attach_input_device(device->handle()->handle());
     d->deviceList << device;
@@ -630,12 +621,12 @@ void WCursor::detachInputDevice(WInputDevice *device)
     W_D(WCursor);
 
     if (!d->deviceList.removeOne(device)) {
-        qCDebug(waylibCursor) << "Cannot detach device" << device->qtDevice()->name()
+        qCDebug(lcWlCursor) << "Cannot detach device" << device->qtDevice()->name()
                              << "- not attached to this cursor";
         return;
     }
 
-    qCDebug(waylibCursor) << "Detaching input device" << device->qtDevice()->name() 
+    qCDebug(lcWlCursor) << "Detaching input device" << device->qtDevice()->name() 
                          << "from cursor";
     d->handle()->detach_input_device(device->handle()->handle());
     d->handle()->map_input_to_output(device->handle()->handle(), nullptr);

--- a/waylib/src/server/kernel/winputdevice.cpp
+++ b/waylib/src/server/kernel/winputdevice.cpp
@@ -4,6 +4,7 @@
 #include "winputdevice.h"
 #include "wseat.h"
 #include "private/wglobal_p.h"
+#include "wayliblogging.h"
 
 #include <qwinputdevice.h>
 
@@ -20,9 +21,6 @@
 
 QW_USE_NAMESPACE
 WAYLIB_SERVER_BEGIN_NAMESPACE
-
-// Input device management and events
-Q_LOGGING_CATEGORY(waylibInput, "waylib.server.input", QtInfoMsg)
 
 // DeviceInfoParser implementation
 DeviceInfoParser& DeviceInfoParser::instance()
@@ -97,7 +95,7 @@ public:
 
     void instantRelease() override {
         if (handle()) {
-            qCDebug(waylibInput) << "Releasing input device:" 
+            qCDebug(lcWlInput) << "Releasing input device:" 
                                 << QString::fromUtf8(nativeHandle()->name);
             handle()->set_data(nullptr, nullptr);
             if (seat)
@@ -152,7 +150,7 @@ WInputDevice::Type WInputDevice::type() const
     case WLR_INPUT_DEVICE_SWITCH: return Type::Switch;
     }
 
-    qCWarning(waylibInput) << "Unknown input device type:" << d->nativeHandle()->type 
+    qCWarning(lcWlInput) << "Unknown input device type:" << d->nativeHandle()->type 
                           << "from device:" << QString::fromUtf8(d->nativeHandle()->name);
     return Type::Unknow;
 }
@@ -176,7 +174,7 @@ void WInputDevice::setSeat(WSeat *seat)
 {
     W_D(WInputDevice);
     if (d->seat != seat) {
-        qCDebug(waylibInput) << "Input device" << QString::fromUtf8(d->nativeHandle()->name)
+        qCDebug(lcWlInput) << "Input device" << QString::fromUtf8(d->nativeHandle()->name)
                             << "assigned to seat:" << (seat ? seat->name() : QString("(null)"));
         d->seat = seat;
     }
@@ -192,7 +190,7 @@ void WInputDevice::setQtDevice(QInputDevice *device)
 {
     W_D(WInputDevice);
     if (d->qtDevice != device) {
-        qCDebug(waylibInput) << "Qt device" << (device ? device->name() : QString("(null)"))
+        qCDebug(lcWlInput) << "Qt device" << (device ? device->name() : QString("(null)"))
                             << "associated with input device:" 
                             << QString::fromUtf8(d->nativeHandle()->name);
         d->qtDevice = device;
@@ -270,16 +268,16 @@ void WInputDevice::setExclusiveGrabber(QObject *grabber)
     W_D(WInputDevice);
     auto pointerDevice = qobject_cast<QPointingDevice*>(d->qtDevice);
     if (!pointerDevice) {
-        qCDebug(waylibInput) << "Cannot set exclusive grabber: device is not a pointing device";
+        qCDebug(lcWlInput) << "Cannot set exclusive grabber: device is not a pointing device";
         return;
     }
     auto dd = QPointingDevicePrivate::get(pointerDevice);
     if (dd->activePoints.isEmpty()) {
-        qCDebug(waylibInput) << "Cannot set exclusive grabber: no active points";
+        qCDebug(lcWlInput) << "Cannot set exclusive grabber: no active points";
         return;
     }
     auto firstPoint = dd->activePoints.values().first();
-    qCDebug(waylibInput) << "Setting exclusive grabber" << grabber 
+    qCDebug(lcWlInput) << "Setting exclusive grabber" << grabber 
                          << "for device:" << QString::fromUtf8(d->nativeHandle()->name);
     dd->setExclusiveGrabber(nullptr, firstPoint.eventPoint, grabber);
 }

--- a/waylib/src/server/kernel/woutput.cpp
+++ b/waylib/src/server/kernel/woutput.cpp
@@ -8,6 +8,7 @@
 #include "wtools.h"
 #include "platformplugin/qwlrootscreen.h"
 #include "private/wglobal_p.h"
+#include "wayliblogging.h"
 
 #include <qwoutput.h>
 #include <qwoutputlayout.h>
@@ -17,7 +18,6 @@
 #include <qwrendererinterface.h>
 #include <qwoutputinterface.h>
 
-#include <QLoggingCategory>
 #include <QCoreApplication>
 #include <QQuickWindow>
 #include <QCursor>
@@ -27,13 +27,6 @@
 
 QW_USE_NAMESPACE
 WAYLIB_SERVER_BEGIN_NAMESPACE
-
-// Output management and configuration
-Q_LOGGING_CATEGORY(waylibOutput, "waylib.server.output", QtInfoMsg)
-// Hardware-specific output operations
-Q_LOGGING_CATEGORY(waylibOutputHW, "waylib.server.output.hardware", QtInfoMsg)
-// Buffer and swapchain management
-Q_LOGGING_CATEGORY(waylibOutputBuffer, "waylib.server.output.buffer", QtDebugMsg)
 
 class Q_DECL_HIDDEN WOutputPrivate : public WWrapObjectPrivate
 {
@@ -184,7 +177,7 @@ static bool wlr_drm_format_add(struct wlr_drm_format *fmt, uint64_t modifier) {
 
         uint64_t *new_modifiers = reinterpret_cast<uint64_t*>(realloc(fmt->modifiers, sizeof(*fmt->modifiers) * capacity));
         if (!new_modifiers) {
-            qCCritical(waylibOutputBuffer) << "Failed to allocate memory for DRM format modifiers";
+            qCCritical(lcWlOutputBuffer) << "Failed to allocate memory for DRM format modifiers";
             return false;
         }
 
@@ -237,14 +230,14 @@ static bool output_pick_format(struct wlr_output *output,
     const struct wlr_drm_format_set *render_formats =
         wlr_renderer_get_render_formats(renderer);
     if (render_formats == NULL) {
-        qCCritical(waylibOutputHW) << "Failed to get renderer format support information";
+        qCCritical(lcWlOutputDrm) << "Failed to get renderer format support information";
         return false;
     }
 
     const struct wlr_drm_format *render_format =
         wlr_drm_format_set_get(render_formats, fmt);
     if (render_format == NULL) {
-        qCDebug(waylibOutputHW) << "Renderer does not support format:" << QString("0x%1").arg(fmt, 0, 16);
+        qCDebug(lcWlOutputDrm) << "Renderer does not support format:" << QString("0x%1").arg(fmt, 0, 16);
         return false;
     }
 
@@ -252,11 +245,11 @@ static bool output_pick_format(struct wlr_output *output,
         const struct wlr_drm_format *display_format =
             wlr_drm_format_set_get(display_formats, fmt);
         if (display_format == NULL) {
-            qCDebug(waylibOutputHW) << "Output does not support format:" << QString("0x%1").arg(fmt, 0, 16);
+            qCDebug(lcWlOutputDrm) << "Output does not support format:" << QString("0x%1").arg(fmt, 0, 16);
             return false;
         }
         if (!wlr_drm_format_intersect(format, display_format, render_format)) {
-            qCWarning(waylibOutputHW) << "Failed to find compatible format modifiers for format" 
+            qCWarning(lcWlOutputDrm) << "Failed to find compatible format modifiers for format" 
                                      << QString("0x%1").arg(fmt, 0, 16) 
                                      << "on output:" << QString::fromUtf8(output->name);
             return false;
@@ -270,7 +263,7 @@ static bool output_pick_format(struct wlr_output *output,
 
     if (format->len == 0) {
         wlr_drm_format_finish(format);
-        qCWarning(waylibOutputHW) << "No compatible output format found";
+        qCWarning(lcWlOutputDrm) << "No compatible output format found";
         return false;
     }
 
@@ -288,12 +281,12 @@ static struct wlr_swapchain *create_swapchain(struct wlr_output *output,
         wlr_output_get_primary_formats(output, allocator->buffer_caps);
     struct wlr_drm_format format{};
     if (!output_pick_format(output, display_formats, &format, render_format)) {
-        qCWarning(waylibOutputBuffer) << "Failed to pick primary buffer format for output:" << QString::fromUtf8(output->name);
+        qCWarning(lcWlOutputBuffer) << "Failed to pick primary buffer format for output:" << QString::fromUtf8(output->name);
         return NULL;
     }
 
     char *format_name = drmGetFormatName(format.format);
-    qCInfo(waylibOutputBuffer) << "Selected primary buffer format:" 
+    qCInfo(lcWlOutputBuffer) << "Selected primary buffer format:" 
                               << (format_name ? QString::fromUtf8(format_name) : QString("<unknown>"))
                               << QString("(0x%1)").arg(format.format, 8, 16, QLatin1Char('0'))
                               << "for output:" << QString::fromUtf8(output->name);
@@ -301,14 +294,14 @@ static struct wlr_swapchain *create_swapchain(struct wlr_output *output,
 
     if (!allow_modifiers && (format.len != 1 || format.modifiers[0] != DRM_FORMAT_MOD_LINEAR)) {
         if (!wlr_drm_format_has(&format, DRM_FORMAT_MOD_INVALID)) {
-            qCWarning(waylibOutputHW) << "No support for implicit modifiers";
+            qCWarning(lcWlOutputDrm) << "No support for implicit modifiers";
             wlr_drm_format_finish(&format);
             return NULL;
         }
 
         format.len = 0;
         if (!wlr_drm_format_add(&format, DRM_FORMAT_MOD_INVALID)) {
-            qCWarning(waylibOutputHW) << "Failed to add implicit modifier to DRM format";
+            qCWarning(lcWlOutputDrm) << "Failed to add implicit modifier to DRM format";
             wlr_drm_format_finish(&format);
             return NULL;
         }
@@ -351,26 +344,26 @@ static bool wlr_output_configure_primary_swapchain(struct wlr_output *output, in
 
     struct wlr_swapchain *swapchain = create_swapchain(output, width, height, format, true);
     if (swapchain == NULL) {
-        qCCritical(waylibOutputBuffer) << "Failed to create swapchain for output:" << QString::fromUtf8(output->name);
+        qCCritical(lcWlOutputBuffer) << "Failed to create swapchain for output:" << QString::fromUtf8(output->name);
         return false;
     }
 
     if (test) {
-        qCDebug(waylibOutputBuffer) << "Testing swapchain for output:" << QString::fromUtf8(output->name);
+        qCDebug(lcWlOutputBuffer) << "Testing swapchain for output:" << QString::fromUtf8(output->name);
         if (!test_swapchain(output, swapchain, state)) {
-            qCDebug(waylibOutputBuffer) << "Output test failed for" << QString::fromUtf8(output->name) 
+            qCDebug(lcWlOutputBuffer) << "Output test failed for" << QString::fromUtf8(output->name) 
                                       << "- retrying without modifiers";
             wlr_swapchain_destroy(swapchain);
             swapchain = create_swapchain(output, width, height, format, false);
             if (swapchain == NULL) {
-                qCCritical(waylibOutputBuffer) << "Failed to create modifier-less swapchain for output:" 
+                qCCritical(lcWlOutputBuffer) << "Failed to create modifier-less swapchain for output:" 
                                              << QString::fromUtf8(output->name);
                 return false;
             }
-            qCDebug(waylibOutputBuffer) << "Testing modifier-less swapchain for output:" 
+            qCDebug(lcWlOutputBuffer) << "Testing modifier-less swapchain for output:" 
                                       << QString::fromUtf8(output->name);
             if (!test_swapchain(output, swapchain, state)) {
-                qCCritical(waylibOutputBuffer) << "Swapchain test failed for output:" 
+                qCCritical(lcWlOutputBuffer) << "Swapchain test failed for output:" 
                                              << QString::fromUtf8(output->name);
                 wlr_swapchain_destroy(swapchain);
                 return false;
@@ -394,7 +387,7 @@ static bool output_pick_cursor_format(struct wlr_output *output,
         display_formats =
             output->impl->get_cursor_formats(output, allocator->buffer_caps);
         if (display_formats == NULL) {
-            qCDebug(waylibOutputHW) << "Failed to get cursor display formats from output";
+            qCDebug(lcWlOutputDrm) << "Failed to get cursor display formats from output";
             return false;
         }
     }
@@ -423,7 +416,7 @@ bool WOutput::configureCursorSwapchain(const QSize &size, uint32_t drmFormat, qw
     if (!sc || sc->handle()->width != size.width() || sc->handle()->height != size.height()) {
         wlr_drm_format format = {};
         if (!output_pick_cursor_format(nativeHandle(), &format, drmFormat)) {
-            qCDebug(waylibOutputHW) << "Failed to select compatible cursor format";
+            qCDebug(lcWlOutputDrm) << "Failed to select compatible cursor format";
             return false;
         }
 
@@ -431,7 +424,7 @@ bool WOutput::configureCursorSwapchain(const QSize &size, uint32_t drmFormat, qw
         sc = qw_swapchain::create(*allocator(), size.width(), size.height(), &format);
         wlr_drm_format_finish(&format);
         if (!sc) {
-            qCDebug(waylibOutputBuffer) << "Failed to create cursor swapchain with selected format";
+            qCDebug(lcWlOutputBuffer) << "Failed to create cursor swapchain with selected format";
             return false;
         }
     }

--- a/waylib/src/server/kernel/wseat.cpp
+++ b/waylib/src/server/kernel/wseat.cpp
@@ -9,6 +9,7 @@
 #include "wxdgsurface.h"
 #include "platformplugin/qwlrootsintegration.h"
 #include "private/wglobal_p.h"
+#include "wayliblogging.h"
 
 #include <qwseat.h>
 #include <qwkeyboard.h>
@@ -38,12 +39,6 @@ QT_END_NAMESPACE
 
 QW_USE_NAMESPACE
 WAYLIB_SERVER_BEGIN_NAMESPACE
-
-// Waylib server seat logging categories
-Q_LOGGING_CATEGORY(waylibSeat, "waylib.server.seat", QtInfoMsg)
-Q_LOGGING_CATEGORY(waylibSeatTouch, "waylib.server.seat.touch", QtInfoMsg)
-Q_LOGGING_CATEGORY(waylibSeatDrag, "waylib.server.seat.drag", QtInfoMsg)
-Q_LOGGING_CATEGORY(waylibSeatGesture, "waylib.server.seat.gesture", QtInfoMsg)
 
 #if QT_CONFIG(wheelevent)
 class Q_DECL_HIDDEN WSeatWheelEvent : public QWheelEvent {
@@ -280,7 +275,7 @@ public:
         Q_ASSERT(qwDevice);
         auto *state = device->getAttachedData<WSeatPrivate::DeviceState>();
 
-        qCDebug(waylibSeatTouch) << "Touch frame for device: " << qwDevice->name()
+        qCDebug(lcWlTouch) << "Touch frame for device: " << qwDevice->name()
                                    << ", handle the following state: " << state->m_points;
 
         if (state->m_points.isEmpty())
@@ -508,7 +503,7 @@ void WSeatPrivate::on_request_start_drag(wlr_seat_request_start_drag_event *even
         return;
     }
 
-    qCWarning(waylibSeatDrag) << "Ignoring start_drag request: "
+    qCWarning(lcWlDrag) << "Ignoring start_drag request: "
                                 << "could not validate pointer or touch serial " << event->serial;
 
     wlr_data_source_destroy(event->drag->source);
@@ -684,7 +679,7 @@ void WSeatPrivate::detachInputDevice(WInputDevice *device)
         cursor->detachInputDevice(device);
 
     if (device->type() == WInputDevice::Type::Touch) {
-        qCDebug(waylibSeat, "WSeat: detachTouchDevice %s", qPrintable(device->qtDevice()->name()));
+        qCDebug(lcWlSeat, "WSeat: detachTouchDevice %s", qPrintable(device->qtDevice()->name()));
         auto *state = device->getAttachedData<WSeatPrivate::DeviceState>();
         device->removeAttachedData<WSeatPrivate::DeviceState>();
         delete state;
@@ -804,7 +799,7 @@ WGlobal::CursorShape WSeat::requestedCursorShape() const
     W_DC(WSeat);
 
     if (d->cursorClient != d->nativeHandle()->pointer_state.focused_client) {
-        qCWarning(waylibSeat, "Focused client never set cursor shape nor surface, will fallback to `Default`");
+        qCWarning(lcWlSeat, "Focused client never set cursor shape nor surface, will fallback to `Default`");
         return WGlobal::CursorShape::Default;
     }
 
@@ -849,7 +844,7 @@ void WSeat::attachInputDevice(WInputDevice *device)
     }
 
     if (device->type() == WInputDevice::Type::Touch) {
-        qCDebug(waylibSeat, "WSeat: registerTouchDevice %s", qPrintable(device->qtDevice()->name()));
+        qCDebug(lcWlSeat, "WSeat: registerTouchDevice %s", qPrintable(device->qtDevice()->name()));
         auto *state = new WSeatPrivate::DeviceState;
         device->setAttachedData<WSeatPrivate::DeviceState>(state);
         d->touchDeviceList << device;
@@ -945,7 +940,7 @@ bool WSeat::sendEvent(WSurface *target, QObject *shellObject, QObject *eventObje
                             -(we->angleDelta().x()+we->angleDelta().y()), // one of them must be 0, restore to wayland direction here.
                             we->timestamp());
         } else {
-            qWarning("An Wheel event was received that was not sent by wlroot and will be ignored");
+            qCWarning(lcWlSeat, "An Wheel event was received that was not sent by wlroot and will be ignored");
         }
         break;
     }
@@ -1242,7 +1237,7 @@ void WSeat::notifyGestureBegin(WCursor *cursor, WInputDevice *device, [[maybe_un
 {
     W_D(WSeat);
     if (d->gestureActive) {
-        qCWarning(waylibSeatGesture) << "Unexpected GestureBegin while already active";
+        qCWarning(lcWlGesture) << "Unexpected GestureBegin while already active";
     }
     d->gestureActive = true;
     d->gestureFingers = fingers;
@@ -1261,7 +1256,7 @@ void WSeat::notifyGestureUpdate(WCursor *cursor, WInputDevice *device, [[maybe_u
 {
     W_D(WSeat);
     if (!d->gestureActive) {
-        qCWarning(waylibSeatGesture) << "Unexpected GestureUpdate while not begin";
+        qCWarning(lcWlGesture) << "Unexpected GestureUpdate while not begin";
         return;
     }
     auto qwDevice = qobject_cast<QPointingDevice*>(device->qtDevice());
@@ -1293,7 +1288,7 @@ void WSeat::notifyGestureEnd(WCursor *cursor, WInputDevice *device, [[maybe_unus
 {
     W_D(WSeat);
     if (!d->gestureActive) {
-        qCWarning(waylibSeatGesture) << "Unexpected GestureEnd while not begin";
+        qCWarning(lcWlGesture) << "Unexpected GestureEnd while not begin";
         return;
     }
     d->gestureActive = false;
@@ -1312,7 +1307,7 @@ void WSeat::notifyHoldBegin(WCursor *cursor, WInputDevice *device, uint32_t time
 {
     W_D(WSeat);
     if (d->gestureActive) {
-        qCWarning(waylibSeatGesture) << "Unexpected HoldBegin while already active";
+        qCWarning(lcWlGesture) << "Unexpected HoldBegin while already active";
     }
     d->gestureActive = true;
     d->gestureFingers = fingers;
@@ -1331,7 +1326,7 @@ void WSeat::notifyHoldEnd(WCursor *cursor, WInputDevice *device, uint32_t time_m
 {
     W_D(WSeat);
     if (!d->gestureActive) {
-        qCWarning(waylibSeatGesture) << "Unexpected HoldEnd while not begin";
+        qCWarning(lcWlGesture) << "Unexpected HoldEnd while not begin";
         return;
     }
     d->gestureActive = false;
@@ -1370,7 +1365,7 @@ void WSeat::notifyTouchDown(WCursor *cursor, WInputDevice *device, int32_t touch
         }
 
         if (state->point(touch_id) != nullptr) {
-            qWarning("Inconsistent touch state, (got 'Down' But touch_id(%d) is not released", touch_id);
+            qCWarning(lcWlSeat, "Inconsistent touch state, (got 'Down' But touch_id(%d) is not released", touch_id);
         }
     }
 
@@ -1382,7 +1377,7 @@ void WSeat::notifyTouchDown(WCursor *cursor, WInputDevice *device, int32_t touch
     newTp.area = QRect(0, 0, 8, 8);
     newTp.area.moveCenter(globalPos);
     state->m_points.append(newTp);
-    qCDebug(waylibSeatTouch) << "Touch down form device: " << qwDevice->name()
+    qCDebug(lcWlTouch) << "Touch down form device: " << qwDevice->name()
                                << ", touch id: " << touch_id
                                << ", at position" << globalPos;
 }
@@ -1406,12 +1401,12 @@ void WSeat::notifyTouchMotion(WCursor *cursor, WInputDevice *device, int32_t tou
         // Handle this by compressing and keeping the Pressed state until the 'frame'.
         if (tp->state != QEventPoint::Pressed && tp->state != QEventPoint::Released)
             tp->state = tmpState;
-        qCDebug(waylibSeatTouch) << "Touch move form device: " << qwDevice->name()
+        qCDebug(lcWlTouch) << "Touch move form device: " << qwDevice->name()
                                    << ", touch id: " << touch_id
                                    << ", to position: " << globalPos
                                    << ", state of the point: " << tp->state;
     } else {
-        qWarning("Inconsistent touch state (got 'Motion' without 'Down'");
+        qCWarning(lcWlSeat, "Inconsistent touch state (got 'Motion' without 'Down'");
     }
 }
 
@@ -1432,7 +1427,7 @@ void WSeat::notifyTouchUp(WCursor *cursor, WInputDevice *device, int32_t touch_i
         for (const auto &point : std::as_const(state->m_points)) {
             s |= point.state;
         }
-        qCDebug(waylibSeatTouch) << "Touch up form device: " << qwDevice->name()
+        qCDebug(lcWlTouch) << "Touch up form device: " << qwDevice->name()
                                    << ", touch id: " << tp->id
                                    << ", at position: " << tp->area.center()
                                    << ", state of all points of this device: " << s;
@@ -1440,9 +1435,9 @@ void WSeat::notifyTouchUp(WCursor *cursor, WInputDevice *device, int32_t touch_i
         if (s == QEventPoint::Released)
             notifyTouchFrame(cursor);
         else
-            qCDebug(waylibSeatTouch) << "waiting for all points to be released";
+            qCDebug(lcWlTouch) << "waiting for all points to be released";
     } else {
-        qWarning("Inconsistent touch state (got 'Up' without 'Down'");
+        qCWarning(lcWlSeat, "Inconsistent touch state (got 'Up' without 'Down'");
     }
 }
 
@@ -1459,7 +1454,7 @@ void WSeat::notifyTouchCancel(WCursor *cursor, WInputDevice *device, int32_t tou
         point->state = static_cast<QEventPoint::State>(WEvent::PointCancelled);
     }
 
-    qCDebug(waylibSeatTouch) << "Touch cancel for device: " << qwDevice->name()
+    qCDebug(lcWlTouch) << "Touch cancel for device: " << qwDevice->name()
         << ", discard the following state: " << state->m_points;
 
     if (cursor->eventWindow()) {

--- a/waylib/src/server/kernel/wsocket.cpp
+++ b/waylib/src/server/kernel/wsocket.cpp
@@ -3,6 +3,7 @@
 
 #include "wsocket.h"
 #include "private/wglobal_p.h"
+#include "wayliblogging.h"
 
 #include <QDir>
 #include <QStandardPaths>
@@ -26,9 +27,6 @@ struct wl_event_source;
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
-// Socket management and client connections
-Q_LOGGING_CATEGORY(waylibSocket, "waylib.server.socket", QtInfoMsg)
-
 #define LOCK_SUFFIX ".lock"
 
 // Copy from libwayland
@@ -45,23 +43,23 @@ static int wl_socket_lock(const QString &socketFile)
                    (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP));
 
     if (fd_lock < 0) {
-        qCWarning(waylibSocket) << "Failed to open lockfile" << lockFile << "- please check file permissions";
+        qCWarning(lcWlSocket) << "Failed to open lockfile" << lockFile << "- please check file permissions";
         goto err;
     }
 
     if (flock(fd_lock, LOCK_EX | LOCK_NB) < 0) {
-        qCWarning(waylibSocket) << "Failed to lock" << lockFile << "- another compositor may be running";
+        qCWarning(lcWlSocket) << "Failed to lock" << lockFile << "- another compositor may be running";
         goto err_fd;
     }
 
     if (lstat(addr_sun_path, &socket_stat) < 0 ) {
         if (errno != ENOENT) {
-            qCWarning(waylibSocket) << "Failed to stat file:" << socketFile;
+            qCWarning(lcWlSocket) << "Failed to stat file:" << socketFile;
             goto err_fd;
         }
     } else if (socket_stat.st_mode & S_IWUSR ||
                socket_stat.st_mode & S_IWGRP) {
-        qCDebug(waylibSocket) << "Removing existing socket file:" << socketFile;
+        qCDebug(lcWlSocket) << "Removing existing socket file:" << socketFile;
         unlink(addr_sun_path);
     }
 
@@ -578,13 +576,13 @@ bool WSocket::create(const QString &filePath)
     socklen_t size = offsetof(sockaddr_un, sun_path) + pathLength;
     if (::bind(d->fd, (sockaddr*) &addr, size) < 0) {
         close();
-        qCWarning(waylibSocket) << "Socket bind failed:" << QString::fromLocal8Bit(strerror(errno));
+        qCWarning(lcWlSocket) << "Socket bind failed:" << QString::fromLocal8Bit(strerror(errno));
         return false;
     }
 
     if (::listen(d->fd, 128) < 0) {
         close();
-        qCWarning(waylibSocket) << "Socket listen failed:" << QString::fromLocal8Bit(strerror(errno));
+        qCWarning(lcWlSocket) << "Socket listen failed:" << QString::fromLocal8Bit(strerror(errno));
         return false;
     }
 
@@ -602,10 +600,10 @@ static QString getSocketFile(int fd, bool doCheck) {
     if (doCheck) {   // check socket file
         struct ::stat stat_buf{};
         if (fstat(fd, &stat_buf) != 0) {
-            qCWarning(waylibSocket) << "Failed to fstat file descriptor";
+            qCWarning(lcWlSocket) << "Failed to fstat file descriptor";
             return {};
         } else if (!S_ISSOCK(stat_buf.st_mode)) {
-            qCWarning(waylibSocket) << "File descriptor is not a socket";
+            qCWarning(lcWlSocket) << "File descriptor is not a socket";
             return {};
         }
 
@@ -613,10 +611,10 @@ static QString getSocketFile(int fd, bool doCheck) {
         socklen_t accept_conn_size = sizeof(accept_conn);
         if (getsockopt(fd, SOL_SOCKET, SO_ACCEPTCONN, &accept_conn,
                        &accept_conn_size) != 0) {
-            qCWarning(waylibSocket) << "Failed to get socket options:" << QString::fromLocal8Bit(strerror(errno));
+            qCWarning(lcWlSocket) << "Failed to get socket options:" << QString::fromLocal8Bit(strerror(errno));
             return {};
         } else if (accept_conn == 0) {
-            qCWarning(waylibSocket) << "File descriptor is not in listening mode";
+            qCWarning(lcWlSocket) << "File descriptor is not in listening mode";
             return {};
         }
     }
@@ -669,7 +667,7 @@ bool WSocket::create(int fd, bool doListen)
         return false;
 
     if (doListen && ::listen(d->fd, 128) < 0) {
-        qCWarning(waylibSocket) << "Failed to listen on socket:" << QString::fromLocal8Bit(strerror(errno));
+        qCWarning(lcWlSocket) << "Failed to listen on socket:" << QString::fromLocal8Bit(strerror(errno));
         return false;
     }
 
@@ -714,9 +712,9 @@ static int socket_data(int fd, uint32_t, void *data)
     length = sizeof name;
     client_fd = wl_os_accept_cloexec(fd, (sockaddr*)&name, &length);
     if (client_fd < 0) {
-        qCWarning(waylibSocket) << "Failed to accept client connection:" << QString::fromLocal8Bit(strerror(errno));
+        qCWarning(lcWlSocket) << "Failed to accept client connection:" << QString::fromLocal8Bit(strerror(errno));
     } else {
-        qCDebug(waylibSocket) << "Accepted new client connection with fd:" << client_fd;
+        qCDebug(lcWlSocket) << "Accepted new client connection with fd:" << client_fd;
         d->q_func()->addClient(client_fd);
     }
 
@@ -751,11 +749,11 @@ WClient *WSocket::addClient(int fd)
     W_D(WSocket);
     auto client = wl_client_create(d->display, fd);
     if (!client) {
-        qCWarning(waylibSocket) << "Failed to create Wayland client for fd:" << fd;
+        qCWarning(lcWlSocket) << "Failed to create Wayland client for fd:" << fd;
         return nullptr;
     }
 
-    qCDebug(waylibSocket) << "Created new Wayland client for fd:" << fd;
+    qCDebug(lcWlSocket) << "Created new Wayland client for fd:" << fd;
     auto wclient = new WClient(client, this);
     d->addClient(wclient);
 

--- a/waylib/src/server/platformplugin/qwlrootsintegration.cpp
+++ b/waylib/src/server/platformplugin/qwlrootsintegration.cpp
@@ -4,6 +4,7 @@
 #include "qwlrootsintegration.h"
 #include "qwlrootscreen.h"
 #include "qwlrootswindow.h"
+#include "wayliblogging.h"
 #include "woutput.h"
 #include "winputdevice.h"
 #include "types.h"
@@ -315,7 +316,7 @@ public:
                 m_format = q_glFormatFromConfig(c->eglDisplay(), eglConfig, m_format);
             Q_ASSERT(m_format.renderableType() == QSurfaceFormat::OpenGLES);
         } else {
-            qWarning() << "The QSurfaceFormat is not initialize";
+            qCWarning(lcWlPlatform) << "The QSurfaceFormat is not initialize";
         }
     }
 

--- a/waylib/src/server/protocols/private/winputmethodv2.cpp
+++ b/waylib/src/server/protocols/private/winputmethodv2.cpp
@@ -7,6 +7,7 @@
 #include "wsurface.h"
 #include "wxdgsurface.h"
 #include "private/wglobal_p.h"
+#include "wayliblogging.h"
 
 #include <qwcompositor.h>
 #include <qwinputmethodv2.h>
@@ -16,12 +17,10 @@
 #include <qwdisplay.h>
 
 #include <QKeySequence>
-#include <QLoggingCategory>
 #include <QRect>
 
 QW_USE_NAMESPACE
 WAYLIB_SERVER_BEGIN_NAMESPACE
-Q_DECLARE_LOGGING_CATEGORY(qLcInputMethod)
 class Q_DECL_HIDDEN WInputMethodManagerV2Private : public WObjectPrivate
 {
 public:

--- a/waylib/src/server/protocols/private/wtextinputv2.cpp
+++ b/waylib/src/server/protocols/private/wtextinputv2.cpp
@@ -6,19 +6,17 @@
 #include "wsurface.h"
 #include "winputmethodv2_p.h"
 #include "wseat.h"
+#include "wayliblogging.h"
 
 #include <qwcompositor.h>
 #include <qwdisplay.h>
 #include <qwseat.h>
-
-#include <QLoggingCategory>
 
 extern "C" {
 #include "text-input-unstable-v2-protocol.h"
 }
 QW_USE_NAMESPACE
 WAYLIB_SERVER_BEGIN_NAMESPACE
-Q_LOGGING_CATEGORY(qLcTextInputV2, "waylib.server.im.ti2", QtInfoMsg)
 using namespace tiv2;
 static struct zwp_text_input_manager_v2_interface manager_impl = {
     .destroy = handle_manager_destroy, .get_text_input = handle_manager_get_text_input
@@ -202,14 +200,14 @@ void handle_text_input_enable([[maybe_unused]] wl_client *client, wl_resource *r
     // However, there can be a race between surface destruction and text input requests,
     // so treat a missing WSurface as a warning rather than a fatal protocol error.
     if (!wSurface) {
-        qCWarning(qLcTextInputV2) << "Client" << client << "sent enable on surface" << surface
+        qCWarning(lcWlTextInput) << "Client" << client << "sent enable on surface" << surface
                                   << "but no WSurface found (may be already destroyed). Ignoring.";
         return;
     }
     auto d = text_input->d_func();
     if (d->enabledSurface) {
         // FIXME: Is this necessary? As protocol does not guarantee disable is ought to happen after enable, we may still need this.
-        qCWarning(qLcTextInputV2) << "Client" << client << "does Q_EMIT disable on surface"
+        qCWarning(lcWlTextInput) << "Client" << client << "does Q_EMIT disable on surface"
                                  << d->enabledSurface << "before enable on surface" << wSurface;
         text_input->clearEnabledSurface();
     }
@@ -224,20 +222,20 @@ void handle_text_input_disable([[maybe_unused]] wl_client *client, wl_resource *
     Q_ASSERT(text_input);
     auto wSurface = WSurface::fromHandle(wlr_surface_from_resource(surface));
     if (!wSurface) {
-        qCWarning(qLcTextInputV2) << "Client" << client << "sent disable on surface" << surface
+        qCWarning(lcWlTextInput) << "Client" << client << "sent disable on surface" << surface
                                   << "but no WSurface found (may be already destroyed). Ignoring.";
         return;
     }
     auto d = text_input->d_func();
     if (!d->enabledSurface) {
-        qCWarning(qLcTextInputV2) << "Client" << wl_resource_get_client(resource)
+        qCWarning(lcWlTextInput) << "Client" << wl_resource_get_client(resource)
                                     << "try to disable surface" << wSurface
                                     << "on a text input" << text_input
                                     << "that is not enabled on this surface. Do nothing!";
         return;
     }
     if (d->enabledSurface != wSurface) {
-        qCWarning(qLcTextInputV2) << "Client" << client
+        qCWarning(lcWlTextInput) << "Client" << client
                                     << "try to disable surface" << wSurface
                                     << "on a text input" << text_input
                                     << "which is enabled on another surface" << d->enabledSurface;
@@ -396,7 +394,7 @@ void WTextInputV2::sendLeave()
 {
     W_D(WTextInputV2);
     if (!d->focusedSurface) {
-        qCWarning(qLcTextInputV2()) << "Send leave to a null focused surface.";
+        qCWarning(lcWlTextInput()) << "Send leave to a null focused surface.";
         return;
     }
     zwp_text_input_v2_send_leave(d->resource, 0, d->focusedSurface->handle()->handle()->resource);
@@ -440,19 +438,19 @@ WTextInputV2::WTextInputV2(QObject *parent)
         }
     });
     connect(this, &WTextInput::enabled, this, [this]{
-        qCDebug(qLcTextInputV2()) << "text input v2" << this << "enabled";
+        qCDebug(lcWlTextInput()) << "text input v2" << this << "enabled";
     });
     connect(this, &WTextInput::disabled, this, [this] {
-        qCDebug(qLcTextInputV2()) << "text input v2" << this << "disabled";
+        qCDebug(lcWlTextInput()) << "text input v2" << this << "disabled";
     });
     connect(this, &WTextInputV2::stateUpdated, this, [this] (UpdateReason reason){
-        qCInfo(qLcTextInputV2()) << "state updated:" << reason;
+        qCInfo(lcWlTextInput()) << "state updated:" << reason;
         switch (reason) {
         case Change:
             break;
         case Enter:
         case Full:
-            qCDebug(qLcTextInputV2()) << "commit text input v2" << this;
+            qCDebug(lcWlTextInput()) << "commit text input v2" << this;
             Q_EMIT this->committed();
             break;
         case Reset:

--- a/waylib/src/server/protocols/private/wtextinputv3.cpp
+++ b/waylib/src/server/protocols/private/wtextinputv3.cpp
@@ -7,18 +7,17 @@
 #include "wtoplevelsurface.h"
 #include "wtools.h"
 #include "private/wglobal_p.h"
+#include "wayliblogging.h"
 
 #include <qwcompositor.h>
 #include <qwseat.h>
 #include <qwtextinputv3.h>
 #include <qwdisplay.h>
 
-#include <QLoggingCategory>
 #include <QQmlInfo>
 
 QW_USE_NAMESPACE
 WAYLIB_SERVER_BEGIN_NAMESPACE
-Q_DECLARE_LOGGING_CATEGORY(qLcInputMethod)
 class Q_DECL_HIDDEN WTextInputManagerV3Private : public WObjectPrivate
 {
 public:

--- a/waylib/src/server/protocols/private/wvirtualkeyboardv1.cpp
+++ b/waylib/src/server/protocols/private/wvirtualkeyboardv1.cpp
@@ -3,15 +3,13 @@
 
 #include "wvirtualkeyboardv1_p.h"
 #include "private/wglobal_p.h"
+#include "wayliblogging.h"
 
 #include <qwvirtualkeyboardv1.h>
 #include <qwdisplay.h>
 
-#include <QLoggingCategory>
-
 QW_USE_NAMESPACE
 WAYLIB_SERVER_BEGIN_NAMESPACE
-Q_DECLARE_LOGGING_CATEGORY(qLcInputMethod)
 
 class Q_DECL_HIDDEN WVirtualKeyboardManagerV1Private : public WObjectPrivate
 {

--- a/waylib/src/server/protocols/wextforeigntoplevellistv1.cpp
+++ b/waylib/src/server/protocols/wextforeigntoplevellistv1.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2025-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wextforeigntoplevellistv1.h"
@@ -6,6 +6,7 @@
 #include "private/wglobal_p.h"
 #include "wglobal.h"
 #include "wtoplevelsurface.h"
+#include "wayliblogging.h"
 
 #include <qwdisplay.h>
 #include <qwextforeigntoplevellistv1.h>
@@ -16,8 +17,6 @@
 
 QW_USE_NAMESPACE
 WAYLIB_SERVER_BEGIN_NAMESPACE
-Q_LOGGING_CATEGORY(qLcExtForeignToplevel, "waylib.protocols.extforeigntoplevel", QtWarningMsg)
-
 class Q_DECL_HIDDEN WExtForeignToplevelListV1Private : public WObjectPrivate
 {
 public:
@@ -31,7 +30,7 @@ public:
         W_Q(WExtForeignToplevelListV1);
 
         if (surfaces.contains(surface)) {
-            qCCritical(qLcExtForeignToplevel)
+            qCCritical(lcWlExtForeignToplevel)
                 << surface << " has been add to ext foreign toplevel list twice";
             return;
         }

--- a/waylib/src/server/protocols/wforeigntoplevelv1.cpp
+++ b/waylib/src/server/protocols/wforeigntoplevelv1.cpp
@@ -9,6 +9,7 @@
 #include "wtoplevelsurface.h"
 #include "wxdgtoplevelsurface.h"
 #include "wxwaylandsurface.h"
+#include "wayliblogging.h"
 
 #include <qwdisplay.h>
 #include <qwforeigntoplevelhandlev1.h>
@@ -18,8 +19,6 @@
 
 QW_USE_NAMESPACE
 WAYLIB_SERVER_BEGIN_NAMESPACE
-Q_LOGGING_CATEGORY(qLcWlrForeignToplevel, "waylib.protocols.foreigntoplevel", QtWarningMsg)
-
 class Q_DECL_HIDDEN WForeignToplevelPrivate : public WObjectPrivate
 {
 public:
@@ -66,7 +65,7 @@ public:
                     return;
                 }
                 if (!surfaces.contains(p)) {
-                    qCCritical(qLcWlrForeignToplevel)
+                    qCCritical(lcWlForeignToplevel)
                         << "Xdg toplevel surface " << xdgSurface
                         << "has set parent surface, but foreign_toplevel_handle for parent surface "
                            "not found!";
@@ -86,7 +85,7 @@ public:
                     return;
                 }
                 if (!surfaces.contains(p)) {
-                    qCCritical(qLcWlrForeignToplevel)
+                    qCCritical(lcWlForeignToplevel)
                         << "X11 surface " << xwaylandSurface
                         << "has set parent surface, but foreign_toplevel_handle for parent surface "
                            "not found!";
@@ -171,7 +170,7 @@ public:
         W_Q(WForeignToplevel);
 
         if (surfaces.contains(surface)) {
-            qCCritical(qLcWlrForeignToplevel)
+            qCCritical(lcWlForeignToplevel)
                 << surface << " has been add to foreign toplevel twice";
             return;
         }

--- a/waylib/src/server/protocols/winputmethodhelper.cpp
+++ b/waylib/src/server/protocols/winputmethodhelper.cpp
@@ -12,6 +12,7 @@
 #include "wseat.h"
 #include "wsurface.h"
 #include "private/wglobal_p.h"
+#include "wayliblogging.h"
 
 #include <qwcompositor.h>
 #include <qwinputmethodv2.h>
@@ -21,13 +22,10 @@
 #include <qwseat.h>
 #include <qwbox.h>
 
-#include <QLoggingCategory>
 #include <QQmlInfo>
 
 QW_USE_NAMESPACE
 WAYLIB_SERVER_BEGIN_NAMESPACE
-Q_LOGGING_CATEGORY(qLcInputMethod, "waylib.server.im", QtInfoMsg)
-
 struct Q_DECL_HIDDEN GrabHandlerArg {
     const WInputMethodHelper *const helper;
     qw_input_method_keyboard_grab_v2 *grab;
@@ -43,7 +41,7 @@ void handleKey(struct wlr_seat_keyboard_grab *grab, uint32_t time_msec, uint32_t
         }
     }
     if (!arg->grab) {
-        qCCritical(qLcInputMethod) << "Ignore key event for destroyed input method keyboard grab"
+        qCCritical(lcWlInputMethod) << "Ignore key event for destroyed input method keyboard grab"
                                   << "key" << key << "state" << state;
         return;
     }
@@ -60,7 +58,7 @@ void handleModifiers(struct wlr_seat_keyboard_grab *grab, const struct wlr_keybo
         }
     }
     if (!arg->grab) {
-        qCCritical(qLcInputMethod) << "Ignore modifiers for destroyed input method keyboard grab";
+        qCCritical(lcWlInputMethod) << "Ignore modifiers for destroyed input method keyboard grab";
         return;
     }
     arg->grab->send_modifiers(const_cast<struct wlr_keyboard_modifiers *>(modifiers));
@@ -97,14 +95,14 @@ public:
     void endGrab(qw_input_method_keyboard_grab_v2 *kgv2)
     {
         if (!seat) {
-            qCCritical(qLcInputMethod) << "Failed to end input method keyboard grab - seat is already destroyed"
+            qCCritical(lcWlInputMethod) << "Failed to end input method keyboard grab - seat is already destroyed"
                                       << kgv2;
             return;
         }
 
         auto *kgHandle = kgv2 ? kgv2->handle() : nullptr;
         if (!kgHandle) {
-            qCCritical(qLcInputMethod) << "Failed to end input method keyboard grab - grab handle is invalid"
+            qCCritical(lcWlInputMethod) << "Failed to end input method keyboard grab - grab handle is invalid"
                                       << kgv2;
             return;
         }
@@ -119,7 +117,7 @@ public:
     {
         auto *kgHandle = kgv2 ? kgv2->handle() : nullptr;
         if (!kgHandle) {
-            qCCritical(qLcInputMethod) << "Failed to set keyboard for input method grab - grab handle is invalid"
+            qCCritical(lcWlInputMethod) << "Failed to set keyboard for input method grab - grab handle is invalid"
                                       << kgv2 << "keyboard" << keyboard;
             return;
         }
@@ -257,7 +255,7 @@ void WInputMethodHelper::handleNewIMV2(qw_input_method_v2 *imv2)
     if (d->seat->name() != wimv2->seat()->name())
         return;
     if (inputMethod()) {
-        qCWarning(qLcInputMethod) << "Ignore second creation of input on the same seat.";
+        qCWarning(lcWlInputMethod) << "Ignore second creation of input on the same seat.";
         wimv2->sendUnavailable();
         return;
     }
@@ -336,16 +334,16 @@ void WInputMethodHelper::handleNewVKV1(wlr_virtual_keyboard_v1 *vkv1)
 void WInputMethodHelper::resendKeyboardFocus()
 {
     W_D(WInputMethodHelper);
-    qCInfo(qLcInputMethod()) << "resend keyboard focus";
+    qCInfo(lcWlInputMethod()) << "resend keyboard focus";
     notifyLeave();
     auto focus = d->seat->keyboardFocusSurface();
     if (!focus)
         return;
-    qCDebug(qLcInputMethod) << "focus" << focus << "from client" << focus->waylandClient();
+    qCDebug(lcWlInputMethod) << "focus" << focus << "from client" << focus->waylandClient();
     for (auto textInput : std::as_const(d->textInputs)) {
-        qCDebug(qLcInputMethod()) << "trying to send focus to" << textInput << "from client" << textInput->waylandClient();
+        qCDebug(lcWlInputMethod()) << "trying to send focus to" << textInput << "from client" << textInput->waylandClient();
         if (focus->waylandClient() == textInput->waylandClient()) {
-            qCDebug(qLcInputMethod) << "focus sent to" << textInput;
+            qCDebug(lcWlInputMethod) << "focus sent to" << textInput;
             if (!textInput->seat() || textInput->seat() == d->seat) {
                 textInput->sendEnter(focus);
             }
@@ -356,7 +354,7 @@ void WInputMethodHelper::resendKeyboardFocus()
 
 void WInputMethodHelper::connectToTI(WTextInput *ti)
 {
-    qCDebug(qLcInputMethod()) << "connect to text input" << ti;
+    qCDebug(lcWlInputMethod()) << "connect to text input" << ti;
     connect(ti, &WTextInput::enabled, this, &WInputMethodHelper::handleTIEnabled, Qt::UniqueConnection);
     connect(ti, &WTextInput::disabled, this, &WInputMethodHelper::handleTIDisabled, Qt::UniqueConnection);
     connect(ti, &WTextInput::requestLeave, ti, &WTextInput::sendLeave, Qt::UniqueConnection);
@@ -379,7 +377,7 @@ void WInputMethodHelper::disableTI(WTextInput *ti)
 void WInputMethodHelper::handleNewTI(WTextInput *ti)
 {
     W_D(WInputMethodHelper);
-    qCDebug(qLcInputMethod()) << "handle new text input" << ti
+    qCDebug(lcWlInputMethod()) << "handle new text input" << ti
                               << "from seat:" << ti->seat();
     if (d->textInputs.contains(ti))
         return;
@@ -448,10 +446,10 @@ void WInputMethodHelper::handleFocusedTICommitted()
     auto ti = enabledTextInput();
     Q_ASSERT(ti);
     if (!ti->focusedSurface()) {
-        qCWarning(qLcInputMethod) << "Discard commit to unfocused but not disabled text input.";
+        qCWarning(lcWlInputMethod) << "Discard commit to unfocused but not disabled text input.";
         return;
     }
-    qCDebug(qLcInputMethod) << "Focused text input" << ti << "committed."
+    qCDebug(lcWlInputMethod) << "Focused text input" << ti << "committed."
                             << "Cursor rectangle:" << ti->cursorRect();
     auto im = inputMethod();
     if (im) {

--- a/waylib/src/server/protocols/wlayershell.cpp
+++ b/waylib/src/server/protocols/wlayershell.cpp
@@ -4,6 +4,7 @@
 #include "wlayershell.h"
 #include "wlayersurface.h"
 #include "woutput.h"
+#include "wayliblogging.h"
 #include "private/wglobal_p.h"
 #include "wxdgshell.h"
 
@@ -54,7 +55,7 @@ void WLayerShellPrivate::onNewSurface(qw_layer_surface_v1 *layerSurface)
         if (xdgShell)
             xdgShell->initializeNewXdgPopupSurface(popup);
         else
-            qWarning() << "Xdg shell not set, will ignore the layer surface's popup request!";
+            qCWarning(lcWlLayerShell) << "Xdg shell not set, will ignore the layer surface's popup request!";
     });
 
     surfaceList.append(surface);

--- a/waylib/src/server/protocols/wlayersurface.cpp
+++ b/waylib/src/server/protocols/wlayersurface.cpp
@@ -5,6 +5,7 @@
 #include "wseat.h"
 #include "wsurface.h"
 #include "woutput.h"
+#include "wayliblogging.h"
 #include "private/wtoplevelsurface_p.h"
 
 #include <qwlayershellv1.h>
@@ -110,7 +111,7 @@ void WLayerSurfacePrivate::connect()
 
 [[maybe_unused]] static inline void debugOutput(wlr_layer_surface_v1_state s)
 {
-    qDebug() << "committed: " << s.committed << " "
+    qCDebug(lcWlLayerSurface) << "committed: " << s.committed << " "
              << "configure_serial: " << s.configure_serial << "\n"
              << "anchor: " << s.anchor << " "
              << "layer: " << s.layer << " "

--- a/waylib/src/server/protocols/wxdgdecorationmanager.cpp
+++ b/waylib/src/server/protocols/wxdgdecorationmanager.cpp
@@ -3,6 +3,7 @@
 
 #include "wxdgdecorationmanager.h"
 #include "wsurface.h"
+#include "wayliblogging.h"
 #include "private/wglobal_p.h"
 
 #include <qwxdgdecorationmanagerv1.h>
@@ -146,7 +147,7 @@ void WXdgDecorationManager::setPreferredMode(DecorationMode mode)
         return;
     }
     if (d->preferredMode == DecorationMode::Undefined || d->preferredMode == DecorationMode::None) {
-        qWarning("Prefer mode must be 'Client' or 'Server'");
+        qCWarning(lcWlXdgDecoration, "Prefer mode must be 'Client' or 'Server'");
         return;
     }
     // update all existing decoration that mode changed

--- a/waylib/src/server/protocols/wxdgoutput.cpp
+++ b/waylib/src/server/protocols/wxdgoutput.cpp
@@ -4,6 +4,7 @@
 #include "wxdgoutput.h"
 #include "woutputlayout.h"
 #include "wsocket.h"
+#include "wayliblogging.h"
 #include "private/wglobal_p.h"
 
 #include "xdg-output-unstable-v1-protocol.h"
@@ -440,7 +441,7 @@ void WXdgOutputManager::create([[maybe_unused]] WServer *wserver)
                                                     d->scaleOverride);
         m_handle = d->manager;
     } else {
-        qWarning() << "Output layout not set, xdg output manager will never be created!";
+        qCWarning(lcWlXdgOutput) << "Output layout not set, xdg output manager will never be created!";
     }
 }
 

--- a/waylib/src/server/qtquick/private/wbufferrenderer.cpp
+++ b/waylib/src/server/qtquick/private/wbufferrenderer.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wbufferrenderer_p.h"
+#include "wayliblogging.h"
 #include "wrenderhelper.h"
 #include "wqmlhelper_p.h"
 #include "wtools.h"
@@ -290,7 +291,7 @@ WSGTextureProvider *WBufferRenderer::wTextureProvider() const
     auto w = qobject_cast<WOutputRenderWindow*>(window());
     auto d = QQuickItemPrivate::get(this);
     if (!w || !d->sceneGraphRenderContext() || QThread::currentThread() != d->sceneGraphRenderContext()->thread()) {
-        qWarning("WBufferRenderer::textureProvider: can only be queried on the rendering thread of an WOutputRenderWindow");
+        qCWarning(lcWlBufferRenderer, "WBufferRenderer::textureProvider: can only be queried on the rendering thread of an WOutputRenderWindow");
         return nullptr;
     }
 
@@ -343,7 +344,7 @@ qw_buffer *WBufferRenderer::beginRender(const QSize &pixelSize, qreal devicePixe
     if (flags.testFlag(RenderFlag::DontConfigureSwapchain)) {
         auto renderFormat = pickFormat(m_output->renderer(), format);
         if (!renderFormat) {
-            qWarning("wlr_renderer doesn't support format 0x%s", drmGetFormatName(format));
+            qCWarning(lcWlBufferRenderer, "wlr_renderer doesn't support format 0x%s", drmGetFormatName(format));
             return nullptr;
         }
 

--- a/waylib/src/server/qtquick/private/wrenderbuffernode.cpp
+++ b/waylib/src/server/qtquick/private/wrenderbuffernode.cpp
@@ -4,6 +4,7 @@
 #include <QDebug>
 
 #include "wrenderhelper.h"
+#include "wayliblogging.h"
 #include "wrenderbuffernode_p.h"
 #include "wbufferrenderer_p.h"
 #include "wqmlhelper_p.h"
@@ -366,7 +367,7 @@ class Q_DECL_HIDDEN RhiTextureManager : public DataManager<RhiTextureManager, Wl
         auto buffer = texture->buffer;
         wlr_dmabuf_attributes attribs;
         if (!wlr_buffer_get_dmabuf(buffer, &attribs)) {
-            qWarning() << "Failed to get dmabuf attributes for texture" << texture << "with buffer" << buffer
+                qCWarning(lcWlRenderBuffer) << "Failed to get dmabuf attributes for texture" << texture << "with buffer" << buffer
                        << ", Can't check texture without dmabuf attributes";
             return false;
         }

--- a/waylib/src/server/qtquick/wbufferitem.cpp
+++ b/waylib/src/server/qtquick/wbufferitem.cpp
@@ -1,22 +1,20 @@
-// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2025-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wbufferitem.h"
 
 #include "woutputrenderwindow.h"
 #include "wsgtextureprovider.h"
+#include "wayliblogging.h"
 
 #include <qwbuffer.h>
 
 #include <QQuickWindow>
 #include <QSGImageNode>
 #include <QThread>
-#include <QLoggingCategory>
 #include <private/qquickitem_p.h>
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
-
-Q_LOGGING_CATEGORY(waylibBufferItem, "waylib.server.qtquick.bufferitem", QtInfoMsg)
 
 class Q_DECL_HIDDEN WBufferItemPrivate : public QQuickItemPrivate
 {
@@ -69,7 +67,7 @@ WSGTextureProvider *WBufferItem::wTextureProvider() const
 
     auto w = qobject_cast<WOutputRenderWindow*>(d->window);
     if (!w || !d->sceneGraphRenderContext() || QThread::currentThread() != d->sceneGraphRenderContext()->thread()) {
-        qCWarning(waylibBufferItem)
+        qCWarning(lcWlBufferItem)
             << "WBufferItem::wTextureProvider can only be queried on the rendering thread of a WOutputRenderWindow";
         return nullptr;
     }
@@ -106,7 +104,7 @@ void WBufferItem::setBuffer(QW_NAMESPACE::qw_buffer *buffer)
     if (buffer) {
         auto *h = buffer->handle();
         if (!h || h->width <= 0 || h->height <= 0) {
-            qCWarning(waylibBufferItem) << "Reject buffer with invalid size or handle"
+            qCWarning(lcWlBufferItem) << "Reject buffer with invalid size or handle"
                                         << buffer << "w" << (h ? h->width : -1)
                                         << "h" << (h ? h->height : -1);
             return;
@@ -136,7 +134,7 @@ QSGNode *WBufferItem::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData *)
 
     auto tp = wTextureProvider();
     if (!tp) {
-        qCWarning(waylibBufferItem) << "wTextureProvider() is nullptr";
+        qCWarning(lcWlBufferItem) << "wTextureProvider() is nullptr";
         return nullptr;
     }
 
@@ -152,7 +150,7 @@ QSGNode *WBufferItem::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData *)
                 bufH = h->height;
             }
         }
-        qCWarning(waylibBufferItem) << "texture missing or item size invalid"
+        qCWarning(lcWlBufferItem) << "texture missing or item size invalid"
                                     << "buffer" << d->buffer.get()
                                     << "bufW" << bufW
                                     << "bufH" << bufH
@@ -168,7 +166,7 @@ QSGNode *WBufferItem::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData *)
     }
 
     auto texture = tp->texture();
-    qCDebug(waylibBufferItem) << "updatePaintNode" << "texSize" << texture->textureSize()
+    qCDebug(lcWlBufferItem) << "updatePaintNode" << "texSize" << texture->textureSize()
                               << "itemSize" << size();
     node->setTexture(texture);
     node->setSourceRect(QRectF(QPointF(), texture->textureSize()));

--- a/waylib/src/server/qtquick/woutputhelper.cpp
+++ b/waylib/src/server/qtquick/woutputhelper.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "woutputhelper.h"
+#include "wayliblogging.h"
 #include "wrenderhelper.h"
 #include "woutput.h"
 #include "platformplugin/types.h"
@@ -241,7 +242,7 @@ bool WOutputHelper::commit()
 
     bool ok = d->qwoutput()->commit_state(&state);
     if (!ok) {
-        qCritical("commit failed on output %s", d->qwoutput()->handle()->name);
+        qCCritical(lcWlOutputHelper, "commit failed on output %s", d->qwoutput()->handle()->name);
     }
     wlr_output_state_finish(&state);
     ExtraState committedExtraState = d->extraState;
@@ -289,13 +290,13 @@ bool WOutputHelper::setExtraState(ExtraState state)
                                   WLR_OUTPUT_STATE_GAMMA_LUT;
 
     if (state->committed & ~allowedFlags) {
-        qWarning() << "WOutputHelper::setExtraState: contains unsupported flags:"
+        qCWarning(lcWlOutputHelper) << "WOutputHelper::setExtraState: contains unsupported flags:"
                    << Qt::hex << (state->committed & ~allowedFlags);
         return false;
     }
 
     if ((state->committed & allowedFlags) == 0) {
-        qWarning() << "WOutputHelper::setExtraState: no valid state changes";
+        qCWarning(lcWlOutputHelper) << "WOutputHelper::setExtraState: no valid state changes";
         return false;
     }
 

--- a/waylib/src/server/qtquick/woutputlayer.cpp
+++ b/waylib/src/server/qtquick/woutputlayer.cpp
@@ -4,6 +4,7 @@
 #include "woutputlayer.h"
 #include "woutputrenderwindow.h"
 #include "wrenderhelper.h"
+#include "wayliblogging.h"
 #include "woutputviewport.h"
 
 #include <QQuickItem>
@@ -71,7 +72,7 @@ void WOutputLayerPrivate::doEnable(bool enable)
     for (auto o : std::as_const(outputs)) {
         if (enable) {
             if (o->window() && o->window() != window) {
-                qWarning() << "OutputLayer: OutputViewport and OutputLayer's target item "
+                qCWarning(lcWlOutputLayer) << "OutputLayer: OutputViewport and OutputLayer's target item "
                               "must both be children of the same window.";
                 continue;
             }

--- a/waylib/src/server/qtquick/woutputrenderwindow.cpp
+++ b/waylib/src/server/qtquick/woutputrenderwindow.cpp
@@ -15,6 +15,7 @@
 #include "weventjunkman.h"
 #include "winputdevice.h"
 #include "wseat.h"
+#include "wayliblogging.h"
 
 #include "platformplugin/qwlrootsintegration.h"
 #include "platformplugin/qwlrootscreen.h"
@@ -37,7 +38,6 @@
 #include <QOffscreenSurface>
 #include <QQuickRenderControl>
 #include <QOpenGLFunctions>
-#include <QLoggingCategory>
 #include <QRunnable>
 #include <memory>
 
@@ -78,12 +78,6 @@ W_DECLARE_PRIVATE_MEMBER(QQuickAnimCtrl_m_runningAnimators_tag, QQuickAnimatorCo
 W_DECLARE_PRIVATE_MEMBER(QQuickAnimCtrl_m_window_tag, QQuickAnimatorController, m_window, QQuickWindow*);
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
-
-#ifdef QT_DEBUG
-Q_LOGGING_CATEGORY(wlcRenderer, "waylib.server.renderer", QtDebugMsg)
-#else
-Q_LOGGING_CATEGORY(wlcRenderer, "waylib.server.renderer", QtWarningMsg)
-#endif
 
 // Call it before any wlroots render to clean up the GL state in Qt.
 // If you don't do this, there will be tearing, flickering and other graphics problems
@@ -303,7 +297,7 @@ public:
         state = Accepted;
         if (!layer->isAccepted()) {
             layer->setAccepted(true);
-            qCInfo(wlcRenderer) << "Layer" << layer->parent() << "is accepted("
+            qCInfo(lcWlRenderer) << "Layer" << layer->parent() << "is accepted("
                                 << (isHardware ? "hardware" : "software") << ") on"
                                 << output;
         }
@@ -323,7 +317,7 @@ public:
         state = Rejected;
         if (layer->isAccepted()) {
             layer->setAccepted(false);
-            qCInfo(wlcRenderer) << "Layer" << layer->parent() << "is rejected on" << output;
+            qCInfo(lcWlRenderer) << "Layer" << layer->parent() << "is rejected on" << output;
         }
 
         if (layer->setInHardware(output, false)) {
@@ -1117,25 +1111,25 @@ bool OutputHelper::tryToHardwareCursor(const LayerData *layer)
         auto get_cursor_formsts = qwoutput()->handle()->impl->get_cursor_formats;
         bool needsRepaintCursor = get_cursor_sizes && get_cursor_formsts;
 
-        if (Q_UNLIKELY(wlcRenderer().isDebugEnabled()))
-            qCDebug(wlcRenderer) << "Request cursor buffer size:" << pixelSize;
+        if (Q_UNLIKELY(lcWlRenderer().isDebugEnabled()))
+            qCDebug(lcWlRenderer) << "Request cursor buffer size:" << pixelSize;
 
         if (get_cursor_sizes) {
-            if (Q_UNLIKELY(wlcRenderer().isDebugEnabled()))
-                qCDebug(wlcRenderer) << "Supported cursor sizes for output" << output() << ":";
+            if (Q_UNLIKELY(lcWlRenderer().isDebugEnabled()))
+                qCDebug(lcWlRenderer) << "Supported cursor sizes for output" << output() << ":";
 
             bool foundTargetSize = false;
             size_t sizes_len = 0;
             const auto sizes = get_cursor_sizes(qwoutput()->handle(), &sizes_len);
             for (size_t i = 0; i < sizes_len; ++i) {
-                if (Q_UNLIKELY(wlcRenderer().isDebugEnabled()))
-                     qCDebug(wlcRenderer) << "    " << sizes[i].width << "x" << sizes[i].height;
+                if (Q_UNLIKELY(lcWlRenderer().isDebugEnabled()))
+                     qCDebug(lcWlRenderer) << "    " << sizes[i].width << "x" << sizes[i].height;
 
                 if (sizes[i].width == pixelSize.width()
                     && sizes[i].height == pixelSize.height()) {
                     foundTargetSize = true;
-                    if (Q_UNLIKELY(wlcRenderer().isDebugEnabled()))
-                        qCDebug(wlcRenderer) << "    " << sizes[i].width << "x" << sizes[i].height << "(matched)";
+                    if (Q_UNLIKELY(lcWlRenderer().isDebugEnabled()))
+                        qCDebug(lcWlRenderer) << "    " << sizes[i].width << "x" << sizes[i].height << "(matched)";
                     else
                         break; //need continue to print other sizes when find matched size
                 }
@@ -1148,8 +1142,8 @@ bool OutputHelper::tryToHardwareCursor(const LayerData *layer)
                         && sizes[i].height > pixelSize.height()) {
                         pixelSize.rwidth() = sizes[i].width;
                         pixelSize.rheight() = sizes[i].height;
-                        if (Q_UNLIKELY(wlcRenderer().isDebugEnabled()))
-                            qCDebug(wlcRenderer) << "Re-render cursor with size" << pixelSize
+                        if (Q_UNLIKELY(lcWlRenderer().isDebugEnabled()))
+                            qCDebug(lcWlRenderer) << "Re-render cursor with size" << pixelSize
                                                  << "because the original cursor size"
                                                  << QSize(buffer->width, buffer->height)
                                                  << "is not supported by wlroots backend";
@@ -1159,7 +1153,7 @@ bool OutputHelper::tryToHardwareCursor(const LayerData *layer)
                 }
 
                 if (Q_UNLIKELY(!needsRepaintCursor)) {
-                    qCWarning(wlcRenderer) << "Can't find suitable cursor size for" << pixelSize;
+                    qCWarning(lcWlRenderer) << "Can't find suitable cursor size for" << pixelSize;
                     return false;
                 }
             } else {
@@ -1398,7 +1392,7 @@ bool WOutputRenderWindowPrivate::initRCWithRhi()
 
     QSGRhiSupport::RhiCreateResult result = rhiSupport->createRhi(q, offscreenSurface);
     if (!result.rhi) {
-        qWarning("WOutput::initRhi: Failed to initialize QRhi");
+        qCWarning(lcWlRenderer, "WOutput::initRhi: Failed to initialize QRhi");
         return false;
     }
 

--- a/waylib/src/server/qtquick/wqmlcreator.cpp
+++ b/waylib/src/server/qtquick/wqmlcreator.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wqmlcreator_p.h"
+#include "wayliblogging.h"
 #include "wxdgsurface.h"
 
 #include <QJSValue>
@@ -284,13 +285,13 @@ void WQmlCreatorComponent::create(QSharedPointer<WQmlCreatorDelegateData> data, 
         Q_EMIT objectAdded(data->object, initialProperties);
         notifyCreatorObjectAdded(creator(), data->object, initialProperties);
     } else {
-        qWarning() << "WQmlCreatorComponent::create failed" << "parent=" << parent << "initialProperties=" << tmp;
+        qCWarning(lcWlQmlCreator) << "WQmlCreatorComponent::create failed" << "parent=" << parent << "initialProperties=" << tmp;
 #if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
         for (auto e: std::as_const(W_PRIVATE_MEMBER(*d, QQmlComponentPrivate_m_state_tag{}).errors))
 #else
         for (auto e: std::as_const(d->state.errors))
 #endif
-            qWarning() << e.error;
+            qCWarning(lcWlQmlCreator) << e.error;
     }
 }
 

--- a/waylib/src/server/qtquick/wquickcursor.cpp
+++ b/waylib/src/server/qtquick/wquickcursor.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wquickcursor.h"
+#include "wayliblogging.h"
 #include "woutputrenderwindow.h"
 #include "woutputitem.h"
 #include "wcursorimage.h"
@@ -366,7 +367,7 @@ WSGTextureProvider *WQuickCursor::wTextureProvider() const
 
     auto w = qobject_cast<WOutputRenderWindow*>(d->window);
     if (!w || !d->sceneGraphRenderContext() || QThread::currentThread() != d->sceneGraphRenderContext()->thread()) {
-        qWarning("WQuickCursor::textureProvider: can only be queried on the rendering thread of an WOutputRenderWindow");
+        qCWarning(lcWlQuickCursor, "WQuickCursor::textureProvider: can only be queried on the rendering thread of an WOutputRenderWindow");
         return nullptr;
     }
 

--- a/waylib/src/server/qtquick/wrenderhelper.cpp
+++ b/waylib/src/server/qtquick/wrenderhelper.cpp
@@ -3,6 +3,7 @@
 
 #include "wrenderhelper.h"
 #include "wtools.h"
+#include "wayliblogging.h"
 #include "private/wqmlhelper_p.h"
 #include "private/wglobal_p.h"
 
@@ -139,7 +140,7 @@ static bool createRhiRenderTarget(const QRhiColorAttachment &colorAttachment,
 {
     std::unique_ptr<QRhiRenderBuffer> depthStencil(rhi->newRenderBuffer(QRhiRenderBuffer::DepthStencil, pixelSize, sampleCount));
     if (!depthStencil->create()) {
-        qWarning("Failed to build depth-stencil buffer for QQuickRenderTarget");
+        qCWarning(lcWlRenderHelper, "Failed to build depth-stencil buffer for QQuickRenderTarget");
         return false;
     }
 
@@ -150,7 +151,7 @@ static bool createRhiRenderTarget(const QRhiColorAttachment &colorAttachment,
     rt->setRenderPassDescriptor(rp.get());
 
     if (!rt->create()) {
-        qWarning("Failed to build texture render target for QQuickRenderTarget");
+        qCWarning(lcWlRenderHelper, "Failed to build texture render target for QQuickRenderTarget");
         return false;
     }
 
@@ -205,7 +206,7 @@ bool createRhiRenderTarget(QRhi *rhi, const QQuickRenderTarget &source, QQuickWi
     case QQuickRenderTargetPrivate::Type::NativeRenderbuffer: {
         std::unique_ptr<QRhiRenderBuffer> renderbuffer(rhi->newRenderBuffer(QRhiRenderBuffer::Color, rtd->pixelSize, rtd->sampleCount));
         if (!renderbuffer->createFrom({ rtd->u.nativeRenderbufferObject })) {
-            qWarning("Failed to build wrapper renderbuffer for QQuickRenderTarget");
+            qCWarning(lcWlRenderHelper, "Failed to build wrapper renderbuffer for QQuickRenderTarget");
             return false;
         }
         QRhiColorAttachment att(renderbuffer.get());
@@ -724,14 +725,14 @@ QSGRendererInterface::GraphicsApi WRenderHelper::probe(qw_backend *testBackend, 
     for (auto api : std::as_const(apiList)) {
         std::unique_ptr<qw_renderer> renderer(createRenderer(testBackend, api));
         if (!renderer) {
-            qInfo() << GraphicsApiName(api) << " api failed to create wlr_renderer";
+            qCInfo(lcWlRenderHelper) << GraphicsApiName(api) << " api failed to create wlr_renderer";
             continue;
         }
 
         const wlr_drm_format_set *formats = wlr_renderer_get_texture_formats(*renderer, WLR_BUFFER_CAP_DMABUF);
 
         if (formats && formats->len == 0) {
-            qInfo() << GraphicsApiName(api) << " api don't support any format";
+            qCInfo(lcWlRenderHelper) << GraphicsApiName(api) << " api don't support any format";
             continue;
         }
 
@@ -758,7 +759,7 @@ QSGRendererInterface::GraphicsApi WRenderHelper::probe(qw_backend *testBackend, 
             }
 
             if (!hasSupportedFormat) {
-                qInfo() << GraphicsApiName(api) << " api failed to convert any buffer to texture";
+                qCInfo(lcWlRenderHelper) << GraphicsApiName(api) << " api failed to convert any buffer to texture";
                 continue;
             }
         }
@@ -861,13 +862,13 @@ WRenderHelper::newTexture(qw_allocator *allocator, qw_renderer *renderer,
 
     wlr_buffer *buffer = allocator->create_buffer(size.width(), size.height(), &format);
     if (!buffer) {
-        qCritical() << "Failed to create qw_buffer from allocator";
+        qCCritical(lcWlRenderHelper) << "Failed to create qw_buffer from allocator";
         return {};
     }
 
     std::unique_ptr<qw_texture> texture(qw_texture::from_buffer(*renderer, buffer));
     if (!texture) {
-        qCritical() << "Failed to create qw_texture from buffer";
+        qCCritical(lcWlRenderHelper) << "Failed to create qw_texture from buffer";
         wlr_buffer_drop(buffer);
         return {};
     }
@@ -885,7 +886,7 @@ WRenderHelper::newTexture(qw_allocator *allocator, qw_renderer *renderer,
         wlr_gles2_texture_get_attribs(*texture.get(), &attribs);
 
         if (!rhiTexture->createFrom({attribs.tex, 0})) {
-            qCritical("Failed to create QRhiTexture from GLES2 texture");
+            qCCritical(lcWlRenderHelper, "Failed to create QRhiTexture from GLES2 texture");
             wlr_buffer_drop(buffer);
             return {};
         }
@@ -900,7 +901,7 @@ WRenderHelper::newTexture(qw_allocator *allocator, qw_renderer *renderer,
         wlr_vk_texture_get_image_attribs(*texture.get(), &attribs);
 
         if (!rhiTexture->createFrom({vkimage_cast(attribs.image), attribs.layout})) {
-            qCritical("Failed to create QRhiTexture from Vulkan image");
+            qCCritical(lcWlRenderHelper, "Failed to create QRhiTexture from Vulkan image");
             wlr_buffer_drop(buffer);
             return {};
         }

--- a/waylib/src/server/qtquick/wsgtextureprovider.cpp
+++ b/waylib/src/server/qtquick/wsgtextureprovider.cpp
@@ -1,10 +1,11 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wsgtextureprovider.h"
 #include "woutputrenderwindow.h"
 #include "wrenderhelper.h"
 #include "private/wglobal_p.h"
+#include "wayliblogging.h"
 
 #include <qwtexture.h>
 #include <qwbuffer.h>
@@ -14,12 +15,6 @@
 #include <private/qsgplaintexture_p.h>
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
-
-#ifdef QT_DEBUG
-Q_LOGGING_CATEGORY(lcQtQuickTexture, "waylib.qtquick.texture", QtDebugMsg);
-#else
-Q_LOGGING_CATEGORY(lcQtQuickTexture, "waylib.qtquick.texture", QtInfoMsg);
-#endif
 
 class Q_DECL_HIDDEN WSGTextureProviderPrivate : public WObjectPrivate
 {
@@ -68,7 +63,7 @@ public:
         Q_ASSERT(texture);
         bool ok = WRenderHelper::makeTexture(window->rhi(), texture, &qtTexture);
         if (Q_UNLIKELY(!ok)) {
-            qCWarning(lcQtQuickTexture) << "Failed to make texture:" << texture
+            qCWarning(lcWlQtQuickTexture) << "Failed to make texture:" << texture
                                         << ", width height:" << texture->handle()->width
                                         << texture->handle()->height;
             return;
@@ -132,7 +127,7 @@ void WSGTextureProvider::setBuffer(qw_buffer *buffer)
             d->ownsTexture = true;
         }
         if (Q_UNLIKELY(!d->texture)) {
-            qCWarning(lcQtQuickTexture) << "Failed to update texture from buffer:" << buffer
+            qCWarning(lcWlQtQuickTexture) << "Failed to update texture from buffer:" << buffer
                                         << ", width height:" << buffer->handle()->width
                                         << buffer->handle()->height
                                         << ", n_locks:" << buffer->handle()->n_locks;

--- a/waylib/src/server/qtquick/wsurfaceitem.cpp
+++ b/waylib/src/server/qtquick/wsurfaceitem.cpp
@@ -11,6 +11,7 @@
 #include "wsgtextureprovider.h"
 #include "wsurface.h"
 #include "wsurfaceitem_p.h"
+#include "wayliblogging.h"
 
 #include <private/qquickitem_p.h>
 
@@ -30,8 +31,6 @@
 
 QW_USE_NAMESPACE
 WAYLIB_SERVER_BEGIN_NAMESPACE
-
-Q_LOGGING_CATEGORY(waylibSurface, "waylib.server.surface", QtInfoMsg)
 
 class Q_DECL_HIDDEN SubsurfaceContainer : public QQuickItem
 {
@@ -297,7 +296,7 @@ public:
                                                        }
                                                    }); // if signal is emitted from seperated rendering thread, default QueuedConnection is used
         } else {
-            qCFatal(waylibSurface) << "Needs a WOutputRenderWindow to render the WSurfaceItemContent, "
+            qCFatal(lcWlSurface) << "Needs a WOutputRenderWindow to render the WSurfaceItemContent, "
                                       "but the current window is:" << q->window();
         }
     }
@@ -454,7 +453,7 @@ WSGTextureProvider *WSurfaceItemContent::wTextureProvider() const
 
     auto w = qobject_cast<WOutputRenderWindow*>(d->window);
     if (!w || !d->sceneGraphRenderContext() || QThread::currentThread() != d->sceneGraphRenderContext()->thread()) {
-        qWarning("WQuickCursor::textureProvider: can only be queried on the rendering thread of an WOutputRenderWindow");
+        qCWarning(lcWlSurface, "WQuickCursor::textureProvider: can only be queried on the rendering thread of an WOutputRenderWindow");
         return nullptr;
     }
 
@@ -1239,7 +1238,7 @@ void WSurfaceItemPrivate::initForDelegate()
     } else if (delegateIsDirty) {
         auto obj = delegate->createWithInitialProperties({{"surface", QVariant::fromValue(q)}}, qmlContext(q));
         if (!obj) {
-            qWarning() << "Failed on create surface item from delegate, error mssage:"
+            qCWarning(lcWlSurface) << "Failed on create surface item from delegate, error mssage:"
                        << delegate->errorString();
             return;
         }
@@ -1418,7 +1417,7 @@ void WSurfaceItemPrivate::connectSubsurfaceContainerSignals(SubsurfaceContainer 
                          // notifications are emitted from ensureSubsurfaceItem() only
                          // after the item is fully initialized.
                          if (subsurfaces.contains(item)) {
-                             qCWarning(waylibSurface)
+                             qCWarning(lcWlSurface)
                                  << "Duplicate subsurface add ignored:" << item;
                              return;
                          }
@@ -1537,7 +1536,7 @@ void WSurfaceItemPrivate::doResize(WSurfaceItem::ResizeMode mode)
 
         resizeSurfaceToItemSize(newSize.toSize(), (newSize - oldSize).toSize());
     } else {
-        qWarning() << "Invalid resize mode" << mode;
+        qCWarning(lcWlSurface) << "Invalid resize mode" << mode;
     }
 }
 

--- a/waylib/src/server/qtquick/wtextureproviderprovider.cpp
+++ b/waylib/src/server/qtquick/wtextureproviderprovider.cpp
@@ -4,12 +4,11 @@
 #include "wtextureproviderprovider.h"
 #include "woutputrenderwindow.h"
 #include "private/wglobal_p.h"
+#include "wayliblogging.h"
 
 #include <rhi/qrhi.h>
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
-Q_LOGGING_CATEGORY(qLcTextureProvider, "waylib.server.texture.provider")
-
 class Q_DECL_HIDDEN WTextureCapturerPrivate : public WObjectPrivate
 {
 public:
@@ -63,7 +62,7 @@ void WTextureCapturer::doGrabToImage()
     if (textureProvider && textureProvider->texture() && textureProvider->texture()->rhiTexture()) {
         // Perform rhi texture read back
         auto texture = textureProvider->texture()->rhiTexture();
-        qCInfo(qLcTextureProvider) << "Perform rhi texture read back for texture" << texture;
+        qCInfo(lcWlTextureProvider) << "Perform rhi texture read back for texture" << texture;
         QRhiReadbackResult *rbResult = new QRhiReadbackResult;
         QRhiCommandBuffer *cb;
         d->renderWindow->rhi()->beginOffscreenFrame(&cb);

--- a/waylib/src/server/utils/wbufferdumper.cpp
+++ b/waylib/src/server/utils/wbufferdumper.cpp
@@ -1,11 +1,11 @@
-// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2025-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wbufferdumper.h"
 #include "wtools.h"
+#include "wayliblogging.h"
 
 #include <QImage>
-#include <QLoggingCategory>
 
 extern "C" {
 #include <wlr/types/wlr_buffer.h>
@@ -14,20 +14,18 @@ extern "C" {
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
-Q_LOGGING_CATEGORY(wlcBufferDumper, "waylib.server.bufferdumper", QtWarningMsg)
-
 WBufferDumper::DumpResult WBufferDumper::dumpBufferToImage(wlr_buffer *buffer, 
                                                            wlr_renderer *renderer, 
                                                            QImage &outputImage)
 {
     if (!buffer || !renderer) {
-        qCWarning(wlcBufferDumper) << "Invalid buffer or renderer";
+        qCWarning(lcWlBufferDumper) << "Invalid buffer or renderer";
         return DumpResult::InvalidBuffer;
     }
 
     wlr_texture *texture = wlr_texture_from_buffer(renderer, buffer);
     if (!texture) {
-        qCWarning(wlcBufferDumper) << "Failed to create texture from buffer";
+        qCWarning(lcWlBufferDumper) << "Failed to create texture from buffer";
         return DumpResult::TextureCreationFailed;
     }
 
@@ -48,7 +46,7 @@ WBufferDumper::DumpResult WBufferDumper::dumpBufferToImage(wlr_buffer *buffer,
     options.stride = stride;
 
     if (!wlr_texture_read_pixels(texture, &options)) {
-        qCWarning(wlcBufferDumper) << "Failed to read pixels from texture";
+        qCWarning(lcWlBufferDumper) << "Failed to read pixels from texture";
         wlr_texture_destroy(texture);
         return DumpResult::TextureReadFailed;
     }
@@ -70,7 +68,7 @@ WBufferDumper::DumpResult WBufferDumper::dumpBufferToFile(wlr_buffer *buffer,
     }
 
     if (!image.save(filePath)) {
-        qCWarning(wlcBufferDumper) << "Failed to save image to" << filePath;
+        qCWarning(lcWlBufferDumper) << "Failed to save image to" << filePath;
         return DumpResult::SaveFailed;
     }
 

--- a/waylib/src/server/utils/wcursorimage.cpp
+++ b/waylib/src/server/utils/wcursorimage.cpp
@@ -1,19 +1,17 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wcursorimage.h"
 #include "wcursor.h"
+#include "wayliblogging.h"
 
 #include <qwxcursormanager.h>
 
 #include <QDebug>
-#include <QLoggingCategory>
 #include <QTimer>
 #include <private/qobject_p.h>
 
 #include <memory>
-
-Q_LOGGING_CATEGORY(qLcCursorImage, "waylib.server.cursor.image", QtWarningMsg)
 
 QW_USE_NAMESPACE
 WAYLIB_SERVER_BEGIN_NAMESPACE
@@ -545,9 +543,9 @@ void WCursorImagePrivate::updateCursorImage()
     if (cursorName) {
         xcursor = getXCursorWithFallback(manager.get(), cursorName, scale);
         if (!xcursor)
-            qCWarning(qLcCursorImage) << "Get empty cursor image for " << cursorName;
+            qCWarning(lcWlCursorImage) << "Get empty cursor image for " << cursorName;
     } else {
-        qCWarning(qLcCursorImage) << "Unknown cursor shape type!";
+        qCWarning(lcWlCursorImage) << "Unknown cursor shape type!";
     }
 
     if (!xcursor || xcursor->image_count == 0) {
@@ -675,7 +673,7 @@ void WCursorImage::setCursorTheme(const QByteArray &name, uint32_t size)
 
     bool theme_loaded = d->manager->load(d->scale);
     if (!theme_loaded)
-        qCCritical(qLcCursorImage) << "Can't load cursor theme:" << name << ", size:" << size;
+        qCCritical(lcWlCursorImage) << "Can't load cursor theme:" << name << ", size:" << size;
 
     d->updateCursorImage();
 }

--- a/waylib/src/server/utils/wextimagecapturesourcev1impl.cpp
+++ b/waylib/src/server/utils/wextimagecapturesourcev1impl.cpp
@@ -7,6 +7,7 @@
 #include "woutputrenderwindow.h"
 #include "woutput.h"
 #include "wtools.h"
+#include "wayliblogging.h"
 
 #include <qwextimagecopycapturev1.h>
 #include <qwrenderer.h>
@@ -15,11 +16,7 @@
 #include <qwallocator.h>
 #include <qwcompositor.h>
 
-#include <QLoggingCategory>
-
 #include <memory>
-
-Q_LOGGING_CATEGORY(qLcImageCapture, "waylib.server.imagecapture")
 
 extern "C" {
 #include <wlr/interfaces/wlr_output.h>
@@ -77,7 +74,7 @@ struct ConstraintBuilder {
         source->shm_formats = formats.release();
         source->shm_formats_len = 1;
         
-        qCDebug(qLcImageCapture) << "Set SHM format:" << format;
+        qCDebug(lcWlImageCapture) << "Set SHM format:" << format;
     }
     
     void buildDmabufFormats() {
@@ -104,7 +101,7 @@ struct ConstraintBuilder {
                     wlr_drm_format_set_add(&source->dmabuf_formats,
                         swapchain->handle()->format.format, swapchain->handle()->format.modifiers[i]);
                 }
-                qCDebug(qLcImageCapture) << "Set DMA-BUF constraints";
+                qCDebug(lcWlImageCapture) << "Set DMA-BUF constraints";
             }
         }
     }
@@ -142,21 +139,21 @@ WExtImageCaptureSourceV1Impl::WExtImageCaptureSourceV1Impl(WSurfaceItemContent *
             builder.buildDmabufFormats();
             builder.apply();
             
-            qCDebug(qLcImageCapture) << "Initial constraints set successfully:";
-            qCDebug(qLcImageCapture) << "  - Width:" << width;
-            qCDebug(qLcImageCapture) << "  - Height:" << height;
+            qCDebug(lcWlImageCapture) << "Initial constraints set successfully:";
+            qCDebug(lcWlImageCapture) << "  - Width:" << width;
+            qCDebug(lcWlImageCapture) << "  - Height:" << height;
         } else {
-            qCWarning(qLcImageCapture) << "Invalid surface dimensions for constraints:" << width << "x" << height;
+            qCWarning(lcWlImageCapture) << "Invalid surface dimensions for constraints:" << width << "x" << height;
         }
     } else {
-        qCWarning(qLcImageCapture) << "No valid surface available for setting initial constraints";
+        qCWarning(lcWlImageCapture) << "No valid surface available for setting initial constraints";
     }
 }
 
 WExtImageCaptureSourceV1Impl::~WExtImageCaptureSourceV1Impl()
 {
     if (m_capturing) {
-        qCDebug(qLcImageCapture) << "WExtImageCaptureSourceV1Impl destroyed while capturing";
+        qCDebug(lcWlImageCapture) << "WExtImageCaptureSourceV1Impl destroyed while capturing";
     }
 }
 
@@ -164,7 +161,7 @@ void WExtImageCaptureSourceV1Impl::start([[maybe_unused]] bool with_cursors)
 {
     // TODO: Implement cursor capture if needed
     m_capturing = true;
-    qCDebug(qLcImageCapture) << "WExtImageCaptureSourceV1Impl::start() with_cursors:" << with_cursors;
+    qCDebug(lcWlImageCapture) << "WExtImageCaptureSourceV1Impl::start() with_cursors:" << with_cursors;
 
     // TODO: Optimize multiple clients capturing the same window
     // Currently each client creates its own WExtImageCaptureSourceV1Impl instance,
@@ -172,20 +169,20 @@ void WExtImageCaptureSourceV1Impl::start([[maybe_unused]] bool with_cursors)
     // a manager to share render events among multiple capture sources.
 
     if (!m_surfaceContent) {
-        qCWarning(qLcImageCapture) << "No surface content available for capture";
+        qCWarning(lcWlImageCapture) << "No surface content available for capture";
         return;
     }
     
     // Get render window
     auto textureProvider = m_surfaceContent->wTextureProvider();
     if (!textureProvider) {
-        qCWarning(qLcImageCapture) << "No texture provider available for start";
+        qCWarning(lcWlImageCapture) << "No texture provider available for start";
         return;
     }
     
     auto renderWindow = textureProvider->window();
     if (!renderWindow) {
-        qCWarning(qLcImageCapture) << "No render window available for start";
+        qCWarning(lcWlImageCapture) << "No render window available for start";
         return;
     }
     
@@ -197,7 +194,7 @@ void WExtImageCaptureSourceV1Impl::start([[maybe_unused]] bool with_cursors)
                                    Qt::AutoConnection);
     
     if (!m_renderEndConnection) {
-        qCWarning(qLcImageCapture) << "Cannot connect to render end of output render window";
+        qCWarning(lcWlImageCapture) << "Cannot connect to render end of output render window";
     }
     
     // If not currently rendering, trigger immediately
@@ -209,7 +206,7 @@ void WExtImageCaptureSourceV1Impl::start([[maybe_unused]] bool with_cursors)
 void WExtImageCaptureSourceV1Impl::stop()
 {
     m_capturing = false;
-    qCDebug(qLcImageCapture) << "WExtImageCaptureSourceV1Impl::stop()";
+    qCDebug(lcWlImageCapture) << "WExtImageCaptureSourceV1Impl::stop()";
     
     // Disconnect render end connection
     if (m_renderEndConnection) {
@@ -220,15 +217,15 @@ void WExtImageCaptureSourceV1Impl::stop()
 
 void WExtImageCaptureSourceV1Impl::schedule_frame()
 {
-    qCDebug(qLcImageCapture) << "WExtImageCaptureSourceV1Impl::schedule_frame()";
+    qCDebug(lcWlImageCapture) << "WExtImageCaptureSourceV1Impl::schedule_frame()";
     
     if (!m_capturing) {
-        qCWarning(qLcImageCapture) << "schedule_frame called but not capturing";
+        qCWarning(lcWlImageCapture) << "schedule_frame called but not capturing";
         return;
     }
     
     if (!m_surfaceContent) {
-        qCWarning(qLcImageCapture) << "No surface content available for frame scheduling";
+        qCWarning(lcWlImageCapture) << "No surface content available for frame scheduling";
         return;
     }
     
@@ -244,22 +241,22 @@ void WExtImageCaptureSourceV1Impl::schedule_frame()
         }
     }
     
-    qCDebug(qLcImageCapture) << "Scheduled frame capture";
+    qCDebug(lcWlImageCapture) << "Scheduled frame capture";
 }
 
 void WExtImageCaptureSourceV1Impl::handleRenderEnd()
 {
-    qCDebug(qLcImageCapture) << "WExtImageCaptureSourceV1Impl::handleRenderEnd() - triggering frame event";
+    qCDebug(lcWlImageCapture) << "WExtImageCaptureSourceV1Impl::handleRenderEnd() - triggering frame event";
     
     if (!m_capturing) {
-        qCWarning(qLcImageCapture) << "handleRenderEnd called but not capturing";
+        qCWarning(lcWlImageCapture) << "handleRenderEnd called but not capturing";
         return;
     }
     
     // Get surface size and validate it
     QSize surfaceSize = m_surfaceContent->size().toSize();
     if (surfaceSize.width() <= 0 || surfaceSize.height() <= 0) {
-        qCWarning(qLcImageCapture) << "Invalid surface size for damage region:" << surfaceSize;
+        qCWarning(lcWlImageCapture) << "Invalid surface size for damage region:" << surfaceSize;
         return;
     }
     
@@ -272,22 +269,22 @@ void WExtImageCaptureSourceV1Impl::handleRenderEnd()
     };
     wl_signal_emit_mutable(&handle()->events.frame, &event);
     
-    qCDebug(qLcImageCapture) << "Frame event emitted with damage region:" << surfaceSize;
+    qCDebug(lcWlImageCapture) << "Frame event emitted with damage region:" << surfaceSize;
 }
 
 void WExtImageCaptureSourceV1Impl::copy_frame(wlr_ext_image_copy_capture_frame_v1 *dst_frame, 
                                               [[maybe_unused]] wlr_ext_image_capture_source_v1_frame_event *frame_event)
 {
-    qCDebug(qLcImageCapture) << "WExtImageCaptureSourceV1Impl::copy_frame()";
+    qCDebug(lcWlImageCapture) << "WExtImageCaptureSourceV1Impl::copy_frame()";
     
     if (!m_capturing) {
-        qCWarning(qLcImageCapture) << "copy_frame called but not capturing";
+        qCWarning(lcWlImageCapture) << "copy_frame called but not capturing";
         qw_ext_image_copy_capture_frame_v1::from(dst_frame)->fail(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_STOPPED);
         return;
     }
     
     if (!m_surfaceContent) {
-        qCWarning(qLcImageCapture) << "No surface content available for frame copy";
+        qCWarning(lcWlImageCapture) << "No surface content available for frame copy";
         qw_ext_image_copy_capture_frame_v1::from(dst_frame)->fail(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
         return;
     }
@@ -295,21 +292,21 @@ void WExtImageCaptureSourceV1Impl::copy_frame(wlr_ext_image_copy_capture_frame_v
     // Get texture provider
     auto textureProvider = m_surfaceContent->wTextureProvider();
     if (!textureProvider) {
-        qCWarning(qLcImageCapture) << "No texture provider available";
+        qCWarning(lcWlImageCapture) << "No texture provider available";
         qw_ext_image_copy_capture_frame_v1::from(dst_frame)->fail(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
         return;
     }
 
     auto buffer = textureProvider->qwBuffer();
     if (!buffer || !buffer->handle()) {
-        qCWarning(qLcImageCapture) << "No internal buffer available";
+        qCWarning(lcWlImageCapture) << "No internal buffer available";
         qw_ext_image_copy_capture_frame_v1::from(dst_frame)->fail(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
         return;
     }
 
     // Lock the buffer for the duration of the copy to prevent races during resize
     if (!buffer->lock()) {
-        qCWarning(qLcImageCapture) << "Failed to lock internal buffer";
+        qCWarning(lcWlImageCapture) << "Failed to lock internal buffer";
         qw_ext_image_copy_capture_frame_v1::from(dst_frame)->fail(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
         return;
     }
@@ -318,14 +315,14 @@ void WExtImageCaptureSourceV1Impl::copy_frame(wlr_ext_image_copy_capture_frame_v
     // Get renderer
     auto renderWindow = textureProvider->window();
     if (!renderWindow) {
-        qCWarning(qLcImageCapture) << "No render window available";
+        qCWarning(lcWlImageCapture) << "No render window available";
         qw_ext_image_copy_capture_frame_v1::from(dst_frame)->fail(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
         return;
     }
     
     auto renderer = m_output->renderer();
     if (!renderer) {
-        qCWarning(qLcImageCapture) << "No renderer available";
+        qCWarning(lcWlImageCapture) << "No renderer available";
         qw_ext_image_copy_capture_frame_v1::from(dst_frame)->fail(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
         return;
     }
@@ -338,7 +335,7 @@ void WExtImageCaptureSourceV1Impl::copy_frame(wlr_ext_image_copy_capture_frame_v
 
     // Critical safety checks: validate all required pointers and buffers before copying
     if (!src) {
-        qCWarning(qLcImageCapture) << "Source buffer is null, cannot copy frame";
+        qCWarning(lcWlImageCapture) << "Source buffer is null, cannot copy frame";
         if (dst_frame) {
             qw_ext_image_copy_capture_frame_v1::from(dst_frame)->fail(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_BUFFER_CONSTRAINTS);
         }
@@ -346,7 +343,7 @@ void WExtImageCaptureSourceV1Impl::copy_frame(wlr_ext_image_copy_capture_frame_v
     }
 
     if (!dst_frame || !dst_frame->buffer) {
-        qCWarning(qLcImageCapture) << "Destination frame or buffer is null, cannot copy";
+        qCWarning(lcWlImageCapture) << "Destination frame or buffer is null, cannot copy";
         if (dst_frame) {
             qw_ext_image_copy_capture_frame_v1::from(dst_frame)->fail(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_BUFFER_CONSTRAINTS);
         }
@@ -355,7 +352,7 @@ void WExtImageCaptureSourceV1Impl::copy_frame(wlr_ext_image_copy_capture_frame_v
 
     // Validate buffer dimensions to prevent crashes during resize
     if (dst_frame->buffer->width != src->width || dst_frame->buffer->height != src->height) {
-        qCWarning(qLcImageCapture) << "Buffer size mismatch during resize (dst:" << dst_frame->buffer->width << "x" << dst_frame->buffer->height
+        qCWarning(lcWlImageCapture) << "Buffer size mismatch during resize (dst:" << dst_frame->buffer->width << "x" << dst_frame->buffer->height
                                    << ", src:" << src->width << "x" << src->height << "), updating constraints";
         
         // Update constraints when we detect a size mismatch
@@ -365,21 +362,21 @@ void WExtImageCaptureSourceV1Impl::copy_frame(wlr_ext_image_copy_capture_frame_v
         builder.buildDmabufFormats();
         builder.apply();
         
-        qCDebug(qLcImageCapture) << "Constraints updated to new size:" << src->width << "x" << src->height;
+        qCDebug(lcWlImageCapture) << "Constraints updated to new size:" << src->width << "x" << src->height;
         
         // Check again after constraints update - the client might have already provided a correctly sized buffer
         if (dst_frame->buffer->width != src->width || dst_frame->buffer->height != src->height) {
-            qCDebug(qLcImageCapture) << "Buffer size still mismatched after constraint update, skipping frame";
+            qCDebug(lcWlImageCapture) << "Buffer size still mismatched after constraint update, skipping frame";
             qw_ext_image_copy_capture_frame_v1::from(dst_frame)->fail(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_BUFFER_CONSTRAINTS);
             return;
         }
         
-        qCDebug(qLcImageCapture) << "Buffer size now matches after constraint update, proceeding with copy";
+        qCDebug(lcWlImageCapture) << "Buffer size now matches after constraint update, proceeding with copy";
     }
 
     // Use wlroots image copy function with validated buffers
     bool success = qw_ext_image_copy_capture_frame_v1::copy_buffer(dst_frame, src, renderer->handle());
-    qCDebug(qLcImageCapture) << "Copy result:" << success;
+    qCDebug(lcWlImageCapture) << "Copy result:" << success;
     
     if (success) {
         // Successfully copied, mark frame as ready
@@ -387,20 +384,20 @@ void WExtImageCaptureSourceV1Impl::copy_frame(wlr_ext_image_copy_capture_frame_v
         clock_gettime(CLOCK_MONOTONIC, &now);
         
         qw_ext_image_copy_capture_frame_v1::from(dst_frame)->ready(WL_OUTPUT_TRANSFORM_NORMAL, &now);
-        qCDebug(qLcImageCapture) << "Frame copy successful";
+        qCDebug(lcWlImageCapture) << "Frame copy successful";
     } else {
-        qCWarning(qLcImageCapture) << "Failed to copy frame buffer";
-        qCWarning(qLcImageCapture) << "Possible reasons:";
-        qCWarning(qLcImageCapture) << "  - Buffer size mismatch";
-        qCWarning(qLcImageCapture) << "  - Unsupported buffer format";
-        qCWarning(qLcImageCapture) << "  - Renderer issues";
-        qCWarning(qLcImageCapture) << "  - Memory access problems";
+        qCWarning(lcWlImageCapture) << "Failed to copy frame buffer";
+        qCWarning(lcWlImageCapture) << "Possible reasons:";
+        qCWarning(lcWlImageCapture) << "  - Buffer size mismatch";
+        qCWarning(lcWlImageCapture) << "  - Unsupported buffer format";
+        qCWarning(lcWlImageCapture) << "  - Renderer issues";
+        qCWarning(lcWlImageCapture) << "  - Memory access problems";
         
         // Check if it's a buffer constraints issue
         if (dst_frame->buffer && buffer->handle()) {
             if (dst_frame->buffer->width != buffer->handle()->width ||
                 dst_frame->buffer->height != buffer->handle()->height) {
-                qCWarning(qLcImageCapture) << "Buffer size mismatch detected, using BUFFER_CONSTRAINTS failure reason";
+                qCWarning(lcWlImageCapture) << "Buffer size mismatch detected, using BUFFER_CONSTRAINTS failure reason";
                 qw_ext_image_copy_capture_frame_v1::from(dst_frame)->fail(EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_BUFFER_CONSTRAINTS);
                 return;
             }
@@ -413,7 +410,7 @@ void WExtImageCaptureSourceV1Impl::copy_frame(wlr_ext_image_copy_capture_frame_v
 
 wlr_ext_image_capture_source_v1_cursor *WExtImageCaptureSourceV1Impl::get_pointer_cursor([[maybe_unused]] wlr_seat *seat)
 {
-    qCDebug(qLcImageCapture) << "WExtImageCaptureSourceV1Impl::get_pointer_cursor()";
+    qCDebug(lcWlImageCapture) << "WExtImageCaptureSourceV1Impl::get_pointer_cursor()";
     // TODO: Implement cursor retrieval logic
     // This needs to get cursor information from seat and create corresponding cursor structure
     // Currently return nullptr to indicate no cursor information

--- a/waylib/src/server/utils/wextimagecapturesourcev1impl.h
+++ b/waylib/src/server/utils/wextimagecapturesourcev1impl.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2025-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #pragma once
@@ -7,8 +7,6 @@
 #include <qwextimagecapturesourcev1interface.h>
 
 #include <QObject>
-
-Q_DECLARE_LOGGING_CATEGORY(qLcImageCapture)
 
 QW_BEGIN_NAMESPACE
 class qw_buffer;

--- a/waylib/src/server/utils/wthreadutils.h
+++ b/waylib/src/server/utils/wthreadutils.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <wglobal.h>
+#include "wayliblogging.h"
 
 #include <QCoreApplication>
 #include <QPointer>
@@ -53,7 +54,7 @@ public:
     {
         auto future = run(std::forward<T>(args)...);
         if (!thread()->isRunning()) {
-            qWarning() << "The target thread is not running, maybe lead to deadlock.";
+            qCWarning(lcWlThreadUtils) << "The target thread is not running, maybe lead to deadlock.";
         }
         future.waitForFinished();
 

--- a/waylib/src/server/wayliblogging.cpp
+++ b/waylib/src/server/wayliblogging.cpp
@@ -1,0 +1,74 @@
+// Copyright (C) 2023-2026 JiDe Zhang <zhangjide@deepin.org>.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "wayliblogging.h"
+
+// Waylib logging category definitions
+// Naming convention: lcWl + PascalCase module name
+// String ID convention: waylib.<module>[.<submodule>] or waylib.protocols.<name> or waylib.qtquick.<name> or waylib.utils.<name>
+
+// Kernel - Core
+Q_LOGGING_CATEGORY(lcWlSocket, "waylib.socket", QtInfoMsg)             // Wayland socket lifecycle
+Q_LOGGING_CATEGORY(lcWlSeat, "waylib.seat", QtInfoMsg)                 // Seat management (keyboard focus, capability)
+Q_LOGGING_CATEGORY(lcWlOutput, "waylib.output", QtInfoMsg)             // Output lifecycle and configuration
+Q_LOGGING_CATEGORY(lcWlOutputDrm, "waylib.output.drm", QtInfoMsg)     // DRM/KMS format negotiation and hardware rendering
+Q_LOGGING_CATEGORY(lcWlOutputBuffer, "waylib.output.buffer", QtDebugMsg) // Output buffer commit and swap
+Q_LOGGING_CATEGORY(lcWlInput, "waylib.input", QtInfoMsg)               // Generic input device events
+Q_LOGGING_CATEGORY(lcWlCursor, "waylib.cursor", QtInfoMsg)             // Cursor image and theme management
+
+// Kernel - Input subcategories
+Q_LOGGING_CATEGORY(lcWlPointer, "waylib.input.pointer", QtInfoMsg)     // Pointer/mouse button and motion events
+Q_LOGGING_CATEGORY(lcWlTouch, "waylib.input.touch", QtInfoMsg)         // Touch down/move/up/cancel events
+Q_LOGGING_CATEGORY(lcWlGesture, "waylib.input.gesture", QtInfoMsg)     // Touchpad gesture begin/update/end and hold
+Q_LOGGING_CATEGORY(lcWlDrag, "waylib.input.drag", QtInfoMsg)           // DnD start/motion/drop operations
+
+// QtQuick
+Q_LOGGING_CATEGORY(lcWlTextureProvider, "waylib.texture.provider")     // QSGTexture provider bridging
+Q_LOGGING_CATEGORY(lcWlSurface, "waylib.qtquick.surface", QtInfoMsg)   // QtQuick surface item lifecycle and rendering
+// More verbose in debug builds for texture inspection
+#ifdef QT_DEBUG
+Q_LOGGING_CATEGORY(lcWlQtQuickTexture, "waylib.qtquick.texture", QtDebugMsg)
+#else
+Q_LOGGING_CATEGORY(lcWlQtQuickTexture, "waylib.qtquick.texture", QtInfoMsg)
+#endif
+// More verbose in debug builds for render diagnostics
+#ifdef QT_DEBUG
+Q_LOGGING_CATEGORY(lcWlRenderer, "waylib.renderer", QtDebugMsg)
+#else
+Q_LOGGING_CATEGORY(lcWlRenderer, "waylib.renderer", QtWarningMsg)
+#endif
+Q_LOGGING_CATEGORY(lcWlBufferItem, "waylib.qtquick.bufferitem", QtInfoMsg) // Buffer item commit and damage
+
+// Utils
+Q_LOGGING_CATEGORY(lcWlImageCapture, "waylib.utils.imagecapture")      // Ext-image-capture-source frame capture
+Q_LOGGING_CATEGORY(lcWlCursorImage, "waylib.utils.cursorimage", QtWarningMsg) // Cursor image scaling and conversion
+Q_LOGGING_CATEGORY(lcWlBufferDumper, "waylib.utils.bufferdumper", QtWarningMsg) // Buffer dump for debugging
+Q_LOGGING_CATEGORY(lcWlThreadUtils, "waylib.utils.thread", QtWarningMsg) // Thread utility async call and deadlock warning
+
+// Protocols
+Q_LOGGING_CATEGORY(lcWlForeignToplevel, "waylib.protocols.foreigntoplevel", QtWarningMsg) // wlr-foreign-toplevel-v1
+Q_LOGGING_CATEGORY(lcWlInputMethod, "waylib.protocols.inputmethod", QtInfoMsg) // Input method v2 and virtual keyboard
+Q_LOGGING_CATEGORY(lcWlExtForeignToplevel, "waylib.protocols.extforeigntoplevel", QtWarningMsg) // ext-foreign-toplevel-list-v1
+Q_LOGGING_CATEGORY(lcWlTextInput, "waylib.protocols.textinput", QtInfoMsg) // Text input v1/v2/v3 protocol
+
+// Layer shell
+Q_LOGGING_CATEGORY(lcWlLayerShell, "waylib.layer.shell", QtWarningMsg) // wlr-layer-shell surface requests
+Q_LOGGING_CATEGORY(lcWlLayerSurface, "waylib.layer.surface", QtWarningMsg) // Layer surface commit/geometry
+
+// XDG
+Q_LOGGING_CATEGORY(lcWlXdgOutput, "waylib.xdg.output", QtWarningMsg)  // XDG output manager
+Q_LOGGING_CATEGORY(lcWlXdgDecoration, "waylib.xdg.decoration", QtWarningMsg) // XDG decoration mode
+
+// Output
+Q_LOGGING_CATEGORY(lcWlOutputLayer, "waylib.output.layer", QtWarningMsg)   // QtQuick output layer
+Q_LOGGING_CATEGORY(lcWlOutputHelper, "waylib.output.helper", QtWarningMsg) // Output helper state/commit
+
+// QtQuick extras
+Q_LOGGING_CATEGORY(lcWlQmlCreator, "waylib.qml.creator", QtWarningMsg)     // QML component creation
+Q_LOGGING_CATEGORY(lcWlQuickCursor, "waylib.cursor.quick", QtWarningMsg)   // QtQuick cursor texture provider
+
+// Platform & Rendering
+Q_LOGGING_CATEGORY(lcWlPlatform, "waylib.platform", QtWarningMsg)          // QPA integration
+Q_LOGGING_CATEGORY(lcWlRenderHelper, "waylib.render.helper", QtWarningMsg) // Render target creation and buffer import
+Q_LOGGING_CATEGORY(lcWlRenderBuffer, "waylib.render.buffer", QtWarningMsg) // Render buffer node DMA-BUF
+Q_LOGGING_CATEGORY(lcWlBufferRenderer, "waylib.render.bufferrenderer", QtWarningMsg) // Buffer renderer texture provider

--- a/waylib/src/server/wayliblogging.h
+++ b/waylib/src/server/wayliblogging.h
@@ -1,0 +1,71 @@
+// Copyright (C) 2023-2026 JiDe Zhang <zhangjide@deepin.org>.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#ifndef WAYLIB_LOGGING_H
+#define WAYLIB_LOGGING_H
+
+#include <QLoggingCategory>
+
+// Waylib Logging Categories
+// Naming convention: lcWl + PascalCase module name
+// String ID convention: waylib.<module>[.<submodule>] or waylib.protocols.<name> or waylib.qtquick.<name> or waylib.utils.<name>
+
+// Kernel - Core
+Q_DECLARE_LOGGING_CATEGORY(lcWlSocket)
+Q_DECLARE_LOGGING_CATEGORY(lcWlSeat)
+Q_DECLARE_LOGGING_CATEGORY(lcWlOutput)
+Q_DECLARE_LOGGING_CATEGORY(lcWlOutputDrm)
+Q_DECLARE_LOGGING_CATEGORY(lcWlOutputBuffer)
+Q_DECLARE_LOGGING_CATEGORY(lcWlInput)
+Q_DECLARE_LOGGING_CATEGORY(lcWlCursor)
+
+// Kernel - Input subcategories
+Q_DECLARE_LOGGING_CATEGORY(lcWlPointer)
+Q_DECLARE_LOGGING_CATEGORY(lcWlTouch)
+Q_DECLARE_LOGGING_CATEGORY(lcWlGesture)
+Q_DECLARE_LOGGING_CATEGORY(lcWlDrag)
+
+// QtQuick
+Q_DECLARE_LOGGING_CATEGORY(lcWlTextureProvider)
+Q_DECLARE_LOGGING_CATEGORY(lcWlSurface)
+Q_DECLARE_LOGGING_CATEGORY(lcWlQtQuickTexture)
+Q_DECLARE_LOGGING_CATEGORY(lcWlRenderer)
+Q_DECLARE_LOGGING_CATEGORY(lcWlBufferItem)
+
+// Utils
+Q_DECLARE_LOGGING_CATEGORY(lcWlImageCapture)
+Q_DECLARE_LOGGING_CATEGORY(lcWlCursorImage)
+Q_DECLARE_LOGGING_CATEGORY(lcWlBufferDumper)
+
+// Thread utilities
+Q_DECLARE_LOGGING_CATEGORY(lcWlThreadUtils)
+
+// Protocols
+Q_DECLARE_LOGGING_CATEGORY(lcWlForeignToplevel)
+Q_DECLARE_LOGGING_CATEGORY(lcWlInputMethod)
+Q_DECLARE_LOGGING_CATEGORY(lcWlExtForeignToplevel)
+Q_DECLARE_LOGGING_CATEGORY(lcWlTextInput)
+
+// Layer shell
+Q_DECLARE_LOGGING_CATEGORY(lcWlLayerShell)
+Q_DECLARE_LOGGING_CATEGORY(lcWlLayerSurface)
+
+// XDG
+Q_DECLARE_LOGGING_CATEGORY(lcWlXdgOutput)
+Q_DECLARE_LOGGING_CATEGORY(lcWlXdgDecoration)
+
+// Output
+Q_DECLARE_LOGGING_CATEGORY(lcWlOutputLayer)
+Q_DECLARE_LOGGING_CATEGORY(lcWlOutputHelper)
+
+// QtQuick extras
+Q_DECLARE_LOGGING_CATEGORY(lcWlQmlCreator)
+Q_DECLARE_LOGGING_CATEGORY(lcWlQuickCursor)
+
+// Platform & Rendering
+Q_DECLARE_LOGGING_CATEGORY(lcWlPlatform)
+Q_DECLARE_LOGGING_CATEGORY(lcWlRenderHelper)
+Q_DECLARE_LOGGING_CATEGORY(lcWlRenderBuffer)
+Q_DECLARE_LOGGING_CATEGORY(lcWlBufferRenderer)
+
+#endif // WAYLIB_LOGGING_H


### PR DESCRIPTION
## Summary

Unify waylib logging category system following Qt convention.

### Changes
1. Create centralized `wayliblogging.h/cpp` with all logging categories
2. Rename category variables to `lcWlXxx` following Qt convention
3. Reorganize string IDs under `waylib.*` hierarchy (remove `.server` prefix)
4. Move scattered `Q_LOGGING_CATEGORY` definitions into `wayliblogging.h/cpp`
5. Migrate raw `qDebug`/`qWarning` calls to categorized `qCDebug`/`qCWarning`
6. Add `QtWarningMsg` default level to all new categories
7. Add comments for conditional compilation blocks in debug builds

### Testing
- Verify logging output still works correctly with existing category filters
- Test that `QT_LOGGING_RULES` environment variable filters work as expected
- Verify no regression in debug/warning/critical message output
- Test waylib builds with and without `QT_DEBUG` defined

Related: linuxdeepin/treeland#990