### PR TITLE
fix: fix destroyed callback issues in GestureRecognizer

### DIFF
--- a/src/input/gestures.cpp
+++ b/src/input/gestures.cpp
@@ -179,22 +179,16 @@ GestureRecognizer::GestureRecognizer(QObject *parent)
 void GestureRecognizer::registerSwipeGesture(SwipeGesture *gesture)
 {
     Q_ASSERT(!m_swipeGestures.contains(gesture));
-    auto connection = connect(gesture,
-                              &QObject::destroyed,
-                              this,
-                              std::bind(&GestureRecognizer::unregisterSwipeGesture, this, gesture));
-    m_destroyConnections.insert(gesture, connection);
+    connect(gesture, &QObject::destroyed, this, [this, gesture] {
+        m_swipeGestures.removeOne(gesture);
+        m_activeSwipeGestures.removeOne(gesture);
+    });
     m_swipeGestures << gesture;
 }
 
 void GestureRecognizer::unregisterSwipeGesture(SwipeGesture *gesture)
 {
-    auto it = m_destroyConnections.find(gesture);
-    if (it != m_destroyConnections.end()) {
-        disconnect(it.value());
-        m_destroyConnections.erase(it);
-    }
-    m_swipeGestures.removeAll(gesture);
+    m_swipeGestures.removeOne(gesture);
     if (m_activeSwipeGestures.removeOne(gesture)) {
         Q_EMIT gesture->cancelled();
     }
@@ -371,7 +365,6 @@ HoldGesture::~HoldGesture()
 {
     if (m_holdTimer != nullptr) {
         m_holdTimer->stop();
-        m_holdTimer->deleteLater();
     }
 }
 
@@ -398,22 +391,17 @@ bool HoldGesture::isActive() const
 void GestureRecognizer::registerHoldGesture(HoldGesture *gesture)
 {
     Q_ASSERT(!m_holdGestures.contains(gesture));
-    auto connection = connect(gesture,
-                              &QObject::destroyed,
-                              this,
-                              std::bind(&GestureRecognizer::unregisterHoldGesture, this, gesture));
-    m_destroyConnections.insert(gesture, connection);
+    connect(gesture, &QObject::destroyed, this, [this, gesture] {
+        m_holdGestures.removeOne(gesture);
+        m_activeHoldGestures.removeOne(gesture);
+    });
     m_holdGestures << gesture;
 }
 
 void GestureRecognizer::unregisterHoldGesture(HoldGesture *gesture)
 {
-    auto it = m_destroyConnections.find(gesture);
-    if (it != m_destroyConnections.end()) {
-        disconnect(it.value());
-        m_destroyConnections.erase(it);
-    }
-    if (m_holdGestures.removeOne(gesture)) {
+    m_holdGestures.removeOne(gesture);
+    if (m_activeHoldGestures.removeOne(gesture)) {
         Q_EMIT gesture->cancelled();
     }
     gesture->deleteLater();

--- a/src/input/gestures.h
+++ b/src/input/gestures.h
@@ -1,5 +1,5 @@
 
-// Copyright (C) 2024-2025 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #pragma once
@@ -158,7 +158,6 @@ private:
     QList<SwipeGesture *> m_activeSwipeGestures;
     QList<HoldGesture *> m_holdGestures;
     QList<HoldGesture *> m_activeHoldGestures;
-    QMap<Gesture *, QMetaObject::Connection> m_destroyConnections;
 
     QPointF m_currentDelta = QPointF(0, 0);
     uint m_currentFingerCount = 0;


### PR DESCRIPTION
## Summary

Fix multiple issues related to the `destroyed` signal callback in `GestureRecognizer`:

1. **Replace destroyed callback with direct list cleanup lambda** — Avoid calling `unregister` on a being-destroyed object which would emit `cancelled` signal and call `deleteLater` on it
2. **Remove `m_destroyConnections`** — Qt auto-disconnects `destroyed` signal connections, so manual management is unnecessary
3. **Fix `unregisterHoldGesture` to clean `m_activeHoldGestures`** — Now matches swipe behavior: emit `cancelled` only when gesture was active
4. **Remove `deleteLater` in `HoldGesture` destructor** — Child objects are auto-destroyed by Qt parent mechanism

## Test Plan

- Test gesture unregister during active gesture recognition
- Test HoldGesture lifecycle and timer behavior
- Test SwipeGesture unregister with active gestures

## Summary by Sourcery

Resolve lifecycle issues in gesture recognition by simplifying destroyed-signal handling and aligning swipe/hold gesture cleanup and cancellation behavior.

Bug Fixes:
- Prevent unwanted cancellation and deleteLater calls when gestures are destroyed by directly cleaning internal gesture lists.
- Ensure hold gestures only emit cancelled when they were active, matching swipe gesture behavior.

Enhancements:
- Remove obsolete destroyed-connection tracking in GestureRecognizer in favor of relying on Qt's automatic signal disconnection.
- Stop manually deleting the hold timer in HoldGesture destructor and rely on Qt parent-child object cleanup.

Chores:
- Update gestures header copyright years to 2024-2026.