### PR TITLE
fix: avoid stale multitaskview surface mapped callback

### DIFF
--- a/src/plugins/multitaskview/multitaskview.cpp
+++ b/src/plugins/multitaskview/multitaskview.cpp
@@ -3,17 +3,19 @@
 
 #include "multitaskview.h"
 
+#include "common/treelandlogging.h"
 #include "output/output.h"
 #include "seat/helper.h"
 #include "surface/surfacecontainer.h"
-#include "workspace/workspace.h"
 #include "treelanduserconfig.hpp"
-#include "common/treelandlogging.h"
+#include "workspace/workspace.h"
 
 #include <woutputitem.h>
 #include <woutputrenderwindow.h>
 
 #include <QtConcurrentMap>
+
+#include <ranges>
 
 WAYLIB_SERVER_USE_NAMESPACE
 
@@ -494,16 +496,35 @@ void MultitaskviewSurfaceModel::handleSurfaceStateChanged()
 void MultitaskviewSurfaceModel::handleSurfaceMappedChanged()
 {
     auto surface = qobject_cast<WSurface *>(sender());
-    auto it = std::find_if(workspace()->surfaces().begin(),
-                           workspace()->surfaces().end(),
-                           [surface](SurfaceWrapper *wrapper) {
-                               return wrapper->surface() == surface;
-                           });
-    Q_ASSERT_X(it != workspace()->surfaces().end(),
-               __func__,
-               "Monitoring mapped of a removed surface wrapper.");
-    if (surfaceReady(*it)) {
-        addReadySurface(*it);
+    if (!surface)
+        return;
+
+    auto findWrapper = [surface](const QList<SurfaceWrapper *> &surfaces) -> SurfaceWrapper * {
+        auto it = std::ranges::find(surfaces, surface, [](SurfaceWrapper *wrapper) {
+            return wrapper->surface();
+        });
+        return it != surfaces.end() ? *it : nullptr;
+    };
+
+    SurfaceWrapper *wrapper = findWrapper(workspace()->surfaces());
+    if (!wrapper) {
+        wrapper =
+            findWrapper(Helper::instance()->workspace()->showOnAllWorkspaceModel()->surfaces());
+    }
+    Q_ASSERT_X(wrapper, __func__, "Monitoring mapped of a removed surface wrapper.");
+    if (!wrapper)
+        return;
+
+    if (!surface->mapped()) {
+        removeReadySurface(wrapper);
+        if (wrapper->ownsOutput() == output()) {
+            monitorUnreadySurface(wrapper);
+        }
+        return;
+    }
+
+    if (surfaceReady(wrapper)) {
+        addReadySurface(wrapper);
     }
 }
 
@@ -532,6 +553,8 @@ void MultitaskviewSurfaceModel::handleSurfaceAdded(SurfaceWrapper *surface)
 
 void MultitaskviewSurfaceModel::handleSurfaceRemoved(SurfaceWrapper *surface)
 {
+    disconnectSurface(surface);
+
     auto toBeRemovedIt =
         std::find_if(m_data.begin(), m_data.end(), [surface](ModelDataPtr modelData) {
             return modelData->wrapper == surface;
@@ -541,14 +564,6 @@ void MultitaskviewSurfaceModel::handleSurfaceRemoved(SurfaceWrapper *surface)
     int toRemove = std::distance(m_data.begin(), toBeRemovedIt);
     beginRemoveRows({}, toRemove, toRemove);
     m_data.remove(toRemove);
-    disconnect(surface,
-               &SurfaceWrapper::ownsOutputChanged,
-               this,
-               &MultitaskviewSurfaceModel::handleWrapperOutputChanged);
-    disconnect(surface,
-               &SurfaceWrapper::surfaceStateChanged,
-               this,
-               &MultitaskviewSurfaceModel::handleSurfaceStateChanged);
     endRemoveRows();
     doCalculateLayout(m_data);
     auto [beginIndex, endIndex] = commitAndGetUpdateRange(m_data);
@@ -640,6 +655,33 @@ void MultitaskviewSurfaceModel::monitorUnreadySurface(SurfaceWrapper *surface)
             this,
             &MultitaskviewSurfaceModel::handleSurfaceMappedChanged,
             Qt::UniqueConnection);
+}
+
+void MultitaskviewSurfaceModel::disconnectSurface(SurfaceWrapper *surface)
+{
+    disconnect(surface,
+               &SurfaceWrapper::ownsOutputChanged,
+               this,
+               &MultitaskviewSurfaceModel::handleWrapperOutputChanged);
+    disconnect(surface,
+               &SurfaceWrapper::surfaceStateChanged,
+               this,
+               &MultitaskviewSurfaceModel::handleSurfaceStateChanged);
+    disconnect(surface,
+               &SurfaceWrapper::normalGeometryChanged,
+               this,
+               &MultitaskviewSurfaceModel::handleWrapperGeometryChanged);
+    disconnect(surface,
+               &SurfaceWrapper::geometryChanged,
+               this,
+               &MultitaskviewSurfaceModel::handleWrapperGeometryChanged);
+
+    if (auto wsurface = surface->surface()) {
+        disconnect(wsurface,
+                   &WSurface::mappedChanged,
+                   this,
+                   &MultitaskviewSurfaceModel::handleSurfaceMappedChanged);
+    }
 }
 
 bool MultitaskviewSurfaceModel::surfaceReady(SurfaceWrapper *surface)

--- a/src/plugins/multitaskview/multitaskview.cpp
+++ b/src/plugins/multitaskview/multitaskview.cpp
@@ -127,6 +127,13 @@ void MultitaskviewSurfaceModel::initializeModel()
                         .translated(-layoutArea().topLeft()),
                     false,
                     surface->isMinimized()));
+                if (auto wsurface = surface->surface()) {
+                    connect(wsurface,
+                            &WSurface::mappedChanged,
+                            this,
+                            &MultitaskviewSurfaceModel::handleSurfaceMappedChanged,
+                            Qt::UniqueConnection);
+                }
             } else {
                 monitorUnreadySurface(surface);
             }
@@ -496,8 +503,10 @@ void MultitaskviewSurfaceModel::handleSurfaceStateChanged()
 void MultitaskviewSurfaceModel::handleSurfaceMappedChanged()
 {
     auto surface = qobject_cast<WSurface *>(sender());
-    if (!surface)
+    if (!surface) {
+        qCWarning(lcTlPlugin) << "handleSurfaceMappedChanged: sender is not a WSurface";
         return;
+    }
 
     auto findWrapper = [surface](const QList<SurfaceWrapper *> &surfaces) -> SurfaceWrapper * {
         auto it = std::ranges::find(surfaces, surface, [](SurfaceWrapper *wrapper) {
@@ -512,19 +521,16 @@ void MultitaskviewSurfaceModel::handleSurfaceMappedChanged()
             findWrapper(Helper::instance()->workspace()->showOnAllWorkspaceModel()->surfaces());
     }
     Q_ASSERT_X(wrapper, __func__, "Monitoring mapped of a removed surface wrapper.");
-    if (!wrapper)
-        return;
 
-    if (!surface->mapped()) {
+    if (surface->mapped()) {
+        if (surfaceReady(wrapper)) {
+            addReadySurface(wrapper);
+        }
+    } else { // unmapped
         removeReadySurface(wrapper);
         if (wrapper->ownsOutput() == output()) {
             monitorUnreadySurface(wrapper);
         }
-        return;
-    }
-
-    if (surfaceReady(wrapper)) {
-        addReadySurface(wrapper);
     }
 }
 
@@ -555,32 +561,7 @@ void MultitaskviewSurfaceModel::handleSurfaceRemoved(SurfaceWrapper *surface)
 {
     disconnectSurface(surface);
 
-    auto toBeRemovedIt =
-        std::find_if(m_data.begin(), m_data.end(), [surface](ModelDataPtr modelData) {
-            return modelData->wrapper == surface;
-        });
-    if (toBeRemovedIt == m_data.end())
-        return;
-    int toRemove = std::distance(m_data.begin(), toBeRemovedIt);
-    beginRemoveRows({}, toRemove, toRemove);
-    m_data.remove(toRemove);
-    endRemoveRows();
-    doCalculateLayout(m_data);
-    auto [beginIndex, endIndex] = commitAndGetUpdateRange(m_data);
-    if (beginIndex <= endIndex) {
-        Q_ASSERT(beginIndex < m_data.size());
-        Q_EMIT dataChanged(index(beginIndex),
-                           index(endIndex),
-                           { GeometryRole,
-                             PaddingRole,
-                             UpIndexRole,
-                             DownIndexRole,
-                             LeftIndexRole,
-                             RightIndexRole });
-    }
-    Q_EMIT rowsChanged();
-    Q_EMIT countChanged();
-    Q_EMIT contentHeightChanged();
+    removeReadySurface(surface);
 }
 
 void MultitaskviewSurfaceModel::addReadySurface(SurfaceWrapper *surface)
@@ -588,6 +569,13 @@ void MultitaskviewSurfaceModel::addReadySurface(SurfaceWrapper *surface)
     Q_ASSERT_X(surfaceReady(surface),
                __func__,
                "Surface wrapper should be ready before adding to multitaskview model.");
+    auto existingIt =
+        std::find_if(m_data.begin(), m_data.end(), [surface](const ModelDataPtr &modelData) {
+            return modelData->wrapper == surface;
+        });
+    if (existingIt != m_data.end())
+        return;
+
     disconnect(surface,
                &SurfaceWrapper::normalGeometryChanged,
                this,
@@ -596,10 +584,13 @@ void MultitaskviewSurfaceModel::addReadySurface(SurfaceWrapper *surface)
                &SurfaceWrapper::geometryChanged,
                this,
                &MultitaskviewSurfaceModel::handleWrapperGeometryChanged);
-    disconnect(surface->surface(),
-               &WSurface::mappedChanged,
-               this,
-               &MultitaskviewSurfaceModel::handleSurfaceMappedChanged);
+    if (auto wsurface = surface->surface()) {
+        connect(wsurface,
+                &WSurface::mappedChanged,
+                this,
+                &MultitaskviewSurfaceModel::handleSurfaceMappedChanged,
+                Qt::UniqueConnection);
+    }
     auto toBeInserted =
         std::make_shared<SurfaceModelData>(surface,
                                            surfaceGeometry(surface)
@@ -635,6 +626,37 @@ void MultitaskviewSurfaceModel::addReadySurface(SurfaceWrapper *surface)
     Q_EMIT rowsChanged();
     Q_EMIT countChanged();
     Q_EMIT contentHeightChanged();
+}
+
+bool MultitaskviewSurfaceModel::removeReadySurface(SurfaceWrapper *surface)
+{
+    auto toBeRemovedIt =
+        std::find_if(m_data.begin(), m_data.end(), [surface](ModelDataPtr modelData) {
+            return modelData->wrapper == surface;
+        });
+    if (toBeRemovedIt == m_data.end())
+        return false;
+    int toRemove = std::distance(m_data.begin(), toBeRemovedIt);
+    beginRemoveRows({}, toRemove, toRemove);
+    m_data.remove(toRemove);
+    endRemoveRows();
+    doCalculateLayout(m_data);
+    auto [beginIndex, endIndex] = commitAndGetUpdateRange(m_data);
+    if (beginIndex <= endIndex) {
+        Q_ASSERT(beginIndex < m_data.size());
+        Q_EMIT dataChanged(index(beginIndex),
+                           index(endIndex),
+                           { GeometryRole,
+                             PaddingRole,
+                             UpIndexRole,
+                             DownIndexRole,
+                             LeftIndexRole,
+                             RightIndexRole });
+    }
+    Q_EMIT rowsChanged();
+    Q_EMIT countChanged();
+    Q_EMIT contentHeightChanged();
+    return true;
 }
 
 void MultitaskviewSurfaceModel::monitorUnreadySurface(SurfaceWrapper *surface)

--- a/src/plugins/multitaskview/multitaskview.h
+++ b/src/plugins/multitaskview/multitaskview.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 #pragma once
 
@@ -186,6 +186,7 @@ private:
     void handleSurfaceAdded(SurfaceWrapper *surface);
     void handleSurfaceRemoved(SurfaceWrapper *surface);
     void addReadySurface(SurfaceWrapper *surface);
+    bool removeReadySurface(SurfaceWrapper *surface);
     void monitorUnreadySurface(SurfaceWrapper *surface);
     void disconnectSurface(SurfaceWrapper *surface);
     bool surfaceReady(SurfaceWrapper *surface);

--- a/src/plugins/multitaskview/multitaskview.h
+++ b/src/plugins/multitaskview/multitaskview.h
@@ -187,6 +187,7 @@ private:
     void handleSurfaceRemoved(SurfaceWrapper *surface);
     void addReadySurface(SurfaceWrapper *surface);
     void monitorUnreadySurface(SurfaceWrapper *surface);
+    void disconnectSurface(SurfaceWrapper *surface);
     bool surfaceReady(SurfaceWrapper *surface);
     QRectF surfaceGeometry(SurfaceWrapper *surface);
     bool laterActiveThan(SurfaceWrapper *a, SurfaceWrapper *b);


### PR DESCRIPTION
## Summary by Sourcery

Prevent stale multitask view surface callbacks when surfaces are removed or shared across workspaces.

Bug Fixes:
- Guard mapped-change handling against null or no-longer-tracked surfaces to avoid acting on stale surfaces.
- Ensure all signal connections for a surface and its underlying WSurface are consistently disconnected when the surface is removed.