### PR TITLE
fix(wallpaper): show wallpaper for newly created workspace

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -206,6 +206,10 @@ Helper::Helper(QObject *parent)
 #endif
 
     m_shellHandler = new ShellHandler(m_rootSurfaceContainer, m_server);
+    connect(m_shellHandler->workspace(),
+            &Workspace::workspaceAdded,
+            m_wallpaperManager,
+            &WallpaperManager::syncAddWorkspace);
     tryInitRemoteSource();
 
     m_outputConfigState = new OutputConfigState(this);

--- a/src/wallpaper/wallpapermanager.cpp
+++ b/src/wallpaper/wallpapermanager.cpp
@@ -271,17 +271,23 @@ void WallpaperManager::syncAddWorkspace()
         return;
     }
 
+    Workspace *workspace = Helper::instance()->workspace();
+    Q_ASSERT(workspace);
+
     bool update = false;
     for (WallpaperOutputConfig &outputConfig : m_wallpaperConfig) {
-        WallpaperWorkspaceConfig refConfig = outputConfig.workspaces[0];
-        Workspace *workspace = Helper::instance()->workspace();
-        Q_ASSERT(workspace);
+        if (outputConfig.workspaces.isEmpty()) {
+            continue;
+        }
+
+        const WallpaperWorkspaceConfig refConfig = outputConfig.workspaces.constFirst();
         for (int i = 0; i < workspace->count(); i++) {
-            if (i >= outputConfig.workspaces.count()) {
+            const int workspaceId = workspace->modelAt(i)->id();
+            if (!outputConfig.containsWorkspace(workspaceId)) {
                 WallpaperWorkspaceConfig workspaceConfig;
                 workspaceConfig.desktopWallpaper = refConfig.desktopWallpaper;
                 workspaceConfig.desktopWallpapertype = refConfig.desktopWallpapertype;
-                workspaceConfig.workspaceId = i;
+                workspaceConfig.workspaceId = workspaceId;
                 workspaceConfig.enable = true;
                 outputConfig.workspaces.append(workspaceConfig);
                 update = true;
@@ -291,6 +297,7 @@ void WallpaperManager::syncAddWorkspace()
 
     if (update) {
         Helper::instance()->m_config->setWallpaperConfig(wallpaperConfigToJsonString());
+        Q_EMIT updateWallpaper();
     }
 }
 


### PR DESCRIPTION
Synchronize wallpaper configuration when a workspace is created and notify wallpaper items after the configuration is updated.
Use the actual workspace ID instead of the workspace index to support non-contiguous IDs after workspace removal.

Log: fix newly created workspace has no wallpaper
PMS: BUG-363295
Influence: Workspace wallpaper display and updates

## Summary by Sourcery

Synchronize workspace wallpaper configuration when workspaces are added and ensure newly created workspaces display the correct wallpaper.

Bug Fixes:
- Ensure wallpaper configs are created for new workspaces using their actual IDs rather than positional indices.
- Trigger wallpaper updates after wallpaper configuration changes so newly added workspaces immediately show wallpapers.