### PR TITLE
fix(surface): stop propagating active state to parent surfaces

### DIFF
--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -533,15 +533,6 @@ void SurfaceWrapper::updateActiveState()
         return;
     }
     m_shellSurface->setActivate(m_isActivated);
-    auto parent = parentSurface();
-    while (parent) {
-        if (!parent->hasActiveCapability()) {
-            // Maybe it's parent is Minimized or Unmapped
-            break;
-        }
-        parent->setActivate(m_isActivated);
-        parent = parent->parentSurface();
-    }
 }
 
 void SurfaceWrapper::setFocus(bool focus, Qt::FocusReason reason)


### PR DESCRIPTION
Log: Fix an issue where minimizing a modal window could leave its parent window minimized but still active.

如果 m_isActivated 为 false, if (!parent->hasActiveCapability()) break 会导致没有清理父窗口的 active, 使父窗口进入最小化同时active状态，实际上窗管没有同步active给父窗口的需求，直接删除


PMS: 367629