### PR TITLE
WM-70: fix: Layer Shell surfaces show shadow only when configured

### DIFF
--- a/src/core/qml/Border.qml
+++ b/src/core/qml/Border.qml
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import QtQuick
@@ -9,9 +9,27 @@ Item {
     property real radius: 0
     property color outsideColor: Qt.rgba(0, 0, 0, 0.1)
     property color insideColor: Qt.rgba(255, 255, 255, 0.1)
+    property int borderWidth: 0
+    property color borderColor: Qt.transparent
+
+    Rectangle {
+        id: personalizationBorder
+        visible: borderWidth > 0
+        anchors {
+            fill: parent
+            margins: -borderWidth
+        }
+        color: "transparent"
+        border {
+            color: borderColor
+            width: borderWidth
+        }
+        radius: GraphicsInfo.api === GraphicsInfo.Software ? 0 : root.radius + borderWidth
+    }
 
     Rectangle {
         id: outsideBorder
+        visible: borderWidth <= 0
         anchors {
             fill: parent
             margins: -border.width
@@ -27,6 +45,7 @@ Item {
 
     Rectangle {
         id: insideBorder
+        visible: borderWidth <= 0
         anchors.fill: parent
         color: "transparent"
         border {

--- a/src/core/qml/Decoration.qml
+++ b/src/core/qml/Decoration.qml
@@ -70,13 +70,18 @@ Item {
         height: surface.height
         cornerRadius: surface.radius
         anchors.centerIn: parent
+        customShadowColor: surface.shadowParams.color
+        customShadowOffsetY: surface.shadowParams.offsetY
+        customShadowBlur: surface.shadowParams.radius
     }
 
     Border {
-        visible: surface.visibleDecoration
+        visible: surface.visibleDecoration && surface.borderParams.width > 0
         parent: surface.surfaceItem ? surface.surfaceItem : surface.prelaunchSplash
         z: SurfaceItem.ZOrder.ContentItem + 1
         anchors.fill: parent
         radius: surface.radius
+        borderWidth: surface.borderParams.width
+        borderColor: surface.borderParams.color
     }
 }

--- a/src/core/qml/XdgShadow.qml
+++ b/src/core/qml/XdgShadow.qml
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import QtQuick
@@ -10,6 +10,10 @@ D.BoxShadow {
     readonly property rect boundingRect: Qt.rect(-shadow.shadowBlur, -shadow.shadowBlur,
                                              width + 2 * shadow.shadowBlur,
                                              height + 2 * shadow.shadowBlur)
+
+    property alias customShadowColor: shadow.shadowColor
+    property alias customShadowOffsetY: shadow.shadowOffsetY
+    property alias customShadowBlur: shadow.shadowBlur
 
     width: parent.width
     height: parent.height

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1117,18 +1117,41 @@ void Helper::onSurfaceWrapperAdded(SurfaceWrapper *wrapper)
         connect(wrapper, &SurfaceWrapper::aboutToBeInvalidated,
                 attached, &Personalization::deleteLater);
 
-        auto updateNoTitlebar = [this, attached] {
+        auto updateDecorationParams = [attached] {
+            auto wrapper = attached->surfaceWrapper();
+            auto shadow = attached->shadow();
+            auto border = attached->border();
+            wrapper->setShadowParams(ShadowParams{
+                shadow.radius,
+                shadow.offset.y(),
+                shadow.color
+            });
+            wrapper->setBorderParams(BorderParams{
+                border.width,
+                border.color
+            });
+        };
+
+        auto updateNoTitlebar = [this, attached, isLayer, updateDecorationParams] {
             auto wrapper = attached->surfaceWrapper();
             if (attached->noTitlebar()) {
                 wrapper->setNoTitleBar(true);
-                auto layer = qobject_cast<WLayerSurface *>(wrapper->shellSurface());
-                if (!isLaunchpad(layer)) {
-                    wrapper->setNoDecoration(false);
+                if (isLayer) {
+                    bool needsDecoration = attached->shadow().radius > 0 || attached->border().width > 0;
+                    if (needsDecoration && wrapper->noDecoration()) {
+                        wrapper->setNoDecoration(false);
+                        updateDecorationParams();
+                    }
+                } else {
+                    wrapper->setNoDecoration(m_xdgDecorationManager->modeBySurface(wrapper->surface())
+                                         != WXdgDecorationManager::Server);
                 }
             } else {
                 wrapper->setNoTitleBar(false);
-                wrapper->setNoDecoration(m_xdgDecorationManager->modeBySurface(wrapper->surface())
-                                     != WXdgDecorationManager::Server);
+                if (!isLayer) {
+                    wrapper->setNoDecoration(m_xdgDecorationManager->modeBySurface(wrapper->surface())
+                                         != WXdgDecorationManager::Server);
+                }
             }
         };
 
@@ -1163,6 +1186,20 @@ void Helper::onSurfaceWrapperAdded(SurfaceWrapper *wrapper)
             auto layer = qobject_cast<WLayerSurface *>(wrapper->shellSurface());
             if (isLaunchpad(layer))
                 wrapper->setCoverEnabled(true);
+
+            connect(attached, &Personalization::shadowChanged, this, [attached, wrapper, updateDecorationParams]() {
+                if (attached->shadow().radius > 0 && wrapper->noDecoration()) {
+                    wrapper->setNoDecoration(false);
+                }
+                updateDecorationParams();
+            });
+
+            connect(attached, &Personalization::borderChanged, this, [attached, wrapper, updateDecorationParams]() {
+                if (attached->border().width > 0 && wrapper->noDecoration()) {
+                    wrapper->setNoDecoration(false);
+                }
+                updateDecorationParams();
+            });
         }
     }
 

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -1629,6 +1629,32 @@ void SurfaceWrapper::setRadius(qreal newRadius)
     Q_EMIT radiusChanged();
 }
 
+ShadowParams SurfaceWrapper::shadowParams() const
+{
+    return m_shadowParams;
+}
+
+void SurfaceWrapper::setShadowParams(const ShadowParams &params)
+{
+    if (m_shadowParams == params)
+        return;
+    m_shadowParams = params;
+    Q_EMIT shadowParamsChanged();
+}
+
+BorderParams SurfaceWrapper::borderParams() const
+{
+    return m_borderParams;
+}
+
+void SurfaceWrapper::setBorderParams(const BorderParams &params)
+{
+    if (m_borderParams == params)
+        return;
+    m_borderParams = params;
+    Q_EMIT borderParamsChanged();
+}
+
 void SurfaceWrapper::minimize(bool onAnimation)
 {
     if (m_surfaceState == State::Minimized)

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -11,6 +11,7 @@
 #include <QQuickItem>
 #include <QString>
 #include <QColor>
+#include <QMetaType>
 
 Q_MOC_INCLUDE(<woutput.h>)
 Q_MOC_INCLUDE(<output / output.h>)
@@ -23,6 +24,30 @@ class SurfaceContainer;
 QW_BEGIN_NAMESPACE
 class qw_buffer;
 QW_END_NAMESPACE
+
+struct ShadowParams
+{
+    Q_GADGET
+    Q_PROPERTY(int radius MEMBER radius)
+    Q_PROPERTY(int offsetY MEMBER offsetY)
+    Q_PROPERTY(QColor color MEMBER color)
+public:
+    int radius = 40;
+    int offsetY = 10;
+    QColor color = QColor(0, 0, 0, 102);
+    bool operator==(const ShadowParams &other) const = default;
+};
+
+struct BorderParams
+{
+    Q_GADGET
+    Q_PROPERTY(int width MEMBER width)
+    Q_PROPERTY(QColor color MEMBER color)
+public:
+    int width = 0;
+    QColor color = Qt::transparent;
+    bool operator==(const BorderParams &other) const = default;
+};
 
 class SurfaceWrapper : public QQuickItem
 {
@@ -84,6 +109,8 @@ class SurfaceWrapper : public QQuickItem
     Q_PROPERTY(bool isIMCandidatePanel READ isIMCandidatePanel NOTIFY isIMCandidatePanelChanged FINAL)
     Q_PROPERTY(bool isResizable READ isResizable NOTIFY resizableChanged FINAL)
     Q_PROPERTY(bool isMaximizable READ isMaximizable NOTIFY maximizableChanged FINAL)
+    Q_PROPERTY(ShadowParams shadowParams READ shadowParams NOTIFY shadowParamsChanged FINAL)
+    Q_PROPERTY(BorderParams borderParams READ borderParams NOTIFY borderParamsChanged FINAL)
 
 public:
     enum class Type
@@ -292,6 +319,11 @@ public:
     bool attention() const;
     bool setAttention(bool attention);
 
+    ShadowParams shadowParams() const;
+    void setShadowParams(const ShadowParams &params);
+    BorderParams borderParams() const;
+    void setBorderParams(const BorderParams &params);
+
 public Q_SLOTS:
     void minimize(bool onAnimation = true);
     void restoreFromMinimized(bool onAnimation = true);
@@ -360,6 +392,8 @@ Q_SIGNALS:
     void surfaceItemCreated(); // Emitted once after surfaceItem is constructed
     void prelaunchSplashChanged();
     void typeChanged();
+    void shadowParamsChanged();
+    void borderParamsChanged();
 
 private:
     ~SurfaceWrapper() override;
@@ -489,6 +523,11 @@ private:
     bool m_windowAnimationEnabled{ true };
     bool m_acceptKeyboardFocus{ true };
     const QString m_appId;
+    ShadowParams m_shadowParams;
+    BorderParams m_borderParams;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(SurfaceWrapper::ActiveControlStates)
+
+Q_DECLARE_METATYPE(ShadowParams)
+Q_DECLARE_METATYPE(BorderParams)


### PR DESCRIPTION
## 修改说明

修复 OSD 图标显示方角阴影的问题。

Layer Shell 表面默认不再创建 Decoration，仅当客户端设置了 `shadow.radius > 0` 或 `border.width > 0` 时按需创建装饰。

### 修改文件（6个）
- `src/seat/helper.cpp` — Layer Shell 装饰创建逻辑改为按需创建
- `src/surface/surfacewrapper.h` — 添加 ShadowParams/BorderParams 结构体及 Q_DECLARE_METATYPE
- `src/surface/surfacewrapper.cpp` — 添加 shadowParams/borderParams 属性的 getter/setter
- `src/core/qml/XdgShadow.qml` — 添加 customShadow 别名属性
- `src/core/qml/Decoration.qml` — 使用 shadowParams/borderParams 传递自定义参数
- `src/core/qml/Border.qml` — 添加个人化边框渲染逻辑

### 关联 Issue
[WM-70](https://agentapi-dev.uniontech.com/issues/82806d03-e4d6-4dce-b987-712deb9b030b)

PMS: BUG-367541