### PR TITLE
fix(personalization): clean up stale Personalization on surface teardown

### DIFF
--- a/src/modules/personalization/personalizationmanagerinterfacev1.cpp
+++ b/src/modules/personalization/personalizationmanagerinterfacev1.cpp
@@ -1023,7 +1023,7 @@ Personalization::Personalization(WToplevelSurface *target,
     , m_manager(manager)
 {
     connect(target, &WToplevelSurface::aboutToBeInvalidated, this, [this] {
-        disconnect(m_connection);
+        disconnect(m_manager, &PersonalizationManagerInterfaceV1::windowContextCreated, this, nullptr);
     });
 
     auto update = [this](PersonalizationWindowContextV1 *context) {
@@ -1032,8 +1032,6 @@ Personalization::Personalization(WToplevelSurface *target,
         if (WSurface::fromHandle(context->surface()) != m_target->surface()) {
             return;
         }
-
-        disconnect(m_connection);
 
         connect(context,
                 &PersonalizationWindowContextV1::backgroundTypeChanged,
@@ -1067,6 +1065,7 @@ Personalization::Personalization(WToplevelSurface *target,
                     m_states = context->states();
                     Q_EMIT windowStateChanged();
                 });
+        connect(context, &QObject::destroyed, this, &Personalization::resetProperties);
 
         m_backgroundType = context->backgroundType();
         m_cornerRadius = context->cornerRadius();
@@ -1075,11 +1074,26 @@ Personalization::Personalization(WToplevelSurface *target,
         m_states = context->states();
     };
 
-    m_connection = connect(m_manager, &PersonalizationManagerInterfaceV1::windowContextCreated, this, update);
+    connect(m_manager, &PersonalizationManagerInterfaceV1::windowContextCreated, this, update);
 
     if (auto *context = PersonalizationWindowContextV1::getWindowContext(m_target->surface())) {
         update(context);
     }
+}
+
+void Personalization::resetProperties()
+{
+    m_backgroundType = Personalization::BackgroundType::Normal;
+    m_cornerRadius = 0;
+    m_shadow = {};
+    m_border = {};
+    m_states = {};
+
+    Q_EMIT backgroundTypeChanged();
+    Q_EMIT cornerRadiusChanged();
+    Q_EMIT shadowChanged();
+    Q_EMIT borderChanged();
+    Q_EMIT windowStateChanged();
 }
 
 SurfaceWrapper *Personalization::surfaceWrapper() const

--- a/src/modules/personalization/personalizationmanagerinterfacev1.h
+++ b/src/modules/personalization/personalizationmanagerinterfacev1.h
@@ -241,6 +241,9 @@ Q_SIGNALS:
     void borderChanged();
     void windowStateChanged();
 
+private Q_SLOTS:
+    void resetProperties();
+
 private:
     WWrapPointer<WToplevelSurface> m_target;
     PersonalizationManagerInterfaceV1 *m_manager = nullptr;
@@ -249,8 +252,6 @@ private:
     Shadow m_shadow {};
     Border m_border {};
     PersonalizationWindowContextV1::WindowStates m_states {};
-
-    QMetaObject::Connection m_connection;
 };
 
 class PersonalizationManagerInterfaceV1 : public QObject, public WServerInterface


### PR DESCRIPTION
When a wl_surface is destroyed and recreated (e.g., XWayland reparenting), the old Personalization object survived with stale properties. Its m_connection to windowContextCreated was already disconnected by aboutToBeInvalidated, so the update lambda never ran for the new context. If the stale properties included Blur backgroundType, the window appeared blurry even after the personalization was cleared.

Fix: deleteLater() the Personalization on aboutToBeInvalidated, add resetProperties() on context destruction, keep the windowContextCreated connection alive across surface mismatch, and remove the single-point- of-failure m_connection member.

当 wl_surface 销毁重建时（如 XWayland reparenting），旧的 Personalization 对象携带过期属性存活。aboutToBeInvalidated 断开了 m_connection，导致 update lambda 再也不会为新 context 执行。若过期属性为 Blur，窗口将持续
显示模糊，即使新 context 已无模糊请求。

修复方案：aboutToBeInvalidated 时 deleteLater() 销毁对象；context 销毁 时 resetProperties() 重置属性；surface 不匹配仅跳过而非断开连接；消除
单点失效的 m_connection 成员。

Log: 修复 wl_surface 重建后 Personalization 携带过期属性导致窗口不应模糊却模糊
PMS: BUG-353769 BUG-344965 BUG-295397
Influence: 修复窗口偶发不应显示模糊却显示模糊的问题，涉及 Personalization 对象的生命周期管理和属性重置逻辑。