### PR TITLE
fix(xwayland): X11 apps cannot connect after treeland restart

### DIFF
--- a/misc/systemd/dde-session-pre.target.wants/treeland-xwayland.service.in
+++ b/misc/systemd/dde-session-pre.target.wants/treeland-xwayland.service.in
@@ -19,5 +19,6 @@ Sockets=treeland-xwayland.socket
 UnsetEnvironment=DISPLAY
 ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/treeland-sd --type xwayland
 ExecStop=-/usr/bin/systemctl --user unset-environment DISPLAY
-Slice=session.slice
+Restart=on-failure
 RestartSec=3s
+Slice=session.slice

--- a/misc/systemd/treeland.service.in
+++ b/misc/systemd/treeland.service.in
@@ -20,6 +20,10 @@ Environment=ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
 Environment=ASAN_OPTIONS=log_path=/tmp/treeland-asan:detect_leaks=0:abort_on_error=1:symbolize=1
 Environment=DDM_DISPLAY_MANAGER=1
 Environment=TREELAND_INPUT_ENHANCE=1
+# Kill orphaned Xwayland processes from previous treeland instance.
+# When treeland crashes, its Xwayland child processes may become orphans
+# because the cleanup code in Session::~Session() is not executed.
+ExecStartPre=-/usr/bin/pkill -9 -u dde -f '^Xwayland[[:space:]]+:[0-9]+'
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/treeland.sh --lockscreen
 Restart=on-failure
 RestartSec=1s

--- a/src/core/treeland.cpp
+++ b/src/core/treeland.cpp
@@ -275,6 +275,7 @@ class Compositor1Adaptor: public QDBusAbstractAdaptor
                 "      <arg direction=\"out\" type=\"ay\" name=\"auth\"/>\n"
                 "    </method>\n"
                 "    <signal name=\"SessionChanged\"/>\n"
+                "    <signal name=\"XWaylandReady\"/>\n"
                 "  </interface>\n"
                 "")
 public:

--- a/src/core/treeland.h
+++ b/src/core/treeland.h
@@ -44,6 +44,7 @@ public:
 Q_SIGNALS:
     void socketDisconnected();
     void SessionChanged();
+    void XWaylandReady();
 
 public Q_SLOTS:
     bool ActivateWayland(QDBusUnixFileDescriptor fd);

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1302,6 +1302,7 @@ void Helper::init(Treeland::Treeland *treeland)
 {
     m_treeland = treeland;
     connect(m_sessionManager, &SessionManager::sessionChanged, treeland, &Treeland::Treeland::SessionChanged);
+    connect(m_sessionManager, &SessionManager::xwaylandReady, treeland, &Treeland::Treeland::XWaylandReady);
 
     auto engine = qmlEngine();
     m_greeterProxy = engine->singletonInstance<GreeterProxy *>("Treeland", "GreeterProxy");

--- a/src/session/session.cpp
+++ b/src/session/session.cpp
@@ -291,6 +291,7 @@ std::shared_ptr<Session> SessionManager::ensureSession(int id, QString username)
         xwayland->setOwnsSocket(socket);
         // Connect signals
         connect(xwayland, &WXWayland::ready, this, [this, xwayland] {
+            Q_EMIT xwaylandReady();
             syncActiveSessionXWaylandPrimaryOutput();
             if (auto session = sessionForXWayland(xwayland)) {
                 session->m_noTitlebarAtom =

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -76,6 +76,7 @@ public:
 Q_SIGNALS:
     void socketFileChanged();
     void sessionChanged();
+    void xwaylandReady();
 
 private:
     std::shared_ptr<Session> ensureSession(int id, QString username);

--- a/src/systemd-socket.cpp
+++ b/src/systemd-socket.cpp
@@ -16,6 +16,7 @@
 #include <QDir>
 #include <QFile>
 #include <QLoggingCategory>
+#include <QTimer>
 #include <QTemporaryFile>
 #include <QtEnvironmentVariables>
 
@@ -29,19 +30,161 @@ Q_LOGGING_CATEGORY(lcSdSocket, "treeland.systemd.socket")
 typedef QMap<QString, QString> StringMap;
 Q_DECLARE_METATYPE(StringMap)
 
-class SignalReceiver : public QObject
+class SocketActivator : public QObject
 {
     Q_OBJECT
 public:
-    SignalReceiver(std::function<void()> activateFdFunc, QObject *parent = nullptr)
-        : QObject(parent), activateFd(activateFdFunc) {
+    SocketActivator(QDBusUnixFileDescriptor unixFileDescriptor,
+                     QString type,
+                     QObject *parent = nullptr)
+        : QObject(parent)
+        , m_unixFileDescriptor(std::make_shared<QDBusUnixFileDescriptor>(std::move(unixFileDescriptor)))
+        , m_type(std::move(type))
+        , m_started(false) {
     }
+
+    bool tryStart(const QDBusConnection &connection) {
+        QDBusInterface test("org.deepin.Compositor1",
+                            "/org/deepin/Compositor1",
+                            "org.deepin.Compositor1",
+                            connection);
+        if (!test.isValid())
+            return false;
+
+        m_busName = connection.name();
+        const QString signal = m_type == "xwayland" ? "XWaylandReady" : "SessionChanged";
+        qCWarning(lcSdSocket) << "start: using bus" << m_busName << "signal:" << signal;
+        if (m_busName == "session")
+            QDBusConnection::sessionBus().connect("org.deepin.Compositor1",
+                                                  "/org/deepin/Compositor1",
+                                                  "org.deepin.Compositor1",
+                                                  signal,
+                                                  this,
+                                                  SLOT(activate()));
+        else
+            QDBusConnection::systemBus().connect("org.deepin.Compositor1",
+                                                 "/org/deepin/Compositor1",
+                                                 "org.deepin.Compositor1",
+                                                 signal,
+                                                 this,
+                                                 SLOT(activate()));
+        return true;
+    }
+
+    void start() {
+        if (tryStart(QDBusConnection::sessionBus()) || tryStart(QDBusConnection::systemBus())) {
+            m_started = true;
+            activate();
+            return;
+        }
+        qCCritical(lcSdSocket) << "org.deepin.Compositor1 not found on session or system bus";
+    }
+
+    ~SocketActivator() {
+        qDeleteAll(m_tmpFiles);
+    }
+
 public Q_SLOTS:
-    void onSessionChanged() {
-        activateFd();
+    void activate() {
+        if (!m_started)
+            return;
+
+        auto connection = m_busName == "session"
+            ? QDBusConnection::sessionBus()
+            : QDBusConnection::systemBus();
+
+        QDBusInterface updateFd("org.deepin.Compositor1",
+                                "/org/deepin/Compositor1",
+                                "org.deepin.Compositor1",
+                                connection);
+
+        qCWarning(lcSdSocket) << "activate:" << m_type << "updateFd.isValid() =" << updateFd.isValid() << "on bus" << m_busName;
+        if (updateFd.isValid()) {
+            if (m_type == "wayland") {
+                updateFd.call("ActivateWayland", QVariant::fromValue(*m_unixFileDescriptor));
+
+                QDBusInterface dbus("org.freedesktop.DBus",
+                                    "/org/freedesktop/DBus",
+                                    "org.freedesktop.DBus",
+                                    QDBusConnection::sessionBus());
+                StringMap env;
+                env["WAYLAND_DISPLAY"] = "treeland.socket";
+
+                const auto extraEnvs = qgetenv("TREELAND_SESSION_ENVIRONMENTS");
+                if (!extraEnvs.isEmpty()) {
+                    const auto envs = extraEnvs.split('\n');
+                    for (const auto &i : envs) {
+                        const auto pair = i.split('=');
+                        if (pair.size() == 2) {
+                            env[QString::fromLocal8Bit(pair[0])] = QString::fromLocal8Bit(pair[1]);
+                        }
+                    }
+                }
+
+                dbus.call("UpdateActivationEnvironment", QVariant::fromValue(env));
+
+                sd_notify(0, "READY=1");
+            } else if (m_type == "xwayland") {
+                QDBusMessage reply = updateFd.call("XWaylandName");
+                qCWarning(lcSdSocket) << "XWaylandName reply type:" << reply.type() << "error:" << reply.errorMessage();
+                if (reply.type() == QDBusMessage::ReplyMessage) {
+                    QVariantList values = reply.arguments();
+                    if (values.size() < 2) {
+                        qCWarning(lcSdSocket) << "Invalid XWaylandName reply";
+                        return;
+                    }
+                    QString xwaylandName = values.at(0).toString();
+                    QByteArray auth = values.at(1).toByteArray();
+
+                    QByteArray runtimeDir = qgetenv("XDG_RUNTIME_DIR");
+                    if (runtimeDir.isEmpty())
+                        runtimeDir = QDir::tempPath().toLocal8Bit();
+                    QTemporaryFile *authFile = new QTemporaryFile();
+                    authFile->setFileTemplate(QStringLiteral("%1/.xauth_XXXXXX").arg(runtimeDir));
+                    if (!authFile->open()) {
+                        qCWarning(lcSdSocket) << "Failed to create temporary xauth file";
+                        return;
+                    }
+                    QString authFileName = authFile->fileName();
+                    m_tmpFiles.append(authFile);
+                    authFile->setPermissions(QFile::ReadOwner | QFile::WriteOwner);
+                    authFile->write(auth);
+                    authFile->flush();
+                    authFile->close();
+
+                    QDBusInterface dbus("org.freedesktop.DBus",
+                                        "/org/freedesktop/DBus",
+                                        "org.freedesktop.DBus",
+                                        QDBusConnection::sessionBus());
+                    StringMap env;
+                    env["DISPLAY"] = xwaylandName;
+                    env["XAUTHORITY"] = authFileName;
+                    dbus.call("UpdateActivationEnvironment", QVariant::fromValue(env));
+
+                    sd_notify(0, "READY=1");
+                    qCWarning(lcSdSocket) << "XWayland ready: DISPLAY=" << xwaylandName << "XAUTHORITY=" << authFileName;
+                } else if (reply.type() == QDBusMessage::ErrorMessage) {
+                    qCWarning(lcSdSocket) << "XWaylandName failed:" << reply.errorMessage();
+                }
+            }
+        }
+        if (m_type == "xwayland" && !updateFd.isValid()) {
+            if (++m_retryCount < 20) {
+                qCWarning(lcSdSocket) << "XWayland D-Bus not ready, retry" << m_retryCount << "/20";
+                QTimer::singleShot(500, this, &SocketActivator::activate);
+            } else {
+                qCWarning(lcSdSocket) << "XWayland activation timed out after 10s";
+            }
+        }
     }
+
 private:
-    std::function<void()> activateFd;
+    std::shared_ptr<QDBusUnixFileDescriptor> m_unixFileDescriptor;
+    QString m_type;
+    QString m_busName;
+    bool m_started = false;
+    QList<QTemporaryFile *> m_tmpFiles;
+    int m_retryCount = 0;
 };
 
 int main(int argc, char *argv[])
@@ -70,100 +213,12 @@ int main(int argc, char *argv[])
         exit(1);
     }
 
-    QList<QTemporaryFile *> tmpFiles;
     QDBusUnixFileDescriptor unixFileDescriptor(SD_LISTEN_FDS_START);
 
-    auto active = [unixFileDescriptor, type, &tmpFiles](QDBusConnection connection) {
-        auto activateFd = [unixFileDescriptor, type, &connection, &tmpFiles] {
-            QDBusInterface updateFd("org.deepin.Compositor1",
-                                    "/org/deepin/Compositor1",
-                                    "org.deepin.Compositor1",
-                                    connection);
+    auto *activator = new SocketActivator(unixFileDescriptor, type, &app);
+    activator->start();
 
-            if (updateFd.isValid()) {
-                if (type == "wayland") {
-                    updateFd.call("ActivateWayland", QVariant::fromValue(unixFileDescriptor));
-
-                    QDBusInterface dbus("org.freedesktop.DBus",
-                                        "/org/freedesktop/DBus",
-                                        "org.freedesktop.DBus",
-                                        QDBusConnection::sessionBus());
-                    StringMap env;
-                    env["WAYLAND_DISPLAY"] = "treeland.socket";
-
-                    const auto extraEnvs = qgetenv("TREELAND_SESSION_ENVIRONMENTS");
-                    if (!extraEnvs.isEmpty()) {
-                        const auto envs = extraEnvs.split('\n');
-                        for (const auto &i : envs) {
-                            const auto pair = i.split('=');
-                            if (pair.size() == 2) {
-                                env[QString::fromLocal8Bit(pair[0])] = QString::fromLocal8Bit(pair[1]);
-                            }
-                        }
-                    }
-
-                    auto reply = dbus.call("UpdateActivationEnvironment", QVariant::fromValue(env));
-
-                    sd_notify(0, "READY=1");
-                } else if (type == "xwayland") {
-                    QDBusMessage reply = updateFd.call("XWaylandName");
-                    if (reply.type() == QDBusMessage::ReplyMessage) {
-                        QVariantList values = reply.arguments();
-                        if (values.size() < 2) {
-                            qCWarning(lcSdSocket) << "Invalid XWaylandName reply";
-                            return;
-                        }
-                        QString xwaylandName = values.at(0).toString();
-                        QByteArray auth = values.at(1).toByteArray();
-
-                        QByteArray runtimeDir = qgetenv("XDG_RUNTIME_DIR");
-                        if (runtimeDir.isEmpty())
-                            runtimeDir = QDir::tempPath().toLocal8Bit();
-                        QTemporaryFile *authFile = new QTemporaryFile();
-                        authFile->setFileTemplate(QStringLiteral("%1/.xauth_XXXXXX").arg(runtimeDir));
-                        if (!authFile->open()) {
-                            qCWarning(lcSdSocket) << "Failed to create temporary xauth file";
-                            return;
-                        }
-                        QString authFileName = authFile->fileName();
-                        tmpFiles.append(authFile);
-                        authFile->setPermissions(QFile::ReadOwner | QFile::WriteOwner);
-                        authFile->write(auth);
-                        authFile->flush();
-                        authFile->close();
-
-                        QDBusInterface dbus("org.freedesktop.DBus",
-                                            "/org/freedesktop/DBus",
-                                            "org.freedesktop.DBus",
-                                            QDBusConnection::sessionBus());
-                        StringMap env;
-                        env["DISPLAY"] = xwaylandName;
-                        env["XAUTHORITY"] = authFileName;
-                        auto reply =
-                            dbus.call("UpdateActivationEnvironment", QVariant::fromValue(env));
-
-                        sd_notify(0, "READY=1");
-                    }
-                }
-            }
-        };
-
-        connection.connect("org.deepin.Compositor1",
-                           "/org/deepin/Compositor1",
-                           "org.deepin.Compositor1",
-                           "SessionChanged",
-                           new SignalReceiver(activateFd),
-                           SLOT(onSessionChanged()));
-        activateFd();
-    };
-
-    active(QDBusConnection::sessionBus());
-    active(QDBusConnection::systemBus());
-
-    int ret = app.exec();
-    for (auto i : std::as_const(tmpFiles))
-        delete i;
-    return ret;
+    return app.exec();
 }
 
 #include "systemd-socket.moc"


### PR DESCRIPTION
When treeland restarts, Xwayland generates a new MIT-MAGIC-COOKIE-1 but treeland-sd (xwayland helper) does not update the user's XAUTHORITY, causing "Invalid MIT-MAGIC-COOKIE-1 key" errors for all X11 apps.

Root cause: sessionChanged() was only emitted on user switch, not when the same session's Xwayland was recreated after a restart. treeland-sd listens for this signal to refresh DISPLAY/XAUTHORITY.

Changes:
- Emit sessionChanged() in WXWayland::ready callback to ensure the xauth cookie is valid before notifying treeland-sd
- Add Restart=on-failure to treeland-xwayland.service so the helper recovers automatically if treeland restarts causes D-Bus disconnection
- Add ExecStartPre to treeland.service to kill orphaned Xwayland processes from a crashed previous instance

Fix: https://github.com/linuxdeepin/treeland/issues/1071
## Summary by Sourcery

Improve Xwayland activation robustness and recovery when treeland restarts.

Bug Fixes:
- Ensure Xwayland activation retries when the compositor D-Bus interface is temporarily unavailable, preventing X11 connection failures after treeland restarts.

Enhancements:
- Add delayed retry logic for Xwayland activation when the compositor D-Bus interface is not yet ready.

Deployment:
- Update treeland systemd units to restart the Xwayland helper on failure and clean up orphaned Xwayland processes on treeland startup.