### PR TITLE
fix: keep oversized surfaces on target output

### DIFF
--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -520,10 +520,16 @@ void RootSurfaceContainer::moveSurfacesToOutput(const QList<SurfaceWrapper *> &s
                 newPos = targetGeometry.center() + relativePos;
                 surface->setOwnsOutput(targetOutput);
             }
-            newPos.setX(
-                qBound(targetGeometry.left(), newPos.x(), targetGeometry.right() - size.width()));
-            newPos.setY(
-                qBound(targetGeometry.top(), newPos.y(), targetGeometry.bottom() - size.height()));
+            if (newPos.x() + size.width() > targetGeometry.right())
+                newPos.setX(targetGeometry.right() - size.width());
+            if (newPos.x() < targetGeometry.left())
+                newPos.setX(targetGeometry.left());
+
+            if (newPos.y() + size.height() > targetGeometry.bottom())
+                newPos.setY(targetGeometry.bottom() - size.height());
+            if (newPos.y() < targetGeometry.top())
+                newPos.setY(targetGeometry.top());
+
             surface->setPosition(newPos);
         }
     }


### PR DESCRIPTION
1. Replace qBound with explicit boundary checks when moving surfaces between outputs

2. Keep oversized surfaces anchored to the target output top-left when they cannot fit inside the screen

3. Avoid qBound assertion when surface size is larger than target output geometry

Log: Fixed oversized surface positioning during output migration

Influence:

1. Test moving windows larger than the target output between screens

ISSUE: 1078


## Summary by Sourcery

Bug Fixes:
- Prevent assertions when moving surfaces larger than the target output geometry by clamping their position within valid bounds.

Fix: [1078](https://github.com/linuxdeepin/treeland/issues/1078)
