### PR TITLE
fix: replace hardcoded wallpaper timers with event-driven ready signal

### DIFF
--- a/src/modules/wallpaper/wallpapershellinterfacev1.cpp
+++ b/src/modules/wallpaper/wallpapershellinterfacev1.cpp
@@ -122,12 +122,14 @@ public:
     wl_resource *resource = nullptr;
     WallpaperSurface *surface = nullptr;
     QString wallpaperSource;
+    bool m_readySent = false;
 
 protected:
     void destroy_resource(Resource *resource) override;
     void destroy(Resource *resource) override;
     void source_failed(Resource *resource,
                                                      uint32_t error) override;
+    void ready(Resource *resource) override;
 };
 
 TreelandWallpaperSurfaceInterfaceV1Private::TreelandWallpaperSurfaceInterfaceV1Private(TreelandWallpaperSurfaceInterfaceV1 *_q,
@@ -157,6 +159,14 @@ void TreelandWallpaperSurfaceInterfaceV1Private::source_failed([[maybe_unused]] 
                                                                uint32_t error)
 {
     Q_EMIT q->failed(error);
+}
+
+void TreelandWallpaperSurfaceInterfaceV1Private::ready([[maybe_unused]] Resource *resource)
+{
+    if (!m_readySent) {
+        m_readySent = true;
+        Q_EMIT q->ready();
+    }
 }
 
 TreelandWallpaperSurfaceInterfaceV1::~TreelandWallpaperSurfaceInterfaceV1() = default;

--- a/src/modules/wallpaper/wallpapershellinterfacev1.h
+++ b/src/modules/wallpaper/wallpapershellinterfacev1.h
@@ -58,6 +58,7 @@ public:
 Q_SIGNALS:
     void failed(uint32_t error);
     void beforeDestroy(TreelandWallpaperSurfaceInterfaceV1 *surface);
+    void ready();
 
 private:
     explicit TreelandWallpaperSurfaceInterfaceV1(wl_resource *surface,

--- a/src/wallpaper/wallpaperitem.cpp
+++ b/src/wallpaper/wallpaperitem.cpp
@@ -196,7 +196,7 @@ void WallpaperItem::updateSurface()
                 setSurface(interface->wSurface());
                 interface->wSurface()->enterOutput(output());
                 update();
-                QTimer::singleShot(2000, this, [this]{ Q_EMIT sourceChanged(); });
+                Q_EMIT sourceChanged();
                 break;
             }
         }
@@ -211,16 +211,50 @@ void WallpaperItem::scheduleUpdate()
     }
 
     if (wallpaperRole() != Lockscreen) {
-        QTimer::singleShot(3000,
-                           this,
-                           [this]{
-                               updateSurface();
-                               if (!Helper::instance()->m_greeterProxy->isLocked()) {
-                                   setPlay(false);
-                               }
-                           });
+        clearPendingUpdate();
+
+        TreelandWallpaperShellInterfaceV1 *shell = Helper::instance()->shellHandler()->wallpaperShell();
+        if (shell) {
+            const QList<QString> &produced = shell->producedWallpapers();
+            if (!produced.isEmpty()) {
+                TreelandWallpaperSurfaceInterfaceV1 *interface = TreelandWallpaperSurfaceInterfaceV1::get(produced.last());
+                if (interface) {
+                    m_readyConnection = QObject::connect(interface,
+                                                         &TreelandWallpaperSurfaceInterfaceV1::ready,
+                                                         this,
+                                                         &WallpaperItem::applyPendingUpdate);
+                }
+            }
+        }
+
+        m_fallbackTimer = new QTimer(this);
+        m_fallbackTimer->setSingleShot(true);
+        QObject::connect(m_fallbackTimer, &QTimer::timeout, this, &WallpaperItem::applyPendingUpdate);
+        m_fallbackTimer->start(500);
     } else {
         updateSurface();
+    }
+}
+
+void WallpaperItem::clearPendingUpdate()
+{
+    if (m_readyConnection) {
+        QObject::disconnect(m_readyConnection);
+        m_readyConnection = {};
+    }
+    if (m_fallbackTimer) {
+        m_fallbackTimer->stop();
+        m_fallbackTimer->deleteLater();
+        m_fallbackTimer = nullptr;
+    }
+}
+
+void WallpaperItem::applyPendingUpdate()
+{
+    clearPendingUpdate();
+    updateSurface();
+    if (!Helper::instance()->m_greeterProxy->isLocked()) {
+        setPlay(false);
     }
 }
 

--- a/src/wallpaper/wallpaperitem.h
+++ b/src/wallpaper/wallpaperitem.h
@@ -10,6 +10,7 @@
 Q_MOC_INCLUDE("workspace/workspace.h")
 
 class TreelandWallpaperSurfaceInterfaceV1;
+class QTimer;
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 class WOutput;
@@ -91,8 +92,10 @@ private Q_SLOTS:
     void updateSurface();
     void scheduleUpdate();
     void handleWorkspaceAdded();
+    void applyPendingUpdate();
 
 private:
+    void clearPendingUpdate();
     int m_userId = -1;
     QPointer<WorkspaceModel> m_workspace = nullptr;
     QPointer<WOutput> m_output = nullptr;
@@ -103,4 +106,6 @@ private:
     bool m_play = true;
     bool m_disableUpdate = false;
     bool m_forceUpdateSource = false;
+    QMetaObject::Connection m_readyConnection;
+    QTimer *m_fallbackTimer = nullptr;
 };

--- a/wallpaper-factory/qwaylandwallpapersurface.cpp
+++ b/wallpaper-factory/qwaylandwallpapersurface.cpp
@@ -14,8 +14,19 @@ QWaylandWallpaperSurface::QWaylandWallpaperSurface(QWaylandWallpaperShellIntegra
     , m_shell(shell)
     , m_interface(WallpaperWindow::get(window->window()))
     , m_window(window)
+    , m_readySent(false)
 {
     init(shell->get_treeland_wallpaper_surface(window->waylandSurface()->object(), m_interface->source()));
+
+    QQuickWindow *quickWindow = qobject_cast<QQuickWindow *>(window->window());
+    if (quickWindow) {
+        connect(quickWindow, &QQuickWindow::afterRendering, this, [this]() {
+            if (!m_readySent) {
+                m_readySent = true;
+                ready();
+            }
+        }, Qt::QueuedConnection);
+    }
 }
 
 QWaylandWallpaperSurface::~QWaylandWallpaperSurface()

--- a/wallpaper-factory/qwaylandwallpapersurface_p.h
+++ b/wallpaper-factory/qwaylandwallpapersurface_p.h
@@ -6,6 +6,7 @@
 #include "wallpaperwindow.h"
 #include "qwayland-treeland-wallpaper-shell-unstable-v1.h"
 
+#include <QQuickWindow>
 #include <QtWaylandClient/private/qwaylandshellsurface_p.h>
 
 class QWaylandWallpaperShellIntegration;
@@ -35,4 +36,5 @@ private:
     QString m_activationToken;
 
     bool m_configured = true;
+    bool m_readySent = false;
 };


### PR DESCRIPTION
## 修复壁纸切换3秒延迟

### 问题
个性化切换壁纸时，存在约3秒延迟，无法立即切换。

### 根因
`WallpaperItem::scheduleUpdate()` 中使用 `QTimer::singleShot(3000, ...)` 硬编码了3秒延迟，compositor不知道wallpaper客户端何时完成渲染，因此用固定3秒等待作为同步机制。

### 修改方案
用协议 v2 已定义的 `ready` 机制替代硬编码定时器，实现事件驱动的壁纸切换：
- 监听 `TreelandWallpaperSurfaceInterfaceV1::ready()` 信号后立即更新
- 保留 500ms fallback 超时
- 客户端在 `afterRendering` 后发送 `ready` 请求

### 涉及文件
- `src/wallpaper/wallpaperitem.cpp` / `.h` — 替换定时器为事件驱动逻辑
- `src/modules/wallpaper/wallpapershellinterfacev1.cpp` / `.h` — 添加 ready 信号
- `wallpaper-factory/qwaylandwallpapersurface.cpp` / `_p.h` — 客户端发送 ready 请求