### PR TITLE
fix: enhance appId matching for prelaunch splash

### DIFF
--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -53,6 +53,15 @@
 QW_USE_NAMESPACE
 WAYLIB_SERVER_USE_NAMESPACE
 
+namespace {
+bool appIdCaseInsensitiveMatch(const QString &splashAppId, const QString &appId)
+{
+    if (splashAppId.isEmpty() || appId.isEmpty())
+        return false;
+    return splashAppId.compare(appId, Qt::CaseInsensitive) == 0;
+}
+} // anonymous namespace
+
 #define TREELAND_XDG_SHELL_VERSION 5
 
 ShellHandler::ShellHandler(RootSurfaceContainer *rootContainer, WServer *server)
@@ -432,6 +441,72 @@ void ShellHandler::onXdgToplevelSurfaceAdded(WXdgToplevelSurface *surface)
     ensureXdgWrapper(surface, QString());
 }
 
+
+SurfaceWrapper *ShellHandler::matchPrelaunchWrapper(const QString &surfaceAppId,
+                                                     const QString &effectiveAppId)
+{
+    if (!m_prelaunchWrappers.isEmpty() && !effectiveAppId.isEmpty()) {
+        m_pendingPrelaunchAppIds.remove(effectiveAppId);
+    }
+
+    // Level 1: Exact match
+    for (int i = 0; i < m_prelaunchWrappers.size(); ++i) {
+        auto *candidate = m_prelaunchWrappers[i];
+        if (candidate->appId() == effectiveAppId) {
+            qCDebug(lcTlShell) << "match prelaunch exact" << effectiveAppId;
+            m_prelaunchWrappers.removeAt(i);
+            return candidate;
+        }
+    }
+
+    // Level 2: Case-insensitive match
+    for (int i = 0; i < m_prelaunchWrappers.size(); ++i) {
+        auto *candidate = m_prelaunchWrappers[i];
+        if (appIdCaseInsensitiveMatch(candidate->appId(), effectiveAppId)) {
+            qCDebug(lcTlShell) << "match prelaunch case-insensitive"
+                               << candidate->appId() << effectiveAppId;
+            m_prelaunchWrappers.removeAt(i);
+            return candidate;
+        }
+    }
+
+    // Level 3: Fallback using surface's own appId
+    if (!surfaceAppId.isEmpty()) {
+        // Exact match with surface appId
+        for (int i = 0; i < m_prelaunchWrappers.size(); ++i) {
+            auto *candidate = m_prelaunchWrappers[i];
+            if (candidate->appId() == surfaceAppId) {
+                qCDebug(lcTlShell) << "match prelaunch fallback exact" << surfaceAppId;
+                m_prelaunchWrappers.removeAt(i);
+                return candidate;
+            }
+        }
+        // Case-insensitive match with surface appId
+        for (int i = 0; i < m_prelaunchWrappers.size(); ++i) {
+            auto *candidate = m_prelaunchWrappers[i];
+            if (appIdCaseInsensitiveMatch(candidate->appId(), surfaceAppId)) {
+                qCDebug(lcTlShell) << "match prelaunch fallback case-insensitive"
+                                   << candidate->appId() << surfaceAppId;
+                m_prelaunchWrappers.removeAt(i);
+                return candidate;
+            }
+        }
+    }
+
+    // Diagnostic log on match failure
+    if (!m_prelaunchWrappers.isEmpty()) {
+        QStringList splashAppIds;
+        for (const auto *w : m_prelaunchWrappers)
+            splashAppIds << w->appId();
+        qCDebug(lcTlShell) << "appId matching failed"
+                           << "targetAppId=" << effectiveAppId
+                           << "surfaceAppId=" << surfaceAppId
+                           << "splashAppIds=" << splashAppIds.join(",");
+    }
+
+    return nullptr;
+}
+
 void ShellHandler::ensureXdgWrapper(WXdgToplevelSurface *surface, const QString &targetAppId)
 {
     // Check if this matches a closed splash screen
@@ -445,20 +520,12 @@ void ShellHandler::ensureXdgWrapper(WXdgToplevelSurface *surface, const QString 
 
     SurfaceWrapper *wrapper = nullptr;
     bool isNewWrapper = true;
+    QString surfaceAppId = surface->appId();
 
-    if (!targetAppId.isEmpty()) {
-        m_pendingPrelaunchAppIds.remove(targetAppId);
-        for (int i = 0; i < m_prelaunchWrappers.size(); ++i) {
-            auto *candidate = m_prelaunchWrappers[i];
-            if (candidate->appId() == targetAppId) {
-                qCDebug(lcTlShell) << "match prelaunch xdg" << targetAppId;
-                m_prelaunchWrappers.removeAt(i);
-                candidate->convertToNormalSurface(surface, SurfaceWrapper::Type::XdgToplevel);
-                wrapper = candidate;
-                isNewWrapper = false; // matched from prelaunch, not newly created
-                break;
-            }
-        }
+    wrapper = matchPrelaunchWrapper(surfaceAppId, targetAppId);
+    if (wrapper) {
+        wrapper->convertToNormalSurface(surface, SurfaceWrapper::Type::XdgToplevel);
+        isNewWrapper = false;
     }
 
     if (!wrapper) {
@@ -716,20 +783,12 @@ void ShellHandler::ensureXwaylandWrapper(WXWaylandSurface *surface, const QStrin
 
     SurfaceWrapper *wrapper = nullptr;
     bool isNewWrapper = true;
+    QString surfaceAppId = surface->appId();
 
-    if (!targetAppId.isEmpty()) {
-        m_pendingPrelaunchAppIds.remove(targetAppId);
-        for (int i = 0; i < m_prelaunchWrappers.size(); ++i) {
-            auto *candidate = m_prelaunchWrappers[i];
-            if (candidate->appId() == targetAppId) {
-                qCDebug(lcTlShell) << "match prelaunch xwayland" << targetAppId;
-                m_prelaunchWrappers.removeAt(i);
-                candidate->convertToNormalSurface(surface, SurfaceWrapper::Type::XWayland);
-                wrapper = candidate;
-                isNewWrapper = false; // matched from prelaunch, not newly created
-                break;
-            }
-        }
+    wrapper = matchPrelaunchWrapper(surfaceAppId, targetAppId);
+    if (wrapper) {
+        wrapper->convertToNormalSurface(surface, SurfaceWrapper::Type::XWayland);
+        isNewWrapper = false;
     }
 
     if (!wrapper) {

--- a/src/core/shellhandler.h
+++ b/src/core/shellhandler.h
@@ -159,6 +159,10 @@ private:
     // Creates or matches a wrapper from prelaunch splash, then initializes it
     void ensureXwaylandWrapper(WAYLIB_SERVER_NAMESPACE::WXWaylandSurface *surface,
                                const QString &appId);
+    // Try to match a prelaunch splash wrapper for the given appId with
+    // progressive fallback: exact -> case-insensitive -> surface own appId.
+    SurfaceWrapper *matchPrelaunchWrapper(const QString &surfaceAppId,
+                                          const QString &effectiveAppId);
     // Unified parent/container update for Xdg & XWayland toplevel wrappers.
     void updateWrapperContainer(SurfaceWrapper *wrapper,
                                 WAYLIB_SERVER_NAMESPACE::WSurface *parentSurface);


### PR DESCRIPTION
## 修改说明

修复开启闪屏后鼠标点击激活 WPS/浏览器窗口未显示在最顶层的问题。

### 根因
闪屏请求中的 appId 与 AppIdResolver 解析出的 appId 不一致（如 `com.wps.Office` vs `wps-office`），导致真实窗口无法匹配到预创建的闪屏 wrapper，从而出现两个 SurfaceWrapper（闪屏 + 真实窗口），闪屏 wrapper 干扰窗口激活和 Z 序。

### 修改内容

1. **新增 `appIdCaseInsensitiveMatch` 辅助函数**：忽略大小写的 appId 完整比较
2. **提取 `matchPrelaunchWrapper` 私有成员函数**：统一 `ensureXdgWrapper` 和 `ensureXwaylandWrapper` 的匹配逻辑，三级匹配：
   - Level 1: 精确匹配
   - Level 2: 忽略大小写匹配
   - Level 3: Fallback 使用 surface 自身 appId 匹配
3. **增加诊断日志**：当 appId 匹配失败且存在未匹配的闪屏 wrapper 时输出诊断信息

### 测试建议

1. 开启闪屏测试 WPS/浏览器窗口激活是否正常显示在最顶层
2. 测试文管和终端窗口激活是否不受影响
3. 验证 appId 忽略大小写匹配场景
4. 检查匹配失败时的诊断日志输出