### PR TITLE
fix: create XWayland wrappers before initial xprop reads caused by #948

### DIFF
--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -2216,6 +2216,16 @@ void SurfaceWrapper::setHasInitializeContainer(bool value)
         // m_prelaunchSplash can't get mapped signal
         createNewOrClose(OPEN_ANIMATION);
     }
+
+    // If the surface was already mapped before the wrapper could connect to
+    // mappedChanged (e.g. wrapper created after the surface's initial map),
+    // onMappedChanged was never triggered. Make up for it here so that
+    // MappedOrSplash gets set and hasActiveCapability() can turn true,
+    // otherwise the window would be drawn but never activated/focused.
+    if (!m_prelaunchSplash && value && surface() && surface()->mapped()
+        && !m_hasActiveCapability.testFlag(ActiveControlState::MappedOrSplash)) {
+        onMappedChanged();
+    }
 }
 
 void SurfaceWrapper::disableWindowAnimation(bool disable)


### PR DESCRIPTION
该PR用于修复 #948 引起的:
1. Xwayland运行的QQ主窗口打开是无动画
2. Xwayland运行的QQ有概率无法响应鼠标点击事件
3. Xwayland运行的QQ查看图片时查看图片的窗口无法显示
4. Xwayland运行的全屏3A大作 (例如JDM:漂移大师) 不仅无法响应键盘点击, 连鼠标光标都无法显示的问题

Create and match XWayland SurfaceWrapper instances as soon as the surface is associated, then read optional initial X11 properties afterwards. This keeps mapped state, activation, animations, focus and input setup from depending on a best-effort async xprop read.

Make WXWayland async property reads independent per request and complete from XCB replies without waiting for PropertyNotify. Keep cancellation scoped by X window so pending reads are discarded when the surface dissociates.

Also handle the late-wrapper case by applying the current mapped state when a mapped surface receives its container after the original mapped signal was missed.