### PR TITLE
fix(output): migrate surfaces when any non-last screen is removed

### DIFF
--- a/src/output/outputlifecyclemanager.cpp
+++ b/src/output/outputlifecyclemanager.cpp
@@ -91,7 +91,7 @@ void OutputLifecycleManager::onScreenRemoved(Output *output,
         markScreenAsPrimaryIntent(output);
     }
 
-    if (!isCurrentPrimary && !wasPrimaryBeforeRemoval) {
+    if (!isCurrentPrimary) {
         auto primaryOutput = m_rootContainer->primaryOutput();
         if (primaryOutput) {
             m_rootContainer->moveSurfacesToOutput(surfaces, primaryOutput, output);


### PR DESCRIPTION
Drop the wasPrimaryBeforeRemoval guard so surfaces on a removed output migrate to the primary output regardless of prior primary intent.

移除 wasPrimaryBeforeRemoval 判断，使任何非最后一屏被移除时都将其窗口迁移到主屏。

Log: 修复非最后一屏被移除时窗口未迁移的问题
PMS: Partially fixes BUG-346635
Influence: 被移除屏上的窗口会迁移到可视范围内。