### PR TITLE
fix(taskswitch): place switcher on cursor screen with correct global …

### DIFF
--- a/src/core/qml/TaskSwitcher.qml
+++ b/src/core/qml/TaskSwitcher.qml
@@ -28,8 +28,8 @@ Item {
     readonly property int rightpreferredMargin: 20
     readonly property real radius: enableRadius ? 18 : 0
 
-    x: output.validRect.x
-    y: output.validRect.y
+    x: output.outputItem.x + output.validRect.x
+    y: output.outputItem.y + output.validRect.y
     width: output.validRect.width
     height: output.validRect.height
 

--- a/src/modules/shortcut/shortcutrunner.cpp
+++ b/src/modules/shortcut/shortcutrunner.cpp
@@ -358,7 +358,10 @@ void ShortcutRunner::taskswitchAction(bool isRepeat, bool isSameApp, bool isPrev
 
     if (helper->m_taskSwitch.isNull()) {
         auto contentItem = helper->window()->contentItem();
-        auto output = helper->rootSurfaceContainer()->primaryOutput();
+        auto output = helper->rootSurfaceContainer()->cursorOutput();
+        if (!output) {
+            output = helper->rootSurfaceContainer()->primaryOutput();
+        }
         helper->m_taskSwitch = helper->qmlEngine()->createTaskSwitcher(output, contentItem);
         helper->restoreFromShowDesktop();
         QObject::connect(helper->m_taskSwitch, SIGNAL(switchOnChanged()), helper, SLOT(deleteTaskSwitch()));
@@ -404,7 +407,10 @@ void ShortcutRunner::onQuickSwitchTimeout()
 
     if (helper->m_taskSwitch.isNull()) {
         auto contentItem = helper->window()->contentItem();
-        auto output = helper->rootSurfaceContainer()->primaryOutput();
+        auto output = helper->rootSurfaceContainer()->cursorOutput();
+        if (!output) {
+            output = helper->rootSurfaceContainer()->primaryOutput();
+        }
         helper->m_taskSwitch = helper->qmlEngine()->createTaskSwitcher(output, contentItem);
         helper->restoreFromShowDesktop();
         QObject::connect(helper->m_taskSwitch,


### PR DESCRIPTION
…position

Use cursorOutput() instead of primaryOutput() for task switcher placement, and add outputItem global position offset to x/y binding in TaskSwitcher.qml so local validRect coordinates map to the correct screen in a multi-output layout.

使用 cursorOutput() 而非 primaryOutput() 定位切换器，
并在 TaskSwitcher.qml 的 x/y 绑定中加上 outputItem 全局偏移，
使本地 validRect 坐标映射到多屏布局中的正确屏幕。

Log: 修复 Alt+Tab 切换器在多屏缩放不同时的位置偏移及跟随光标
Influence: 修复后切换器显示在光标所在屏幕，且在混用缩放的屏幕布局中位置正确。