### PR TITLE
WM-58: fix: preserve Debian build flags in CMake preset ci

### DIFF
--- a/.github/workflows/waylib-debian-build.yml
+++ b/.github/workflows/waylib-debian-build.yml
@@ -65,12 +65,6 @@ jobs:
           # Install waylib build dependencies (qwlroots is now available from the installed deb)
           mk-build-deps --install --remove --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes' debian/control
 
-          # Build waylib with submodule disabled (use system qwlroots)
-          # Modify debian/rules to disable submodule
-          sed -i 's/-DCMAKE_INSTALL_PREFIX=\/usr/-DCMAKE_INSTALL_PREFIX=\/usr -DWITH_SUBMODULE_QWLROOTS=OFF/' debian/rules
-          echo "Modified debian/rules to disable qwlroots submodule:"
-          cat debian/rules
-
           dpkg-buildpackage -uc -us -b
           echo "✅ waylib deb package built successfully!"
           ls -la ../*.deb

--- a/.github/workflows/waylib-deepin-build.yml
+++ b/.github/workflows/waylib-deepin-build.yml
@@ -61,10 +61,6 @@ jobs:
         working-directory: waylib
         run: |
           set -euxo pipefail
-          # Disable qwlroots submodule, use system-installed qwlroots package
-          sed -i 's/-DCMAKE_INSTALL_PREFIX=\/usr/-DCMAKE_INSTALL_PREFIX=\/usr -DWITH_SUBMODULE_QWLROOTS=OFF/' debian/rules
-          echo "Modified debian/rules to disable qwlroots submodule:"
-          cat debian/rules
 
           dpkg-buildpackage -uc -us -b
           echo "✅ waylib deb package built successfully!"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -32,8 +32,8 @@
             "generator": "Ninja",
             "binaryDir": "${sourceDir}/build",
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror -Wno-stringop-overflow -Wno-sfinae-incomplete",
-                "CMAKE_C_FLAGS": "-Wall -Wextra -Werror -Wno-stringop-overflow"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -Wall -Wextra -Werror -Wno-error=stringop-overflow -Wno-sfinae-incomplete",
+                "CMAKE_C_FLAGS": "$env{CFLAGS} -Wall -Wextra -Werror -Wno-error=stringop-overflow"
             }
         },
         {

--- a/debian/rules
+++ b/debian/rules
@@ -6,18 +6,14 @@
 # see FEATURE AREAS in dpkg-buildflags(1)
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
-# see ENVIRONMENT in dpkg-buildflags(1)
-# package maintainers to append CFLAGS
-export DEB_CFLAGS_MAINT_APPEND  = -Wall -Wextra -Werror -Wno-error=stringop-overflow
-export DEB_CXXFLAGS_MAINT_APPEND = -Wall -Wextra -Werror -Wno-error=stringop-overflow
 # package maintainers to append LDFLAGS
 export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
 %:
-	dh $@ --buildsystem=cmake+ninja
+	dh $@ --buildsystem=cmake+ninja --builddirectory=build
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DBUILD_TREELAND_EXAMPLES=ON
+	dh_auto_configure -- --preset ci -DBUILD_TREELAND_EXAMPLES=ON
 
 override_dh_installsystemd:
 	dh_installsystemd --no-start --no-stop-on-upgrade

--- a/qwlroots/CMakePresets.json
+++ b/qwlroots/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 4,
   "configurePresets": [
     {
       "name": "ci",
@@ -9,8 +9,8 @@
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror -Wno-sfinae-incomplete",
-        "CMAKE_C_FLAGS": "-Wall -Wextra -Werror"
+        "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -Wall -Wextra -Werror -Wno-sfinae-incomplete",
+        "CMAKE_C_FLAGS": "$env{CFLAGS} -Wall -Wextra -Werror"
       }
     }
   ],

--- a/qwlroots/debian/rules
+++ b/qwlroots/debian/rules
@@ -15,12 +15,7 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 
 %:
-	dh $@
+	dh $@ --buildsystem=cmake+ninja --builddirectory=build
 
-
-# dh_make generated override targets
-# This is example for Cmake (See https://bugs.debian.org/641051 )
 override_dh_auto_configure:
-	dh_auto_configure -- \
-	-GNinja \
-	-DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)
+	dh_auto_configure -- --preset ci -DCMAKE_BUILD_TYPE=None -DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)

--- a/waylib/CMakePresets.json
+++ b/waylib/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 4,
   "configurePresets": [
     {
       "name": "ci",
@@ -9,8 +9,8 @@
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror -Wno-stringop-overflow -Wno-sfinae-incomplete",
-        "CMAKE_C_FLAGS": "-Wall -Wextra -Werror -Wno-stringop-overflow"
+        "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -Wall -Wextra -Werror -Wno-error=stringop-overflow -Wno-sfinae-incomplete",
+        "CMAKE_C_FLAGS": "$env{CFLAGS} -Wall -Wextra -Werror -Wno-error=stringop-overflow"
       }
     }
   ],

--- a/waylib/debian/rules
+++ b/waylib/debian/rules
@@ -8,10 +8,10 @@ include /usr/share/dpkg/default.mk
 export QT_SELECT = qt6
 
 %:
-	dh $@ --parallel
+	dh $@ --buildsystem=cmake+ninja --builddirectory=build
 
 override_dh_auto_configure:
-	dh_auto_configure -- -GNinja -DCMAKE_INSTALL_PREFIX=/usr
+	dh_auto_configure -- --preset ci -DCMAKE_BUILD_TYPE=None -DWITH_SUBMODULE_QWLROOTS=OFF
 
 #override_dh_auto_test:
 #	echo "skip auto test"


### PR DESCRIPTION
Fixes GitHub Actions builds not using the correct CMake configuration (CI Build Config).

## Changes

1. Use `$env{CFLAGS}`/`$env{CXXFLAGS}` in ci preset to preserve dpkg-buildflags security flags instead of overriding them
2. Change `-Wno-stringop-overflow` to `-Wno-error=stringop-overflow` in treeland/waylib ci presets
3. Switch `debian/rules` to use `--preset ci` with `--builddirectory=build` for consistent builds
4. Add `-DCMAKE_BUILD_TYPE=None` to qwlroots/waylib `debian/rules` to comply with Debian packaging policy
5. Restore `CMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)` in qwlroots
6. Bump qwlroots/waylib `CMakePresets.json` version 3 → 4 (required for `$env{}` macro support)
7. Add `-DWITH_SUBMODULE_QWLROOTS=OFF` to waylib `debian/rules` for system qwlroots

## Files Changed

- `CMakePresets.json` — ci preset: `$env{}` macros, `-Wno-error=stringop-overflow`
- `debian/rules` — use `--preset ci --builddirectory=build`, remove `DEB_CFLAGS_MAINT_APPEND`/`DEB_CXXFLAGS_MAINT_APPEND`
- `qwlroots/CMakePresets.json` — version 3→4, `$env{}` macros
- `qwlroots/debian/rules` — `--preset ci -DCMAKE_BUILD_TYPE=None -DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH) --builddirectory=build`
- `waylib/CMakePresets.json` — version 3→4, `$env{}` macros, `-Wno-error=stringop-overflow`
- `waylib/debian/rules` — `--preset ci -DCMAKE_BUILD_TYPE=None -DWITH_SUBMODULE_QWLROOTS=OFF --builddirectory=build`

Related: #WM-58

## Summary by Sourcery

Align CMake CI presets and Debian packaging rules to use the shared `ci` preset while preserving Debian build flags and disabling the qwlroots submodule where appropriate.

Bug Fixes:
- Ensure GitHub Actions Debian builds use the correct CMake CI configuration and Debian-provided security build flags instead of overriding them.

Enhancements:
- Unify `debian/rules` across qwlroots and waylib to build via the `ci` CMake preset with explicit build directories and Debian-compliant `CMAKE_BUILD_TYPE` settings.
- Relax string operation overflow diagnostics in CI by treating them as non-fatal warnings rather than errors in treeland/waylib presets.
- Restore `CMAKE_LIBRARY_PATH` configuration for qwlroots to ensure correct multiarch library discovery and prefer system qwlroots over the submodule in waylib builds.
- Upgrade CMakePresets schema versions to support environment macro usage and centralize qwlroots submodule disabling in packaging instead of CI workflow hacks.

CI:
- Simplify waylib GitHub Actions workflows by removing inline edits to `debian/rules`, relying instead on packaging configuration for submodule control.