### PR TITLE
fix(core): defer output rearrangement to fix VT switch issues

### DIFF
--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -90,6 +90,13 @@ int Workspace::getRightWorkspaceId(int workspaceId)
     return modelAt(index + 1)->id();
 }
 
+void Workspace::addOutput([[maybe_unused]] Output *output)
+{
+    // Update even if surface already has ownsOutput - the new output may be                    
+    // its original one 
+    updateSurfacesOwnsOutput();
+}
+
 void Workspace::addSurface(SurfaceWrapper *surface, int workspaceId)
 {
     Q_ASSERT(surface && !surface->container() && surface->workspaceId() == -1);

--- a/src/workspace/workspace.h
+++ b/src/workspace/workspace.h
@@ -47,6 +47,7 @@ public:
     Q_INVOKABLE int getLeftWorkspaceId(int workspaceId);
     Q_INVOKABLE int getRightWorkspaceId(int workspaceId);
 
+    void addOutput(Output *output) override;
     void addSurface(SurfaceWrapper *surface, int workspaceId);
     void addSurface(SurfaceWrapper *surface) override;
     Q_INVOKABLE void moveModelTo(int workspaceId, int destinationIndex);


### PR DESCRIPTION
Add a single-shot timer in RootSurfaceContainer to batch surface output updates. This fixes the issue where windows could not be dragged after VT switch by ensuring proper output recovery sequence.

在RootSurfaceContainer中添加单次定时器合并表面输出更新，
修复VT切换后窗口无法拖动等问题。

Log: 修复VT切换后窗口无法拖动的bug
PMS: BUG-366537
Influence: 切换VT后窗口可正常拖动，多显示器恢复更平滑

## Summary by Sourcery

Defer surface-output rearrangement in the root surface container to batch output updates and improve output recovery after VT switches.

Bug Fixes:
- Fix window drag failures and related focus issues after VT switches by ensuring outputs and surface ownership are updated in the correct sequence.

Enhancements:
- Batch surface-output updates using a single-shot timer in the root surface container to make multi-display configuration changes and recovery smoother.