### PR TITLE
fix: fix wallpaper-only display after lid reopen

### DIFF
--- a/src/core/lockscreen.cpp
+++ b/src/core/lockscreen.cpp
@@ -9,6 +9,7 @@
 #include "utils/cmdline.h"
 #include "common/treelandlogging.h"
 #include "greeter/greeterproxy.h"
+#include <woutputrenderwindow.h>
 
 #ifdef EXT_SESSION_LOCK_V1
 #include <wsessionlock.h>
@@ -95,6 +96,26 @@ void LockScreen::addOutput(Output *output)
     const auto &[_, ok] = m_lockSurfaces.emplace(outputItem, nullptr);
     Q_ASSERT(ok);
 #endif
+
+    connect(output->output(), &WOutput::enabledChanged, this, [this, output]() {
+        if (!output->output()->isEnabled() || !isLocked()) {
+            return;
+        }
+#if EXT_SESSION_LOCK_V1
+        auto outputItem = output->outputItem();
+        if (outputItem) {
+            auto *lockSurface = m_lockSurfaces[outputItem].get();
+            if (lockSurface) {
+                lockSurface->configureSize(outputItem->size().toSize());
+            }
+        }
+#endif
+        auto it = m_components.find(output);
+        if (it != m_components.end() && it->second) {
+            it->second->setSize(output->outputItem()->size());
+        }
+        Helper::instance()->window()->update();
+    });
 
     if (!m_impl) {
         return;

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -936,9 +936,23 @@ void Helper::onSetOutputPowerMode(wlr_output_power_v1_set_mode_event *event)
         if (output->handle()->enabled) {
             return;
         }
+        if (!output->handle()->current_mode) {
+            auto mode = output->preferred_mode();
+            if (mode) {
+                newState.set_mode(mode);
+            }
+        }
+        auto outputObj = getOutput(WOutput::fromHandle(output));
+        if (outputObj) {
+            newState.set_scale(outputObj->preferredScaleFactor(output->handle()->width > 0
+                                                                ? QSize(output->handle()->width, output->handle()->height)
+                                                                : QSize()));
+        }
         newState.set_enabled(true);
         if (!output->commit_state(newState)) {
             qCCritical(lcTlCore, "commit failed on output %s", output->handle()->name);
+        } else {
+            output->schedule_frame();
         }
         break;
     }
@@ -2773,6 +2787,12 @@ void Helper::onPrepareForSleep(bool sleep)
     } else {
         qCInfo(lcTlCore) << "Re-enabled rendering after hibernate";
         enableRender();
+        for (auto o : std::as_const(m_outputList)) {
+            if (o && o->output() && o->output()->isEnabled()) {
+                o->output()->scheduleFrame();
+            }
+        }
+        m_renderWindow->update();
     }
 }
 


### PR DESCRIPTION
## Summary

Fix the issue where only wallpaper is displayed after reopening the laptop lid.

### Changes

1. **onSetOutputPowerMode MODE_ON**: Restore current mode and scale when re-enabling output, and call `schedule_frame()` after successful commit to trigger render pipeline recovery.
2. **onPrepareForSleep(false)**: Iterate all enabled outputs to call `scheduleFrame()` and trigger `m_renderWindow->update()` for full repaint after resume.
3. **LockScreen::addOutput**: Connect `WOutput::enabledChanged` signal to reconfigure ext_session_lock_v1 lock surface size and update DDM lockscreen component size when output re-enables.

### Root Cause

When the laptop lid is closed and reopened, the render pipeline is not fully restored:
- `onSetOutputPowerMode` only sets `enabled=true` without restoring mode/scale or triggering frame scheduling
- `onPrepareForSleep(false)` only calls `enableRender()` without scheduling frames or triggering repaint
- LockScreen doesn't listen for output re-enable events, causing lock surface state inconsistency

Fixes: #WM-37

## Summary by Sourcery

Ensure display and lockscreen state are fully restored after outputs are re-enabled from power events such as lid reopen or resume from sleep.

Bug Fixes:
- Restore output mode and scale and schedule frame commits when turning an output back on via power management events to avoid wallpaper-only display after lid reopen.
- Trigger frame scheduling and a full render window repaint when resuming from sleep so all enabled outputs repaint correctly.
- Update lockscreen surfaces and component sizes when an output is re-enabled to keep the lockscreen layout consistent across outputs.