### PR TITLE
fix(wallpaper): ignore output enable state for valid wallpapers

### DIFF
--- a/src/wallpaper/wallpapermanager.cpp
+++ b/src/wallpaper/wallpapermanager.cpp
@@ -50,10 +50,13 @@ WallpaperManager::~WallpaperManager()
 
 QString WallpaperManager::getOutputId(wlr_output *output)
 {
-    QString model = output->model;
-    QString outputId = model.append(output->serial);
+    const QString model = QString::fromUtf8(output->model);
+    const QString serial = QString::fromUtf8(output->serial);
+    if (!model.isEmpty() && !serial.isEmpty()) {
+        return model + serial;
+    }
 
-    return outputId;
+    return QString::fromUtf8(output->name);
 }
 
 QString WallpaperManager::getOutputId(Output *output)
@@ -312,14 +315,22 @@ QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> WallpaperManager::glo
 {
     QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> wallpapers;
     for (const WallpaperOutputConfig& output : std::as_const(m_wallpaperConfig)) {
-        if (!wallpapers.contains(output.lockscreenWallpaper)) {
-            if (!(exclusiveOutput &&
-                  output.outputName == getOutputId(exclusiveOutput)) && output.enable) {
-                wallpapers.insert(output.lockscreenWallpaper, output.lockScreenWallpapertype);
+        bool outputConnected = false;
+        for (Output *connectedOutput : std::as_const(Helper::instance()->m_outputList)) {
+            if (output.outputName == getOutputId(connectedOutput)) {
+                outputConnected = true;
+                break;
             }
         }
-        if (!output.enable) {
+        if (!outputConnected) {
             continue;
+        }
+
+        if (!wallpapers.contains(output.lockscreenWallpaper)) {
+            if (!(exclusiveOutput &&
+                  output.outputName == getOutputId(exclusiveOutput))) {
+                wallpapers.insert(output.lockscreenWallpaper, output.lockScreenWallpapertype);
+            }
         }
         for (const WallpaperWorkspaceConfig& workspace : std::as_const(output.workspaces)) {
             if (exclusiveOutput &&
@@ -328,7 +339,7 @@ QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> WallpaperManager::glo
                 continue;
             }
 
-            if (!wallpapers.contains(workspace.desktopWallpaper) && workspace.enable) {
+            if (!wallpapers.contains(workspace.desktopWallpaper)) {
                 wallpapers.insert(workspace.desktopWallpaper, workspace.desktopWallpapertype);
             }
         }


### PR DESCRIPTION
Use model and serial as the wallpaper output id when both are available, and fall back to the connector name for outputs without stable EDID identity.

When computing global wallpapers, treat connected outputs as valid regardless of their enabled state. This keeps output disable/enable from affecting wallpaper references, while still allowing unplugged outputs to be ignored so unused wallpapers can be removed correctly.

Log: keep wallpaper validity tied to connected outputs
PMS: BUG-367447
Influence: Wallpaper notifications when outputs are disabled

## Summary by Sourcery

Ensure wallpaper validity is based on connected outputs while stabilizing wallpaper output identifiers.

Bug Fixes:
- Prevent wallpaper notifications and references from changing when outputs are disabled by ignoring the enable state for connected outputs.

Enhancements:
- Use a stable output identifier derived from EDID model and serial when available, falling back to connector name when needed.