### PR TITLE
fix(output): avoid wrong rearrange on exclusive zone removal

### DIFF
--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -473,11 +473,16 @@ void Output::removeSurface(SurfaceWrapper *surface)
     surface->disconnect(this);
 
     if (surface->type() == SurfaceWrapper::Type::Layer) {
+        bool exclusiveZoneRemoved = false;
         if (auto ss = surface->shellSurface()) {
             ss->safeDisconnect(this);
-            removeExclusiveZone(ss);
+            exclusiveZoneRemoved = removeExclusiveZone(ss);
         }
-        arrangeAllSurfaces();
+        arrangeLayerSurfaces();
+        if (exclusiveZoneRemoved) {
+            arrangeNonLayerSurfaces(ArrangeReason::LayerSurfaceRemoved);
+            Q_EMIT exclusiveZoneChanged();
+        }
     }
 }
 

--- a/src/output/output.h
+++ b/src/output/output.h
@@ -57,6 +57,7 @@ public:
     {
         InitialPlacement,
         ExclusiveZoneChanged,
+        LayerSurfaceRemoved,
         OutputGeometryChanged,
     };
 


### PR DESCRIPTION
Log: Add LayerSurfaceRemoved arrange reason.
PMS: BUG-294745
Influence: Avoid moving non-layer windows via the output geometry path.
