### PR TITLE
fix(output): window display not updated after VT switch

### DIFF
--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -135,6 +135,14 @@ void RootSurfaceContainer::addOutput(Output *output)
     // Register all outputs (including primary and proxy/copy) to ensure
     // LayerSurfaceContainer is initialized for every active display.
     SurfaceContainer::addOutput(output);
+
+    // Layer surfaces are re-entered by LayerSurfaceContainer::addOutput
+    // which calls setOutputs. Skip them here to avoid double re-enter.
+    for (auto s : std::as_const(surfaces())) {
+        if (s->type() == SurfaceWrapper::Type::Layer)
+            continue;
+        updateSurfaceOutputs(s);
+    }
 }
 
 void RootSurfaceContainer::removeOutput(Output *output)

--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -90,13 +90,6 @@ int Workspace::getRightWorkspaceId(int workspaceId)
     return modelAt(index + 1)->id();
 }
 
-void Workspace::addOutput([[maybe_unused]] Output *output)
-{
-    // Update even if surface already has ownsOutput - the new output may be                    
-    // its original one 
-    updateSurfacesOwnsOutput();
-}
-
 void Workspace::addSurface(SurfaceWrapper *surface, int workspaceId)
 {
     Q_ASSERT(surface && !surface->container() && surface->workspaceId() == -1);

--- a/src/workspace/workspace.h
+++ b/src/workspace/workspace.h
@@ -47,7 +47,6 @@ public:
     Q_INVOKABLE int getLeftWorkspaceId(int workspaceId);
     Q_INVOKABLE int getRightWorkspaceId(int workspaceId);
 
-    void addOutput(Output *output) override;
     void addSurface(SurfaceWrapper *surface, int workspaceId);
     void addSurface(SurfaceWrapper *surface) override;
     Q_INVOKABLE void moveModelTo(int workspaceId, int destinationIndex);


### PR DESCRIPTION
When a new output is added (e.g. after VT switch), iterate non-layer surfaces in RootSurfaceContainer to update both the output assignment (setOutputs) and the ownsOutput state, ensuring windows render on the correct display. This replaces the previous Workspace::addOutput which only updated ownsOutput.

添加新输出时（如切换 VT 后），遍历 RootSurfaceContainer 中所有非
Layer surface，同时更新输出分配和 ownsOutput 状态，确保窗口正确渲
染到对应显示器。替代了原来仅更新 ownsOutput 的逻辑。

Log: 修复切 VT 后窗口不更新画面的问题
PMS: BUG-366537
Influence: 切换 VT 后窗口能正常更新画面。

## Summary by Sourcery

Ensure window surfaces update their output assignment when a new display is added so they render on the correct screen after VT switches.

Bug Fixes:
- Fix windows not refreshing their display content after VT switches by updating outputs for non-layer surfaces when an output is added.

Enhancements:
- Centralize output-assignment updates in RootSurfaceContainer when outputs are added, removing the redundant Workspace-level addOutput hook.