### PR TITLE
fix: disconnect signals before removing surface

### DIFF
--- a/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
+++ b/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
@@ -309,7 +309,17 @@ void ForeignToplevelManagerInterfaceV1::removeSurface(SurfaceWrapper *wrapper)
     }
 
     auto *entry = it->second.get();
+    auto *surface = wrapper->shellSurface();
     for (auto *handle : std::as_const(entry->handles)) {
+        if (surface) {
+            QObject::disconnect(surface, nullptr, handle, nullptr);
+            if (auto *wsurface = surface->surface()) {
+                QObject::disconnect(wsurface, nullptr, handle, nullptr);
+            }
+        }
+        QObject::disconnect(wrapper, nullptr, handle, nullptr);
+        QObject::disconnect(handle, nullptr, wrapper, nullptr);
+
         handle->send_closed();
         handle->clearEntry();
     }


### PR DESCRIPTION
1. Disconnect all signals from surface, wsurface, and wrapper to handle before sending closed event
2. Prevents crash when xwayland set_class triggers appid changed signal after dissociate is called

Influence:
1. Test xwayland window closing to ensure no crash occurs

- 在发送 closed 事件前断开从 surface、wsurface 和 wrapper 到 handle 的 所有信号
- 防止 xwayland set_class 在调用 dissociate 后触发 appid changed 信号导 致崩溃