### PR TITLE
fix: keep wine window z-order within parent groups

### DIFF
--- a/src/modules/wine-window-management/winewindowmanagement.cpp
+++ b/src/modules/wine-window-management/winewindowmanagement.cpp
@@ -173,7 +173,7 @@ protected:
         }
 
         qCDebug(lcTlProtocol) << "set_position serial" << x << y << serial << "for window_id"
-                                  << m_windowId;
+                              << m_windowId;
 
         m_wrapper->setPositionAutomatic(false);
         // Suppress only this class's xChanged/yChanged handlers to avoid
@@ -248,51 +248,77 @@ private:
     // Raise to top of current stacking tier (no tier change)
     void applyHwndTop()
     {
-        if (!m_wrapper || !m_wrapper->parentItem())
+        if (!m_wrapper)
             return;
-        auto *parent = m_wrapper->parentItem();
-        const auto children = parent->childItems();
-        if (children.isEmpty() || children.last() == m_wrapper)
-            return;
-        // stackAfter(last) brings this above the last child
-        m_wrapper->QQuickItem::stackAfter(children.last());
+        m_wrapper->stackToLast();
     }
 
-    // Lower to absolute bottom, clear topmost tier
+    // Lower to absolute bottom, clear topmost tier.
     void applyHwndBottom()
     {
         if (!m_wrapper)
             return;
         m_wrapper->setAlwaysOnTop(false);
-        if (!m_wrapper->parentItem())
-            return;
-        auto *parent = m_wrapper->parentItem();
-        const auto children = parent->childItems();
-        if (children.isEmpty() || children.first() == m_wrapper)
-            return;
-        m_wrapper->QQuickItem::stackBefore(children.first());
+        m_wrapper->stackToFirst();
     }
 
-    // Place this window directly below the identified sibling
+    // Place this window directly below the identified sibling.
+    // Matches Windows SetWindowPos semantics: top-level windows may only be
+    // ordered relative to other top-level peers, and child windows only
+    // relative to same-parent siblings. Cross-group requests are ignored.
     void applyHwndInsertAfter(uint32_t siblingId)
     {
         if (!m_manager || !m_wrapper)
             return;
 
         WineWindowControl *sibling = m_manager->controlForId(siblingId);
-        // If sibling not found or in different tier, fall back to hwnd_top
-        if (!sibling || !sibling->wrapper()) {
+        // If sibling is not found, the request has no effect (e.g. the
+        // sibling window was destroyed before this message arrived).
+        if (!sibling || !sibling->wrapper())
             return;
-        }
+        if (sibling == this)
+            return;
 
         SurfaceWrapper *siblingWrapper = sibling->wrapper();
-        // Both must share the same parent container
-        if (!m_wrapper->parentItem() || siblingWrapper->parentItem() != m_wrapper->parentItem()) {
+
+        // Protocol set_z_order: child windows may only be ordered relative to
+        // same-parent siblings. An independent top-level has no parentSurface,
+        // so the check only fires when m_wrapper is a child and its top-level
+        // ancestor differs from the sibling's.
+        if (m_wrapper->parentSurface()
+            && topLevelSurface(m_wrapper) != topLevelSurface(siblingWrapper)) {
+            qCWarning(lcTlProtocol)
+                << "hwnd_insert_after: child window" << m_windowId << "and sibling_id" << siblingId
+                << "belong to different top-level groups; ignoring";
             return;
         }
 
-        // Place this window before the sibling (visually below sibling)
-        m_wrapper->stackBefore(siblingWrapper);
+        // Protocol set_z_order: hwnd_insert_after must not mix tiers.
+        if (m_wrapper->effectiveAlwaysOnTop() != siblingWrapper->effectiveAlwaysOnTop()) {
+            qCWarning(lcTlProtocol) << "hwnd_insert_after: window" << m_windowId << "and sibling_id"
+                                    << siblingId << "belong to different tiers; ignoring";
+            return;
+        }
+
+        // Safety check: both windows must share the same Qt parent container.
+        if (!m_wrapper->parentItem() || siblingWrapper->parentItem() != m_wrapper->parentItem()) {
+            qCWarning(lcTlProtocol) << "hwnd_insert_after: window" << m_windowId << "and sibling_id"
+                                    << siblingId << "do not share a parent container; ignoring";
+            return;
+        }
+
+        // Place this window before the sibling (visually below sibling).
+        if (!m_wrapper->stackBefore(siblingWrapper)) {
+            qCWarning(lcTlProtocol) << "hwnd_insert_after: stackBefore failed for window"
+                                    << m_windowId << "(sibling_id =" << siblingId << ")";
+        }
+    }
+
+    static SurfaceWrapper *topLevelSurface(SurfaceWrapper *wrapper)
+    {
+        while (wrapper && wrapper->parentSurface())
+            wrapper = wrapper->parentSurface();
+        return wrapper;
     }
 
 private:

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -1825,6 +1825,20 @@ void SurfaceWrapper::stackToLast()
     }
 }
 
+void SurfaceWrapper::stackToFirst()
+{
+    if (!parentItem())
+        return;
+
+    if (m_parentSurface) {
+        m_parentSurface->stackToFirst();
+        stackBefore(m_parentSurface->stackFirstSurface());
+    } else {
+        auto first = parentItem()->childItems().first();
+        stackBefore(first);
+    }
+}
+
 void SurfaceWrapper::addSubSurface(SurfaceWrapper *surface)
 {
     Q_ASSERT(!surface->m_parentSurface);
@@ -1997,6 +2011,11 @@ void SurfaceWrapper::setHideByWorkspace(bool hide)
 bool SurfaceWrapper::alwaysOnTop() const
 {
     return m_alwaysOnTop;
+}
+
+bool SurfaceWrapper::effectiveAlwaysOnTop() const
+{
+    return m_explicitAlwaysOnTop > 0;
 }
 
 void SurfaceWrapper::setAlwaysOnTop(bool alwaysOnTop)

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -235,6 +235,7 @@ public:
     void setHideByWorkspace(bool hide);
 
     bool alwaysOnTop() const;
+    bool effectiveAlwaysOnTop() const;
     void setAlwaysOnTop(bool alwaysOnTop);
 
     bool showOnAllWorkspace() const;
@@ -307,6 +308,7 @@ public Q_SLOTS:
     bool stackBefore(QQuickItem *item);
     bool stackAfter(QQuickItem *item);
     void stackToLast();
+    void stackToFirst();
 
     void updateSurfaceSizeRatio();
 


### PR DESCRIPTION
fix: 修复 wine 窗口管理中的 z-order 问题

1. 新增 SurfaceWrapper::stackToFirst()，作为 stackToLast() 的完全对称反操作：
   顶层 surface 调用 stackBefore 插到第一个子项前；子 surface 先递归将父组降底，
   再将自身插到父组的 stackFirstSurface 之前。

2. 将 applyHwndBottom 中手动遍历 childItems() 的逻辑替换为 stackToFirst()，
   避免直接访问容器中可能混杂的合成器内部 QQuickItem（非 wine 窗口组件）。

3. 修复 applyHwndInsertAfter 的父容器校验时序问题：retarget 到
   topLevelSurface(sibling) 后，原有的 parentItem() 等价性检查仍然针对
   原始 siblingWrapper 而非最终 target。将校验移至 target 确定之后，
   确保 stackBefore 实际操作的对象总是经过验证。

4. 检查并记录 applyHwndInsertAfter 中 stackBefore 的返回值；
   对所有因状态异常而提前退出的路径添加 qCWarning，
   使客户端与合成器间静默的 z-order 状态不同步变得可观测。

Log: 修复 wine 窗口 z-order 管理中的边界情况

Influence:
1. 测试子 wine 窗口的 hwnd_bottom 操作，验证其始终处于父组内且位于
   合成器背景项之上
2. 测试不同顶层组之间的 hwnd_insert_after 操作
3. 测试 resolved target 属于不同容器时的 hwnd_insert_after，
   验证 warning 日志正确输出