### PR TITLE
fix: skip decoration for all Layer Shell surfaces

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1122,7 +1122,9 @@ void Helper::onSurfaceWrapperAdded(SurfaceWrapper *wrapper)
             if (attached->noTitlebar()) {
                 wrapper->setNoTitleBar(true);
                 auto layer = qobject_cast<WLayerSurface *>(wrapper->shellSurface());
-                if (!isLaunchpad(layer)) {
+                // Layer Shell surfaces (OSD, notifications, dock, etc.) should not have
+                // server-side decoration regardless of Personalization noTitlebar state.
+                if (!layer) {
                     wrapper->setNoDecoration(false);
                 }
             } else {


### PR DESCRIPTION
## Summary

Fix OSD showing square-corner shadow in treeland mode by preventing decoration creation for all Layer Shell surfaces.

## Changes

1. Change condition from `!isLaunchpad(layer)` to `!layer` in `updateNoTitlebar` lambda in `src/seat/helper.cpp`
2. Add comment explaining why Layer Shell surfaces should not have server-side decoration regardless of Personalization noTitlebar state

## Root Cause

Layer Shell surfaces (OSD, notifications, dock) were incorrectly getting server-side decorations when Personalization protocol set noTitlebar. The original condition `!isLaunchpad(layer)` only excluded launchpad, leaving other Layer Shell surfaces (like OSD) vulnerable. `SurfaceWrapper::radius()` returns 0 for Layer Shell surfaces, causing XdgShadow to render with square corners.

## Testing

- Verify OSD (e.g. Caps Lock indicator) no longer shows shadow
- Verify Dock and notification surfaces have no decoration
- Verify XDG Toplevel window decoration behavior is unchanged
- Verify Launchpad still has no decoration as before

PMS: BUG-367541