### PR TITLE
fix: fix Layer Shell popup positioning race condition

### DIFF
--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -30,6 +30,7 @@
 #include <qwoutputlayout.h>
 
 #include <QQmlEngine>
+#include <QPointer>
 
 #include <algorithm>
 #include <optional>
@@ -454,6 +455,28 @@ void Output::addSurface(SurfaceWrapper *surface)
                 // Reposition should ignore positionAutomatic
                 arrangePopupSurface(surface);
             });
+
+            auto parentLayerSurface = surface->parentSurface();
+            if (parentLayerSurface
+                && parentLayerSurface->type() == SurfaceWrapper::Type::Layer) {
+                QPointer<SurfaceWrapper> surfacePtr(surface);
+                auto conn1 = connect(parentLayerSurface, &SurfaceWrapper::normalGeometryChanged,
+                        this, [surfacePtr, this] {
+                    if (!surfacePtr) return;
+                    QMetaObject::invokeMethod(this, [surfacePtr, this] {
+                        if (!surfacePtr) return;
+                        arrangePopupSurface(surfacePtr);
+                    }, Qt::QueuedConnection);
+                });
+                auto conn2 = connect(parentLayerSurface, &SurfaceWrapper::hasInitializeContainerChanged,
+                        this, [surfacePtr, this] {
+                    if (!surfacePtr) return;
+                    if (!surfacePtr->parentSurface()
+                        || !surfacePtr->parentSurface()->hasInitializeContainer()) return;
+                    arrangePopupSurface(surfacePtr);
+                });
+                m_parentLayerConnections[surface] = {conn1, conn2};
+            }
         } else if (surface->type() == SurfaceWrapper::Type::InputPopup) {
             auto inputPopupSurfaceItem = qobject_cast<WInputPopupSurfaceItem *>(surface->surfaceItem());
             connect(inputPopupSurfaceItem, &WInputPopupSurfaceItem::referenceRectChanged, this, [surface, this] {
@@ -469,6 +492,16 @@ void Output::removeSurface(SurfaceWrapper *surface)
     clearPopupCache(surface);
     m_initialWindowPositionRatio.remove(surface);
     Q_ASSERT(hasSurface(surface));
+
+    if (surface->type() == SurfaceWrapper::Type::XdgPopup) {
+        auto it = m_parentLayerConnections.find(surface);
+        if (it != m_parentLayerConnections.end()) {
+            for (auto &conn : it.value())
+                QObject::disconnect(conn);
+            m_parentLayerConnections.erase(it);
+        }
+    }
+
     SurfaceListModel::removeSurface(surface);
     surface->disconnect(this);
 
@@ -846,7 +879,21 @@ void Output::handleLayerShellPopup(SurfaceWrapper *surface, const QRectF &normal
         return;
     }
 
-    auto parentOutput = surface->parentSurface()->ownsOutput()->outputItem();
+    auto parentSurface = surface->parentSurface();
+    if (!parentSurface->hasInitializeContainer()) {
+        qCInfo(lcTlOutput) << " LayerShell parent not initialized, deferring popup positioning"
+                           << "surface=" << surface << "parent=" << parentSurface;
+        return;
+    }
+
+    QRectF parentGeo = parentSurface->normalGeometry();
+    if (parentGeo.isEmpty()) {
+        qCInfo(lcTlOutput) << " LayerShell parent geometry is empty, deferring popup positioning"
+                           << "surface=" << surface << "parentGeo=" << parentGeo;
+        return;
+    }
+
+    auto parentOutput = parentSurface->ownsOutput()->outputItem();
     auto dPos = popupDPos(surface);
     if (!dPos.has_value())
         return;
@@ -917,10 +964,18 @@ void Output::arrangePopupSurface(SurfaceWrapper *surface)
 {
     SurfaceWrapper *parentSurfaceWrapper = surface->parentSurface();
     if (!parentSurfaceWrapper) {
-        //  When an input popup is still alive while its parent text-input client is being torn down, 
-        //  arrangePopupSurface() can run in a transient state where parentSurface is temporarily unavailable.
+        // When an input popup is still alive while its parent text-input client is being torn down,
+        // arrangePopupSurface() can run in a transient state where parentSurface is temporarily unavailable.
         qCWarning(lcTlSurface) << "[popup] skip arrangePopupSurface: missing parent surface"
                                 << "surface=" << surface;
+        return;
+    }
+
+    if (parentSurfaceWrapper->type() == SurfaceWrapper::Type::Layer
+        && !parentSurfaceWrapper->hasInitializeContainer()) {
+        qCInfo(lcTlSurface) << "[popup] skip arrangePopupSurface: LayerShell parent not initialized"
+                            << "surface=" << surface
+                            << "parentSurface=" << parentSurfaceWrapper;
         return;
     }
 

--- a/src/output/output.h
+++ b/src/output/output.h
@@ -158,6 +158,7 @@ private:
 
     QMap<SurfaceWrapper*, QPair<QPointF, QRectF>> m_positionCache;
     QHash<SurfaceWrapper*, QPointF> m_initialWindowPositionRatio;
+    QHash<SurfaceWrapper*, QVector<QMetaObject::Connection>> m_parentLayerConnections;
 
     std::unique_ptr<Backlight> m_backlight = nullptr;
     OutputConfig *m_config;


### PR DESCRIPTION
## 问题描述

UOS ID 登录窗口概率性显示异常，不可点击。根本原因是 Layer Shell 弹窗定位时存在时序竞态：当弹窗创建时，其父 Layer Surface 的几何信息可能尚未完成初始化，导致弹窗定位到错误位置。

## 修改内容

1. `handleLayerShellPopup()` — 增加父窗口几何有效性检查（hasInitializeContainer 和 parentGeo.isEmpty()），未通过则跳过定位等待重新触发
2. `arrangePopupSurface()` — 对 Layer 类型父窗口增加 hasInitializeContainer() 检查
3. `addSurface()` — 连接父 Layer Surface 的 normalGeometryChanged 和 hasInitializeContainerChanged 信号触发弹窗重新定位，使用 QPointer 保证安全，使用 QMetaObject::Connection + m_parentLayerConnections 哈希表管理连接生命周期
4. `removeSurface()` — popup 移除时精确断开父表面到 Output 的信号连接
5. 添加 #include <QPointer> 显式声明，恢复 input popup teardown 边界注释

## 修改文件

- `src/output/output.cpp`
- `src/output/output.h`

## 测试建议

1. 测试 UOS ID 登录窗口每次打开均正常显示
2. 测试父表面调整大小后 Layer Shell 弹窗定位正确
3. 测试父表面销毁时弹窗正确清理
4. 测试其他 Layer Shell 弹窗（菜单、工具提示）正常工作