### PR TITLE
fix: fix wrong output state broadcast after reboot

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -488,7 +488,6 @@ void Helper::onOutputAdded(WOutput *output)
     }
 
     o->enable();
-    m_outputManager->newOutput(output);
 
     QString cache_location = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
     QSettings settings(cache_location + "/output.ini", QSettings::IniFormat);
@@ -523,6 +522,7 @@ void Helper::onOutputAdded(WOutput *output)
         }
     }
     settings.endGroup();
+    m_outputManager->newOutput(output);
     m_wallpaperManager->ensureWallpaperConfigForOutput(o);
 }
 


### PR DESCRIPTION
## Summary

Move `m_outputManager->newOutput(output)` call after output.ini config reading and `commit_state` in `Helper::onOutputAdded()`.

## Root Cause

In `Helper::onOutputAdded()`, `m_outputManager->newOutput(output)` was called right after `o->enable()`, which is before the output.ini configuration is read and committed via `commit_state()`. This causes `newOutput()` to broadcast the `preferredScaleFactor()` default value (e.g. 1.75) instead of the user's saved scale value from output.ini.

## Fix

Move `m_outputManager->newOutput(output)` to after `settings.endGroup()`, ensuring it reads the correct `wlr_output->scale` value that has been updated by `commit_state()`.

## Impact

This fix affects all saved output states in output.ini (scale, mode, transform, customModeSize, adaptiveSync) that were incorrectly broadcast on the first broadcast after reboot.

Fixes: 重启后控制中心显示的缩放值与用户设置不一致