### PR TITLE
fix(output): persist output state with dconfig

### DIFF
--- a/misc/dconfig/org.deepin.dde.treeland.json
+++ b/misc/dconfig/org.deepin.dde.treeland.json
@@ -67,6 +67,17 @@
             "description[zh_CN]": "在登录用户列表中显示 Other... 选项，允许以未列出的用户（如 LDAP/NSS 用户）登录",
             "permissions": "readwrite",
             "visibility": "public"
+        },
+        "primaryOutputId": {
+            "value": "",
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Primary Output ID",
+            "name[zh_CN]": "主屏幕 ID",
+            "description": "Output id recorded as the primary output. Empty means no primary output has been saved.",
+            "description[zh_CN]": "记录为主屏幕的输出 ID。空字符串表示未保存主屏幕。",
+            "permissions": "readwrite",
+            "visibility": "public"
         }
     }
 }

--- a/misc/dconfig/org.deepin.dde.treeland.output.json
+++ b/misc/dconfig/org.deepin.dde.treeland.output.json
@@ -23,6 +23,105 @@
             "description[zh_CN]": "当前输出的色温",
             "permissions": "readwrite",
             "visibility": "public"
+        },
+        "enabled": {
+            "value": true,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Enabled",
+            "name[zh_CN]": "启用",
+            "description": "Whether this output was enabled in the last applied wlr-output-management configuration.",
+            "description[zh_CN]": "当前输出在上次应用的 wlr-output-management 配置中是否启用。",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "x": {
+            "value": 0,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "X Position",
+            "name[zh_CN]": "X 坐标",
+            "description": "Last applied x position of this output in the global compositor space.",
+            "description[zh_CN]": "当前输出上次应用到全局合成器空间的 X 坐标。",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "y": {
+            "value": 0,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Y Position",
+            "name[zh_CN]": "Y 坐标",
+            "description": "Last applied y position of this output in the global compositor space.",
+            "description[zh_CN]": "当前输出上次应用到全局合成器空间的 Y 坐标。",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "width": {
+            "value": 0,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Width",
+            "name[zh_CN]": "宽度",
+            "description": "Last committed output mode width in pixels. 0 means no output mode has been saved.",
+            "description[zh_CN]": "上次提交的输出模式宽度，单位为像素。0 表示未保存输出模式。",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "height": {
+            "value": 0,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Height",
+            "name[zh_CN]": "高度",
+            "description": "Last committed output mode height in pixels. 0 means no output mode has been saved.",
+            "description[zh_CN]": "上次提交的输出模式高度，单位为像素。0 表示未保存输出模式。",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "refresh": {
+            "value": 0,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Refresh Rate",
+            "name[zh_CN]": "刷新率",
+            "description": "Last committed output refresh rate in mHz. 0 means no output mode has been saved.",
+            "description[zh_CN]": "上次提交的输出刷新率，单位为 mHz。0 表示未保存输出模式。",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "transform": {
+            "value": 0,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Transform",
+            "name[zh_CN]": "变换",
+            "description": "Last committed wl_output_transform enum value for this output.",
+            "description[zh_CN]": "当前输出上次提交的 wl_output_transform 枚举值。",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "scale": {
+            "value": 1.0,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Scale",
+            "name[zh_CN]": "缩放",
+            "description": "Last committed output scale. Values must be greater than 0. The default value means no output mode has been saved.",
+            "description[zh_CN]": "当前输出上次提交的缩放值，必须大于 0。默认值表示未保存输出模式。",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "adaptiveSyncEnabled": {
+            "value": false,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Adaptive Sync Enabled",
+            "name[zh_CN]": "启用自适应同步",
+            "description": "Whether adaptive sync was enabled in the last committed output state.",
+            "description[zh_CN]": "当前输出上次提交的状态是否启用了自适应同步。",
+            "permissions": "readwrite",
+            "visibility": "public"
         }
     }
 }

--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -8,6 +8,8 @@
 #include "seat/helper.h"
 #include "seat/seatsmanager.h"
 #include "surface/surfacewrapper.h"
+#include "treelandconfig.hpp"
+#include "wallpaper/wallpapermanager.h"
 #include "workspace/workspace.h"
 
 #include <wcursor.h>
@@ -21,9 +23,37 @@
 
 #include <qwoutputlayout.h>
 
+#include <QPointer>
 #include <QQuickWindow>
 
 WAYLIB_SERVER_USE_NAMESPACE
+
+namespace {
+
+void setPrimaryOutputConfig(Output *output)
+{
+    auto *helper = Helper::instance();
+    if (!helper)
+        return;
+
+    auto *config = helper->globalConfig();
+    auto setConfig = [config, output = QPointer<Output>(output)] {
+        const QString outputId = output ? WallpaperManager::getOutputId(output) : QString();
+        config->setPrimaryOutputId(outputId);
+    };
+
+    if (config->isInitializeSucceeded()) {
+        setConfig();
+    } else if (!config->isInitializeFailed()) {
+        QObject::connect(config,
+                         &TreelandConfig::configInitializeSucceed,
+                         helper,
+                         setConfig,
+                         Qt::SingleShotConnection);
+    }
+}
+
+}
 
 OutputListModel::OutputListModel(QObject *parent)
     : ObjectListModel("output", parent)
@@ -375,12 +405,15 @@ Output *RootSurfaceContainer::primaryOutput() const
     return m_primaryOutput;
 }
 
-void RootSurfaceContainer::setPrimaryOutput(Output *newPrimaryOutput)
+void RootSurfaceContainer::setPrimaryOutput(Output *newPrimaryOutput, bool updateDconfig)
 {
     if (m_primaryOutput == newPrimaryOutput)
         return;
+
     m_primaryOutput = newPrimaryOutput;
     Q_EMIT primaryOutputChanged();
+    if (updateDconfig)
+        setPrimaryOutputConfig(newPrimaryOutput);
 }
 
 const QList<Output *> &RootSurfaceContainer::outputs() const

--- a/src/core/rootsurfacecontainer.h
+++ b/src/core/rootsurfacecontainer.h
@@ -82,7 +82,7 @@ public:
 
     Output *cursorOutput() const;
     Output *primaryOutput() const;
-    void setPrimaryOutput(Output *newPrimaryOutput);
+    void setPrimaryOutput(Output *newPrimaryOutput, bool updateDconfig = false);
     const QList<Output *> &outputs() const;
 
     void addOutput(Output *output) override;

--- a/src/modules/output-manager/outputmanagement.cpp
+++ b/src/modules/output-manager/outputmanagement.cpp
@@ -181,7 +181,7 @@ void OutputManagerV1Private::set_primary_output(Resource *resource, const QStrin
     auto *rootSurfaceContainer = Helper::instance()->rootSurfaceContainer();
     for (Output *o : std::as_const(rootSurfaceContainer->outputs())) {
         if (o->output()->name() == output) {
-            rootSurfaceContainer->setPrimaryOutput(o);
+            rootSurfaceContainer->setPrimaryOutput(o, true);
             break;
         }
     }

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -12,6 +12,7 @@
 #include "treelandconfig.hpp"
 #include "treelanduserconfig.hpp"
 #include "workspace/workspace.h"
+#include "wallpapermanager.h"
 
 #include <wcursor.h>
 #include <winputpopupsurface.h>
@@ -89,7 +90,7 @@ Output *Output::create(WOutput *output, QQmlEngine *engine, QObject *parent)
 
 
     // reset output color to config value
-    o->setOutputColor(-1, 0);
+    o->applyOutputColorConfig();
 
     if (CmdLine::ref().enableDebugView()) {
         o->m_debugMenuBar = Helper::instance()->qmlEngine()->createMenuBar(outputItem, contentItem);
@@ -150,9 +151,7 @@ Output::Output(WOutputItem *output, QObject *parent)
 {
     m_outputViewport = output->property("screenViewport").value<WOutputViewport *>();
 
-    // TODO: Investigate better ways to track the panel specific persistent settings.
-    // The connector name of the panel may change.
-    QString outputName = output->output()->name();
+    QString outputName = WallpaperManager::getOutputId(output->output()->nativeHandle());
     m_config = OutputConfig::createByName("org.deepin.dde.treeland.output",
                                     "org.deepin.dde.treeland",
                                     "/" + outputName, this);
@@ -1016,6 +1015,28 @@ OutputConfig *Output::config() const
     return m_config;
 }
 
+void Output::applyOutputColorConfig()
+{
+    auto *outputConfig = config();
+    auto applyConfig = [this, outputConfig] {
+        setOutputColor(outputConfig->brightness(),
+                       static_cast<uint32_t>(outputConfig->colorTemperature()));
+    };
+
+    if (outputConfig->isInitializeSucceeded()) {
+        applyConfig();
+        return;
+    }
+
+    if (!outputConfig->isInitializeFailed()) {
+        connect(outputConfig,
+                &OutputConfig::configInitializeSucceed,
+                this,
+                applyConfig,
+                Qt::SingleShotConnection);
+    }
+}
+
 namespace {
 static inline void kelvinToRGB(double kelvin, double &r, double &g, double &b)
 {
@@ -1068,15 +1089,23 @@ void Output::setOutputColor(qreal brightness,
                             uint32_t colorTemperature,
                             std::function<void(bool)> resultCallback)
 {
-    if (brightness < 0)
+    const bool brightnessRequested = brightness >= 0;
+    const bool colorTemperatureRequested = colorTemperature != 0;
+
+    if (!brightnessRequested)
         brightness = config()->brightness();
-    if (colorTemperature == 0)
+    if (!colorTemperatureRequested)
         colorTemperature = config()->colorTemperature();
 
+    brightness = qBound(0.0, brightness, 1.0);
+    colorTemperature = std::clamp(colorTemperature, 1000u, 20000u);
+
     qreal brightnessCorrection = 1.0;
+    bool backlightApplied = false;
 
     if (m_backlight) {
         qreal backlightBrightness = m_backlight->setBrightness(brightness);
+        backlightApplied = qFuzzyCompare(backlightBrightness, brightness);
         if (backlightBrightness != 0)
             brightnessCorrection = qBound(0.0, brightness / backlightBrightness, 1.0);
     } else {
@@ -1085,8 +1114,11 @@ void Output::setOutputColor(qreal brightness,
 
     const size_t gammaSize = output()->handle()->get_gamma_size();
     if (gammaSize == 0) {
+        if (backlightApplied) {
+            config()->setBrightness(brightness);
+        }
         if (resultCallback)
-            resultCallback(false);
+            resultCallback(backlightApplied && !colorTemperatureRequested);
         qCWarning(lcTlOutput) << " Output " << output()->name()
                              << " does not support gamma LUT! Brightness and color temperature adjustments through gamma will have no effect.";
         return;

--- a/src/output/output.h
+++ b/src/output/output.h
@@ -123,6 +123,7 @@ private:
     void arrangePopupSurface(SurfaceWrapper *surface);
     void arrangeNonLayerSurfaces(ArrangeReason reason);
     void arrangeAllSurfaces();
+    void applyOutputColorConfig();
     std::pair<WOutputViewport *, QQuickItem *> getOutputItemProperty();
     void placeUnderCursor(SurfaceWrapper *surface, quint32 yOffset);
     void placeClientRequstPos(SurfaceWrapper *surface, QPoint clientRequstPos);

--- a/src/output/outputlifecyclemanager.cpp
+++ b/src/output/outputlifecyclemanager.cpp
@@ -7,6 +7,7 @@
 #include "core/rootsurfacecontainer.h"
 #include "output.h"
 #include "outputconfigstate.h"
+#include "wallpaper/wallpapermanager.h"
 
 OutputLifecycleManager::OutputLifecycleManager(RootSurfaceContainer *rootContainer,
                                                OutputConfigState *configState,

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -5,6 +5,7 @@
 #include "seatsmanager.h"
 #include <QScopeGuard>
 #include <QFile>
+#include <QRandomGenerator>
 #include <QJsonDocument>
 #include <QJsonArray>
 #include <QJsonObject>
@@ -47,6 +48,7 @@
 #include "output/output.h"
 #include "output/outputconfigstate.h"
 #include "output/outputlifecyclemanager.h"
+#include "outputconfig.hpp"
 #include "session/session.h"
 #include "surface/surfacecontainer.h"
 #include "surface/surfacewrapper.h"
@@ -133,6 +135,7 @@
 #include <QKeySequence>
 #include <QLoggingCategory>
 #include <QMouseEvent>
+#include <QPointer>
 #include <QQmlContext>
 #include <QQuickWindow>
 #include <QThreadPool>
@@ -175,6 +178,87 @@ static QByteArray readWindowProperty(xcb_connection_t *connection,
     } while (remaining > 0);
 
     return data;
+}
+
+static void runWhenOutputConfigInitialized(OutputConfig *config,
+                                           QObject *context,
+                                           std::function<void()> callback)
+{
+    if (!config || !context) {
+        return;
+    }
+
+    if (config->isInitializeSucceeded()) {
+        callback();
+        return;
+    }
+
+    QObject::connect(config,
+                     &OutputConfig::configInitializeSucceed,
+                     context,
+                     [callback = std::move(callback)] { callback(); });
+}
+
+static void runWhenTreelandConfigInitialized(TreelandConfig *config,
+                                             QObject *context,
+                                             std::function<void()> callback)
+{
+    if (!config || !context) {
+        return;
+    }
+
+    if (config->isInitializeSucceeded() || config->isInitializeFailed()) {
+        callback();
+        return;
+    }
+
+    auto sharedCallback = std::make_shared<std::function<void()>>(std::move(callback));
+    QObject::connect(config,
+                     &TreelandConfig::configInitializeSucceed,
+                     context,
+                     [sharedCallback] { (*sharedCallback)(); });
+    QObject::connect(config,
+                     &TreelandConfig::configInitializeFailed,
+                     context,
+                     [sharedCallback] { (*sharedCallback)(); });
+}
+
+static bool hasSavedOutputState(OutputConfig *config)
+{
+    return config && (!config->enabledIsDefaultValue()
+                      || !config->widthIsDefaultValue()
+                      || !config->heightIsDefaultValue()
+                      || !config->refreshIsDefaultValue()
+                      || !config->scaleIsDefaultValue()
+                      || !config->transformIsDefaultValue()
+                      || !config->adaptiveSyncEnabledIsDefaultValue());
+}
+
+static bool outputMatchesId(Output *output, const QString &outputId)
+{
+    return output && output->output() && output->output()->isEnabled()
+        && WallpaperManager::getOutputId(output) == outputId;
+}
+
+static bool currentPrimaryMatchesId(RootSurfaceContainer *rootContainer, const QString &outputId)
+{
+    return rootContainer && outputMatchesId(rootContainer->primaryOutput(), outputId);
+}
+
+static Output *findFirstEnabledOutput(RootSurfaceContainer *rootContainer,
+                                      Output *excludeOutput = nullptr)
+{
+    if (!rootContainer) {
+        return nullptr;
+    }
+
+    for (auto *output : rootContainer->outputs()) {
+        if (output != excludeOutput && output && output->output() && output->output()->isEnabled()) {
+            return output;
+        }
+    }
+
+    return nullptr;
 }
 
 Helper *Helper::m_instance = nullptr;
@@ -489,16 +573,77 @@ void Helper::onOutputAdded(WOutput *output)
 
     o->enable();
 
-    QString cache_location = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
-    QSettings settings(cache_location + "/output.ini", QSettings::IniFormat);
-    settings.beginGroup(QString("output.%1").arg(output->name()));
-    if (settings.contains("scale") && m_mode != OutputMode::Copy) {
+    auto publishOutput = [this, output, outputObject = QPointer<Output>(o)] {
+        if (!outputObject) {
+            return;
+        }
+
+        m_outputManager->newOutput(output);
+        m_wallpaperManager->ensureWallpaperConfigForOutput(outputObject);
+    };
+    auto restoreOutputConfig = [this, output, outputObject = QPointer<Output>(o), publishOutput] {
+        auto publish = qScopeGuard(publishOutput);
+        if (!outputObject || m_mode == OutputMode::Copy) {
+            return;
+        }
+
+        auto *config = outputObject->config();
+        const QString outputId = WallpaperManager::getOutputId(outputObject);
+        const QString primaryOutputId = m_globalConfig->primaryOutputId();
+        if (config->enabled() && primaryOutputId == outputId) {
+            m_rootSurfaceContainer->setPrimaryOutput(outputObject);
+        } else if (config->enabled()
+                   && m_rootSurfaceContainer->primaryOutput()
+                   && m_rootSurfaceContainer->primaryOutput()->output()
+                   && !m_rootSurfaceContainer->primaryOutput()->output()->isEnabled()
+                   && !currentPrimaryMatchesId(m_rootSurfaceContainer, primaryOutputId)) {
+            m_rootSurfaceContainer->setPrimaryOutput(outputObject);
+        }
+
+        if (!hasSavedOutputState(config)) {
+            return;
+        }
+
+        if (!config->enabled()) {
+            qw_output_state newState;
+            newState.set_enabled(false);
+            if (!output->handle()->commit_state(newState)) {
+                qCCritical(lcTlCore) << "commit failed on output" << output->name();
+            }
+            if (outputObject == m_rootSurfaceContainer->primaryOutput()) {
+                auto *fallbackOutput = findFirstEnabledOutput(m_rootSurfaceContainer, outputObject);
+                if (fallbackOutput) {
+                    m_rootSurfaceContainer->setPrimaryOutput(fallbackOutput);
+                }
+            }
+            return;
+        }
+
+        const int width = static_cast<int>(config->width());
+        const int height = static_cast<int>(config->height());
+        const int refresh = static_cast<int>(config->refresh());
+        const double scale = config->scale();
+        const qlonglong transform = config->transform();
+        if (width <= 0 || height <= 0 || refresh <= 0 || scale <= 0.0) {
+            qCWarning(lcTlCore) << "Ignoring invalid output dconfig for" << output->name()
+                                << "width:" << width
+                                << "height:" << height
+                                << "refresh:" << refresh
+                                << "scale:" << scale;
+            return;
+        }
+        if (transform < WL_OUTPUT_TRANSFORM_NORMAL || transform > WL_OUTPUT_TRANSFORM_FLIPPED_270) {
+            qCWarning(lcTlCore) << "Ignoring invalid output dconfig for" << output->name()
+                                << "transform:" << transform;
+            return;
+        }
+
         qw_output_state newState;
         newState.set_enabled(true);
 
-        int width = settings.value("width").toInt();
-        int height = settings.value("height").toInt();
-        int refresh = settings.value("refresh").toInt();
+        if (auto *layout = m_rootSurfaceContainer->outputLayout()) {
+            layout->move(output, QPoint(static_cast<int>(config->x()), static_cast<int>(config->y())));
+        }
 
         wlr_output_mode *mode, *configMode = nullptr;
         wl_list_for_each(mode, &output->nativeHandle()->modes, link) {
@@ -514,16 +659,37 @@ void Helper::onOutputAdded(WOutput *output)
                                      height,
                                      refresh);
 
-        newState.set_adaptive_sync_enabled(settings.value("adaptiveSyncEnabled").toBool());
-        newState.set_transform(static_cast<wl_output_transform>(settings.value("transform").toInt()));
-        newState.set_scale(settings.value("scale").toFloat());
+        newState.set_adaptive_sync_enabled(config->adaptiveSyncEnabled());
+        newState.set_transform(static_cast<wl_output_transform>(transform));
+        newState.set_scale(scale);
         if (!output->handle()->commit_state(newState)) {
             qCCritical(lcTlCore) << "commit failed on output" << output->name();
+            return;
         }
+
+        if (auto *outputItem = outputObject->outputItem()) {
+            QMetaObject::invokeMethod(outputItem,
+                                      "setTransform",
+                                      Q_ARG(QVariant, QVariant::fromValue(static_cast<WOutput::Transform>(transform))));
+        }
+    };
+    auto *outputConfig = o->config();
+    if (outputConfig->isInitializeFailed()) {
+        publishOutput();
+    } else {
+        if (!outputConfig->isInitializeSucceeded()) {
+            connect(outputConfig, &OutputConfig::configInitializeFailed, o, publishOutput);
+        }
+        runWhenOutputConfigInitialized(outputConfig,
+                                       o,
+                                       [this,
+                                        restoreOutputConfig = std::move(restoreOutputConfig),
+                                        outputObject = QPointer<Output>(o)]() mutable {
+                                           runWhenTreelandConfigInitialized(m_globalConfig.get(),
+                                                                           outputObject,
+                                                                           std::move(restoreOutputConfig));
+                                       });
     }
-    settings.endGroup();
-    m_outputManager->newOutput(output);
-    m_wallpaperManager->ensureWallpaperConfigForOutput(o);
 }
 
 void Helper::onOutputRemoved(WOutput *output)
@@ -801,11 +967,9 @@ void Helper::onOutputTestOrApply(qw_output_configuration_v1 *config, bool onlyTe
         WOutputHelper::ExtraState extraState;
         wlr_output_state_set_enabled(extraState.get(), state.enabled);
 
-        // Only set mode/scale/transform properties when enabling output
-        // Reason: wlroots doesn't allow setting these properties on disabled outputs
-        // When user disables output and changes properties:
-        //   1. Properties are saved in QSettings (see onOutputCommitFinished)
-        //   2. When re-enabling, properties are loaded from QSettings and applied here
+        // Only set mode/scale/transform properties when enabling output.
+        // wlroots doesn't allow setting these properties on disabled outputs,
+        // so they are persisted only after a successful enabled commit.
         if (state.enabled) {
             if (state.mode) {
                 wlr_output_state_set_mode(extraState.get(), state.mode);
@@ -893,27 +1057,52 @@ void Helper::onOutputCommitFinished(qw_output_configuration_v1 *config, bool suc
     if (m_pendingOutputConfig.pendingCommits == 0) {
         bool ok = m_pendingOutputConfig.allSuccess;
         if (ok) {
-            // TODO: Replace QSettings with DConfig to support customization
-            // and avoid IO operations in main thread
-            QString cache_location = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
-            QSettings settings(cache_location + "/output.ini", QSettings::IniFormat);
             for (const WOutputState &state : std::as_const(m_pendingOutputConfig.states)) {
-                // Only save configuration for enabled outputs
-                // Reason: When disabled, mode/scale/transform are not committed to wlroots,
-                // so we should not save uncommitted values
-                if (!state.enabled) {
-                    qCDebug(lcTlCore) << "Skipping config save for disabled output:" << state.output->name();
+                auto *output = getOutput(state.output);
+                if (!output) {
+                    qCWarning(lcTlCore) << "Cannot save output dconfig, output object not found:"
+                                        << state.output->name();
                     continue;
                 }
 
-                settings.beginGroup(QString("output.%1").arg(state.output->name()));
-                settings.setValue("width", state.mode ? state.mode->width : state.customModeSize.width());
-                settings.setValue("height", state.mode ? state.mode->height : state.customModeSize.height());
-                settings.setValue("refresh", state.mode ? state.mode->refresh : state.customModeRefresh);
-                settings.setValue("transform", state.transform);
-                settings.setValue("scale", state.scale);
-                settings.setValue("adaptiveSyncEnabled", state.adaptiveSyncEnabled);
-                settings.endGroup();
+                auto *outputConfig = output->config();
+                const bool enabled = state.enabled;
+                const qlonglong x = state.x;
+                const qlonglong y = state.y;
+                const qlonglong width = state.mode ? state.mode->width : state.customModeSize.width();
+                const qlonglong height = state.mode ? state.mode->height : state.customModeSize.height();
+                const qlonglong refresh = state.mode ? state.mode->refresh : state.customModeRefresh;
+                const qlonglong transform = output->output()->nativeHandle()->transform;
+                const double scale = state.scale;
+                const bool adaptiveSyncEnabled = state.adaptiveSyncEnabled;
+                runWhenOutputConfigInitialized(outputConfig, output, [outputConfig = QPointer<OutputConfig>(outputConfig),
+                                                                      enabled,
+                                                                      x,
+                                                                      y,
+                                                                      width,
+                                                                      height,
+                                                                      refresh,
+                                                                      transform,
+                                                                      scale,
+                                                                      adaptiveSyncEnabled] {
+                    if (!outputConfig) {
+                        return;
+                    }
+
+                    outputConfig->setEnabled(enabled);
+                    if (!enabled) {
+                        return;
+                    }
+
+                    outputConfig->setX(x);
+                    outputConfig->setY(y);
+                    outputConfig->setWidth(width);
+                    outputConfig->setHeight(height);
+                    outputConfig->setRefresh(refresh);
+                    outputConfig->setTransform(transform);
+                    outputConfig->setScale(scale);
+                    outputConfig->setAdaptiveSyncEnabled(adaptiveSyncEnabled);
+                });
             }
         }
         m_outputManager->sendResult(config, ok);
@@ -1735,6 +1924,16 @@ void Helper::init(Treeland::Treeland *treeland)
     }
 
     m_backend->handle()->start();
+
+    // If the stored primary output is no longer present, select a random one as primary
+    const QString primaryOutputId = m_globalConfig->primaryOutputId();
+    if (!currentPrimaryMatchesId(m_rootSurfaceContainer, primaryOutputId)) {
+        const auto &outputs = m_rootSurfaceContainer->outputs();
+        if (!outputs.isEmpty()) {
+            int randomIndex = QRandomGenerator::global()->bounded(outputs.size());
+            m_rootSurfaceContainer->setPrimaryOutput(outputs.at(randomIndex));
+        }
+    }
 }
 
 SeatsManager *Helper::seatManager() const


### PR DESCRIPTION
Use the stable wallpaper output id for per-output configuration so settings follow EDID-backed outputs and fall back to the connector name when stable identity is unavailable.

Move output state persistence from QSettings to OutputConfig, including enabled state, primary state, position, mode, transform, scale, and adaptive sync. Restore saved output state after dconfig initialization, and keep disabled outputs recorded without writing uncommitted mode properties.

Apply brightness and color temperature only after output dconfig is initialized, and clamp invalid runtime values before applying gamma or backlight changes.

Log: keep output configuration tied to stable output identity
PMS: BUG-301689、300647
Influence: Output configuration restore and wallpaper references when outputs are disabled