### PR TITLE
fix(wallpaper): switching wallpapers is too slow.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -215,6 +215,8 @@ qt_add_qml_module(libtreeland
         wallpaper/wallpaperconfig.cpp
         wallpaper/wallpaperlauncher.h
         wallpaper/wallpaperlauncher.cpp
+        wallpaper/wallpaperswitcheritem.cpp
+        wallpaper/wallpaperswitcheritem.h
         workspace/workspace.cpp
         workspace/workspace.h
         workspace/workspaceanimationcontroller.cpp

--- a/src/core/qml/PrimaryOutput.qml
+++ b/src/core/qml/PrimaryOutput.qml
@@ -92,17 +92,18 @@ OutputItem {
         }
     }
 
-
     Item {
         clip: true
         anchors.fill: parent
-        Item {
+        WallpaperSwitcher {
             id: wallpaper
 
-            readonly property int duration: 1000
-            property Wallpaper currentWallpaper: fontWallpaper
             clip: true
             anchors.fill: parent
+            output: rootOutputItem.output
+            workspace: Helper.workspace.current
+
+            readonly property int duration: 1000
             states: [
                 State {
                     name: "Normal"
@@ -172,68 +173,6 @@ OutputItem {
                 }
             ]
 
-            Wallpaper {
-                id: backWallpaper
-
-                anchors.fill: parent
-                disableUpdate: true
-                output: rootOutputItem.output
-                workspace: Helper.workspace.current
-                opacity: 0
-                live: false
-                z: 0
-                onSourceChanged: {
-                    wallpaper.currentWallpaper = backWallpaper
-
-                    backWallpaper.disableUpdate = true
-                    backWallpaper.live = true
-                    backWallpaper.z = 1
-                    backWallpaper.opacity = 1
-                    backWallpaper.forceUpdateSource = true
-
-                    fontWallpaper.disableUpdate = false
-                    fontWallpaper.z = 0
-                    fontWallpaper.opacity = 0
-                }
-                Behavior on opacity {
-                    enabled: wallpaper.state = "Normal"
-                    NumberAnimation {
-                        duration: 500
-                        easing.type: Easing.InOutQuad
-                    }
-                }
-            }
-
-            Wallpaper {
-                id: fontWallpaper
-
-                anchors.fill: parent
-                output: rootOutputItem.output
-                workspace: Helper.workspace.current
-                z: 1
-                onSourceChanged: {
-                    wallpaper.currentWallpaper = fontWallpaper
-
-                    fontWallpaper.disableUpdate = true
-                    fontWallpaper.live = true
-                    fontWallpaper.z = 1
-                    fontWallpaper.opacity = 1
-                    fontWallpaper.forceUpdateSource = true
-
-                    backWallpaper.disableUpdate = false
-                    backWallpaper.live = false
-                    backWallpaper.z = 0
-                }
-
-                Behavior on opacity {
-                    enabled: wallpaper.state = "Normal"
-                    NumberAnimation {
-                        duration: 500
-                        easing.type: Easing.InOutQuad
-                    }
-                }
-            }
-
             Connections {
                 target: Helper
                 function onLaunchpadMappedChanged(output, mapped) {
@@ -250,8 +189,8 @@ OutputItem {
                     }
 
                     wallpaper.state = "Normal"
-                    wallpaper.currentWallpaper.play = true
-                    wallpaper.currentWallpaper.slowDown()
+                    wallpaper.play = true
+                    wallpaper.slowDown()
                 }
 
                 function onStartLockscreened(output, showAnimation) {
@@ -259,7 +198,7 @@ OutputItem {
                         return;
                     }
 
-                    wallpaper.currentWallpaper.play = false
+                    wallpaper.play = false
                     wallpaper.state = showAnimation ? "ScaleTo1.2" : "ScaleWithoutAnimation"
                 }
             }

--- a/src/modules/wallpaper/wallpapershellinterfacev1.cpp
+++ b/src/modules/wallpaper/wallpapershellinterfacev1.cpp
@@ -68,7 +68,7 @@ void TreelandWallpaperShellInterfaceV1Private::get_treeland_wallpaper_surface(Re
     auto wallpaperSurface = new TreelandWallpaperSurfaceInterfaceV1(surface, file_source, surfaceResource);
     s_wallpaperSurfaces.append(wallpaperSurface);
 
-    QObject::connect(wallpaperSurface, &QObject::destroyed, [wallpaperSurface, this]() {
+    QObject::connect(wallpaperSurface, &TreelandWallpaperSurfaceInterfaceV1::beforeDestroy, [wallpaperSurface, this]() {
         s_wallpaperSurfaces.removeOne(wallpaperSurface);
         producedWallpapers.removeOne(wallpaperSurface->source());
     });
@@ -122,12 +122,14 @@ public:
     wl_resource *resource = nullptr;
     WallpaperSurface *surface = nullptr;
     QString wallpaperSource;
+    bool wallpaperReady = false;
 
 protected:
     void destroy_resource(Resource *resource) override;
     void destroy(Resource *resource) override;
     void source_failed(Resource *resource,
                                                      uint32_t error) override;
+    void ready(Resource *resource) override;
 };
 
 TreelandWallpaperSurfaceInterfaceV1Private::TreelandWallpaperSurfaceInterfaceV1Private(TreelandWallpaperSurfaceInterfaceV1 *_q,
@@ -144,7 +146,7 @@ TreelandWallpaperSurfaceInterfaceV1Private::TreelandWallpaperSurfaceInterfaceV1P
 
 void TreelandWallpaperSurfaceInterfaceV1Private::destroy_resource([[maybe_unused]] Resource *resource)
 {
-    Q_EMIT q->beforeDestroy(q);
+    Q_EMIT q->beforeDestroy();
     delete q;
 }
 
@@ -157,6 +159,23 @@ void TreelandWallpaperSurfaceInterfaceV1Private::source_failed([[maybe_unused]] 
                                                                uint32_t error)
 {
     Q_EMIT q->failed(error);
+}
+
+void TreelandWallpaperSurfaceInterfaceV1Private::ready([[maybe_unused]] Resource *resource)
+{
+    if (wallpaperReady) {
+        return;
+    }
+
+    if (q->wSurface()->mapped()) {
+        wallpaperReady = true;
+        Q_EMIT q->ready();
+    } else {
+        QObject::connect(q->wSurface(), &WSurface::commit, q, [this](quint32) {
+            wallpaperReady = true;
+            Q_EMIT q->ready();
+        }, Qt::SingleShotConnection);
+    }
 }
 
 TreelandWallpaperSurfaceInterfaceV1::~TreelandWallpaperSurfaceInterfaceV1() = default;
@@ -215,6 +234,11 @@ void TreelandWallpaperSurfaceInterfaceV1::setPlay(bool value)
 void TreelandWallpaperSurfaceInterfaceV1::slowDown(uint32_t duration)
 {
     d->send_slow_down(duration);
+}
+
+bool TreelandWallpaperSurfaceInterfaceV1::wallpaperReady()
+{
+    return d->wallpaperReady;
 }
 
 TreelandWallpaperSurfaceInterfaceV1::TreelandWallpaperSurfaceInterfaceV1(wl_resource *surface,

--- a/src/modules/wallpaper/wallpapershellinterfacev1.h
+++ b/src/modules/wallpaper/wallpapershellinterfacev1.h
@@ -54,10 +54,12 @@ public:
     static TreelandWallpaperSurfaceInterfaceV1 *get(const QString &source);
     void setPlay(bool value);
     void slowDown(uint32_t duration = 3000);
+    bool wallpaperReady();
 
 Q_SIGNALS:
+    void beforeDestroy();
     void failed(uint32_t error);
-    void beforeDestroy(TreelandWallpaperSurfaceInterfaceV1 *surface);
+    void ready();
 
 private:
     explicit TreelandWallpaperSurfaceInterfaceV1(wl_resource *surface,

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -321,6 +321,7 @@ private:
     friend class SessionManager;
     friend class WallpaperManager;
     friend class WallpaperItem;
+    friend class WallpaperSwitcherItem;
     friend class InputManager;
 
     void allowNonDrmOutputAutoChangeMode(WOutput *output);

--- a/src/wallpaper/wallpaperitem.cpp
+++ b/src/wallpaper/wallpaperitem.cpp
@@ -21,26 +21,33 @@
 WAYLIB_SERVER_USE_NAMESPACE
 
 WallpaperItem::WallpaperItem(QQuickItem *parent)
+    : WallpaperItem(parent, true)
+{
+}
+
+WallpaperItem::WallpaperItem(QQuickItem *parent, bool autoUpdate)
     : WSurfaceItemContent(parent)
 {
     m_model = Helper::instance()->qmlEngine()->singletonInstance<UserModel *>("Treeland",
                                                                               "UserModel");
-    connect(m_model,
-            &UserModel::currentUserNameChanged,
-            this,
-            &WallpaperItem::handleCurrentuserChanged);
-    connect(Helper::instance()->shellHandler()->wallpaperShell(),
-            &TreelandWallpaperShellInterfaceV1::wallpaperSurfaceAdded,
-            this,
-            &WallpaperItem::scheduleUpdate);
-    connect(Helper::instance()->m_wallpaperManager,
-            &WallpaperManager::updateWallpaper,
-            this,
-            &WallpaperItem::scheduleUpdate);
-    connect(Helper::instance()->workspace(),
-            &Workspace::workspaceAdded,
-            this,
-            &WallpaperItem::handleWorkspaceAdded);
+    if (autoUpdate) {
+        connect(m_model,
+                &UserModel::currentUserNameChanged,
+                this,
+                &WallpaperItem::handleCurrentuserChanged);
+        connect(Helper::instance()->shellHandler()->wallpaperShell(),
+                &TreelandWallpaperShellInterfaceV1::wallpaperSurfaceAdded,
+                this,
+                &WallpaperItem::handleWallpaperSurfaceAdded);
+        connect(Helper::instance()->m_wallpaperManager,
+                &WallpaperManager::updateWallpaper,
+                this,
+                &WallpaperItem::updateSurface);
+        connect(Helper::instance()->workspace(),
+                &Workspace::workspaceAdded,
+                this,
+                &WallpaperItem::handleWorkspaceAdded);
+    }
 }
 
 WallpaperItem::~WallpaperItem() = default;
@@ -151,10 +158,6 @@ WallpaperItem::WallpaperRole WallpaperItem::wallpaperRole()
 
 void WallpaperItem::updateSurface()
 {
-    if (m_disableUpdate) {
-        return;
-    }
-
     if (!output()) {
         return;
     }
@@ -166,7 +169,7 @@ void WallpaperItem::updateSurface()
     WallpaperOutputConfig config =
         Helper::instance()->m_wallpaperManager->getOutputConfig(output()->nativeHandle());
     if (wallpaperRole() == Lockscreen) {
-        if (config.lockscreenWallpaper != m_source || forceUpdateSource()) {
+        if (config.lockscreenWallpaper != m_source) {
                 TreelandWallpaperSurfaceInterfaceV1 *interface =
                     TreelandWallpaperSurfaceInterfaceV1::get(config.lockscreenWallpaper);
                 if (!interface) {
@@ -186,7 +189,7 @@ void WallpaperItem::updateSurface()
         }
         for (WallpaperWorkspaceConfig workspaceConfig : std::as_const(config.workspaces)) {
             if (workspaceConfig.workspaceId == workspace()->id() &&
-                (workspaceConfig.desktopWallpaper != m_source || forceUpdateSource())) {
+                (workspaceConfig.desktopWallpaper != m_source)) {
                 TreelandWallpaperSurfaceInterfaceV1 *interface =
                     TreelandWallpaperSurfaceInterfaceV1::get(workspaceConfig.desktopWallpaper);
                 if (!interface) {
@@ -196,7 +199,9 @@ void WallpaperItem::updateSurface()
                 setSurface(interface->wSurface());
                 interface->wSurface()->enterOutput(output());
                 update();
-                QTimer::singleShot(2000, this, [this]{ Q_EMIT sourceChanged(); });
+                if (!Helper::instance()->m_greeterProxy->isLocked())
+                    setPlay(false);
+
                 break;
             }
         }
@@ -204,32 +209,8 @@ void WallpaperItem::updateSurface()
     }
 }
 
-void WallpaperItem::scheduleUpdate()
-{
-    if (m_disableUpdate) {
-        return;
-    }
-
-    if (wallpaperRole() != Lockscreen) {
-        QTimer::singleShot(3000,
-                           this,
-                           [this]{
-                               updateSurface();
-                               if (!Helper::instance()->m_greeterProxy->isLocked()) {
-                                   setPlay(false);
-                               }
-                           });
-    } else {
-        updateSurface();
-    }
-}
-
 void WallpaperItem::handleWorkspaceAdded()
 {
-    if (m_disableUpdate) {
-        return;
-    }
-
     if (wallpaperRole() == Lockscreen) {
         return;
     }
@@ -242,32 +223,15 @@ void WallpaperItem::handleWorkspaceAdded()
     updateSurface();
 }
 
-bool WallpaperItem::disableUpdate() const
+void WallpaperItem::handleWallpaperSurfaceAdded(TreelandWallpaperSurfaceInterfaceV1 *interface)
 {
-    return m_disableUpdate;
-}
-
-void WallpaperItem::setDisableUpdate(bool disable)
-{
-    if (m_disableUpdate == disable) {
-        return;
+    if (interface->wallpaperReady()) {
+        updateSurface();
+    } else {
+        connect(interface,
+                &TreelandWallpaperSurfaceInterfaceV1::ready,
+                this,
+                &WallpaperItem::updateSurface,
+                Qt::SingleShotConnection);
     }
-
-    m_disableUpdate = disable;
-    Q_EMIT disableUpdateChanged();
-}
-
-bool WallpaperItem::forceUpdateSource() const
-{
-    return m_forceUpdateSource;
-}
-
-void WallpaperItem::setForceUpdateSource(bool value)
-{
-    if (m_forceUpdateSource == value) {
-        return;
-    }
-
-    m_forceUpdateSource = value;
-    Q_EMIT forceUpdateSourceChanged();
 }

--- a/src/wallpaper/wallpaperitem.h
+++ b/src/wallpaper/wallpaperitem.h
@@ -25,11 +25,9 @@ class WallpaperItem : public WSurfaceItemContent
     Q_PROPERTY(WorkspaceModel* workspace READ workspace WRITE setWorkspace NOTIFY workspaceChanged FINAL)
     Q_PROPERTY(WAYLIB_SERVER_NAMESPACE::WOutput* output READ output WRITE setOutput NOTIFY outputChanged FINAL)
     Q_PROPERTY(WallpaperRole wallpaperRole READ wallpaperRole WRITE setWallpaperRole NOTIFY wallpaperRoleChanged FINAL)
-    Q_PROPERTY(QString source READ source NOTIFY sourceChanged FINAL)
+    Q_PROPERTY(QString source READ source FINAL)
     Q_PROPERTY(WallpaperState wallpaperState READ wallpaperState WRITE setWallpaperState NOTIFY wallpaperStateChanged FINAL)
     Q_PROPERTY(bool play READ play WRITE setPlay NOTIFY playChanged FINAL)
-    Q_PROPERTY(bool disableUpdate READ disableUpdate WRITE setDisableUpdate NOTIFY disableUpdateChanged FINAL)
-    Q_PROPERTY(bool forceUpdateSource READ forceUpdateSource WRITE setForceUpdateSource NOTIFY forceUpdateSourceChanged FINAL)
 
     QML_NAMED_ELEMENT(Wallpaper)
     QML_ADDED_IN_VERSION(1, 0)
@@ -70,27 +68,22 @@ public:
     void setPlay(bool value);
 
     Q_INVOKABLE void slowDown();
+    void updateSurface();
 
-    bool disableUpdate() const;
-    void setDisableUpdate(bool disable);
-
-    bool forceUpdateSource() const;
-    void setForceUpdateSource(bool value);
 Q_SIGNALS:
     void outputChanged();
     void workspaceChanged();
     void wallpaperRoleChanged();
-    void sourceChanged();
     void wallpaperStateChanged();
     void playChanged();
-    void disableUpdateChanged();
-    void forceUpdateSourceChanged();
 
 private Q_SLOTS:
     void handleCurrentuserChanged();
-    void updateSurface();
-    void scheduleUpdate();
     void handleWorkspaceAdded();
+    void handleWallpaperSurfaceAdded(TreelandWallpaperSurfaceInterfaceV1 *interface);
+
+protected:
+    WallpaperItem(QQuickItem *parent, bool autoUpdate);
 
 private:
     int m_userId = -1;
@@ -101,6 +94,4 @@ private:
     QString m_source;
     UserModel *m_model;
     bool m_play = true;
-    bool m_disableUpdate = false;
-    bool m_forceUpdateSource = false;
 };

--- a/src/wallpaper/wallpaperswitcheritem.cpp
+++ b/src/wallpaper/wallpaperswitcheritem.cpp
@@ -1,0 +1,228 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "wallpaperswitcheritem.h"
+
+#include "wallpaperitem.h"
+#include "seat/helper.h"
+#include "workspace/workspacemodel.h"
+#include "wallpapershellinterfacev1.h"
+#include "wallpapermanager.h"
+#include "workspace.h"
+#include "shellhandler.h"
+
+#include <woutput.h>
+
+#include <private/qquickitem_p.h>
+
+#include <QPropertyAnimation>
+#include <QTimer>
+
+WAYLIB_SERVER_USE_NAMESPACE
+
+class WallpaperSlot : public WallpaperItem
+{
+public:
+    WallpaperSlot(QQuickItem *parent)
+        : WallpaperItem(parent, false)
+    {
+        setLive(true);
+    }
+};
+
+WallpaperSwitcherItem::WallpaperSwitcherItem(QQuickItem *parent)
+    : QQuickItem(parent)
+{
+    m_currentSlot = new WallpaperSlot(this);
+    QQuickItemPrivate::get(m_currentSlot)->anchors()->setFill(this);
+
+    connect(Helper::instance()->m_wallpaperManager,
+            &WallpaperManager::updateWallpaper,
+            this,
+            &WallpaperSwitcherItem::handleWallpaperUpdate);
+    connect(Helper::instance()->shellHandler()->wallpaperShell(),
+            &TreelandWallpaperShellInterfaceV1::wallpaperSurfaceAdded,
+            this,
+            &WallpaperSwitcherItem::handleWallpaperUpdate);
+    connect(Helper::instance()->workspace(),
+            &Workspace::workspaceAdded,
+            this,
+            &WallpaperSwitcherItem::handleWorkspaceAdded);
+}
+
+WallpaperSwitcherItem::~WallpaperSwitcherItem()
+{
+    delete m_oldSlot;
+    delete m_currentSlot;
+}
+
+WOutput *WallpaperSwitcherItem::output() const
+{
+    return m_output;
+}
+
+void WallpaperSwitcherItem::setOutput(WOutput *output)
+{
+    if (m_output == output)
+        return;
+
+    m_output = output;
+    Q_EMIT outputChanged();
+
+    if (m_currentSlot)
+        m_currentSlot->setOutput(output);
+    if (m_oldSlot)
+        m_oldSlot->setOutput(output);
+}
+
+WorkspaceModel *WallpaperSwitcherItem::workspace() const
+{
+    return m_workspace;
+}
+
+void WallpaperSwitcherItem::setWorkspace(WorkspaceModel *workspace)
+{
+    if (m_workspace == workspace)
+        return;
+
+    m_workspace = workspace;
+    Q_EMIT workspaceChanged();
+
+    if (m_currentSlot)
+        m_currentSlot->setWorkspace(workspace);
+    if (m_oldSlot)
+        m_oldSlot->setWorkspace(workspace);
+}
+
+bool WallpaperSwitcherItem::play() const
+{
+    return m_play;
+}
+
+void WallpaperSwitcherItem::setPlay(bool value)
+{
+    if (m_play == value)
+        return;
+
+    m_play = value;
+    Q_EMIT playChanged();
+
+    if (m_currentSlot)
+        m_currentSlot->setPlay(value);
+    if (m_oldSlot)
+        m_oldSlot->setPlay(value);
+}
+
+QString WallpaperSwitcherItem::source() const
+{
+    return m_currentSlot ? m_currentSlot->source() : QString();
+}
+
+int WallpaperSwitcherItem::opacityDuration() const
+{
+    return m_opacityDuration;
+}
+
+void WallpaperSwitcherItem::setOpacityDuration(int duration)
+{
+    if (m_opacityDuration == duration)
+        return;
+
+    m_opacityDuration = duration;
+    Q_EMIT opacityDurationChanged();
+}
+
+void WallpaperSwitcherItem::slowDown()
+{
+    if (m_currentSlot)
+        m_currentSlot->slowDown();
+}
+
+void WallpaperSwitcherItem::handleWallpaperUpdate()
+{
+    if (!m_output || !m_currentSlot)
+        return;
+
+    auto config = Helper::instance()->m_wallpaperManager->getOutputConfig(m_output->nativeHandle());
+    QString newSource;
+
+    if (m_workspace) {
+        for (const auto &wsConfig : std::as_const(config.workspaces)) {
+            if (wsConfig.workspaceId == m_workspace->id()) {
+                newSource = wsConfig.desktopWallpaper;
+                break;
+            }
+        }
+    }
+
+    if (newSource == m_currentSlot->source())
+        return;
+
+    switchToNewSlot();
+}
+
+void WallpaperSwitcherItem::handleWorkspaceAdded()
+{
+    Helper::instance()->m_wallpaperManager->syncAddWorkspace();
+    if (m_currentSlot)
+        m_currentSlot->updateSurface();
+}
+
+void WallpaperSwitcherItem::switchToNewSlot()
+{
+    auto *newSlot = new WallpaperSlot(this);
+    QQuickItemPrivate::get(newSlot)->anchors()->setFill(this);
+    newSlot->setOpacity(0);
+    newSlot->setOutput(m_output);
+    newSlot->setWorkspace(m_workspace);
+
+    if (newSlot->source().isEmpty()) {
+        newSlot->deleteLater();
+        return;
+    }
+
+    m_oldSlot = m_currentSlot;
+    m_currentSlot = newSlot;
+
+    Q_EMIT sourceChanged();
+
+    auto *fadeOut = new QPropertyAnimation(m_oldSlot, "opacity");
+    fadeOut->setDuration(m_opacityDuration);
+    fadeOut->setStartValue(1.0);
+    fadeOut->setEndValue(0.0);
+    fadeOut->setEasingCurve(QEasingCurve::InOutQuad);
+    connect(fadeOut, &QPropertyAnimation::finished, this, &WallpaperSwitcherItem::onAnimationFinished);
+    fadeOut->start(QAbstractAnimation::DeleteWhenStopped);
+
+    auto *interface = TreelandWallpaperSurfaceInterfaceV1::get(newSlot->source());
+    if (interface && interface->wallpaperReady()) {
+        startFadeIn(newSlot);
+    } else if (interface) {
+        connect(interface,
+                &TreelandWallpaperSurfaceInterfaceV1::ready,
+                this,
+                [this, newSlot]() {
+                    if (m_currentSlot == newSlot)
+                        startFadeIn(newSlot);
+                },
+                Qt::SingleShotConnection);
+    }
+}
+
+void WallpaperSwitcherItem::startFadeIn(WallpaperSlot *slot)
+{
+    auto *anim = new QPropertyAnimation(slot, "opacity");
+    anim->setDuration(m_opacityDuration);
+    anim->setStartValue(0.0);
+    anim->setEndValue(1.0);
+    anim->setEasingCurve(QEasingCurve::InOutQuad);
+    anim->start(QAbstractAnimation::DeleteWhenStopped);
+}
+
+void WallpaperSwitcherItem::onAnimationFinished()
+{
+    if (m_oldSlot) {
+        m_oldSlot->deleteLater();
+        m_oldSlot = nullptr;
+    }
+}

--- a/src/wallpaper/wallpaperswitcheritem.h
+++ b/src/wallpaper/wallpaperswitcheritem.h
@@ -1,0 +1,76 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include "wglobal.h"
+#include <QQuickItem>
+
+Q_MOC_INCLUDE("workspace/workspace.h")
+
+class WallpaperSlot;
+class TreelandWallpaperSurfaceInterfaceV1;
+
+WAYLIB_SERVER_BEGIN_NAMESPACE
+class WOutput;
+WAYLIB_SERVER_END_NAMESPACE
+
+WAYLIB_SERVER_USE_NAMESPACE
+
+class WorkspaceModel;
+
+class WallpaperSwitcherItem : public QQuickItem
+{
+    Q_OBJECT
+    Q_PROPERTY(WAYLIB_SERVER_NAMESPACE::WOutput *output READ output WRITE setOutput NOTIFY outputChanged FINAL)
+    Q_PROPERTY(WorkspaceModel *workspace READ workspace WRITE setWorkspace NOTIFY workspaceChanged FINAL)
+    Q_PROPERTY(bool play READ play WRITE setPlay NOTIFY playChanged FINAL)
+    Q_PROPERTY(QString source READ source NOTIFY sourceChanged FINAL)
+    Q_PROPERTY(int opacityDuration READ opacityDuration WRITE setOpacityDuration NOTIFY opacityDurationChanged FINAL)
+
+    QML_NAMED_ELEMENT(WallpaperSwitcher)
+    QML_ADDED_IN_VERSION(1, 0)
+
+public:
+    explicit WallpaperSwitcherItem(QQuickItem *parent = nullptr);
+    ~WallpaperSwitcherItem() override;
+
+    WOutput *output() const;
+    void setOutput(WOutput *output);
+
+    WorkspaceModel *workspace() const;
+    void setWorkspace(WorkspaceModel *workspace);
+
+    bool play() const;
+    void setPlay(bool value);
+
+    QString source() const;
+
+    int opacityDuration() const;
+    void setOpacityDuration(int duration);
+
+    Q_INVOKABLE void slowDown();
+
+Q_SIGNALS:
+    void outputChanged();
+    void workspaceChanged();
+    void playChanged();
+    void sourceChanged();
+    void opacityDurationChanged();
+
+private:
+    void handleWallpaperUpdate();
+    void handleWorkspaceAdded();
+    void switchToNewSlot();
+    void onAnimationFinished();
+    void startFadeIn(WallpaperSlot *slot);
+
+    QPointer<WorkspaceModel> m_workspace;
+    QPointer<WOutput> m_output;
+    bool m_play = true;
+    QString m_source;
+    int m_opacityDuration = 500;
+
+    WallpaperSlot *m_currentSlot = nullptr;
+    WallpaperSlot *m_oldSlot = nullptr;
+};

--- a/wallpaper-factory/CMakeLists.txt
+++ b/wallpaper-factory/CMakeLists.txt
@@ -2,6 +2,7 @@ set(BIN_NAME treeland-wallpaper-factory)
 
 find_package(PkgConfig REQUIRED)
 find_package(Qt6 REQUIRED COMPONENTS WaylandClient Quick)
+find_package(Dtk6 REQUIRED COMPONENTS Core)
 if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10)
     find_package(Qt6 REQUIRED COMPONENTS WaylandClientPrivate QuickPrivate)
 endif()
@@ -48,6 +49,7 @@ target_link_libraries(${BIN_NAME}
         Qt6::QuickPrivate
         Qt6::WaylandClient
         Qt6::WaylandClientPrivate
+        Dtk6::Core
         PkgConfig::MPV
 )
 

--- a/wallpaper-factory/Image.qml
+++ b/wallpaper-factory/Image.qml
@@ -5,4 +5,5 @@ import QtQuick
 import QtQuick.Controls
 
 AnimatedImage {
+    asynchronous: true
 }

--- a/wallpaper-factory/main.cpp
+++ b/wallpaper-factory/main.cpp
@@ -3,9 +3,13 @@
 
 #include "treelandwallpapernotifierclient.h"
 
+#include <DLog>
+
 #include <QGuiApplication>
 #include <QQuickWindow>
 #include <QSGRendererInterface>
+
+DCORE_USE_NAMESPACE;
 
 int main(int argc, char *argv[])
 {
@@ -15,6 +19,8 @@ int main(int argc, char *argv[])
 
     app.setOrganizationName("deepin");
     app.setApplicationName("treeland-wallpaper-factory");
+
+    DLogManager::registerJournalAppender();
 
     std::unique_ptr<TreelandWallpaperNotifierClientV1> produce;
     produce.reset(new TreelandWallpaperNotifierClientV1);

--- a/wallpaper-factory/qwaylandwallpapershellintegration.cpp
+++ b/wallpaper-factory/qwaylandwallpapershellintegration.cpp
@@ -18,9 +18,7 @@ QWaylandWallpaperShellIntegration::QWaylandWallpaperShellIntegration()
 
 QWaylandWallpaperShellIntegration::~QWaylandWallpaperShellIntegration()
 {
-    if (object()) {
-        treeland_wallpaper_shell_v1_destroy(object());
-    }
+    destroy();
 }
 
 QtWaylandClient::QWaylandShellSurface *QWaylandWallpaperShellIntegration::createShellSurface(QtWaylandClient::QWaylandWindow *window)

--- a/wallpaper-factory/qwaylandwallpapersurface.cpp
+++ b/wallpaper-factory/qwaylandwallpapersurface.cpp
@@ -16,6 +16,15 @@ QWaylandWallpaperSurface::QWaylandWallpaperSurface(QWaylandWallpaperShellIntegra
     , m_window(window)
 {
     init(shell->get_treeland_wallpaper_surface(window->waylandSurface()->object(), m_interface->source()));
+    if (m_interface->loaded()) {
+        onFileLoaded();
+    } else {
+        connect(m_interface,
+                &WallpaperWindow::loadedChanged,
+                this,
+                &QWaylandWallpaperSurface::onFileLoaded,
+                Qt::SingleShotConnection);
+    }
 }
 
 QWaylandWallpaperSurface::~QWaylandWallpaperSurface()
@@ -41,4 +50,12 @@ void QWaylandWallpaperSurface::treeland_wallpaper_surface_v1_play()
 void QWaylandWallpaperSurface::treeland_wallpaper_surface_v1_slow_down(uint32_t duration)
 {
     Q_EMIT m_interface->slowDownChanged(duration);
+}
+
+void QWaylandWallpaperSurface::onFileLoaded()
+{
+    if (version() < TREELAND_WALLPAPER_SURFACE_V1_READY)
+        return;
+
+    ready();
 }

--- a/wallpaper-factory/qwaylandwallpapersurface_p.h
+++ b/wallpaper-factory/qwaylandwallpapersurface_p.h
@@ -27,6 +27,9 @@ private:
     void treeland_wallpaper_surface_v1_play() override;
     void treeland_wallpaper_surface_v1_slow_down(uint32_t duration) override;
 
+private Q_SLOTS:
+    void onFileLoaded();
+
 private:
     QWaylandWallpaperShellIntegration *m_shell;
     WallpaperWindow *m_interface;

--- a/wallpaper-factory/treelandwallpapernotifierclient.cpp
+++ b/wallpaper-factory/treelandwallpapernotifierclient.cpp
@@ -9,6 +9,7 @@
 #include <private/qquickanimatedimage_p.h>
 
 #define TREELANDWALLPAPERPRODUCEV1VERSION 1
+#define WALLPAPERSOURCE "wallpaperSource"
 
 static QSize maxScreenSize()
 {
@@ -90,7 +91,12 @@ void TreelandWallpaperNotifierClientV1::treeland_wallpaper_notifier_v1_add(uint3
             delete wallpaperWindow;
             return;
         }
-
+        connect(image,
+                &QQuickAnimatedImage::statusChanged,
+                window, [window](QQuickImageBase::Status status) {
+                    if (status == QQuickImageBase::Ready)
+                        window->setLoaded(true);
+                });
         image->setSource(QUrl::fromLocalFile(file_source));
         break;
     }
@@ -107,6 +113,12 @@ void TreelandWallpaperNotifierClientV1::treeland_wallpaper_notifier_v1_add(uint3
             return;
         }
 
+        connect(video,
+            &MpvVideoItem::fileLoaded,
+            window,[window]() {
+                window->setLoaded(true);
+            },
+            Qt::SingleShotConnection);
         video->setSource(file_source);
         break;
     }
@@ -118,6 +130,7 @@ void TreelandWallpaperNotifierClientV1::treeland_wallpaper_notifier_v1_add(uint3
         return;
     }
 
+    wallpaperWindow->setProperty(WALLPAPERSOURCE, file_source);
     wallpaperWindow->resize(maxScreenSize());
     wallpaperWindow->show();
     m_windows.append(wallpaperWindow);
@@ -134,7 +147,7 @@ void TreelandWallpaperNotifierClientV1::treeland_wallpaper_notifier_v1_add(uint3
 void TreelandWallpaperNotifierClientV1::treeland_wallpaper_notifier_v1_remove(const QString &file_source)
 {
     foreach (auto window, m_windows) {
-        if (window->source() == file_source) {
+        if (window->property(WALLPAPERSOURCE).toString() == file_source) {
             m_windows.removeOne(window);
             delete window;
 

--- a/wallpaper-factory/wallpaperwindow.cpp
+++ b/wallpaper-factory/wallpaperwindow.cpp
@@ -22,11 +22,16 @@ public:
 
     QWindow *parentWindow;
     QString source;
+    bool loaded = false;
+    QWaylandWallpaperShellIntegration *shellIntegration = nullptr;
 };
 
 WallpaperWindow::~WallpaperWindow()
 {
     s_map.remove(d->parentWindow);
+    if (d->shellIntegration) {
+        delete d->shellIntegration;
+    }
 }
 
 QString WallpaperWindow::source()
@@ -82,6 +87,21 @@ QWindow *WallpaperWindow::parentWindow() const
     return d->parentWindow;
 }
 
+bool WallpaperWindow::loaded()
+{
+    return d->loaded;
+}
+
+void WallpaperWindow::setLoaded(bool loaded)
+{
+    if (d->loaded == loaded) {
+        return;
+    }
+
+    d->loaded = loaded;
+    Q_EMIT loadedChanged();
+}
+
 void WallpaperWindow::initializeShellIntegration()
 {
     auto waylandWindow = dynamic_cast<QtWaylandClient::QWaylandWindow *>(d->parentWindow->handle());
@@ -90,18 +110,17 @@ void WallpaperWindow::initializeShellIntegration()
         return;
     }
 
-    static QWaylandWallpaperShellIntegration *shellIntegration = nullptr;
-    if (!shellIntegration) {
-        shellIntegration = new QWaylandWallpaperShellIntegration();
-        if (!shellIntegration->initialize(waylandWindow->display())) {
-            delete shellIntegration;
-            shellIntegration = nullptr;
+    if (!d->shellIntegration) {
+        d->shellIntegration = new QWaylandWallpaperShellIntegration();
+        if (!d->shellIntegration->initialize(waylandWindow->display())) {
+            delete d->shellIntegration;
+            d->shellIntegration = nullptr;
             qCWarning(WALLPAPER) << "Failed to initialize treeland_wallpaper_produce integration, possibly because compositor does not support the treeland_wallpaper_produce_v1 protocol";
             return;
         }
     }
 
-    waylandWindow->setShellIntegration(shellIntegration);
+    waylandWindow->setShellIntegration(d->shellIntegration);
 }
 
 WallpaperWindow::WallpaperWindow(QWindow *window)

--- a/wallpaper-factory/wallpaperwindow.h
+++ b/wallpaper-factory/wallpaperwindow.h
@@ -24,11 +24,14 @@ public:
     static WallpaperWindow *qmlAttachedProperties(QObject *object);
     QWindow *parentWindow() const;
 
+    bool loaded();
+    void setLoaded(bool loaded);
 Q_SIGNALS:
     void sourceChanged();
     void positionChanged(double position);
     void playChanged(bool play);
     void slowDownChanged(uint32_t duration);
+    void loadedChanged();
 
 private:
     void initializeShellIntegration();


### PR DESCRIPTION
Add synchronization for wallpaper loading and surface commit completion.
Refine the wallpaper disposal logic to prevent memory and video memory leaks, and avoid incorrect video
decoding resource usage that causes video stuttering. Added `WallpaperSwitcherItem` to encapsulate the desktop wallpaper switching animation.

Log: fix switching wallpapers is too slow
PMS: BUG-363035
Influence: Wallpaper display and updates