### PR TITLE
ci(debian): enable -Werror in qwlroots and waylib deb builds

### DIFF
--- a/qwlroots/debian/rules
+++ b/qwlroots/debian/rules
@@ -9,9 +9,10 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 # see ENVIRONMENT in dpkg-buildflags(1)
 # package maintainers to append CFLAGS
-#export DEB_CFLAGS_MAINT_APPEND  = -Wall -pedantic
+export DEB_CFLAGS_MAINT_APPEND  = -Wall -Wextra -Werror -Wno-error=stringop-overflow
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall -Wextra -Werror -Wno-error=stringop-overflow
 # package maintainers to append LDFLAGS
-#export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
 
 %:

--- a/waylib/debian/rules
+++ b/waylib/debian/rules
@@ -4,6 +4,13 @@ DPKG_EXPORT_BUILDFLAGS = 1
 # see FEATURE AREAS in dpkg-buildflags(1)
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
+# see ENVIRONMENT in dpkg-buildflags(1)
+# package maintainers to append CFLAGS
+export DEB_CFLAGS_MAINT_APPEND  = -Wall -Wextra -Werror -Wno-error=stringop-overflow
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall -Wextra -Werror -Wno-error=stringop-overflow
+# package maintainers to append LDFLAGS
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
+
 include /usr/share/dpkg/default.mk
 export QT_SELECT = qt6
 


### PR DESCRIPTION
Unify warning flags across all sub-projects so that deb packaging (Deepin/Debian CI) catches the same warnings as the Arch Linux CMakePresets ci builds:

  -Wall -Wextra -Werror -Wno-error=stringop-overflow

This matches treeland's existing debian/rules configuration.

## Summary by Sourcery

Align Debian packaging builds for qwlroots and waylib with existing CI warning policy.

Build:
- Update qwlroots and waylib debian/rules to use unified warning flags including -Werror to match Arch Linux and treeland configurations.

CI:
- Ensure Deepin/Debian CI deb builds for qwlroots and waylib fail on warnings consistently with other CI presets.