### PR TITLE
fix: window corner radius setting not taking effect

### DIFF
--- a/src/modules/personalization/personalizationmanagerinterfacev1.cpp
+++ b/src/modules/personalization/personalizationmanagerinterfacev1.cpp
@@ -209,7 +209,7 @@ public:
     wlr_surface *surface = nullptr;
 
     int32_t backgroundType = 0;
-    int32_t cornerRadius = 0;
+    int32_t cornerRadius = -1;
     Shadow shadow;
     Border border;
     PersonalizationWindowContextV1::WindowStates states;

--- a/src/modules/personalization/personalizationmanagerinterfacev1.h
+++ b/src/modules/personalization/personalizationmanagerinterfacev1.h
@@ -222,6 +222,14 @@ public:
         return m_cornerRadius;
     }
 
+    void resetCornerRadius()
+    {
+        if (m_cornerRadius == -1)
+            return;
+        m_cornerRadius = -1;
+        Q_EMIT cornerRadiusChanged();
+    }
+
     Shadow shadow() const
     {
         return m_shadow;
@@ -245,7 +253,7 @@ private:
     WWrapPointer<WToplevelSurface> m_target;
     PersonalizationManagerInterfaceV1 *m_manager = nullptr;
     int32_t m_backgroundType = Personalization::BackgroundType::Normal;
-    int32_t m_cornerRadius = 0;
+    int32_t m_cornerRadius = -1;
     Shadow m_shadow {};
     Border m_border {};
     PersonalizationWindowContextV1::WindowStates m_states {};

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -456,14 +456,17 @@ void SurfaceWrapper::setup()
                 });
         updateX11shouldSkipDock();
     }
-    // Connect DConfig windowRadius change so QML bindings re-evaluate radius()
+    // When DConfig windowRadius changes, reset per-window override so
+    // radius() falls back to the new DConfig value.
     if (m_type == Type::XdgToplevel || m_type == Type::XWayland) {
         if (auto *helper = Helper::instance()) {
             if (auto *config = helper->config()) {
-                connect(config,
-                        &TreelandUserConfig::windowRadiusChanged,
-                        this,
-                        &SurfaceWrapper::radiusChanged);
+                connect(config, &TreelandUserConfig::windowRadiusChanged, this, [this] {
+                    if (m_radius >= 0) {
+                        m_radius = -1.0;
+                        Q_EMIT radiusChanged();
+                    }
+                });
             }
         }
     }
@@ -1621,9 +1624,11 @@ qreal SurfaceWrapper::radius() const
         return 8;
 
     qreal radius = m_radius;
-    // m_radius > 1 means radius was explicitly set via Personalization protocol;
-    // m_radius <= 1 means no per-window override, fall back to DConfig.
-    if (radius < 1 && m_type != Type::Layer) {
+    // m_radius >= 0 means radius was explicitly set via Personalization protocol;
+    // m_radius < 0 means no per-window override, fall back to DConfig.
+    if (radius < 0) {
+        if (m_type == Type::Layer)
+            return 0;
         radius = Helper::instance()->config()->windowRadius();
     }
 

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -453,7 +453,7 @@ private:
                                          &SurfaceWrapper::surfaceStateChanged)
     int m_workspaceId = -1;
     int m_explicitAlwaysOnTop = 0;
-    qreal m_radius = 0.0;
+    qreal m_radius = -1.0;
     QRect m_iconGeometry;
     ActiveControlStates m_hasActiveCapability = ActiveControlState::UnMinimized;
 


### PR DESCRIPTION
Use -1 as sentinel value to distinguish "never set" from "explicitly set" for per-window cornerRadius, and reset per-window overrides when DConfig windowRadius changes.

## Changes

1. Use -1 as sentinel value for per-window cornerRadius in SurfaceWrapper and PersonalizationWindowContextV1
2. Reset per-window m_radius override to -1 when DConfig windowRadius changes
3. Fix Layer type windows returning -1.0 instead of 0 when no per-window override is set
4. Add resetCornerRadius() method with early-return guard

## Testing

- Test window corner radius change via control center
- Verify existing windows update radius in real-time
- Test Layer windows do not show rounded corners

PMS: BUG-2500U1-271537