### PR TITLE
fix: intercept events during interactive move

### DIFF
--- a/src/core/rootsurfacecontainer.h
+++ b/src/core/rootsurfacecontainer.h
@@ -64,6 +64,7 @@ public:
     void destroyForSurface(SurfaceWrapper *wrapper);
 
     SeatSurfaceManager *getSeatContainer(WSeat *seat) const;
+    const QMap<WSeat*, SeatSurfaceManager*> &seatContainers() const { return m_seatContainers; }
     WSeat *getDefaultSeat() const;
     SeatSurfaceManager *getSeatContainerOrDefault(WSeat *seat = nullptr) const;
 

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1832,6 +1832,21 @@ void Helper::fakePressSurfaceBottomRightToReszie(SurfaceWrapper *surface)
     Q_EMIT surface->resizeRequested(Qt::BottomEdge | Qt::RightEdge);
 }
 
+bool Helper::beforeHandleEvent(WSeat *seat, WSurface *watched, QObject *,
+                                QObject *, QInputEvent *event)
+{
+    auto eventType = event->type();
+    if (eventType != QEvent::MouseMove && eventType != QEvent::HoverMove)
+        return false;
+
+    auto *container = m_rootSurfaceContainer->getSeatContainer(seat);
+    if (container && container->moveResizeState().surface
+        && container->moveResizeState().surface->surface() == watched)
+        return true;
+
+    return false;
+}
+
 bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *targetWindow, QInputEvent *event)
 {
     if (!m_instance || !m_renderWindow || !m_backend) {
@@ -1957,10 +1972,12 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *targetWindow, QInputEvent 
     // Per-seat move/resize handling
     const auto *seatContainer = m_rootSurfaceContainer->getSeatContainer(seat);
     if (seatContainer && seatContainer->moveResizeState().surface) {
-        if (Q_LIKELY(event->type() == QEvent::MouseMove || event->type() == QEvent::TouchUpdate)) {
+        if (Q_LIKELY(event->type() == QEvent::MouseMove
+                      || event->type() == QEvent::HoverMove
+                      || event->type() == QEvent::TouchUpdate)) {
             auto cursor = seat->cursor();
             Q_ASSERT(cursor);
-            QMouseEvent *ev = static_cast<QMouseEvent *>(event);
+            auto *ev = static_cast<QSinglePointEvent *>(event);
 
             const auto &moveResizeState = seatContainer->moveResizeState();
             auto ownsOutput = moveResizeState.surface->ownsOutput();

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -334,6 +334,8 @@ private:
     void setCursorPosition(const QPointF &position);
 
     bool beforeDisposeEvent(WSeat *seat, QWindow *window, QInputEvent *event) override;
+    bool beforeHandleEvent(WSeat *seat, WSurface *watched, QObject *shellObject,
+                           QObject *eventObject, QInputEvent *event) override;
     bool afterHandleEvent(WSeat *seat, WSurface *watched, QObject *shellObject,
                          QObject *eventObject, QInputEvent *event) override;
     bool unacceptedEvent(WSeat *seat, QWindow *window, QInputEvent *event) override;

--- a/src/surface/seatsurfacemanager.cpp
+++ b/src/surface/seatsurfacemanager.cpp
@@ -94,6 +94,13 @@ void SeatSurfaceManager::setKeyboardFocusSurface(SurfaceWrapper *surface)
 
 void SeatSurfaceManager::beginMoveResize(SurfaceWrapper *surface, Qt::Edges edges)
 {
+    // Guard against re-entry: beginMoveResizeForSeat() may invoke this again
+    // with the same surface+edges. Without this early return, the subsequent
+    // endMoveResize() call would briefly clear the state, causing the
+    // surface to lose its move/resize tracking.
+    if (m_moveResizeState.surface == surface && m_moveResizeState.edges == edges)
+        return;
+
     if (m_moveResizeState.surface)
         endMoveResize();
 


### PR DESCRIPTION
## Summary

Fix interactive move event interception defects in Treeland compositor, preventing pointer events from leaking to clients during interactive move/resize.

## Changes

1. Add `HoverMove` interception in `beforeDisposeEvent` to block hover events during interactive move/resize
2. Add `beforeHandleEvent` override to prevent synthetic pointer events from bypassing the interception
3. Add re-entry guard in `beginMoveResize` to prevent state corruption from duplicate `beginMoveResizeForSeat` calls
4. Expose `seatContainers()` for per-seat container lookup
5. Use `QSinglePointEvent` instead of `QMouseEvent` for `HoverMove` compatibility

## Related

- Fixes: linuxdeepin/treeland#822
- Paired with dtkgui PR: fix MoveWindowHelper re-entry