### PR TITLE
feat: make QDeepinTheme follow DConfig settings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -373,6 +373,8 @@ add_subdirectory(treeland-screensaver)
 set(BIN_NAME treeland)
 
 qt_add_executable(${BIN_NAME}
+    deepintheme.cpp
+    deepintheme.h
     main.cpp
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -421,6 +421,8 @@ add_subdirectory(treeland-screensaver)
 set(BIN_NAME treeland)
 
 qt_add_executable(${BIN_NAME}
+    deepintheme.cpp
+    deepintheme.h
     main.cpp
 )
 

--- a/src/core/treelandinit.cpp
+++ b/src/core/treelandinit.cpp
@@ -2,20 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 #include "treelandinit.h"
 
+#include "deepintheme.h"
+
 #include <DGuiApplicationHelper>
 #include <QGuiApplication>
-#include <QPalette>
 #include <QQuickStyle>
 #include <wrenderhelper.h>
 #include <wlogging.h>
 #include <wbackend.h>
 #include <wserver.h>
-
-#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
-#  include <private/qgenericunixtheme_p.h>
-#else
-#  include <private/qgenericunixthemes_p.h>
-#endif
 
 #include <qpa/qplatformtheme.h>
 
@@ -26,19 +21,11 @@ DCORE_USE_NAMESPACE
 
 namespace Treeland {
 
-namespace {
-class QDeepinTheme : public QGenericUnixTheme
+static QDeepinTheme *g_theme = nullptr;
+
+QDeepinTheme *deepinTheme()
 {
-public:
-    const QPalette *palette(QPlatformTheme::Palette type) const override
-    {
-        if (type != QPlatformTheme::SystemPalette)
-            return QGenericUnixTheme::palette(type);
-        static QPalette palette;
-        palette = Dtk::Gui::DGuiApplicationHelper::instance()->applicationPalette();
-        return &palette;
-    }
-};
+    return g_theme;
 }
 
 std::unique_ptr<QGuiApplication> preInit(int &argc, char *argv[])
@@ -47,7 +34,8 @@ std::unique_ptr<QGuiApplication> preInit(int &argc, char *argv[])
     DTK_GUI_NAMESPACE::DGuiApplicationHelper::setAttribute(
         DTK_GUI_NAMESPACE::DGuiApplicationHelper::DontSaveApplicationTheme, true);
     WServer::initializeQPA({}, [](const QString &) {
-        return static_cast<QPlatformTheme *>(new QDeepinTheme());
+        g_theme = new QDeepinTheme();
+        return static_cast<QPlatformTheme *>(g_theme);
     });
     QGuiApplication::setAttribute(Qt::AA_UseOpenGLES);
     QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);

--- a/src/core/treelandinit.h
+++ b/src/core/treelandinit.h
@@ -7,6 +7,7 @@
 #include <memory>
 
 class QGuiApplication;
+class QDeepinTheme;
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 class WServer;
@@ -16,4 +17,5 @@ namespace Treeland {
 std::unique_ptr<QGuiApplication> preInit(int &argc, char *argv[]);
 void postInit();
 void initTestServer(WAYLIB_SERVER_NAMESPACE::WServer *server);
+QDeepinTheme *deepinTheme();
 }

--- a/src/deepintheme.cpp
+++ b/src/deepintheme.cpp
@@ -10,6 +10,7 @@
 #include <DGuiApplicationHelper>
 
 #include <QGuiApplication>
+#include <QSizeF>
 #include <QStyleHints>
 #include <private/qguiapplication_p.h>
 
@@ -51,7 +52,7 @@ QVariant QDeepinTheme::themeHint(ThemeHint hint) const
     case MouseCursorTheme:
         return m_config->cursorThemeName();
     case MouseCursorSize:
-        return m_config->cursorSize();
+        return QSizeF(m_config->cursorSize(), m_config->cursorSize());
     case KeyboardAutoRepeatRate:
         return m_seatConfig ? m_seatConfig->keyboardRate() : QGenericUnixTheme::themeHint(hint);
     case KeyboardInputInterval:
@@ -103,7 +104,7 @@ void QDeepinTheme::bindConfig(TreelandUserConfig *config)
     addConnection(QObject::connect(m_config, &TreelandUserConfig::cursorBlinkChanged, m_config, [this]() { applyCursorSettings(); }));
     addConnection(QObject::connect(m_config, &TreelandUserConfig::cursorBlinkTimeChanged, m_config, [this]() { applyCursorSettings(); }));
     addConnection(QObject::connect(m_config, &TreelandUserConfig::doubleClickTimeChanged, m_config, [this]() { applyStyleHintSettings(); }));
-    addConnection(QObject::connect(m_config, &TreelandUserConfig::doubleClickDistanceChanged, m_config, [this]() { applyStyleHintSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::doubleClickDistanceChanged, m_config, [this]() { applyThemeSettings(); }));
     addConnection(QObject::connect(m_config, &TreelandUserConfig::dndDragThresholdChanged, m_config, [this]() { applyStyleHintSettings(); }));
     addConnection(QObject::connect(m_config, &TreelandUserConfig::fontChanged, m_config, [this]() { applyFontSettings(); }));
     addConnection(QObject::connect(m_config, &TreelandUserConfig::monoFontChanged, m_config, [this]() { applyFontSettings(); }));
@@ -111,7 +112,7 @@ void QDeepinTheme::bindConfig(TreelandUserConfig *config)
     addConnection(QObject::connect(m_config, &TreelandUserConfig::iconThemeNameChanged, m_config, [this]() { applyThemeSettings(); }));
     addConnection(QObject::connect(m_config, &TreelandUserConfig::themeNameChanged, m_config, [this]() { applyThemeSettings(); }));
     addConnection(QObject::connect(m_config, &TreelandUserConfig::preferDarkChanged, m_config, [this]() { applyStyleHintSettings(); }));
-    addConnection(QObject::connect(m_config, &TreelandUserConfig::cursorThemeNameChanged, m_config, [this]() { applyStyleHintSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::cursorThemeNameChanged, m_config, [this]() { applyThemeSettings(); }));
     addConnection(QObject::connect(m_config, &TreelandUserConfig::cursorSizeChanged, m_config, [this]() { applyThemeSettings(); }));
 
     applyAllSettings();

--- a/src/deepintheme.cpp
+++ b/src/deepintheme.cpp
@@ -4,13 +4,14 @@
 #include "deepintheme.h"
 
 #include "seat/helper.h"
+#include "seatuserconfig.hpp"
 #include "treelanduserconfig.hpp"
 
 #include <DGuiApplicationHelper>
 
-#include <QCoreApplication>
 #include <QGuiApplication>
 #include <QStyleHints>
+#include <private/qguiapplication_p.h>
 
 DCORE_USE_NAMESPACE;
 DGUI_USE_NAMESPACE;
@@ -20,6 +21,7 @@ QDeepinTheme::QDeepinTheme() = default;
 QDeepinTheme::~QDeepinTheme()
 {
     disconnectConfig();
+    disconnectSeatConfig();
 }
 
 const QPalette *QDeepinTheme::palette(QPlatformTheme::Palette type) const
@@ -38,10 +40,22 @@ QVariant QDeepinTheme::themeHint(ThemeHint hint) const
         return QGenericUnixTheme::themeHint(hint);
 
     switch (hint) {
+    case CursorFlashTime:
+        return m_config->cursorBlink() ? m_config->cursorBlinkTime() : 0;
+    case MouseDoubleClickInterval:
+        return m_config->doubleClickTime();
     case MouseDoubleClickDistance:
         return m_config->doubleClickDistance();
+    case StartDragDistance:
+        return m_config->dndDragThreshold();
     case MouseCursorTheme:
         return m_config->cursorThemeName();
+    case MouseCursorSize:
+        return m_config->cursorSize();
+    case KeyboardAutoRepeatRate:
+        return m_seatConfig ? m_seatConfig->keyboardRate() : QGenericUnixTheme::themeHint(hint);
+    case KeyboardInputInterval:
+        return m_seatConfig ? m_seatConfig->keyboardDelay() : QGenericUnixTheme::themeHint(hint);
     default:
         break;
     }
@@ -98,6 +112,7 @@ void QDeepinTheme::bindConfig(TreelandUserConfig *config)
     addConnection(QObject::connect(m_config, &TreelandUserConfig::themeNameChanged, m_config, [this]() { applyThemeSettings(); }));
     addConnection(QObject::connect(m_config, &TreelandUserConfig::preferDarkChanged, m_config, [this]() { applyStyleHintSettings(); }));
     addConnection(QObject::connect(m_config, &TreelandUserConfig::cursorThemeNameChanged, m_config, [this]() { applyStyleHintSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::cursorSizeChanged, m_config, [this]() { applyThemeSettings(); }));
 
     applyAllSettings();
 }
@@ -108,6 +123,7 @@ void QDeepinTheme::applyAllSettings()
     applyStyleHintSettings();
     applyFontSettings();
     applyThemeSettings();
+    applyKeyboardSettings();
 }
 
 void QDeepinTheme::applyCursorSettings()
@@ -135,7 +151,7 @@ void QDeepinTheme::applyThemeSettings()
     if (!m_config)
         return;
 
-    QCoreApplication::postEvent(qGuiApp, new QEvent(QEvent::ThemeChange));
+    QGuiApplicationPrivate::handleThemeChanged();
 }
 
 void QDeepinTheme::applyStyleHintSettings()
@@ -161,4 +177,45 @@ void QDeepinTheme::disconnectConfig()
     }
     m_connections.clear();
     m_config = nullptr;
+}
+
+void QDeepinTheme::bindSeatConfig(SeatUserDConfig *config)
+{
+    if (m_seatConfig == config)
+        return;
+
+    disconnectSeatConfig();
+    m_seatConfig = config;
+    if (!m_seatConfig)
+        return;
+
+    auto addConnection = [this](const QMetaObject::Connection &conn) {
+        m_seatConnections.push_back(conn);
+    };
+
+    addConnection(QObject::connect(m_seatConfig, &SeatUserDConfig::keyboardRateChanged,
+                                   m_seatConfig, [this]() { applyKeyboardSettings(); }));
+    addConnection(QObject::connect(m_seatConfig, &SeatUserDConfig::keyboardDelayChanged,
+                                   m_seatConfig, [this]() { applyKeyboardSettings(); }));
+
+    applyKeyboardSettings();
+}
+
+void QDeepinTheme::applyKeyboardSettings()
+{
+    if (!m_seatConfig)
+        return;
+
+    auto *hints = QGuiApplication::styleHints();
+    hints->setKeyboardAutoRepeatRate(m_seatConfig->keyboardRate());
+    hints->setKeyboardInputInterval(m_seatConfig->keyboardDelay());
+}
+
+void QDeepinTheme::disconnectSeatConfig()
+{
+    for (const auto &conn : std::as_const(m_seatConnections)) {
+        QObject::disconnect(conn);
+    }
+    m_seatConnections.clear();
+    m_seatConfig = nullptr;
 }

--- a/src/deepintheme.cpp
+++ b/src/deepintheme.cpp
@@ -1,0 +1,164 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "deepintheme.h"
+
+#include "seat/helper.h"
+#include "treelanduserconfig.hpp"
+
+#include <DGuiApplicationHelper>
+
+#include <QCoreApplication>
+#include <QGuiApplication>
+#include <QStyleHints>
+
+DCORE_USE_NAMESPACE;
+DGUI_USE_NAMESPACE;
+
+QDeepinTheme::QDeepinTheme() = default;
+
+QDeepinTheme::~QDeepinTheme()
+{
+    disconnectConfig();
+}
+
+const QPalette *QDeepinTheme::palette(QPlatformTheme::Palette type) const
+{
+    if (type != QPlatformTheme::SystemPalette) {
+        return QGenericUnixTheme::palette(type);
+    }
+    static QPalette palette;
+    palette = DGuiApplicationHelper::instance()->applicationPalette();
+    return &palette;
+}
+
+QVariant QDeepinTheme::themeHint(ThemeHint hint) const
+{
+    if (!m_config)
+        return QGenericUnixTheme::themeHint(hint);
+
+    switch (hint) {
+    case MouseDoubleClickDistance:
+        return m_config->doubleClickDistance();
+    case MouseCursorTheme:
+        return m_config->cursorThemeName();
+    default:
+        break;
+    }
+    return QGenericUnixTheme::themeHint(hint);
+}
+
+const QFont *QDeepinTheme::font(Font type) const
+{
+    if (!m_config)
+        return QGenericUnixTheme::font(type);
+
+    switch (type) {
+    case SystemFont: {
+        static QFont f;
+        f.setFamily(m_config->font());
+        f.setPointSize(m_config->fontSize() / 10.0);
+        return &f;
+    }
+    case FixedFont: {
+        static QFont f;
+        f.setFamily(m_config->monoFont());
+        f.setPointSize(m_config->fontSize() / 10.0);
+        return &f;
+    }
+    default:
+        break;
+    }
+    return QGenericUnixTheme::font(type);
+}
+
+void QDeepinTheme::bindConfig(TreelandUserConfig *config)
+{
+    if (m_config == config)
+        return;
+
+    disconnectConfig();
+    m_config = config;
+    if (!m_config)
+        return;
+
+    auto addConnection = [this](const QMetaObject::Connection &conn) {
+        m_connections.push_back(conn);
+    };
+
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::cursorBlinkChanged, m_config, [this]() { applyCursorSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::cursorBlinkTimeChanged, m_config, [this]() { applyCursorSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::doubleClickTimeChanged, m_config, [this]() { applyStyleHintSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::doubleClickDistanceChanged, m_config, [this]() { applyStyleHintSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::dndDragThresholdChanged, m_config, [this]() { applyStyleHintSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::fontChanged, m_config, [this]() { applyFontSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::monoFontChanged, m_config, [this]() { applyFontSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::fontSizeChanged, m_config, [this]() { applyFontSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::iconThemeNameChanged, m_config, [this]() { applyThemeSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::themeNameChanged, m_config, [this]() { applyThemeSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::preferDarkChanged, m_config, [this]() { applyStyleHintSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::cursorThemeNameChanged, m_config, [this]() { applyStyleHintSettings(); }));
+
+    applyAllSettings();
+}
+
+void QDeepinTheme::applyAllSettings()
+{
+    applyCursorSettings();
+    applyStyleHintSettings();
+    applyFontSettings();
+    applyThemeSettings();
+}
+
+void QDeepinTheme::applyCursorSettings()
+{
+    if (!m_config)
+        return;
+
+    int flashTime = m_config->cursorBlink() ? m_config->cursorBlinkTime() : 0;
+    QGuiApplication::styleHints()->setCursorFlashTime(flashTime);
+}
+
+void QDeepinTheme::applyFontSettings()
+{
+    if (!m_config)
+        return;
+
+    QFont systemFont;
+    systemFont.setFamily(m_config->font());
+    systemFont.setPointSize(m_config->fontSize() / 10.0);
+    QGuiApplication::setFont(systemFont);
+}
+
+void QDeepinTheme::applyThemeSettings()
+{
+    if (!m_config)
+        return;
+
+    QCoreApplication::postEvent(qGuiApp, new QEvent(QEvent::ThemeChange));
+}
+
+void QDeepinTheme::applyStyleHintSettings()
+{
+    if (!m_config)
+        return;
+
+    auto *hints = QGuiApplication::styleHints();
+    hints->setMouseDoubleClickInterval(m_config->doubleClickTime());
+    hints->setStartDragDistance(m_config->dndDragThreshold());
+
+    if (m_config->preferDark()) {
+        hints->setColorScheme(Qt::ColorScheme::Dark);
+    } else {
+        hints->setColorScheme(Qt::ColorScheme::Light);
+    }
+}
+
+void QDeepinTheme::disconnectConfig()
+{
+    for (const auto &conn : std::as_const(m_connections)) {
+        QObject::disconnect(conn);
+    }
+    m_connections.clear();
+    m_config = nullptr;
+}

--- a/src/deepintheme.cpp
+++ b/src/deepintheme.cpp
@@ -9,10 +9,10 @@
 
 #include <DGuiApplicationHelper>
 
+#include <QCoreApplication>
 #include <QGuiApplication>
 #include <QSizeF>
 #include <QStyleHints>
-#include <private/qguiapplication_p.h>
 
 DCORE_USE_NAMESPACE;
 DGUI_USE_NAMESPACE;
@@ -152,7 +152,7 @@ void QDeepinTheme::applyThemeSettings()
     if (!m_config)
         return;
 
-    QGuiApplicationPrivate::handleThemeChanged();
+    QCoreApplication::postEvent(qGuiApp, new QEvent(QEvent::ThemeChange));
 }
 
 void QDeepinTheme::applyStyleHintSettings()

--- a/src/deepintheme.cpp
+++ b/src/deepintheme.cpp
@@ -1,0 +1,221 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "deepintheme.h"
+
+#include "seat/helper.h"
+#include "seatuserconfig.hpp"
+#include "treelanduserconfig.hpp"
+
+#include <DGuiApplicationHelper>
+
+#include <QCoreApplication>
+#include <QGuiApplication>
+#include <QSizeF>
+#include <QStyleHints>
+
+DCORE_USE_NAMESPACE;
+DGUI_USE_NAMESPACE;
+
+QDeepinTheme::QDeepinTheme() = default;
+
+QDeepinTheme::~QDeepinTheme()
+{
+    disconnectConfig();
+    disconnectSeatConfig();
+}
+
+const QPalette *QDeepinTheme::palette(QPlatformTheme::Palette type) const
+{
+    if (type != QPlatformTheme::SystemPalette) {
+        return QGenericUnixTheme::palette(type);
+    }
+    static QPalette palette;
+    palette = DGuiApplicationHelper::instance()->applicationPalette();
+    return &palette;
+}
+
+QVariant QDeepinTheme::themeHint(ThemeHint hint) const
+{
+    if (!m_config)
+        return QGenericUnixTheme::themeHint(hint);
+
+    switch (hint) {
+    case CursorFlashTime:
+        return m_config->cursorBlink() ? m_config->cursorBlinkTime() : 0;
+    case MouseDoubleClickInterval:
+        return m_config->doubleClickTime();
+    case MouseDoubleClickDistance:
+        return m_config->doubleClickDistance();
+    case StartDragDistance:
+        return m_config->dndDragThreshold();
+    case MouseCursorTheme:
+        return m_config->cursorThemeName();
+    case MouseCursorSize:
+        return QSizeF(m_config->cursorSize(), m_config->cursorSize());
+    case KeyboardAutoRepeatRate:
+        return m_seatConfig ? m_seatConfig->keyboardRate() : QGenericUnixTheme::themeHint(hint);
+    case KeyboardInputInterval:
+        return m_seatConfig ? m_seatConfig->keyboardDelay() : QGenericUnixTheme::themeHint(hint);
+    default:
+        break;
+    }
+    return QGenericUnixTheme::themeHint(hint);
+}
+
+const QFont *QDeepinTheme::font(Font type) const
+{
+    if (!m_config)
+        return QGenericUnixTheme::font(type);
+
+    switch (type) {
+    case SystemFont: {
+        static QFont f;
+        f.setFamily(m_config->font());
+        f.setPointSize(m_config->fontSize() / 10.0);
+        return &f;
+    }
+    case FixedFont: {
+        static QFont f;
+        f.setFamily(m_config->monoFont());
+        f.setPointSize(m_config->fontSize() / 10.0);
+        return &f;
+    }
+    default:
+        break;
+    }
+    return QGenericUnixTheme::font(type);
+}
+
+void QDeepinTheme::bindConfig(TreelandUserConfig *config)
+{
+    if (m_config == config)
+        return;
+
+    disconnectConfig();
+    m_config = config;
+    if (!m_config)
+        return;
+
+    auto addConnection = [this](const QMetaObject::Connection &conn) {
+        m_connections.push_back(conn);
+    };
+
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::cursorBlinkChanged, m_config, [this]() { applyCursorSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::cursorBlinkTimeChanged, m_config, [this]() { applyCursorSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::doubleClickTimeChanged, m_config, [this]() { applyStyleHintSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::doubleClickDistanceChanged, m_config, [this]() { applyThemeSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::dndDragThresholdChanged, m_config, [this]() { applyStyleHintSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::fontChanged, m_config, [this]() { applyFontSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::monoFontChanged, m_config, [this]() { applyFontSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::fontSizeChanged, m_config, [this]() { applyFontSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::iconThemeNameChanged, m_config, [this]() { applyThemeSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::themeNameChanged, m_config, [this]() { applyThemeSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::preferDarkChanged, m_config, [this]() { applyStyleHintSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::cursorThemeNameChanged, m_config, [this]() { applyThemeSettings(); }));
+    addConnection(QObject::connect(m_config, &TreelandUserConfig::cursorSizeChanged, m_config, [this]() { applyThemeSettings(); }));
+
+    applyAllSettings();
+}
+
+void QDeepinTheme::applyAllSettings()
+{
+    applyCursorSettings();
+    applyStyleHintSettings();
+    applyFontSettings();
+    applyThemeSettings();
+    applyKeyboardSettings();
+}
+
+void QDeepinTheme::applyCursorSettings()
+{
+    if (!m_config)
+        return;
+
+    int flashTime = m_config->cursorBlink() ? m_config->cursorBlinkTime() : 0;
+    QGuiApplication::styleHints()->setCursorFlashTime(flashTime);
+}
+
+void QDeepinTheme::applyFontSettings()
+{
+    if (!m_config)
+        return;
+
+    QFont systemFont;
+    systemFont.setFamily(m_config->font());
+    systemFont.setPointSize(m_config->fontSize() / 10.0);
+    QGuiApplication::setFont(systemFont);
+}
+
+void QDeepinTheme::applyThemeSettings()
+{
+    if (!m_config)
+        return;
+
+    QCoreApplication::postEvent(qGuiApp, new QEvent(QEvent::ThemeChange));
+}
+
+void QDeepinTheme::applyStyleHintSettings()
+{
+    if (!m_config)
+        return;
+
+    auto *hints = QGuiApplication::styleHints();
+    hints->setMouseDoubleClickInterval(m_config->doubleClickTime());
+    hints->setStartDragDistance(m_config->dndDragThreshold());
+
+    if (m_config->preferDark()) {
+        hints->setColorScheme(Qt::ColorScheme::Dark);
+    } else {
+        hints->setColorScheme(Qt::ColorScheme::Light);
+    }
+}
+
+void QDeepinTheme::disconnectConfig()
+{
+    for (const auto &conn : std::as_const(m_connections)) {
+        QObject::disconnect(conn);
+    }
+    m_connections.clear();
+    m_config = nullptr;
+}
+
+void QDeepinTheme::bindSeatConfig(SeatUserDConfig *config)
+{
+    if (m_seatConfig == config)
+        return;
+
+    disconnectSeatConfig();
+    m_seatConfig = config;
+    if (!m_seatConfig)
+        return;
+
+    auto addConnection = [this](const QMetaObject::Connection &conn) {
+        m_seatConnections.push_back(conn);
+    };
+
+    addConnection(QObject::connect(m_seatConfig, &SeatUserDConfig::keyboardRateChanged,
+                                   m_seatConfig, [this]() { applyKeyboardSettings(); }));
+    addConnection(QObject::connect(m_seatConfig, &SeatUserDConfig::keyboardDelayChanged,
+                                   m_seatConfig, [this]() { applyKeyboardSettings(); }));
+
+    applyKeyboardSettings();
+}
+
+void QDeepinTheme::applyKeyboardSettings()
+{
+    if (!m_seatConfig)
+        return;
+
+    auto *hints = QGuiApplication::styleHints();
+    hints->setKeyboardInputInterval(m_seatConfig->keyboardDelay());
+}
+
+void QDeepinTheme::disconnectSeatConfig()
+{
+    for (const auto &conn : std::as_const(m_seatConnections)) {
+        QObject::disconnect(conn);
+    }
+    m_seatConnections.clear();
+    m_seatConfig = nullptr;
+}

--- a/src/deepintheme.h
+++ b/src/deepintheme.h
@@ -16,6 +16,7 @@
 #include <functional>
 #include <vector>
 
+class SeatUserDConfig;
 class TreelandUserConfig;
 
 class QDeepinTheme : public QGenericUnixTheme
@@ -29,6 +30,7 @@ public:
     const QFont *font(Font type) const override;
 
     void bindConfig(TreelandUserConfig *config);
+    void bindSeatConfig(SeatUserDConfig *config);
 
 private:
     void applyAllSettings();
@@ -36,9 +38,13 @@ private:
     void applyFontSettings();
     void applyThemeSettings();
     void applyStyleHintSettings();
+    void applyKeyboardSettings();
 
     void disconnectConfig();
+    void disconnectSeatConfig();
 
     QPointer<TreelandUserConfig> m_config;
+    QPointer<SeatUserDConfig> m_seatConfig;
     std::vector<QMetaObject::Connection> m_connections;
+    std::vector<QMetaObject::Connection> m_seatConnections;
 };

--- a/src/deepintheme.h
+++ b/src/deepintheme.h
@@ -13,7 +13,6 @@
 #  include <private/qgenericunixthemes_p.h>
 #endif
 
-#include <functional>
 #include <vector>
 
 class SeatUserDConfig;

--- a/src/deepintheme.h
+++ b/src/deepintheme.h
@@ -1,0 +1,44 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <QFont>
+#include <QPalette>
+#include <QPointer>
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+#  include <private/qgenericunixtheme_p.h>
+#else
+#  include <private/qgenericunixthemes_p.h>
+#endif
+
+#include <functional>
+#include <vector>
+
+class TreelandUserConfig;
+
+class QDeepinTheme : public QGenericUnixTheme
+{
+public:
+    QDeepinTheme();
+    ~QDeepinTheme() override;
+
+    const QPalette *palette(QPlatformTheme::Palette type) const override;
+    QVariant themeHint(ThemeHint hint) const override;
+    const QFont *font(Font type) const override;
+
+    void bindConfig(TreelandUserConfig *config);
+
+private:
+    void applyAllSettings();
+    void applyCursorSettings();
+    void applyFontSettings();
+    void applyThemeSettings();
+    void applyStyleHintSettings();
+
+    void disconnectConfig();
+
+    QPointer<TreelandUserConfig> m_config;
+    std::vector<QMetaObject::Connection> m_connections;
+};

--- a/src/deepintheme.h
+++ b/src/deepintheme.h
@@ -1,0 +1,49 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <QFont>
+#include <QPalette>
+#include <QPointer>
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+#  include <private/qgenericunixtheme_p.h>
+#else
+#  include <private/qgenericunixthemes_p.h>
+#endif
+
+#include <vector>
+
+class SeatUserDConfig;
+class TreelandUserConfig;
+
+class QDeepinTheme : public QGenericUnixTheme
+{
+public:
+    QDeepinTheme();
+    ~QDeepinTheme() override;
+
+    const QPalette *palette(QPlatformTheme::Palette type) const override;
+    QVariant themeHint(ThemeHint hint) const override;
+    const QFont *font(Font type) const override;
+
+    void bindConfig(TreelandUserConfig *config);
+    void bindSeatConfig(SeatUserDConfig *config);
+
+private:
+    void applyAllSettings();
+    void applyCursorSettings();
+    void applyFontSettings();
+    void applyThemeSettings();
+    void applyStyleHintSettings();
+    void applyKeyboardSettings();
+
+    void disconnectConfig();
+    void disconnectSeatConfig();
+
+    QPointer<TreelandUserConfig> m_config;
+    QPointer<SeatUserDConfig> m_seatConfig;
+    std::vector<QMetaObject::Connection> m_connections;
+    std::vector<QMetaObject::Connection> m_seatConnections;
+};

--- a/src/input/inputmanager.cpp
+++ b/src/input/inputmanager.cpp
@@ -41,6 +41,8 @@ void InputManager::setupSeatUserConfig(const QString &userName)
                                                    "org.deepin.dde.treeland",
                                                    "/" + userName);
 
+    Q_EMIT seatConfigChanged(m_seatDConfig);
+
 #if SEATUSERDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
     if (m_seatDConfig->isInitializeSucceeded()) {
 #else

--- a/src/input/inputmanager.cpp
+++ b/src/input/inputmanager.cpp
@@ -70,6 +70,8 @@ void InputManager::setupSeatUserConfig(const QString &userName)
                                                    "org.deepin.dde.treeland",
                                                    "/" + userName);
 
+    Q_EMIT seatConfigChanged(m_seatDConfig);
+
     if (isSeatDConfigInitialized(m_seatDConfig)) {
         onConfigInitializeSucceed();
     } else {

--- a/src/input/inputmanager.h
+++ b/src/input/inputmanager.h
@@ -33,6 +33,9 @@ public Q_SLOTS:
     void onMousePointerConfigCreated(PointerDeviceConfigurationV1 *config);
     void onTouchpadPointerConfigCreated(PointerDeviceConfigurationV1 *config);
 
+Q_SIGNALS:
+    void seatConfigChanged(SeatUserDConfig *config);
+
 private Q_SLOTS:
     void handleMousePointerConfigApplied(PointerDeviceConfigurationV1::ChangeFlags changes);
     void handleTouchpadPointerConfigApplied(PointerDeviceConfigurationV1::ChangeFlags changes);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
         bindThemeConfig();
         QObject::connect(Helper::instance(), &Helper::configChanged, &bindThemeConfig);
         QObject::connect(Helper::instance()->inputManager(), &InputManager::seatConfigChanged,
-                         g_theme, &QDeepinTheme::bindSeatConfig);
+                         [](SeatUserDConfig *config) { g_theme->bindSeatConfig(config); });
 
         quitCode = app.exec();
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "core/treeland.h"
+#include "deepintheme.h"
+#include "seat/helper.h"
 #include "utils/cmdline.h"
 
 #include <wrenderhelper.h>
@@ -14,13 +16,6 @@
 
 #include <QGuiApplication>
 #include <QMetaType>
-#include <QPalette>
-
-#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
-#  include <private/qgenericunixtheme_p.h>
-#else
-#  include <private/qgenericunixthemes_p.h>
-#endif
 
 #include <wserver.h>
 
@@ -29,19 +24,16 @@
 WAYLIB_SERVER_USE_NAMESPACE
 DCORE_USE_NAMESPACE;
 
-class QDeepinTheme : public QGenericUnixTheme
+static QDeepinTheme *g_theme = nullptr;
+
+static void bindThemeConfig()
 {
-public:
-    const QPalette *palette(QPlatformTheme::Palette type) const override
-    {
-        if (type != QPlatformTheme::SystemPalette) {
-            return QGenericUnixTheme::palette(type);
-        }
-        static QPalette palette;
-        palette = Dtk::Gui::DGuiApplicationHelper::instance()->applicationPalette();
-        return &palette;
-    }
-};
+    auto *helper = Helper::instance();
+    if (!helper || !g_theme)
+        return;
+
+    g_theme->bindConfig(helper->config());
+}
 
 int main(int argc, char *argv[])
 {
@@ -50,9 +42,9 @@ int main(int argc, char *argv[])
         DTK_GUI_NAMESPACE::DGuiApplicationHelper::DontSaveApplicationTheme,
         true);
     WServer::initializeQPA({}, [](const QString &) {
-        return static_cast<QPlatformTheme *>(new QDeepinTheme());
+        g_theme = new QDeepinTheme();
+        return static_cast<QPlatformTheme *>(g_theme);
     });
-    //    QQuickStyle::setStyle("Material");
 
     QGuiApplication::setAttribute(Qt::AA_UseOpenGLES);
     QGuiApplication::setHighDpiScaleFactorRoundingPolicy(
@@ -85,6 +77,9 @@ int main(int argc, char *argv[])
     int quitCode = 0;
     {
         Treeland::Treeland treeland;
+
+        bindThemeConfig();
+        QObject::connect(Helper::instance(), &Helper::configChanged, &bindThemeConfig);
 
         quitCode = app.exec();
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 
 #include "core/treeland.h"
 #include "deepintheme.h"
+#include "input/inputmanager.h"
 #include "seat/helper.h"
 #include "utils/cmdline.h"
 
@@ -80,6 +81,8 @@ int main(int argc, char *argv[])
 
         bindThemeConfig();
         QObject::connect(Helper::instance(), &Helper::configChanged, &bindThemeConfig);
+        QObject::connect(Helper::instance()->inputManager(), &InputManager::seatConfigChanged,
+                         g_theme, &QDeepinTheme::bindSeatConfig);
 
         quitCode = app.exec();
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,9 @@
 
 #include "core/treeland.h"
 #include "core/treelandinit.h"
+#include "deepintheme.h"
+#include "input/inputmanager.h"
+#include "seat/helper.h"
 #include "utils/cmdline.h"
 
 #include <wrenderhelper.h>
@@ -11,6 +14,16 @@
 
 #include <DLog>
 #include <QGuiApplication>
+
+static void bindThemeConfig()
+{
+    auto *helper = Helper::instance();
+    auto *theme = Treeland::deepinTheme();
+    if (!helper || !theme)
+        return;
+
+    theme->bindConfig(helper->config());
+}
 
 int main(int argc, char *argv[])
 {
@@ -35,6 +48,11 @@ int main(int argc, char *argv[])
     int quitCode = 0;
     {
         Treeland::Treeland treeland;
+
+        bindThemeConfig();
+        QObject::connect(Helper::instance(), &Helper::configChanged, &bindThemeConfig);
+        QObject::connect(Helper::instance()->inputManager(), &InputManager::seatConfigChanged,
+                         [](SeatUserDConfig *config) { Treeland::deepinTheme()->bindSeatConfig(config); });
 
         quitCode = QGuiApplication::exec();
     }

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -267,6 +267,7 @@ public:
 
     RootSurfaceContainer *rootContainer() const { return m_rootSurfaceContainer; }
     inline WBackend *backend() const { return m_backend; }
+    InputManager *inputManager() const { return m_inputManager; }
 public Q_SLOTS:
     void activateSurface(SurfaceWrapper *wrapper, Qt::FocusReason reason = Qt::OtherFocusReason);
     void forceActivateSurface(SurfaceWrapper *wrapper,

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -279,6 +279,7 @@ public:
 
     RootSurfaceContainer *rootContainer() const { return m_rootSurfaceContainer; }
     inline WBackend *backend() const { return m_backend; }
+    InputManager *inputManager() const { return m_inputManager; }
 public Q_SLOTS:
     void activateSurface(SurfaceWrapper *wrapper,
                          Qt::FocusReason reason = Qt::OtherFocusReason,


### PR DESCRIPTION
增强 QDeepinTheme，让 treeland 自身的光标闪动间隔、双击间隔、系统字体、等宽字体跟随 DConfig 设置。

1. Override themeHint() to return CursorFlashTime and MouseDoubleClickInterval from TreelandUserConfig
2. Override font() to return SystemFont and FixedFont based on DConfig font/monoFont/fontSize settings
3. Add notifyThemeChanged() to trigger Qt theme refresh via QWindowSystemInterface::handleThemeChanged()
4. Add connectConfigSignals() to bind DConfig change signals to theme refresh, with disconnect on user switch to prevent duplicate connections
5. Connect Helper::configChanged to reconnect signals when user configuration is rebuilt

WM-25

## Summary by Sourcery

Synchronize Treeland’s Qt theme, fonts, input timing, and interaction settings with the active user and seat DConfig configuration.

New Features:
- Make the application theme follow per-user DConfig settings for cursor behavior, mouse interaction thresholds, cursor theme, and system and monospace fonts.
- Apply seat-specific keyboard timing settings from DConfig to Qt style hints.

Enhancements:
- Refresh Qt theme and style settings when user or seat configuration changes, while safely reconnecting when configurations are rebuilt.
- Preserve system palette integration through the reusable QDeepinTheme implementation.

Build:
- Add the QDeepinTheme implementation and header to the Treeland executable.

Chores:
- Expose configuration change notifications needed to keep theme settings synchronized.