### PR TITLE
fix(workspace): prevent window titlebar from being obscured by dock

### DIFF
--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -729,6 +729,31 @@ void Output::arrangeNonLayerSurface(SurfaceWrapper *surface, const QSizeF &sizeD
             break;
         }
     } while (false);
+
+    QRectF titlebarGeometry = surface->titlebarGeometry();
+    if (!titlebarGeometry.isValid()) {
+        qreal titleHeight = Helper::instance()->config()->windowTitlebarHeight();
+        titlebarGeometry = QRectF(0, 0, normalGeo.width(), titleHeight);
+    }
+    titlebarGeometry.translate(normalGeo.topLeft());
+
+    if ((titlebarGeometry & validGeo).isEmpty()) {
+        if (titlebarGeometry.top() < validGeo.top()) {
+            normalGeo.moveTop(normalGeo.top() + validGeo.top() - titlebarGeometry.top());
+        } else if (titlebarGeometry.bottom() > validGeo.bottom()) {
+            normalGeo.moveBottom(normalGeo.bottom() - (titlebarGeometry.bottom() - validGeo.bottom()));
+        }
+
+        if (titlebarGeometry.left() < validGeo.left()) {
+            normalGeo.moveLeft(normalGeo.left() + validGeo.left() - titlebarGeometry.left());
+        } else if (titlebarGeometry.right() > validGeo.right()) {
+            normalGeo.moveRight(normalGeo.right() - (titlebarGeometry.right() - validGeo.right()));
+        }
+
+        if (normalGeo != surface->normalGeometry()) {
+            surface->moveNormalGeometryInOutput(normalGeo.topLeft());
+        }
+    }
 }
 
 namespace {


### PR DESCRIPTION
Ensure titlebar stays reachable when dock/panel resizes and encroaches on window area, preventing user from being unable to move the window.

修复dock栏调整大小时窗口标题栏被遮挡导致用户无法移动窗口的问题。

Log: 修复dock遮挡标题栏导致窗口无法移动的问题
PMS: BUG-344911
Influence: dock或面板调整大小时，窗口标题栏会被自动调整到有效区域内，确保用户始终能通过标题栏拖动窗口

## Summary by Sourcery

Bug Fixes:
- Prevent windows from ending up with their titlebars obscured by the dock or panel after workspace changes, so users can always drag and move the window.