### PR TITLE
fix: safe iteration with removeAt/erase across codebase

### DIFF
--- a/waylib/src/server/kernel/wglobal.cpp
+++ b/waylib/src/server/kernel/wglobal.cpp
@@ -166,7 +166,7 @@ bool WWrapObject::safeDisconnect(const QObject *receiver)
     W_D(WWrapObject);
 
     bool ok = false;
-    for (int i = 0; i < d->connectionsWithHandle.size(); ++i) {
+    for (int i = d->connectionsWithHandle.size() - 1; i >= 0; --i) {
         const QMetaObject::Connection &connection = d->connectionsWithHandle.at(i);
         auto c_d = getConnectionDPtr(&connection);
         if (c_d->receiver == receiver) {
@@ -174,8 +174,6 @@ bool WWrapObject::safeDisconnect(const QObject *receiver)
                 ok = true;
 
             d->connectionsWithHandle.removeAt(i);
-            // reset index
-            --i;
         }
     }
 

--- a/waylib/src/server/kernel/wseat.cpp
+++ b/waylib/src/server/kernel/wseat.cpp
@@ -241,12 +241,12 @@ public:
     }
     inline void doTouchNotifyCancel(WInputDevice *device) {
         auto *state = device->getAttachedData<WSeatPrivate::DeviceState>();
-        for (int i = 0; i < state->m_points.size(); ++i) {
+        for (int i = state->m_points.size() - 1; i >= 0; --i) {
             const auto &qtPoint = state->m_points.at(i);
             if (qtPoint.state == static_cast<QEventPoint::State>(WEvent::PointCancelled)) {
                 auto point = handle()->touch_get_point(qtPoint.id);
                 Q_ASSERT(point);
-                state->m_points.removeAt(i--);
+                state->m_points.removeAt(i);
                 handle()->touch_notify_cancel(point->client);
             }
         }
@@ -286,10 +286,10 @@ public:
                                                      keyModifiers);
         }
 
-        for (int i = 0; i < state->m_points.size(); ++i) {
+        for (int i = state->m_points.size() - 1; i >= 0; --i) {
             QWindowSystemInterface::TouchPoint &tp(state->m_points[i]);
             if (tp.state == QEventPoint::Released)
-                state->m_points.removeAt(i--);
+                state->m_points.removeAt(i);
             else if (tp.state == QEventPoint::Pressed || tp.state == QEventPoint::Updated)
                 tp.state = QEventPoint::Stationary;  // notify: qtbase does not change Updated
             else if (tp.state != QEventPoint::Stationary)

--- a/waylib/src/server/qtquick/private/wbufferrenderer.cpp
+++ b/waylib/src/server/qtquick/private/wbufferrenderer.cpp
@@ -168,6 +168,7 @@ void WBufferRenderer::setSourceList(QList<QQuickItem*> sources, bool hideSource)
         connect(s, &QQuickItem::destroyed, this, [this] {
             const int index = indexOfSource(static_cast<QQuickItem*>(sender()));
             Q_ASSERT(index >= 0);
+            // destroySource accesses m_sourceList[index], so must be called before removeAt
             destroySource(index);
             m_sourceList.removeAt(index);
         });


### PR DESCRIPTION
## Summary

Iterator/erase/remove safety fixes (P0+P1) to prevent use-after-destroy and iterator invalidation issues.

## Changes

### `src/core/shellhandler.cpp` — for+removeAt+break → indexOf+takeAt (8 places)
Replaced forward-iteration patterns that called `removeAt(i)` followed by `break` with a safer `indexOf` + `takeAt` approach. The original pattern was fragile: if the `break` were ever removed or the loop continued, the iterator would be invalidated.

### `waylib/src/server/kernel/wseat.cpp` — removeAt(i--) → reverse iteration (2 places)
In `doTouchNotifyCancel` and `doTouchFrame`, replaced forward `removeAt(i--)` with reverse traversal (`for (int i = size - 1; i >= 0; --i)`). Reverse iteration is inherently safe with `removeAt` because removing an element only shifts indices below the current position.

### `waylib/src/server/kernel/wglobal.cpp` — removeAt(i--)+--i → reverse iteration
In `WWrapObject::safeDisconnect`, replaced forward loop with `removeAt(i)` + manual `--i` reset with a clean reverse iteration loop. Same safety rationale as above.

### `waylib/src/server/qtquick/private/wbufferrenderer.cpp` — add ordering constraint comment
Added a comment clarifying that `destroySource(index)` must be called before `m_sourceList.removeAt(index)` because `destroySource` accesses `m_sourceList[index]`.

### `src/input/gestures.cpp` — remove redundant deleteLater in destroyed callback (2 places)
Removed `gesture->deleteLater()` calls from `unregisterSwipeGesture` and `unregisterHoldGesture`. These callbacks are connected to `QObject::destroyed`, which fires during object destruction — calling `deleteLater()` on a being-destroyed object is redundant and potentially harmful.

## Testing

- Touch input (multi-touch cancel and frame) for correctness after removing touch points
- Prelaunch splash creation, close, and timeout flows
- Xdg toplevel and xwayland surface creation with appId resolution
- Gesture unregister during active gesture recognition
- safeDisconnect with multiple connections to same receiver