### PR TITLE
chore(wxwayland): remove unused Xcb::Property class and fix range-for

### DIFF
--- a/waylib/src/server/protocols/wxwayland.cpp
+++ b/waylib/src/server/protocols/wxwayland.cpp
@@ -27,87 +27,6 @@
 QW_USE_NAMESPACE
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
-bool xwayland_user_event_handler(wlr_xwayland *xwayland, xcb_generic_event_t *event);
-
-// --- Xcb::Property ---
-
-Xcb::Property::Property() = default;
-
-Xcb::Property::Property(xcb_connection_t *conn,
-                        xcb_window_t win,
-                        xcb_atom_t prop,
-                        xcb_atom_t type,
-                        uint32_t offset,
-                        uint32_t length)
-    : m_conn(conn)
-    , m_win(win)
-    , m_type(type)
-    , m_offset(offset)
-    , m_length(length)
-    , m_cookie(xcb_get_property_unchecked(conn, false, win, prop, type, offset, length))
-{
-}
-
-Xcb::Property::~Property()
-{
-    if (!m_retrieved && m_cookie.sequence)
-        xcb_discard_reply(m_conn, m_cookie.sequence);
-    else if (m_reply)
-        free(m_reply);
-}
-
-Xcb::Property::Property(Property &&other) noexcept
-    : m_conn(other.m_conn)
-    , m_win(other.m_win)
-    , m_type(other.m_type)
-    , m_cookie(other.m_cookie)
-    , m_reply(other.m_reply)
-{
-    other.m_retrieved = true;
-    other.m_reply = nullptr;
-    other.m_cookie = {};
-}
-
-Xcb::Property &Xcb::Property::operator=(Property &&other) noexcept
-{
-    if (this != &other) {
-        if (!m_retrieved && m_cookie.sequence)
-            xcb_discard_reply(m_conn, m_cookie.sequence);
-        else if (m_reply)
-            free(m_reply);
-
-        m_conn = other.m_conn;
-        m_win = other.m_win;
-        m_type = other.m_type;
-        m_cookie = other.m_cookie;
-        m_reply = other.m_reply;
-
-        other.m_retrieved = true;
-        other.m_reply = nullptr;
-        other.m_cookie = {};
-    }
-    return *this;
-}
-
-void Xcb::Property::getReply() const
-{
-    if (m_retrieved || !m_cookie.sequence)
-        return;
-    m_reply = xcb_get_property_reply(m_conn, m_cookie, nullptr);
-    m_retrieved = true;
-}
-
-QByteArray Xcb::Property::toByteArray() const
-{
-    getReply();
-    if (!m_reply || m_reply->type != m_type || m_reply->value_len == 0)
-        return QByteArray();
-    return QByteArray(static_cast<const char *>(xcb_get_property_value(m_reply)),
-                      xcb_get_property_value_length(m_reply));
-}
-
-// --- WXWayland ---
-
 class Q_DECL_HIDDEN WXWaylandPrivate : public WWrapObjectPrivate
 {
 public:
@@ -206,7 +125,8 @@ bool xwayland_user_event_handler(wlr_xwayland *xwayland, xcb_generic_event_t *ev
         }
     }
 
-    for (auto *surface : self->surfaceList()) {
+    const auto &list = self->surfaceList();
+    for (auto *surface : list) {
         QPointer<WXWaylandSurface> sp(surface);
         if (!sp)
             continue;

--- a/waylib/src/server/protocols/wxwayland.h
+++ b/waylib/src/server/protocols/wxwayland.h
@@ -27,41 +27,6 @@ class WSeat;
 class WXWaylandSurface;
 class WXWaylandPrivate;
 
-namespace Xcb {
-
-class Property
-{
-public:
-    Property(xcb_connection_t *conn,
-             xcb_window_t win,
-             xcb_atom_t prop,
-             xcb_atom_t type,
-             uint32_t offset = 0,
-             uint32_t length = 1024);
-    Property();
-    ~Property();
-    Property(const Property &) = delete;
-    Property &operator=(const Property &) = delete;
-    Property(Property &&other) noexcept;
-    Property &operator=(Property &&other) noexcept;
-
-    QByteArray toByteArray() const;
-
-private:
-    void getReply() const;
-
-    xcb_connection_t *m_conn = nullptr;
-    xcb_window_t m_win = XCB_WINDOW_NONE;
-    xcb_atom_t m_type = XCB_ATOM_NONE;
-    uint32_t m_offset = 0;
-    uint32_t m_length = 0;
-    mutable bool m_retrieved = false;
-    mutable xcb_get_property_cookie_t m_cookie = {};
-    mutable xcb_get_property_reply_t *m_reply = nullptr;
-};
-
-} // namespace Xcb
-
 class WAYLIB_SERVER_EXPORT WXWayland : public WWrapObject, public WServerInterface
 {
     Q_OBJECT


### PR DESCRIPTION
Remove dead Xcb::Property implementation and its forward declaration.

移除未使用的 Xcb::Property 实现及其前向声明。

Log: 清理无用代码并修复遍历写法
Influence: 删除冗余的 Xcb::Property 类；遍历改用 const 引用