### PR TITLE
fix: reset partialFactor in C++ exit path

### DIFF
--- a/src/plugins/multitaskview/multitaskview.cpp
+++ b/src/plugins/multitaskview/multitaskview.cpp
@@ -83,6 +83,13 @@ void Multitaskview::exit(SurfaceWrapper *surface, bool immediately)
     // TODO: handle taskview gesture
     Q_EMIT aboutToExit();
 
+    if (!qFuzzyCompare(m_partialFactor, 0.0)) {
+        m_partialFactor = 0.0;
+        Q_EMIT partialFactorChanged();
+    } else {
+        m_partialFactor = 0.0;
+    }
+
     if (immediately) {
         setVisible(false);
     } else {

--- a/src/plugins/multitaskview/qml/MultitaskviewProxy.qml
+++ b/src/plugins/multitaskview/qml/MultitaskviewProxy.qml
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import QtQuick
@@ -69,7 +69,6 @@ Multitaskview {
 
         if (exited) {
             root.visible = false;
-            partialFactor = 0;
 
             return "initial";
         }


### PR DESCRIPTION
## Summary

Fix QML TypeError: Cannot assign to read-only property "partialFactor" in MultitaskviewProxy.qml.

### Changes
1. **multitaskview.cpp `exit()`**: Add `qFuzzyCompare` guard to reset `m_partialFactor` to 0.0, consistent with `updatePartialFactor()` style. When the value differs from 0.0, emit `partialFactorChanged`; otherwise just ensure exact 0.0 without redundant signal.
2. **MultitaskviewProxy.qml**: Remove invalid assignment `partialFactor = 0` to the read-only Q_PROPERTY. The reset is now handled in C++.

### Related
- PMS: BUG-346717

## Summary by Sourcery

Ensure the multitask view resets its partial factor state on exit without violating QML read-only property constraints.

Bug Fixes:
- Reset the C++ partial factor state on multitask view exit and emit change notifications only when needed to avoid stale values.
- Remove an invalid QML assignment to a read-only partialFactor property that caused runtime TypeErrors.