### PR TITLE
fix(wallpaper): pause video playback after slowdown

### DIFF
--- a/wallpaper-factory/mpvvideoitem.cpp
+++ b/wallpaper-factory/mpvvideoitem.cpp
@@ -559,6 +559,7 @@ void MpvVideoItem::updatePlaybackSpeed()
 {
     constexpr double minSpeed = 0.0;
     constexpr double maxSpeed = 1.0;
+    constexpr double pauseThreshold = 0.5;
 
     if (m_elapsed.hasExpired(m_slowDownDuration)) {
         m_speedTimer->stop();
@@ -571,6 +572,13 @@ void MpvVideoItem::updatePlaybackSpeed()
 
     double ease = easeOutExpo(t);
     double speed = maxSpeed - ease * (maxSpeed - minSpeed);
+
+    if (speed < pauseThreshold) {
+        m_speedTimer->stop();
+        setPause(true);
+        return;
+    }
+
     setSpeed(speed);
 }
 


### PR DESCRIPTION
Pause the mpv video item once playback speed drops below the slowdown threshold, instead of continuing to update near-zero playback speed. This stops the slowdown timer and marks playback as paused when the fade-out has effectively completed.

Log: pause wallpaper video after slowdown completes
PMS: BUG-367447
Influence: Video wallpaper pause behavior during slowdown

## Summary by Sourcery

Bug Fixes:
- Stop the slowdown timer and mark playback as paused once playback speed drops below the configured threshold to avoid lingering near-zero playback.