### PR TITLE
fix(wallpaper): guard against invalid output resources

### DIFF
--- a/src/modules/wallpaper/wallpapermanagerinterfacev1.cpp
+++ b/src/modules/wallpaper/wallpapermanagerinterfacev1.cpp
@@ -19,7 +19,22 @@
 #include <qwoutput.h>
 #include <qwseat.h>
 
+#include <QPointer>
+
 static QList<TreelandWallpaperInterfaceV1 *> s_wallpapers;
+
+static WOutput *outputFromResource(wl_resource *resource)
+{
+    if (!resource)
+        return nullptr;
+
+    auto *nativeOutput = wlr_output_from_resource(resource);
+    if (!nativeOutput)
+        return nullptr;
+
+    auto *output = qw_output::from(nativeOutput);
+    return output ? WOutput::fromHandle(output) : nullptr;
+}
 
 static const char *usernameFromUid(uid_t uid)
 {
@@ -72,8 +87,11 @@ void TreelandWallpaperManagerInterfaceV1Private::get_treeland_wallpaper(Resource
                                                                         struct ::wl_resource *output,
                                                                         struct ::wl_resource *surface)
 {
-    if (!output) {
-        wl_resource_post_error(resource->handle, 0, "output resource is NULL!");
+    auto *wOutput = outputFromResource(output);
+    if (!wOutput) {
+        wl_resource_post_error(resource->handle,
+                               WL_DISPLAY_ERROR_INVALID_OBJECT,
+                               "Invalid output resource");
         return;
     }
 
@@ -87,7 +105,7 @@ void TreelandWallpaperManagerInterfaceV1Private::get_treeland_wallpaper(Resource
     }
 
     QSharedPointer<WClient::Credentials>  credentials = WClient::getCredentials(wallpaperResource->client);
-    auto wallpaper = new TreelandWallpaperInterfaceV1(output, QString(usernameFromUid(credentials->uid)), wallpaperResource, surface);
+    auto wallpaper = new TreelandWallpaperInterfaceV1(wOutput, QString(usernameFromUid(credentials->uid)), wallpaperResource, surface);
     s_wallpapers.append(wallpaper);
 
     QObject::connect(wallpaper, &QObject::destroyed, [wallpaper]() {
@@ -129,13 +147,13 @@ class TreelandWallpaperInterfaceV1Private : public QtWaylandServer::treeland_wal
 {
 public:
     TreelandWallpaperInterfaceV1Private(TreelandWallpaperInterfaceV1 *_q,
-                                    wl_resource *output,
-                                    const QString &name,
-                                    wl_resource *_resource,
-                                    wl_resource *refsurface);
+                                         WOutput *output,
+                                         const QString &name,
+                                         wl_resource *_resource,
+                                         wl_resource *refsurface);
 
     TreelandWallpaperInterfaceV1 *q = nullptr;
-    wl_resource *outputResource = nullptr;
+    QPointer<WOutput> wOutput;
     QString userName;
     wl_resource *resource = nullptr;
     wl_resource *refSurfaceResource = nullptr;
@@ -148,13 +166,13 @@ protected:
 };
 
 TreelandWallpaperInterfaceV1Private::TreelandWallpaperInterfaceV1Private(TreelandWallpaperInterfaceV1 *_q,
-                                                                         wl_resource *output,
+                                                                         WOutput *output,
                                                                          const QString &name,
                                                                          wl_resource *_resource,
                                                                          wl_resource *refsurface)
     : QtWaylandServer::treeland_wallpaper_v1(_resource)
     , q(_q)
-    , outputResource(output)
+    , wOutput(output)
     , userName(name)
     , resource(_resource)
     , refSurfaceResource(refsurface)
@@ -193,7 +211,7 @@ void TreelandWallpaperInterfaceV1Private::set_video_source([[maybe_unused]] Reso
     Q_EMIT q->videoSourceChanged(workspace->currentIndex(), fileSource, roles);
 }
 
-TreelandWallpaperInterfaceV1::TreelandWallpaperInterfaceV1(wl_resource *output,
+TreelandWallpaperInterfaceV1::TreelandWallpaperInterfaceV1(WOutput *output,
                                                            const QString &userName,
                                                            wl_resource *resource,
                                                            wl_resource *refsurface,
@@ -221,7 +239,7 @@ QString TreelandWallpaperInterfaceV1::userName() const
 
 WOutput *TreelandWallpaperInterfaceV1::wOutput() const
 {
-    return WOutput::fromHandle(qw_output::from(wlr_output_from_resource(d->outputResource)));
+    return d->wOutput && !d->wOutput->isInvalidated() ? d->wOutput.get() : nullptr;
 }
 
 void TreelandWallpaperInterfaceV1::sendError(const QString &source, Error error)

--- a/src/modules/wallpaper/wallpapermanagerinterfacev1.h
+++ b/src/modules/wallpaper/wallpapermanagerinterfacev1.h
@@ -81,7 +81,7 @@ Q_SIGNALS:
                             WallpaperRoles roles);
 
 private:
-    explicit TreelandWallpaperInterfaceV1(struct wl_resource *output,
+    explicit TreelandWallpaperInterfaceV1(WOutput *output,
                                           const QString &userName,
                                           wl_resource *resource,
                                           wl_resource *refsurface,

--- a/src/wallpaper/wallpapermanager.cpp
+++ b/src/wallpaper/wallpapermanager.cpp
@@ -359,10 +359,14 @@ TreelandWallpaperInterfaceV1::WallpaperType WallpaperManager::getWallpaperType(c
 
 void WallpaperManager::onWallpaperAdded(TreelandWallpaperInterfaceV1 *interface)
 {
+    auto *output = interface->wOutput();
+    if (!output)
+        return;
+
     Workspace *workspace = Helper::instance()->workspace();
     Q_ASSERT(workspace);
     for (int i = 0; i < m_wallpaperConfig.size(); ++i) {
-        if (m_wallpaperConfig[i].outputName == getOutputId(interface->wOutput()->nativeHandle())) {
+        if (m_wallpaperConfig[i].outputName == getOutputId(output->nativeHandle())) {
             WallpaperOutputConfig outputConfig = m_wallpaperConfig[i];
             interface->sendChanged(TreelandWallpaperInterfaceV1::Lockscreen, outputConfig.lockScreenWallpapertype, outputConfig.lockscreenWallpaper);
             for (WallpaperWorkspaceConfig workspaceConfig : std::as_const(outputConfig.workspaces)) {
@@ -388,8 +392,12 @@ void WallpaperManager::onImageChanged(int workspaceIndex, const QString &fileSou
 {
     TreelandWallpaperInterfaceV1 *interface =
         static_cast<TreelandWallpaperInterfaceV1 *>(sender());
+    auto *output = interface->wOutput();
+    if (!output)
+        return;
+
     QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> globalWallpapers = globalValidWallpaper(nullptr, -1);
-    setOutputWallpaper(interface->wOutput()->nativeHandle(),
+    setOutputWallpaper(output->nativeHandle(),
                        workspaceIndex,
                        fileSource,
                        roles,
@@ -406,8 +414,12 @@ void WallpaperManager::onVideoChanged(int workspaceIndex, const QString &fileSou
 {
     TreelandWallpaperInterfaceV1 *interface =
         static_cast<TreelandWallpaperInterfaceV1 *>(sender());
+    auto *output = interface->wOutput();
+    if (!output)
+        return;
+
     QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> globalWallpapers = globalValidWallpaper(nullptr, -1);
-    setOutputWallpaper(interface->wOutput()->nativeHandle(),
+    setOutputWallpaper(output->nativeHandle(),
                        workspaceIndex,
                        fileSource,
                        roles,
@@ -440,4 +452,3 @@ void WallpaperManager::handleWallpaperSurfaceAdded([[maybe_unused]] TreelandWall
         }
     }
 }
-


### PR DESCRIPTION
Resolve and validate the wl_output when creating a wallpaper object, and store the corresponding WOutput with QPointer instead of retaining the Wayland resource. Guard wallpaper operations when the output has been invalidated to avoid dereferencing a removed output.

Log: prevent invalid output access in wallpaper manager
PMS: BUG-365765
Influence: Wallpaper handling when an output is removed

## Summary by Sourcery

Guard wallpaper handling against invalid or removed Wayland outputs to prevent dereferencing stale resources.

Bug Fixes:
- Validate wl_output resources when creating wallpaper interfaces and reject invalid outputs with a protocol error.
- Avoid accessing wallpaper outputs after they have been invalidated by tracking WOutput via QPointer and bailing out of wallpaper operations when no valid output is available.