### PR TITLE
docs: update logging-guidelines SKILL.md for centralized categories

### DIFF
--- a/.agents/skills/logging-guidelines/SKILL.md
+++ b/.agents/skills/logging-guidelines/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: logging-guidelines
-description: Use this skill whenever a task adds, changes, reviews, or removes logging in treeland, waylib, or qwlroots code. Trigger on logging categories, `Q_LOGGING_CATEGORY`, `Q_DECLARE_LOGGING_CATEGORY`, `qCDebug`, `qCInfo`, `qCWarning`, `qCCritical`, log level selection, category naming, or requests to clean up log messages. For treeland code, prefer centralized categories in `src/common/treelandlogging.h/.cpp`. For waylib code, prefer per-file local categories named `waylib.<module>.<component>[.<subcomponent>]`.
+description: Use this skill whenever a task adds, changes, reviews, or removes logging in treeland, waylib, or qwlroots code. Trigger on logging categories, Q_LOGGING_CATEGORY, Q_DECLARE_LOGGING_CATEGORY, qCDebug, qCInfo, qCWarning, qCCritical, log level selection, category naming, or requests to clean up log messages. For treeland code, prefer centralized categories in src/common/treelandlogging.h/.cpp. For waylib code, prefer centralized categories in waylib/src/server/wayliblogging.h/.cpp.
 ---
 
 # Logging Guidelines
 
 ## Goal
-Keep logging changes consistent with this repository's existing split:
+Keep logging changes consistent with the centralized category system:
 
-- `treeland`: centralized categories in `src/common/treelandlogging.h/.cpp`
-- `waylib`: local per-file categories
+- **treeland**: centralized categories in `src/common/treelandlogging.h/.cpp`
+- **waylib**: centralized categories in `waylib/src/server/wayliblogging.h/.cpp`
 
 Use this skill for both implementation work and review work.
 
@@ -22,21 +22,85 @@ Use centralized categories declared in:
 - `src/common/treelandlogging.h`
 - `src/common/treelandlogging.cpp`
 
-Do not introduce ad hoc local `Q_LOGGING_CATEGORY` definitions in treeland code unless the repository already has an explicit exception in that area.
+Category variable naming: `lcTl` + PascalCase module name (e.g. `lcTlCore`, `lcTlInput`, `lcTlGestures`).
+
+String ID naming: `treeland.<module>[.<submodule>]` (e.g. `treeland.core`, `treeland.input.gestures`).
+
+The only exceptions are standalone executables that cannot include the centralized header (e.g. `treeland-xwayland`, `treeland-sd`, `treeland-shortcut`). These may define local `Q_LOGGING_CATEGORY` in their own `.cpp` file.
 
 ### Waylib code
-Define categories locally in the file that uses them.
+Use centralized categories declared in:
 
-Use the naming pattern:
+- `waylib/src/server/wayliblogging.h`
+- `waylib/src/server/wayliblogging.cpp`
 
-`waylib.<module>.<component>[.<subcomponent>]`
+Category variable naming: `lcWl` + PascalCase module name (e.g. `lcWlSeat`, `lcWlOutput`, `lcWlCursor`).
 
-Example:
+String ID naming: `waylib.<module>[.<submodule>]` or `waylib.protocols.<name>` or `waylib.qtquick.<name>` or `waylib.utils.<name>` (e.g. `waylib.seat`, `waylib.input.pointer`, `waylib.protocols.inputmethod`).
 
-```cpp
-Q_LOGGING_CATEGORY(waylibCursor, "waylib.server.cursor", QtInfoMsg)
-Q_LOGGING_CATEGORY(waylibCursorInput, "waylib.server.cursor.input", QtDebugMsg)
+## Waylib Category Hierarchy
+
 ```
+waylib
+├── Kernel
+│   ├── waylib.socket               lcWlSocket
+│   ├── waylib.seat                  lcWlSeat
+│   ├── waylib.output                lcWlOutput
+│   ├── waylib.output.drm            lcWlOutputDrm
+│   ├── waylib.output.buffer         lcWlOutputBuffer
+│   ├── waylib.input                 lcWlInput
+│   ├── waylib.cursor                lcWlCursor
+│   ├── waylib.input.pointer         lcWlPointer
+│   ├── waylib.input.touch           lcWlTouch
+│   ├── waylib.input.gesture         lcWlGesture
+│   └── waylib.input.drag            lcWlDrag
+├── QtQuick
+│   ├── waylib.texture.provider      lcWlTextureProvider
+│   ├── waylib.qtquick.surface       lcWlSurface
+│   ├── waylib.qtquick.texture       lcWlQtQuickTexture
+│   ├── waylib.renderer              lcWlRenderer
+│   └── waylib.qtquick.bufferitem    lcWlBufferItem
+├── Utils
+│   ├── waylib.utils.imagecapture    lcWlImageCapture
+│   ├── waylib.utils.cursorimage     lcWlCursorImage
+│   ├── waylib.utils.bufferdumper    lcWlBufferDumper
+│   └── waylib.utils.thread          lcWlThreadUtils
+├── Protocols
+│   ├── waylib.protocols.foreigntoplevel       lcWlForeignToplevel
+│   ├── waylib.protocols.inputmethod           lcWlInputMethod
+│   ├── waylib.protocols.extforeigntoplevel    lcWlExtForeignToplevel
+│   └── waylib.protocols.textinput             lcWlTextInput
+├── Layer shell
+│   ├── waylib.layer.shell          lcWlLayerShell
+│   └── waylib.layer.surface        lcWlLayerSurface
+├── XDG
+│   ├── waylib.xdg.output           lcWlXdgOutput
+│   └── waylib.xdg.decoration       lcWlXdgDecoration
+├── Output extras
+│   ├── waylib.output.layer         lcWlOutputLayer
+│   └── waylib.output.helper        lcWlOutputHelper
+├── QtQuick extras
+│   ├── waylib.qml.creator          lcWlQmlCreator
+│   └── waylib.cursor.quick         lcWlQuickCursor
+└── Platform & Rendering
+    ├── waylib.platform              lcWlPlatform
+    ├── waylib.render.helper         lcWlRenderHelper
+    ├── waylib.render.buffer         lcWlRenderBuffer
+    └── waylib.render.bufferrenderer lcWlBufferRenderer
+```
+
+## Mandatory Rules
+
+1. **No uncategorized logging** — Never use bare `qDebug()`, `qWarning()`, `qCritical()`, or `qInfo()`. Always use the categorized variants: `qCDebug(cat)`, `qCInfo(cat)`, `qCWarning(cat)`, `qCCritical(cat)`.
+
+2. **No local Q_LOGGING_CATEGORY in library code** — All categories for treeland and waylib library code must be declared in the centralized `*logging.h/.cpp`. Only standalone executables (e.g. `treeland-xwayland`) may define local categories in their own `.cpp` file.
+
+3. **No logging header includes in .h files** — Only `treelandlogging.h` / `wayliblogging.h` themselves may declare categories. Other `.h` files must not `#include` logging headers or use `qC*()` macros. Use forward-declared categories in `.h` only if absolutely necessary (prefer moving the log call to `.cpp`).
+
+4. **Every category must have a comment** — Each `Q_LOGGING_CATEGORY` definition must have a `//` comment explaining its scope, e.g.:
+   ```cpp
+   Q_LOGGING_CATEGORY(lcWlSeat, "waylib.seat", QtInfoMsg) // Seat management (keyboard focus, capability)
+   ```
 
 ## Log Levels
 Choose the lowest level that still matches the operational importance.
@@ -54,13 +118,13 @@ Write messages that are specific and filterable.
 Prefer:
 
 ```cpp
-qCDebug(waylibCursor) << "Cursor moved from" << oldPos << "to" << newPos;
+qCDebug(lcWlCursor) << "Cursor moved from" << oldPos << "to" << newPos;
 ```
 
 Avoid:
 
 ```cpp
-qCDebug(waylibCursor) << "Cursor moved";
+qCDebug(lcWlCursor) << "Cursor moved";
 ```
 
 When useful, include:
@@ -70,19 +134,14 @@ When useful, include:
 - identifiers or names
 - the impact of an error
 
-## Category Organization
-Use the most specific category that matches the event.
-
-Prefer a narrower category for a sub-area when the file already separates them. Do not log unrelated events through a broad category if a better one exists.
-
 ## Error Logging
 When logging failures, include enough context to debug the issue without reading surrounding code.
 
 Prefer:
 
 ```cpp
-qCWarning(waylibCursor) << "Failed to attach device" << device->name()
-                        << "- not a pointing device";
+qCWarning(lcWlCursor) << "Failed to attach device" << device->name()
+                      << "- not a pointing device";
 ```
 
 Avoid vague failure messages with no object, cause, or impact.
@@ -90,15 +149,32 @@ Avoid vague failure messages with no object, cause, or impact.
 ## Sensitive Data
 Do not log secrets, passwords, tokens, or other sensitive user data.
 
+## Adding a New Category
+
+Follow these steps when you need to add a new logging category:
+
+1. **Choose the naming** — Pick a variable name (`lcTl*` or `lcWl*` + PascalCase) and a string ID under the appropriate hierarchy.
+2. **Add declaration** — Add `Q_DECLARE_LOGGING_CATEGORY(lcXxx)` to the centralized `.h` file (`treelandlogging.h` or `wayliblogging.h`) in the correct section.
+3. **Add definition** — Add `Q_LOGGING_CATEGORY(lcXxx, "domain.path", level)` to the centralized `.cpp` file with a `//` comment explaining its scope.
+4. **Include the header** — In the `.cpp` file where you use the category, add `#include "treelandlogging.h"` or `#include "wayliblogging.h"`.
+5. **Migrate calls** — Replace bare `qDebug()`/`qWarning()` etc. with `qCDebug(lcXxx)`/`qCWarning(lcXxx)` etc.
+6. **Verify** — Run `rg 'qWarning\(\)|qDebug\(\)|qCritical\(\)|qInfo\(\)' src/ waylib/src/` to confirm no uncategorized calls remain.
+
 ## Review Checklist
 When reviewing a logging change, verify:
 
-1. the category follows the correct treeland or waylib pattern
-2. the chosen log level matches severity
-3. the message contains enough context
-4. the change does not leak sensitive information
-5. the change does not introduce unrelated category churn
+1. the category follows the correct `lcTl*`/`lcWl*` naming convention
+2. the category is declared in the centralized header (not locally in library code)
+3. no `.h` file (other than the logging header itself) includes a logging header or uses `qC*()`
+4. each `Q_LOGGING_CATEGORY` definition has a `//` comment explaining its scope
+5. the chosen log level matches severity
+6. the message contains enough context
+7. the change does not leak sensitive information
+8. the change does not introduce bare `qDebug()`/`qWarning()`/`qCritical()`/`qInfo()` calls
+9. the change does not introduce unrelated category churn
 
 ## Repository References
 - `src/common/treelandlogging.h`
 - `src/common/treelandlogging.cpp`
+- `waylib/src/server/wayliblogging.h`
+- `waylib/src/server/wayliblogging.cpp`


### PR DESCRIPTION
Update the logging-guidelines agent skill to reflect the new centralized category system.

## Changes

1. Change waylib from per-file local categories to centralized `wayliblogging.h/cpp`
2. Update variable naming convention: `lcTl*` (treeland), `lcWl*` (waylib)
3. Add complete waylib category hierarchy tree
4. Add mandatory rules: no uncategorized logging, no local `Q_LOGGING_CATEGORY` in library code, no logging headers in `.h` files, every category must have a comment
5. Update review checklist
6. Add "Adding a New Category" workflow guide

Context: linuxdeepin/treeland#990