### PR TITLE
fix(waylib): prevent stale subsurface access

### DIFF
--- a/waylib/src/server/qtquick/wsurfaceitem.cpp
+++ b/waylib/src/server/qtquick/wsurfaceitem.cpp
@@ -1014,18 +1014,19 @@ void WSurfaceItem::releaseResources()
         // queued auto-destroy handler below will skip deleteLater().
         const auto subsurfaces = d->subsurfaces;
         for (auto item : subsurfaces) {
+            d->subsurfaces.removeOne(item);
             item->releaseResources();
             auto surface = item->surface();
             if (surface) {
                 bool ok = QObject::disconnect(surface, &WSurface::destroyed, this, nullptr);
                 Q_ASSERT(ok);
             }
-            d->subsurfaces.removeOne(item);
         }
     } else {
-        for (auto item : std::as_const(d->subsurfaces))
+        QList<WSurfaceItem*> tmp;
+        tmp.swap(d->subsurfaces);
+        for (auto item : std::as_const(tmp))
             item->deleteLater();
-        d->subsurfaces.clear();
     }
 
     if (auto content = d->getItemContent())
@@ -1197,9 +1198,10 @@ void WSurfaceItemPrivate::initForSurface()
 
     // clean subsurfaces, if cacheLastBuffer is enabled will cache
     // the previous WSurface's subsurfaces.
-    for (auto item : std::as_const(subsurfaces))
+    QList<WSurfaceItem*> tmp;
+    tmp.swap(subsurfaces);
+    for (auto item : std::as_const(tmp))
         item->deleteLater();
-    subsurfaces.clear();
 
     if (!surfaceState)
         surfaceState.reset(new SurfaceState());


### PR DESCRIPTION
Keep the subsurface registry synchronized across all destruction paths, and remove subsurface items before releasing their resources. This prevents calculateBoundingRect() from dereferencing destroyed items during a surface commit.

Log: prevent stale subsurface access in WSurfaceItem
Influence: Surface geometry updates during subsurface destruction

## Summary by Sourcery

Keep WSurfaceItem subsurface tracking consistent during resource release and surface reinitialization to avoid accessing destroyed subsurfaces.

Bug Fixes:
- Remove subsurface items from the registry before releasing their resources to prevent stale pointer access during surface commits.
- Avoid iterating over a mutating subsurface list by swapping it into a temporary container before deferred deletion.