### PR TITLE
fix(waylib): guard text-input-v3 focus transitions to avoid crash

### DIFF
--- a/waylib/src/server/protocols/private/wtextinputv3.cpp
+++ b/waylib/src/server/protocols/private/wtextinputv3.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Yixue Wang <wangyixue@deepin.org>.
+// Copyright (C) 2023-2026 Yixue Wang <wangyixue@deepin.org>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wtextinputv3_p.h"
@@ -155,12 +155,24 @@ qw_text_input_v3 *WTextInputV3::handle() const
 
 void WTextInputV3::sendEnter(WSurface *surface)
 {
-    handle()->send_enter(surface->handle()->handle());
+    Q_ASSERT(surface);
+    if (!surface)
+        return;
+
+    auto *targetSurface = surface->handle()->handle();
+    auto *focusedSurface = handle()->handle()->focused_surface;
+    if (focusedSurface == targetSurface)
+        return;
+
+    if (focusedSurface)
+        handle()->send_leave();
+
+    handle()->send_enter(targetSurface);
 }
 
 void WTextInputV3::sendLeave()
 {
-    if (focusedSurface()) {
+    if (handle()->handle()->focused_surface) {
         handle()->send_leave();
     }
 }

--- a/waylib/src/server/protocols/winputmethodhelper.cpp
+++ b/waylib/src/server/protocols/winputmethodhelper.cpp
@@ -500,8 +500,10 @@ void WInputMethodHelper::handleActiveIMDestroyed()
 
 void WInputMethodHelper::notifyLeave()
 {
-    if (auto ti = focusedTextInput()) {
-        ti->sendLeave();
+    W_D(WInputMethodHelper);
+    for (auto *ti : std::as_const(d->textInputs)) {
+        if (ti->focusedSurface())
+            ti->sendLeave();
     }
 }
 


### PR DESCRIPTION
该treeland崩溃在我使用Android Studio时遇到

wlroots requires wlr_text_input_v3_send_enter() to be called only when the text input has no focused surface. WInputMethodHelper could resend keyboard focus while wlroots still kept a raw focused_surface, causing the focused_surface == NULL assertion to abort.

Make WTextInputV3::sendEnter() synchronize with the wlroots focus state by no-oping when the target surface is already focused and sending leave before entering a different surface. Also make sendLeave() check the raw wlroots focused_surface directly, and let notifyLeave() clear all currently focused text inputs instead of only the first wrapper-visible one.

This keeps text-input-v3 focus transitions idempotent and avoids crashes when focus is resent for Xwayland/Wayland surfaces.

## Summary by Sourcery

Guard text-input-v3 focus transitions to align with wlroots expectations and prevent crashes when focus is resent.

Bug Fixes:
- Prevent text-input-v3 crashes by avoiding send_enter when the target surface is already focused and ensuring leave is sent before entering a different surface.
- Ensure sendLeave uses the raw wlroots focused_surface state and notifyLeave clears all focused text inputs instead of only the first one.