### PR TITLE
fix: broadcast output state after applying config

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -488,7 +488,6 @@ void Helper::onOutputAdded(WOutput *output)
     }
 
     o->enable();
-    m_outputManager->newOutput(output);
 
     QString cache_location = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
     QSettings settings(cache_location + "/output.ini", QSettings::IniFormat);
@@ -523,6 +522,7 @@ void Helper::onOutputAdded(WOutput *output)
         }
     }
     settings.endGroup();
+    m_outputManager->newOutput(output);
     m_wallpaperManager->ensureWallpaperConfigForOutput(o);
 }
 


### PR DESCRIPTION
Move m_outputManager->newOutput(output) call from after o->enable() to after output.ini config read and commit_state in Helper::onOutputAdded().

Previously newOutput() was called before commit_state, causing the preferredScaleFactor() default value to be broadcast instead of the user-saved value. This fix addresses all saved output states (scale, mode, transform, customModeSize, adaptiveSync) being incorrectly broadcast on reboot.

PMS: TASK-304761