### PR TITLE
fix: switch user login password input unresponsive

### DIFF
--- a/src/greeter/greeterproxy.cpp
+++ b/src/greeter/greeterproxy.cpp
@@ -137,6 +137,7 @@ void GreeterProxy::setShowShutdownView(bool show) {
 void GreeterProxy::setLock(bool isLocked)
 {
     if (isLocked && !m_isLocked) {
+        // m_isLocked must be set before m_lockScreen->lock() to prevent re-entry
         m_isLocked = true;
         if (m_lockScreen && !m_lockScreen->isVisible())
             m_lockScreen->lock();
@@ -242,6 +243,7 @@ void GreeterProxy::lock()
     }
     qCInfo(lcTlGreeter) << "Locking user" << session->username() << "with session id" << session->id();
     SocketWriter(m_socket) << quint32(GreeterMessages::Lock) << session->id();
+    setLock(true);
 }
 
 //////////////////////////////
@@ -347,8 +349,8 @@ void GreeterProxy::onSessionLock()
             qCWarning(lcTlGreeter)
                 << "Lock signal received for non-exist session id:" << id << ", ignore.";
         else if (activeSession->id() != id)
-            qCWarning(lcTlGreeter)
-                << "Lock signal received for non-active session id:" << id << ", ignore.";
+            qCDebug(lcTlGreeter)
+                << "Lock signal received for session id:" << id << ", already locked via lock() call.";
         else
             QMetaObject::invokeMethod(this, [this] {
                 setLock(true);

--- a/src/plugins/lockscreen/qml/UserInput.qml
+++ b/src/plugins/lockscreen/qml/UserInput.qml
@@ -323,6 +323,7 @@ Item {
         passwordField.text = ''
         avatar.fallbackSource = currentUser.icon
         hintText.text = normalHint
+        Qt.callLater(function() { passwordField.forceActiveFocus() })
     }
 
     function startOtherUserMode() {


### PR DESCRIPTION
## Summary

Fix the issue where switching users results in an unresponsive password input field on the login screen.

### Root Cause
`GreeterProxy::lock()` did not immediately set `isLocked` when the active session is a real user (non-"dde"), causing keyboard focus to not transfer to the lock screen QML.

### Changes
1. Add `setLock(true)` in `lock()` for real user branch to immediately set `isLocked` state
2. Downgrade `onSessionLock()` log from `qCWarning` to `qCDebug` for non-active session ID branch, since this is expected when `lock()` already set `isLocked`
3. Add ordering dependency comment in `setLock()` to prevent re-entry (`m_isLocked` must be set before `m_lockScreen->lock()`)
4. Use `Qt.callLater` in `updateUser()` to delay `forceActiveFocus` until event loop iteration ends, ensuring UserList Popup close has taken effect

### Testing
- Test user switching from power management interface
- Verify password input field gets focus after user selection
- Test lock/unlock cycle with real user sessions