### PR TITLE
refactor: add guarded setter methods for Personalization properties

### DIFF
--- a/src/modules/personalization/personalizationmanagerinterfacev1.cpp
+++ b/src/modules/personalization/personalizationmanagerinterfacev1.cpp
@@ -1037,41 +1037,35 @@ Personalization::Personalization(WToplevelSurface *target,
                 &PersonalizationWindowContextV1::backgroundTypeChanged,
                 this,
                 [this, context] {
-                    m_backgroundType = context->backgroundType();
-                    Q_EMIT backgroundTypeChanged();
+                    setBackgroundType(static_cast<Personalization::BackgroundType>(context->backgroundType()));
                 });
         connect(context,
                 &PersonalizationWindowContextV1::cornerRadiusChanged,
                 this,
                 [this, context] {
-                    m_cornerRadius = context->cornerRadius();
-                    Q_EMIT cornerRadiusChanged();
+                    setCornerRadius(context->cornerRadius());
                 });
 
         connect(context, &PersonalizationWindowContextV1::shadowChanged, this, [this, context] {
-            m_shadow = context->shadow();
-            Q_EMIT shadowChanged();
+            setShadow(context->shadow());
         });
 
         connect(context, &PersonalizationWindowContextV1::borderChanged, this, [this, context] {
-            m_border = context->border();
-            Q_EMIT borderChanged();
+            setBorder(context->border());
         });
 
         connect(context,
                 &PersonalizationWindowContextV1::windowStateChanged,
                 this,
                 [this, context] {
-                    m_states = context->states();
-                    Q_EMIT windowStateChanged();
+                    setWindowStates(context->states());
                 });
-        connect(context, &QObject::destroyed, this, &Personalization::resetProperties);
 
-        m_backgroundType = context->backgroundType();
-        m_cornerRadius = context->cornerRadius();
-        m_shadow = context->shadow();
-        m_border = context->border();
-        m_states = context->states();
+        setBackgroundType(static_cast<Personalization::BackgroundType>(context->backgroundType()));
+        setCornerRadius(context->cornerRadius());
+        setShadow(context->shadow());
+        setBorder(context->border());
+        setWindowStates(context->states());
     };
 
     connect(m_manager, &PersonalizationManagerInterfaceV1::windowContextCreated, this, update);
@@ -1083,17 +1077,11 @@ Personalization::Personalization(WToplevelSurface *target,
 
 void Personalization::resetProperties()
 {
-    m_backgroundType = Personalization::BackgroundType::Normal;
-    m_cornerRadius = 0;
-    m_shadow = {};
-    m_border = {};
-    m_states = {};
-
-    Q_EMIT backgroundTypeChanged();
-    Q_EMIT cornerRadiusChanged();
-    Q_EMIT shadowChanged();
-    Q_EMIT borderChanged();
-    Q_EMIT windowStateChanged();
+    setBackgroundType(Personalization::BackgroundType::Normal);
+    setCornerRadius(0);
+    setShadow({});
+    setBorder({});
+    setWindowStates({});
 }
 
 SurfaceWrapper *Personalization::surfaceWrapper() const
@@ -1103,7 +1091,7 @@ SurfaceWrapper *Personalization::surfaceWrapper() const
 
 Personalization::BackgroundType Personalization::backgroundType() const
 {
-    return static_cast<Personalization::BackgroundType>(m_backgroundType);
+    return m_backgroundType;
 }
 
 bool Personalization::noTitlebar() const
@@ -1113,6 +1101,46 @@ bool Personalization::noTitlebar() const
     }
 
     return m_states.testFlag(PersonalizationWindowContextV1::NoTitleBar);
+}
+
+void Personalization::setBackgroundType(BackgroundType type)
+{
+    if (m_backgroundType == type)
+        return;
+    m_backgroundType = type;
+    Q_EMIT backgroundTypeChanged();
+}
+
+void Personalization::setCornerRadius(int32_t radius)
+{
+    if (m_cornerRadius == radius)
+        return;
+    m_cornerRadius = radius;
+    Q_EMIT cornerRadiusChanged();
+}
+
+void Personalization::setShadow(const Shadow &shadow)
+{
+    if (m_shadow == shadow)
+        return;
+    m_shadow = shadow;
+    Q_EMIT shadowChanged();
+}
+
+void Personalization::setBorder(const Border &border)
+{
+    if (m_border == border)
+        return;
+    m_border = border;
+    Q_EMIT borderChanged();
+}
+
+void Personalization::setWindowStates(PersonalizationWindowContextV1::WindowStates states)
+{
+    if (m_states == states)
+        return;
+    m_states = states;
+    Q_EMIT windowStateChanged();
 }
 
 void PersonalizationManagerInterfaceV1::create(WServer *server)

--- a/src/modules/personalization/personalizationmanagerinterfacev1.h
+++ b/src/modules/personalization/personalizationmanagerinterfacev1.h
@@ -22,12 +22,14 @@ struct Shadow
     int32_t radius;
     QPoint offset;
     QColor color;
+    bool operator==(const Shadow &other) const = default;
 };
 
 struct Border
 {
     int32_t width;
     QColor color;
+    bool operator==(const Border &other) const = default;
 };
 
 class PersonalizationManagerInterfaceV1Private;
@@ -195,7 +197,7 @@ class Personalization : public QObject
 {
     Q_OBJECT
     QML_ANONYMOUS
-    Q_PROPERTY(int32_t backgroundType READ backgroundType NOTIFY backgroundTypeChanged)
+    Q_PROPERTY(BackgroundType backgroundType READ backgroundType NOTIFY backgroundTypeChanged)
     Q_PROPERTY(int32_t cornerRadius READ cornerRadius NOTIFY cornerRadiusChanged)
     Q_PROPERTY(Shadow shadow READ shadow NOTIFY shadowChanged)
     Q_PROPERTY(Border border READ border NOTIFY borderChanged)
@@ -245,9 +247,16 @@ private Q_SLOTS:
     void resetProperties();
 
 private:
+    void setBackgroundType(BackgroundType type);
+    void setCornerRadius(int32_t radius);
+    void setShadow(const Shadow &shadow);
+    void setBorder(const Border &border);
+    void setWindowStates(PersonalizationWindowContextV1::WindowStates states);
+
+private:
     WWrapPointer<WToplevelSurface> m_target;
     PersonalizationManagerInterfaceV1 *m_manager = nullptr;
-    int32_t m_backgroundType = Personalization::BackgroundType::Normal;
+    BackgroundType m_backgroundType = BackgroundType::Normal;
     int32_t m_cornerRadius = 0;
     Shadow m_shadow {};
     Border m_border {};


### PR DESCRIPTION
1. Add setBackgroundType, setCornerRadius, setShadow, setBorder, setWindowStates setters with guard checks to skip emit on no-change.
2. Refactor constructor signal handlers and resetProperties() to use setters instead of direct member assignment.
3. Remove context->destroyed connection to resetProperties to avoid stale property resets on surface rebuild.

Log: Refactor Personalization property update path to use centralized setters

Influence:
1. Verify Personalization properties update correctly on signal changes.
2. Confirm no-change writes do not emit redundant signals.
3. Test surface rebuild (e.g. XWayland reparenting) — no stale property leakage.

refactor: 为Personalization属性添加带守卫的setter方法

1. 添加setBackgroundType、setCornerRadius、setShadow、setBorder、 setWindowStates setter方法，值不变时跳过信号发射。
2. 重构构造函数信号处理和resetProperties()使用setter替代直接成员赋值。
3. 移除context->destroyed到resetProperties的连接，防止surface重建时 残留过期属性。

Log: 重构Personalization属性更新路径，统一使用setter

Influence:
1. 验证Personalization属性在信号变化时正确更新。
2. 确认值未变化时不会发射冗余信号。
3. 测试surface重建（如XWayland reparenting）——无残留过期属性。

PMS: TASK-390751