### PR TITLE
fix(lockscreen): prevent window interaction on secondary screens whil…

### DIFF
--- a/src/plugins/lockscreen/qml/Greeter.qml
+++ b/src/plugins/lockscreen/qml/Greeter.qml
@@ -16,7 +16,8 @@ FocusScope {
     required property QtObject output
     required property QtObject outputItem
     property string primaryOutputName
-    visible: primaryOutputName === "" || primaryOutputName === output.name
+    property bool isPrimaryOutput: primaryOutputName === "" || primaryOutputName === output.name
+    visible: true
 
     x: outputItem.x
     y: outputItem.y
@@ -119,23 +120,41 @@ FocusScope {
         enabled: true
     }
 
-    LockView {
-        id: lockView
+    Loader {
+        id: lockViewLoader
         anchors.fill: parent
-        onAnimationPlayFinished: function () {
-            if (lockView.state === LoginAnimation.Hide) {
-                root.animationPlayFinished()
+        active: isPrimaryOutput
+        sourceComponent: lockViewComponent
+    }
+
+    Component {
+        id: lockViewComponent
+        LockView {
+            id: lockView
+            anchors.fill: parent
+            onAnimationPlayFinished: function () {
+                if (lockView.state === LoginAnimation.Hide) {
+                    root.animationPlayFinished()
+                }
             }
         }
     }
 
-    ShutdownView {
-        id: shutdownView
-        visible: GreeterProxy.showShutdownView
+    Loader {
+        id: shutdownViewLoader
         anchors.fill: parent
+        active: GreeterProxy.showShutdownView && isPrimaryOutput
+        sourceComponent: shutdownViewComponent
+    }
 
-        onSwitchUser: {
-            root.switchUser()
+    Component {
+        id: shutdownViewComponent
+        ShutdownView {
+            id: shutdownView
+            anchors.fill: parent
+            onSwitchUser: {
+                root.switchUser()
+            }
         }
     }
 


### PR DESCRIPTION
…e locked

Set Greeter visible to true so it covers all outputs with MouseArea, preventing interaction with windows on secondary screens. LockView and ShutdownView are wrapped in a Loader with the original primary‑output condition, keeping them instantiated only on the primary display.

将 Greeter 的 visible 设为 true 使其覆盖所有输出并拦截输入；
LockView 和 ShutdownView 通过 Loader 仅在主屏加载，修复多屏锁屏
时副屏窗口仍可操作的问题。

Log: 修复多屏锁屏副屏可操作的问题
PMS: BUG-367461
Influence: 锁屏状态下副屏不再有可交互的锁屏界面，输入被正确拦截。

## Summary by Sourcery

Ensure the lockscreen greeter covers all outputs while only rendering lock and shutdown views on the primary display to fix multi‑monitor interaction issues.

Bug Fixes:
- Prevent window interaction on secondary screens while the system is locked by globally showing the greeter and intercepting input across all outputs.

Enhancements:
- Refactor LockView and ShutdownView into Loader-based components that activate only on the primary output or when the shutdown view is requested.