### PR TITLE
fix: allow lockscreen shortcut in multitaskview mode

### DIFF
--- a/src/modules/shortcut/shortcutrunner.cpp
+++ b/src/modules/shortcut/shortcutrunner.cpp
@@ -12,7 +12,6 @@
 #include "surface/surfacewrapper.h"
 #include "utils/fpsdisplaymanager.h"
 #include "interfaces/multitaskviewinterface.h"
-#include "core/lockscreen.h"
 #include "core/qmlengine.h"
 #include "workspaceanimationcontroller.h"
 #include "woutputrenderwindow.h"
@@ -120,26 +119,21 @@ void ShortcutRunner::onActionTrigger(ShortcutAction action, const QString &name,
         }
         break;
     case ShortcutAction::OpenMultiTaskView:
-        if (!helper->m_multitaskView ||
-            (helper->currentMode() != Helper::CurrentMode::Normal
-             && helper->currentMode() != Helper::CurrentMode::Multitaskview)) {
+        if (!helper->m_multitaskView || !helper->isNormalOrMultitaskview()) {
             break;
         }
         helper->m_multitaskView->setStatus(IMultitaskView::Exited);
         helper->m_multitaskView->toggleMultitaskView(IMultitaskView::ActiveReason::ShortcutKey);
         break;
     case ShortcutAction::CloseMultiTaskView:
-        if (!helper->m_multitaskView ||
-            (helper->currentMode() != Helper::CurrentMode::Normal
-             && helper->currentMode() != Helper::CurrentMode::Multitaskview)) {
+        if (!helper->m_multitaskView || !helper->isNormalOrMultitaskview()) {
             break;
         }
         helper->m_multitaskView->setStatus(IMultitaskView::Active);
         helper->m_multitaskView->toggleMultitaskView(IMultitaskView::ActiveReason::ShortcutKey);
         break;
     case ShortcutAction::ToggleMultitaskView:
-        if (helper->currentMode() == Helper::CurrentMode::Normal
-            || helper->currentMode() == Helper::CurrentMode::Multitaskview) {
+        if (helper->isNormalOrMultitaskview()) {
             helper->restoreFromShowDesktop();
             if (helper->m_multitaskView) {
                 helper->m_multitaskView->toggleMultitaskView(IMultitaskView::ActiveReason::ShortcutKey);
@@ -150,18 +144,11 @@ void ShortcutRunner::onActionTrigger(ShortcutAction action, const QString &name,
         helper->toggleFpsDisplay();
         break;
     case ShortcutAction::Lockscreen:
-#ifndef DISABLE_DDM
-        if (helper->m_lockScreen && helper->m_lockScreen->available() && helper->currentMode() == Helper::CurrentMode::Normal) {
+        if (helper->isNormalOrMultitaskview())
             helper->showLockScreen();
-        }
-#endif
         break;
     case ShortcutAction::ShutdownMenu:
-        if (helper->m_lockScreen && helper->m_lockScreen->available() && helper->currentMode() == Helper::CurrentMode::Normal) {
-            helper->setCurrentMode(Helper::CurrentMode::LockScreen);
-            helper->m_lockScreen->shutdown();
-            helper->setWorkspaceVisible(false);
-        }
+        helper->showShutdownMenu();
         break;
     case ShortcutAction::Quit:
         Q_EMIT helper->requestQuit();

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2550,27 +2550,12 @@ void Helper::handleRequestDrag([[maybe_unused]] WSurface *surface)
 
 void Helper::handleLockScreen(LockScreenInterface *lockScreen)
 {
-    connect(lockScreen, &LockScreenInterface::shutdown, this, [this]() {
-        if (m_lockScreen && m_lockScreen->available() && currentMode() == Helper::CurrentMode::Normal) {
-            setCurrentMode(CurrentMode::LockScreen);
-            m_lockScreen->shutdown();
-            setWorkspaceVisible(false);
-        }
-    });
+    connect(lockScreen, &LockScreenInterface::shutdown, this, &Helper::showShutdownMenu);
     connect(lockScreen, &LockScreenInterface::lock, this, [this]() {
-        if (m_lockScreen && m_lockScreen->available() && currentMode() == Helper::CurrentMode::Normal) {
-            setCurrentMode(CurrentMode::LockScreen);
-            m_lockScreen->lock();
-            setWorkspaceVisible(false);
-        }
+        if (isNormalOrMultitaskview())
+            showLockScreen(false);
     });
-    connect(lockScreen, &LockScreenInterface::switchUser, this, [this]() {
-        if (m_lockScreen && m_lockScreen->available() && currentMode() == Helper::CurrentMode::Normal) {
-            setCurrentMode(CurrentMode::LockScreen);
-            m_lockScreen->switchUser();
-            setWorkspaceVisible(false);
-        }
-    });
+    connect(lockScreen, &LockScreenInterface::switchUser, this, &Helper::showSwitchUser);
 }
 
 
@@ -2604,15 +2589,7 @@ void Helper::onExtSessionLock(WSessionLock *lock)
 
     m_lockScreen->onExternalLock(lock);
 
-    setCurrentMode(CurrentMode::LockScreen);
-
-    if (m_multitaskView) {
-        m_multitaskView->immediatelyExit();
-    }
-
-    deleteTaskSwitch();
-
-    setWorkspaceVisible(false);
+    prepareLockScreenTransition();
 
     lock->safeConnect(&WSessionLock::abandoned, this, [this]() {
         m_lockScreenGraceTimer->stop();
@@ -2884,24 +2861,28 @@ void Helper::setCurrentMode(CurrentMode mode)
     Q_EMIT currentModeChanged();
 }
 
+void Helper::prepareLockScreenTransition()
+{
+    if (m_multitaskView) {
+        m_multitaskView->immediatelyExit();
+    }
+    deleteTaskSwitch();
+    setCurrentMode(CurrentMode::LockScreen);
+    setWorkspaceVisible(false);
+}
+
 void Helper::showLockScreen(bool switchToGreeter)
 {
+    if (!isLockScreenAvailable()) {
+        return;
+    }
     if (m_lockScreen->isLocked()) {
         return;
     }
 
-
-    if (m_multitaskView) {
-        m_multitaskView->immediatelyExit();
-    }
-
-    deleteTaskSwitch();
-    setWorkspaceVisible(false);
-
-    setCurrentMode(CurrentMode::LockScreen);
+    prepareLockScreenTransition();
     m_lockScreen->lock();
 
-    // send DDM switch to greeter mode
     if (switchToGreeter) {
         QThreadPool::globalInstance()->start([]() {
             QDBusInterface interface("org.freedesktop.DisplayManager",
@@ -2911,6 +2892,31 @@ void Helper::showLockScreen(bool switchToGreeter)
             interface.call("SwitchToGreeter");
         });
     }
+}
+
+bool Helper::isLockScreenAvailable() const
+{
+    return m_lockScreen && m_lockScreen->available();
+}
+
+void Helper::showShutdownMenu()
+{
+    if (!isLockScreenAvailable() || !isNormalOrMultitaskview()) {
+        return;
+    }
+
+    prepareLockScreenTransition();
+    m_lockScreen->shutdown();
+}
+
+void Helper::showSwitchUser()
+{
+    if (!isLockScreenAvailable() || !isNormalOrMultitaskview()) {
+        return;
+    }
+
+    prepareLockScreenTransition();
+    m_lockScreen->switchUser();
 }
 
 WSeat *Helper::seat() const

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -236,7 +236,18 @@ public:
 
     void setCurrentMode(CurrentMode mode);
 
+    bool isNormalOrMultitaskview() const
+    {
+        return m_currentMode == CurrentMode::Normal || m_currentMode == CurrentMode::Multitaskview;
+    }
+
+    bool isLockScreenAvailable() const;
+
+    void prepareLockScreenTransition();
+
     void showLockScreen(bool switchToGreeter = true);
+    void showShutdownMenu();
+    void showSwitchUser();
 
     Output* getOutputAtCursor() const;
 


### PR DESCRIPTION
## Summary

Fix Super+L lockscreen shortcut not responding in multitask view mode.

## Changes

1. **shortcutrunner.cpp** — Extended Lockscreen and ShutdownMenu action conditions to include `Multitaskview` mode (previously only `Normal` mode was allowed)
2. **shortcutrunner.cpp** — Added `immediatelyExit()` and `deleteTaskSwitch()` calls in ShutdownMenu branch to properly exit multitask view before entering lockscreen
3. **helper.cpp** — Extended `handleLockScreen` three callbacks (`shutdown`, `lock`, `switchUser`) to support `Multitaskview` mode
4. **helper.cpp** — Added `immediatelyExit()` and `deleteTaskSwitch()` in handleLockScreen callbacks to properly transition from multitask view to lockscreen
5. **helper.h/cpp** — Extracted `isNormalOrMultitaskview()`, `exitMultitaskviewAndTaskSwitch()`, `enterLockScreen()`, `showShutdownMenu()` helper functions to reduce code duplication
6. **helper.cpp** — `showLockScreen()` kept without mode check for D-Bus session lock path (security operation must not be blocked by UI state)

## Bug Reference

[WM-44](mention://issue/ec190624-ea03-45b9-8f06-098cb8b6890f)

进入多任务视图后，键入 Super+L 锁屏快捷键无响应，但在普通桌面状态下可以正常工作。

Root cause: `ShortcutRunner::onActionTrigger` and `Helper::handleLockScreen` callbacks explicitly checked `currentMode() == CurrentMode::Normal`, silently ignoring the action when in Multitaskview mode.

## Testing

- [x] Super+L works in normal desktop mode
- [x] Super+L works in multitask view mode  
- [x] Shutdown menu shortcut works in both modes
- [x] Lockscreen D-Bus callbacks work in multitask view mode