### PR TITLE
fix: 窗口恢复动画曲线异常，未从任务栏方向展开

### DIFF
--- a/src/core/qml/Animations/MinimizeAnimation.qml
+++ b/src/core/qml/Animations/MinimizeAnimation.qml
@@ -49,14 +49,14 @@ Item {
             target: effect
             from: root.direction === MinimizeAnimation.Direction.Hide ? root.target.x : position.x
             to: root.direction === MinimizeAnimation.Direction.Hide ? position.x : root.target.x
-            easing.type: root.direction === MinimizeAnimation.Direction.Hide ? Easing.OutExpo : Easing.InExpo
+            easing.type: Easing.OutExpo
             duration: root.duration
         }
         YAnimator {
             target: effect
             from: root.direction === MinimizeAnimation.Direction.Hide ? root.target.y : position.y
             to: root.direction === MinimizeAnimation.Direction.Hide ? position.y : root.target.y
-            easing.type: root.direction === MinimizeAnimation.Direction.Hide ? Easing.OutExpo : Easing.InExpo
+            easing.type: Easing.OutExpo
             duration: root.duration
         }
         NumberAnimation {
@@ -64,7 +64,7 @@ Item {
             property: "width"
             from: root.direction === MinimizeAnimation.Direction.Hide ? root.target.width : position.width
             to: root.direction === MinimizeAnimation.Direction.Hide ? position.width : root.target.width
-            easing.type: root.direction === MinimizeAnimation.Direction.Hide ? Easing.OutExpo : Easing.InExpo
+            easing.type: Easing.OutExpo
             duration: root.duration
         }
         NumberAnimation {
@@ -72,14 +72,14 @@ Item {
             property: "height"
             from: root.direction === MinimizeAnimation.Direction.Hide ? root.target.height : position.height
             to: root.direction === MinimizeAnimation.Direction.Hide ? position.height : root.target.height
-            easing.type: root.direction === MinimizeAnimation.Direction.Hide ? Easing.OutExpo : Easing.InExpo
+            easing.type: Easing.OutExpo
             duration: root.duration
         }
         OpacityAnimator {
             target: effect
             from: root.direction === MinimizeAnimation.Direction.Hide ? 1 : 0
             to: root.direction === MinimizeAnimation.Direction.Hide ? 0 : 1
-            easing.type: root.direction === MinimizeAnimation.Direction.Hide ? Easing.OutExpo : Easing.InExpo
+            easing.type: Easing.OutExpo
             duration: root.duration
         }
         RotationAnimator {
@@ -87,6 +87,7 @@ Item {
             from: root.direction === MinimizeAnimation.Direction.Hide ? 0 : -30;
             to: root.direction === MinimizeAnimation.Direction.Hide ? -30 : 0;
             direction: root.direction === MinimizeAnimation.Direction.Hide ? RotationAnimator.Counterclockwise : RotationAnimator.Clockwise
+            easing.type: Easing.OutExpo
             duration: root.duration
         }
     }


### PR DESCRIPTION
## 问题

窗口最小化动画正常（往任务栏方向收起），但恢复动画曲线不自然——恢复时窗口没有从任务栏方向展开的效果，感觉像是"犹豫后猛冲"。

## 原因

MinimizeAnimation.qml 中恢复动画使用 Easing.InExpo（先慢后快），导致窗口从任务栏图标位置起步时几乎不动，然后突然加速冲到目标位置。

## 修改

- 将 5 处条件 easing 统一改为 Easing.OutExpo（先快后慢），使恢复动画体现"从任务栏弹出"效果
- 给 RotationAnimator 新增 easing.type: Easing.OutExpo（原默认 Linear），与其它动画属性曲线统一

## 影响范围

仅修改 src/core/qml/Animations/MinimizeAnimation.qml，不影响其他动画组件。