### PR TITLE
fix: emit radiusChanged on DConfig windowRadius change

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1146,6 +1146,11 @@ void Helper::onSurfaceWrapperAdded(SurfaceWrapper *wrapper)
             attached->surfaceWrapper()->setBlur(attached->backgroundType() == Personalization::BackgroundType::Blur);
         };
         connect(attached, &Personalization::backgroundTypeChanged, this, updateBlur);
+        auto updateCornerRadius = [attached] {
+            attached->surfaceWrapper()->setRadius(attached->cornerRadius());
+        };
+        connect(attached, &Personalization::cornerRadiusChanged, this, updateCornerRadius);
+        updateCornerRadius();
         updateBlur();
         if (isLayer) {
             auto layer = qobject_cast<WLayerSurface *>(wrapper->shellSurface());

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -453,6 +453,17 @@ void SurfaceWrapper::setup()
                 });
         updateX11shouldSkipDock();
     }
+    // Connect DConfig windowRadius change so QML bindings re-evaluate radius()
+    if (m_type == Type::XdgToplevel || m_type == Type::XWayland) {
+        if (auto *helper = Helper::instance()) {
+            if (auto *config = helper->config()) {
+                connect(config,
+                        &TreelandUserConfig::windowRadiusChanged,
+                        this,
+                        &SurfaceWrapper::radiusChanged);
+            }
+        }
+    }
 }
 
 void SurfaceWrapper::convertToNormalSurface(WToplevelSurface *shellSurface, Type type)
@@ -1583,16 +1594,14 @@ void SurfaceWrapper::startShowDesktopAnimation(bool show)
 
 qreal SurfaceWrapper::radius() const
 {
-    // TODO: move to dconfig
     if (m_type == Type::InputPopup)
         return 0;
     if (m_type == Type::XdgPopup)
         return 8;
 
     qreal radius = m_radius;
-
-    // TODO: Handle: XdgToplevel, popup, InputPopup, XWayland (bypass, window type:
-    // menu/normal/popup)
+    // m_radius > 1 means radius was explicitly set via Personalization protocol;
+    // m_radius <= 1 means no per-window override, fall back to DConfig.
     if (radius < 1 && m_type != Type::Layer) {
         radius = Helper::instance()->config()->windowRadius();
     }


### PR DESCRIPTION
## Problem

When changing the window corner radius setting in Control Center (个性化 → 窗口特效 → 窗口圆角), the corner radius of all application windows does not update.

## Root Cause

`SurfaceWrapper::radius()` uses a lazy fallback pattern: `m_radius` is 0 (default) and falls back to `Helper::instance()->config()->windowRadius()` from DConfig. When DConfig `windowRadius` changes, `m_radius` doesn't change, so `radiusChanged()` never fires, and QML property bindings don't re-evaluate.

## Fix

1. **`src/surface/surfacewrapper.cpp`**: Connect `TreelandUserConfig::windowRadiusChanged` to `SurfaceWrapper::radiusChanged` in `setup()` for `XdgToplevel` and `XWayland` types, so QML bindings re-evaluate when DConfig changes.
2. **`src/seat/helper.cpp`**: Connect `Personalization::cornerRadiusChanged` to `SurfaceWrapper::setRadius()`, so per-window Personalization protocol radius overrides propagate correctly.
3. **`src/surface/surfacewrapper.cpp`**: Update `radius()` getter comment to clarify the `m_radius > 1` threshold meaning.

## Testing

- Change window radius in Control Center and verify all app windows update corner radius immediately
- Test with XdgToplevel and XWayland window types
- Verify per-window Personalization protocol override still works correctly

Fixes: https://github.com/linuxdeepin/treeland/issues