### PR TITLE
fix(session): force-destroy sandbox surfaces on session removal

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1282,8 +1282,20 @@ bool Helper::surfaceBelongsToCurrentSession(SurfaceWrapper *wrapper)
         return true;
     }
     WClient *client = wrapper->surface()->waylandClient();
-    WSocket *socket = client ? client->socket()->rootSocket() : nullptr;
-    return socket && socket->isEnabled();
+    if (!client)
+        return false;
+
+    auto session = m_sessionManager->sessionForClient(client);
+    // If session lookup fails, conservatively treat as not belonging to current
+    // session rather than falling back to rootSocket check (which would
+    // incorrectly classify sandbox apps as belonging to the current session).
+    if (!session)
+        return false;
+    // Global session surfaces (Dock, launcher) are always visible
+    if (session == m_sessionManager->globalSession())
+        return true;
+    // User session surfaces are visible only when their session is active
+    return m_sessionManager->activeSession().lock() == session;
 }
 
 void Helper::deleteTaskSwitch()

--- a/src/session/session.cpp
+++ b/src/session/session.cpp
@@ -199,6 +199,22 @@ void SessionManager::removeSession(std::shared_ptr<Session> session)
         Helper::instance()->activateSurface(nullptr);
     }
 
+    // Force-destroy all surfaces belonging to this session so that sandbox
+    // apps (which bypass the closeSurface request) are cleaned up on logout.
+    // Collect first to avoid mutating the surface list during iteration.
+    auto *container = Helper::instance()->rootSurfaceContainer();
+    QList<SurfaceWrapper *> toDestroy;
+    for (auto *wrapper : std::as_const(container->surfaces())) {
+        WClient *client = wrapper->surface()->waylandClient();
+        if (!client)
+            continue;
+        auto wrapperSession = sessionForClient(client);
+        if (wrapperSession == session)
+            toDestroy.append(wrapper);
+    }
+    for (auto *wrapper : std::as_const(toDestroy))
+        container->destroyForSurface(wrapper);
+
     for (auto s : std::as_const(m_sessions)) {
         if (s.get() == session.get()) {
             m_sessions.removeOne(s);
@@ -432,6 +448,51 @@ std::shared_ptr<Session> SessionManager::sessionForSocket(WSocket *socket) const
     for (const auto &session : std::as_const(m_sessions)) {
         if (session && session->m_socket == socket)
             return session;
+    }
+    return nullptr;
+}
+
+/**
+ * Find the session for the given WClient
+ *
+ * For sandbox clients (socket has parentSocket), uid matching is used first
+ * because their socket chain traverses the global socket rather than a user
+ * session socket. Falls back to walking the socket parent chain for normal
+ * and system UI clients.
+ *
+ * @param client WClient to find session for
+ * @returns Session for the given client, or nullptr if not found
+ */
+std::shared_ptr<Session> SessionManager::sessionForClient(WClient *client) const
+{
+    if (!client)
+        return nullptr;
+
+    auto global = globalSession();
+    WSocket *socket = client->socket();
+
+    // Sandbox clients connect via a child socket whose parent chain goes
+    // through the global socket, so socket-based lookup would always find
+    // the global session. Use uid matching instead to find the real user session.
+    // The uid comes from Wayland client credentials (wl_client_get_credentials),
+    // which reflects the OS-level uid of the process that opened the Wayland
+    // connection — for sandbox apps this is the user who launched them, even
+    // though their socket chain only reaches the global socket.
+    if (socket && socket->parentSocket()) {
+        auto creds = client->credentials();
+        if (creds) {
+            for (const auto &session : std::as_const(m_sessions)) {
+                if (session && session != global && session->uid() == creds->uid)
+                    return session;
+            }
+        }
+    }
+
+    // Walk socket parent chain for normal and system UI clients
+    while (socket) {
+        if (auto session = sessionForSocket(socket))
+            return session;
+        socket = socket->parentSocket();
     }
     return nullptr;
 }

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -69,6 +69,7 @@ public:
     std::shared_ptr<Session> sessionForUser(const QString &username) const;
     std::shared_ptr<Session> sessionForXWayland(WXWayland *xwayland) const;
     std::shared_ptr<Session> sessionForSocket(WSocket *socket) const;
+    std::shared_ptr<Session> sessionForClient(WClient *client) const;
     bool isDDEUserClient(WClient *client);
     void syncActiveSessionCursorSettings();
 


### PR DESCRIPTION
## Summary

Force-destroy sandbox surfaces on session removal to fix the issue where sandbox app windows (e.g., linglong app store) remain visible after logout.

## Changes

1. Add `sessionForClient()` that uses uid matching for sandbox clients and socket chain walking for normal clients
2. Force-destroy all surfaces belonging to removed session in `removeSession()` to clean up sandbox apps that ignore close
3. Fix `surfaceBelongsToCurrentSession()` to use `sessionForClient()` instead of rootSocket-based check which fails for sandbox apps

Fixes: #347759
