### PR TITLE
fix: correct active state handling on window minimize

### DIFF
--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -816,8 +816,16 @@ void ShellHandler::setupSurfaceActiveWatcher(SurfaceWrapper *wrapper)
             m_workspace->removeActivedSurface(wrapper);
             // The window may already be inactive. Keep history cleanup above, but
             // avoid changing focus unless this window still owns keyboard focus.
-            if (Helper::instance()->keyboardFocusSurface() != wrapper)
+            if (Helper::instance()->keyboardFocusSurface() != wrapper) {
+                // Requests from task bars or other external controllers can minimize the
+                // active window after keyboard focus has already moved away from it. Clear
+                // the compositor active state so foreign-toplevel clients do not observe a
+                // minimized-but-activated window, but do not fall back focus from the
+                // current keyboard focus owner.
+                if (Helper::instance()->activatedSurface() == wrapper)
+                    Helper::instance()->setActivatedSurface(nullptr);
                 return;
+            }
 
             Helper::instance()->activateSurface(m_workspace->current()->latestActiveSurface());
         });

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -1362,8 +1362,8 @@ void SurfaceWrapper::doSetSurfaceState(State newSurfaceState)
         m_shellSurface->setMaximize(true);
         break;
     case State::Minimized:
-        m_shellSurface->setMinimize(true);
         updateHasActiveCapability(ActiveControlState::UnMinimized, false);
+        m_shellSurface->setMinimize(true);
         break;
     case State::Fullscreen:
         m_shellSurface->setFullScreen(true);


### PR DESCRIPTION
This change refines the logic for handling window minimization and active state updates. In `ShellHandler::setupSurfaceActiveWatcher`, the code now ensures that if a window is minimized after losing keyboard focus (e.g., by a taskbar or external controller), the compositor's active state is cleared only if the minimized window was still marked as active. This prevents foreign-toplevel clients from seeing a minimized window as still activated, while avoiding unnecessary focus changes. Additionally, in `SurfaceWrapper::doSetSurfaceState`, the order of operations is adjusted so that the active capability is updated before actually minimizing the shell surface, ensuring proper state synchronization.

本次更改优化了窗口最小化及活动状态更新的逻辑。在
`ShellHandler::setupSurfaceActiveWatcher` 中，代码现在确保当窗口在 失去键盘焦点后被最小化（如通过任务栏或外部控制器）时，只有当该窗口
仍被标记为活动时才清除合成器的活动状态，从而防止 foreign-toplevel 客
户端看到已最小化窗口仍为活动状态，并避免不必要的焦点切换。此外，在
`SurfaceWrapper::doSetSurfaceState` 中，调整了操作顺序，确保在实际最小化 shell surface 之前先更新活动能力，实现状态同步。

Log: 改进窗口最小化行为，避免最小化窗口被显示为活动状态

Influence:
1. 通过任务栏或外部控制器最小化窗口，验证 foreign-toplevel 协议下不会将 其报告为活动窗口
2. 确认在最小化已失去焦点的窗口时，键盘焦点不会发生变化
3. 测试窗口最小化与还原时的激活/焦点切换是否正常
4. 检查合成器、shell surface 与客户端应用在最小化/取消最小化操作下的状态 同步

PMS: 366835