### PR TITLE
fix(xwayland): synchronize the primary output

### DIFF
--- a/.github/workflows/treeland-archlinux-build.yml
+++ b/.github/workflows/treeland-archlinux-build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install graphics and wayland dependencies
         run: |
           # Core graphics and wayland dependencies (matching qwlroots and waylib builds)
-          pacman -S --noconfirm --noprogressbar pixman vulkan-headers wayland wayland-protocols wlr-protocols
+          pacman -S --noconfirm --noprogressbar pixman vulkan-headers wayland wayland-protocols wlr-protocols libxcb
           pacman -S --noconfirm --noprogressbar wlroots0.19 libinput pam systemd-libs jemalloc gcc-libs glibc
 
       - name: Install additional waylib/qwlroots dependencies

--- a/debian/control
+++ b/debian/control
@@ -37,6 +37,7 @@ Build-Depends: cmake (>= 3.25.0),
                treeland-protocols (>= 0.5.9),
                libpam0g-dev,
                libmpv-dev,
+               libxcb-randr0-dev,
 Standards-Version: 4.6.0
 Section: dde
 Homepage: https://github.com/linuxdeepin/treeland.git

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,7 @@ pkg_search_module(PIXMAN REQUIRED IMPORTED_TARGET pixman-1)
 pkg_search_module(WAYLAND REQUIRED IMPORTED_TARGET wayland-server)
 pkg_search_module(LIBINPUT REQUIRED IMPORTED_TARGET libinput)
 pkg_search_module(XCB REQUIRED IMPORTED_TARGET xcb)
+pkg_search_module(XCB_RANDR REQUIRED IMPORTED_TARGET xcb-randr)
 pkg_check_modules(PAM REQUIRED IMPORTED_TARGET pam)
 pkg_check_modules(Systemd REQUIRED IMPORTED_TARGET libsystemd)
 # qt_finalize_target will collect all executable's private dependencies that are CMake targets
@@ -362,6 +363,7 @@ target_link_libraries(libtreeland
         PkgConfig::WAYLAND
         PkgConfig::LIBINPUT
         PkgConfig::XCB
+        PkgConfig::XCB_RANDR
         $<$<NOT:$<BOOL:${DISABLE_DDM}>>:DDM::Common>
         $<$<NOT:$<BOOL:${DISABLE_DDM}>>:PkgConfig::PAM>
         $<$<NOT:$<BOOL:${DISABLE_DDM}>>:PkgConfig::Systemd>

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1359,6 +1359,10 @@ void Helper::init(Treeland::Treeland *treeland)
             &RootSurfaceContainer::primaryOutputChanged,
             m_outputManagerV1,
             &OutputManagerV1::onPrimaryOutputChanged);
+    connect(m_rootSurfaceContainer,
+            &RootSurfaceContainer::primaryOutputChanged,
+            m_sessionManager,
+            &SessionManager::syncActiveSessionXWaylandPrimaryOutput);
     m_wallpaperColorV1 = m_server->attach<WallpaperColorInterfaceV1>();
     m_windowManagementInterfaceV1 = m_server->attach<WindowManagementInterfaceV1>();
     m_virtualOutputInterfaceV1 = m_server->attach<VirtualOutputManagerInterfaceV1>();

--- a/src/session/session.cpp
+++ b/src/session/session.cpp
@@ -6,6 +6,7 @@
 #include "common/treelandlogging.h"
 #include "core/rootsurfacecontainer.h"
 #include "core/shellhandler.h"
+#include "output/output.h"
 #include "seat/helper.h"
 #include "treelanduserconfig.hpp"
 #include "wallpaper/wallpaperlauncher.h"
@@ -17,6 +18,7 @@
 #include <wxwayland.h>
 
 #include <pwd.h>
+#include <xcb/randr.h>
 
 #define _DEEPIN_NO_TITLEBAR "_DEEPIN_NO_TITLEBAR"
 
@@ -126,6 +128,50 @@ SessionManager::~SessionManager()
         delete m_wallpaperLauncher;
         m_wallpaperLauncher = nullptr;
     }
+}
+
+void SessionManager::syncActiveSessionXWaylandPrimaryOutput()
+{
+    const auto *primaryOutput = Helper::instance()->rootSurfaceContainer()->primaryOutput();
+    if (!primaryOutput)
+        return;
+
+    const QString primaryOutputName = primaryOutput->output()->name();
+    auto *xwayland = activeSession().lock()->xwayland();
+    auto *connection = xwayland ? xwayland->xcbConnection() : nullptr;
+    auto *screen = xwayland ? xwayland->xcbScreen() : nullptr;
+    if (!connection || !screen)
+        return;
+
+    const auto resourcesCookie =
+        xcb_randr_get_screen_resources_current(connection, screen->root);
+    auto *resources =
+        xcb_randr_get_screen_resources_current_reply(connection, resourcesCookie, nullptr);
+    if (!resources)
+        return;
+
+    const int outputCount = xcb_randr_get_screen_resources_current_outputs_length(resources);
+    const auto *outputs = xcb_randr_get_screen_resources_current_outputs(resources);
+    for (int i = 0; i < outputCount; ++i) {
+        const auto outputInfoCookie =
+            xcb_randr_get_output_info(connection, outputs[i], resources->config_timestamp);
+        auto *outputInfo =
+            xcb_randr_get_output_info_reply(connection, outputInfoCookie, nullptr);
+        if (!outputInfo)
+            continue;
+
+        const QString outputName = QString::fromUtf8(
+            reinterpret_cast<const char *>(xcb_randr_get_output_info_name(outputInfo)),
+            xcb_randr_get_output_info_name_length(outputInfo));
+        if (outputName == primaryOutputName) {
+            xcb_randr_set_output_primary(connection, screen->root, outputs[i]);
+            xcb_flush(connection);
+            free(outputInfo);
+            break;
+        }
+        free(outputInfo);
+    }
+    free(resources);
 }
 
 const QList<std::shared_ptr<Session>> &SessionManager::sessions() const
@@ -245,6 +291,7 @@ std::shared_ptr<Session> SessionManager::ensureSession(int id, QString username)
         xwayland->setOwnsSocket(socket);
         // Connect signals
         connect(xwayland, &WXWayland::ready, this, [this, xwayland] {
+            syncActiveSessionXWaylandPrimaryOutput();
             if (auto session = sessionForXWayland(xwayland)) {
                 session->m_noTitlebarAtom =
                     internAtom(session->m_xwayland->xcbConnection(), _DEEPIN_NO_TITLEBAR, false);
@@ -497,6 +544,7 @@ void SessionManager::updateActiveUserSession(const QString &username, int id)
         Q_EMIT socketFileChanged();
         // Notify session changed through DBus, treeland-sd will listen it to update envs
         Q_EMIT sessionChanged();
+        syncActiveSessionXWaylandPrimaryOutput();
     }
     qCInfo(lcTlCore) << "Listening on:" << session->m_socket->fullServerName();
     syncActiveSessionCursorSettings();

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -71,6 +71,7 @@ public:
     std::shared_ptr<Session> sessionForSocket(WSocket *socket) const;
     bool isDDEUserClient(WClient *client);
     void syncActiveSessionCursorSettings();
+    void syncActiveSessionXWaylandPrimaryOutput();
 
 Q_SIGNALS:
     void socketFileChanged();


### PR DESCRIPTION
Synchronize the active session's XWayland RandR primary output with Treeland when XWayland becomes ready, the active user session changes, or the compositor's primary output changes. Add the xcb-randr build dependency required to query outputs and mark the matching X11 output as primary.

Log: fix inconsistent XWayland primary output
Influence: Primary output selection for X11 applications in multi-display sessions