### PR TITLE
feat: implement Personalization v2 shadow/border enable/disable

### DIFF
--- a/src/core/qml/Border.qml
+++ b/src/core/qml/Border.qml
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import QtQuick
@@ -9,9 +9,27 @@ Item {
     property real radius: 0
     property color outsideColor: Qt.rgba(0, 0, 0, 0.1)
     property color insideColor: Qt.rgba(255, 255, 255, 0.1)
+    property int borderWidth: 0
+    property color borderColor: Qt.transparent
+
+    Rectangle {
+        id: personalizationBorder
+        visible: borderWidth > 0
+        anchors {
+            fill: parent
+            margins: -borderWidth
+        }
+        color: "transparent"
+        border {
+            color: borderColor
+            width: borderWidth
+        }
+        radius: GraphicsInfo.api === GraphicsInfo.Software ? 0 : root.radius + borderWidth
+    }
 
     Rectangle {
         id: outsideBorder
+        visible: borderWidth <= 0
         anchors {
             fill: parent
             margins: -border.width
@@ -27,6 +45,7 @@ Item {
 
     Rectangle {
         id: insideBorder
+        visible: borderWidth <= 0
         anchors.fill: parent
         color: "transparent"
         border {

--- a/src/core/qml/Decoration.qml
+++ b/src/core/qml/Decoration.qml
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import QtQuick
@@ -60,7 +60,7 @@ Item {
             // Maybe missing onPositionChanged when use touchscreen
             edges = WaylibHelper.getEdges(Qt.rect(0, 0, width, height), Qt.point(event.x, event.y), 10)
             if (edges)
-                surface.requestResize(edges)
+                surface.resizeRequested(edges)
         }
     }
 
@@ -70,13 +70,18 @@ Item {
         height: surface.height
         cornerRadius: surface.radius
         anchors.centerIn: parent
+        customShadowColor: surface.shadowParams.color
+        customShadowOffsetY: surface.shadowParams.offsetY
+        customShadowBlur: surface.shadowParams.radius
     }
 
     Border {
-        visible: surface.visibleDecoration
+        visible: surface.visibleDecoration && surface.borderParams.width > 0
         parent: surface.surfaceItem ? surface.surfaceItem : surface.prelaunchSplash
         z: SurfaceItem.ZOrder.ContentItem + 1
         anchors.fill: parent
         radius: surface.radius
+        borderWidth: surface.borderParams.width
+        borderColor: surface.borderParams.color
     }
 }

--- a/src/core/qml/XdgShadow.qml
+++ b/src/core/qml/XdgShadow.qml
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import QtQuick
@@ -10,6 +10,10 @@ D.BoxShadow {
     readonly property rect boundingRect: Qt.rect(-shadow.shadowBlur, -shadow.shadowBlur,
                                              width + 2 * shadow.shadowBlur,
                                              height + 2 * shadow.shadowBlur)
+
+    property alias customShadowColor: shadow.shadowColor
+    property alias customShadowOffsetY: shadow.shadowOffsetY
+    property alias customShadowBlur: shadow.shadowBlur
 
     width: parent.width
     height: parent.height

--- a/src/modules/personalization/personalizationmanagerinterfacev1.cpp
+++ b/src/modules/personalization/personalizationmanagerinterfacev1.cpp
@@ -37,22 +37,9 @@
 DCORE_USE_NAMESPACE
 
 static QList<PersonalizationWindowContextV1 *> s_windowContexts;
-static QList<PersonalizationWallpaperContextV1 *> s_wallpaperContexts;
 static QList<PersonalizationCursorContextV1 *> s_cursorContexts;
 static QList<PersonalizationFontContextV1 *> s_fontContexts;
 static QList<PersonalizationAppearanceContextV1 *> s_appearanceContexts;
-
-#define DEFAULT_WALLPAPER "qrc:/desktop.webp"
-#define DEFAULT_WALLPAPER_ISDARK false
-
-static QString defaultBackground()
-{
-    static QString defaultBg = [] {
-        const QString configDefaultBg = Helper::instance()->config()->defaultBackground();
-        return QFile::exists(configDefaultBg) ? configDefaultBg : DEFAULT_WALLPAPER;
-    }();
-    return defaultBg;
-}
 
 static std::optional<int32_t> protocolWindowThemeTypeToDConfig(uint32_t type)
 {
@@ -62,11 +49,11 @@ static std::optional<int32_t> protocolWindowThemeTypeToDConfig(uint32_t type)
     case TREELAND_PERSONALIZATION_APPEARANCE_CONTEXT_V1_THEME_TYPE_DARK:
         return 2;
     case TREELAND_PERSONALIZATION_APPEARANCE_CONTEXT_V1_THEME_TYPE_AUTO:
-        qCCritical(treelandConfig)
+        qCCritical(lcTlConfig)
             << "Protocol window theme type AUTO is not supported by dconfig.";
         return std::nullopt;
     default:
-        qCWarning(treelandConfig) << "Unknown protocol window theme type:" << type;
+        qCWarning(lcTlConfig) << "Unknown protocol window theme type:" << type;
         return std::nullopt;
     }
 }
@@ -79,7 +66,7 @@ static uint32_t dconfigWindowThemeTypeToProtocol(int32_t type)
     case 2:
         return TREELAND_PERSONALIZATION_APPEARANCE_CONTEXT_V1_THEME_TYPE_DARK;
     default:
-        qCWarning(treelandConfig)
+        qCWarning(lcTlConfig)
             << "Unknown dconfig windowThemeType:" << type << ", fallback to light.";
         return TREELAND_PERSONALIZATION_APPEARANCE_CONTEXT_V1_THEME_TYPE_LIGHT;
     }
@@ -102,7 +89,6 @@ public:
 
 protected:
     void get_window_context(Resource *resource, uint32_t id, struct ::wl_resource *surface) override;
-    void get_wallpaper_context(Resource *resource, uint32_t id) override;
     void get_cursor_context(Resource *resource, uint32_t id) override;
     void get_font_context(Resource *resource, uint32_t id) override;
     void get_appearance_context(Resource *resource, uint32_t id) override;
@@ -146,26 +132,6 @@ void PersonalizationManagerInterfaceV1Private::get_window_context(Resource *reso
     });
 
     Q_EMIT q->windowContextCreated(context);
-}
-
-void PersonalizationManagerInterfaceV1Private::get_wallpaper_context(Resource *resource, uint32_t id)
-{
-    wl_resource *wallpaperContextResource = wl_resource_create(resource->client(),
-                                                            &treeland_personalization_wallpaper_context_v1_interface,
-                                                            resource->version(),
-                                                            id);
-    if (!wallpaperContextResource) {
-        wl_client_post_no_memory(resource->client());
-        return;
-    }
-
-    auto *context = new PersonalizationWallpaperContextV1(wallpaperContextResource);
-    s_wallpaperContexts.append(context);
-    QObject::connect(context, &QObject::destroyed, [context]() {
-        s_wallpaperContexts.removeOne(context);
-    });
-
-    Q_EMIT q->onWallpaperContextCreated(context);
 }
 
 void PersonalizationManagerInterfaceV1Private::get_cursor_context(Resource *resource, uint32_t id)
@@ -247,6 +213,8 @@ public:
     Shadow shadow;
     Border border;
     PersonalizationWindowContextV1::WindowStates states;
+    PersonalizationWindowContextV1::ShadowState shadowState = PersonalizationWindowContextV1::ShadowState::Unset;
+    PersonalizationWindowContextV1::BorderState borderState = PersonalizationWindowContextV1::BorderState::Unset;
 
 protected:
     void destroy_resource(Resource *resource) override;
@@ -255,6 +223,10 @@ protected:
     void set_round_corner_radius(Resource *resource, int32_t radius) override;
     void set_shadow(Resource *resource, int32_t radius, int32_t offset_x, int32_t offset_y, int32_t r, int32_t g, int32_t b, int32_t a) override;
     void set_border(Resource *resource, int32_t width, int32_t r, int32_t g, int32_t b, int32_t a) override;
+    void enable_shadow(Resource *resource) override;
+    void disable_shadow(Resource *resource) override;
+    void enable_border(Resource *resource) override;
+    void disable_border(Resource *resource) override;
     void set_titlebar(Resource *resource, int32_t mode) override;
 };
 
@@ -300,6 +272,8 @@ void PersonalizationWindowContextV1Private::set_shadow([[maybe_unused]] Resource
                                                         int32_t a)
 {
     shadow = Shadow{ radius, QPoint{ offset_x, offset_y }, QColor{ r, g, b, a } };
+    shadowState = PersonalizationWindowContextV1::ShadowState::Enabled;
+    send_shadow_configured(radius, offset_x, offset_y, r, g, b, a);
     Q_EMIT q->shadowChanged();
 }
 
@@ -311,6 +285,39 @@ void PersonalizationWindowContextV1Private::set_border([[maybe_unused]] Resource
                                                         int32_t a)
 {
     border = Border{ width, QColor{ r, g, b, a } };
+    borderState = PersonalizationWindowContextV1::BorderState::Enabled;
+    send_border_configured(width, r, g, b, a);
+    Q_EMIT q->borderChanged();
+}
+
+void PersonalizationWindowContextV1Private::enable_shadow([[maybe_unused]] Resource *resource)
+{
+    shadow = Shadow{ 40, QPoint{ 0, 10 }, QColor{ 0, 0, 0, 102 } };
+    shadowState = PersonalizationWindowContextV1::ShadowState::Enabled;
+    send_shadow_configured(shadow.radius, shadow.offset.x(), shadow.offset.y(),
+                           shadow.color.red(), shadow.color.green(),
+                           shadow.color.blue(), shadow.color.alpha());
+    Q_EMIT q->shadowChanged();
+}
+
+void PersonalizationWindowContextV1Private::disable_shadow([[maybe_unused]] Resource *resource)
+{
+    shadowState = PersonalizationWindowContextV1::ShadowState::Disabled;
+    Q_EMIT q->shadowChanged();
+}
+
+void PersonalizationWindowContextV1Private::enable_border([[maybe_unused]] Resource *resource)
+{
+    border = Border{ 1, QColor{ 255, 255, 255, 26 } };
+    borderState = PersonalizationWindowContextV1::BorderState::Enabled;
+    send_border_configured(border.width, border.color.red(), border.color.green(),
+                           border.color.blue(), border.color.alpha());
+    Q_EMIT q->borderChanged();
+}
+
+void PersonalizationWindowContextV1Private::disable_border([[maybe_unused]] Resource *resource)
+{
+    borderState = PersonalizationWindowContextV1::BorderState::Disabled;
     Q_EMIT q->borderChanged();
 }
 
@@ -357,14 +364,24 @@ Shadow PersonalizationWindowContextV1::shadow() const
     return d->shadow;
 }
 
+PersonalizationWindowContextV1::ShadowState PersonalizationWindowContextV1::shadowState() const
+{
+    return d->shadowState;
+}
+
 Border PersonalizationWindowContextV1::border() const
 {
     return d->border;
 }
 
+PersonalizationWindowContextV1::BorderState PersonalizationWindowContextV1::borderState() const
+{
+    return d->borderState;
+}
+
 PersonalizationWindowContextV1 *PersonalizationWindowContextV1::get(wl_resource *resource)
 {
-    for (auto *context : s_windowContexts) {
+    for (auto *context : std::as_const(s_windowContexts)) {
         if (context->resource() == resource) {
             return context;
         }
@@ -375,7 +392,7 @@ PersonalizationWindowContextV1 *PersonalizationWindowContextV1::get(wl_resource 
 
 PersonalizationWindowContextV1 *PersonalizationWindowContextV1::getWindowContext(WSurface *surface)
 {
-    for (auto *context : s_windowContexts) {
+    for (auto *context : std::as_const(s_windowContexts)) {
         if (context->surface() == surface->handle()->handle()) {
             return context;
         }
@@ -387,157 +404,6 @@ PersonalizationWindowContextV1 *PersonalizationWindowContextV1::getWindowContext
 PersonalizationWindowContextV1::WindowStates PersonalizationWindowContextV1::states() const
 {
     return d->states;
-}
-
-
-
-class PersonalizationWallpaperContextV1Private
-    : public QtWaylandServer::treeland_personalization_wallpaper_context_v1
-{
-public:
-    PersonalizationWallpaperContextV1Private(PersonalizationWallpaperContextV1 *_q,
-                                             wl_resource *resource);
-    ~PersonalizationWallpaperContextV1Private() override = default;
-
-    PersonalizationWallpaperContextV1 *q = nullptr;
-
-    int32_t fd = -1;
-    uint32_t uid = 0;
-    uint32_t options = 0;
-    bool isDark = false;
-    QString metaData;
-    QString identifier;
-    QString outputName;
-
-protected:
-    void destroy_resource(Resource *resource) override;
-    void destroy(Resource *resource) override;
-    void set_fd(Resource *resource, int32_t fd, const QString &metadata) override;
-    void set_identifier(Resource *resource, const QString &identifier) override;
-    void set_output(Resource *resource, const QString &output) override;
-    void set_on(Resource *resource, uint32_t options) override;
-    void set_isdark(Resource *resource, uint32_t isdark) override;
-    void commit(Resource *resource) override;
-    void get_metadata(Resource *resource) override;
-};
-
-PersonalizationWallpaperContextV1Private::PersonalizationWallpaperContextV1Private(
-    PersonalizationWallpaperContextV1 *_q,
-    wl_resource *resource)
-    : QtWaylandServer::treeland_personalization_wallpaper_context_v1(resource)
-    , q(_q)
-{
-}
-
-void PersonalizationWallpaperContextV1Private::destroy_resource([[maybe_unused]] Resource *resource)
-{
-    delete q;
-}
-
-void PersonalizationWallpaperContextV1Private::destroy(Resource *resource)
-{
-    wl_resource_destroy(resource->handle);
-}
-
-void PersonalizationWallpaperContextV1Private::set_fd([[maybe_unused]] Resource *resource, int32_t _fd, const QString &_metadata)
-{
-    fd = _fd;
-    metaData = _metadata;
-}
-
-void PersonalizationWallpaperContextV1Private::set_identifier([[maybe_unused]] Resource *resource, const QString &_identifier)
-{
-    identifier = _identifier;
-}
-
-void PersonalizationWallpaperContextV1Private::set_output([[maybe_unused]] Resource *resource, const QString &_output)
-{
-    outputName = _output;
-}
-
-void PersonalizationWallpaperContextV1Private::set_on([[maybe_unused]] Resource *resource, uint32_t _options)
-{
-    options = _options;
-}
-
-void PersonalizationWallpaperContextV1Private::set_isdark([[maybe_unused]] Resource *resource, uint32_t _isdark)
-{
-    isDark = _isdark;
-}
-
-void PersonalizationWallpaperContextV1Private::commit([[maybe_unused]] Resource *resource)
-{
-    Q_EMIT q->commit(q);
-}
-
-void PersonalizationWallpaperContextV1Private::get_metadata([[maybe_unused]] Resource *resource)
-{
-    Q_EMIT q->getWallpapers(q);
-}
-
-PersonalizationWallpaperContextV1::PersonalizationWallpaperContextV1(wl_resource *resource)
-    : QObject(nullptr)
-    , d(new PersonalizationWallpaperContextV1Private(this, resource))
-{
-}
-
-PersonalizationWallpaperContextV1::~PersonalizationWallpaperContextV1() = default;
-
-wl_resource *PersonalizationWallpaperContextV1::resource() const
-{
-    return d->resource()->handle;
-}
-
-int32_t PersonalizationWallpaperContextV1::fd() const
-{
-    return d->fd;
-}
-
-uint32_t PersonalizationWallpaperContextV1::uid() const
-{
-    return d->uid;
-}
-
-uint32_t PersonalizationWallpaperContextV1::options() const
-{
-    return d->options;
-}
-
-bool PersonalizationWallpaperContextV1::isDark() const
-{
-    return d->isDark;
-}
-
-QString PersonalizationWallpaperContextV1::metaData() const
-{
-    return d->metaData;
-}
-
-QString PersonalizationWallpaperContextV1::identifier() const
-{
-    return d->identifier;
-}
-
-QString PersonalizationWallpaperContextV1::outputName() const
-{
-    return d->outputName;
-}
-
-void PersonalizationWallpaperContextV1::setMetaData(const QString &data)
-{
-    d->metaData = data;
-    d->send_metadata(data);
-}
-
-PersonalizationWallpaperContextV1 *PersonalizationWallpaperContextV1::get(wl_resource *resource)
-{
-    for (auto *context : s_wallpaperContexts) {
-        if (context->resource() == resource) {
-            return context;
-        }
-    }
-
-    return nullptr;
 }
 
 class PersonalizationCursorContextV1Private
@@ -663,7 +529,7 @@ void PersonalizationCursorContextV1::sendSize()
 
 PersonalizationCursorContextV1 *PersonalizationCursorContextV1::get(wl_resource *resource)
 {
-    for (auto *context : s_cursorContexts) {
+    for (auto *context : std::as_const(s_cursorContexts)) {
         if (context->resource() == resource) {
             return context;
         }
@@ -852,7 +718,7 @@ void PersonalizationAppearanceContextV1::sendWindowTitlebarHeight(uint32_t heigh
 
 PersonalizationAppearanceContextV1 *PersonalizationAppearanceContextV1::get(wl_resource *resource)
 {
-    for (auto *context : s_appearanceContexts) {
+    for (auto *context : std::as_const(s_appearanceContexts)) {
         if (context->resource() == resource) {
             return context;
         }
@@ -959,35 +825,13 @@ void PersonalizationFontContextV1::sendFontSize(uint32_t size)
 
 PersonalizationFontContextV1 *PersonalizationFontContextV1::get(wl_resource *resource)
 {
-    for (auto *context : s_fontContexts) {
+    for (auto *context : std::as_const(s_fontContexts)) {
         if (context->resource() == resource) {
             return context;
         }
     }
 
     return nullptr;
-}
-
-void PersonalizationManagerInterfaceV1::updateCacheWallpaperPath(uid_t uid)
-{
-    QString cache_location = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
-    d->cacheDirectory = cache_location + QString("/wallpaper/%1/").arg(uid);
-    d->settingFile = d->cacheDirectory + "wallpaper.ini";
-
-    QSettings settings(d->settingFile, QSettings::IniFormat);
-    d->iniMetaData = settings.value("metadata").toString();
-}
-
-QString PersonalizationManagerInterfaceV1::readWallpaperSettings(const QString &group,
-                                                  const QString &output,
-                                                  int workspaceId)
-{
-    if (d->settingFile.isEmpty() || output.isEmpty() || workspaceId < 1)
-        return defaultBackground();
-
-    QSettings settings(d->settingFile, QSettings::IniFormat);
-    settings.beginGroup(QString("%1.%2.%3").arg(group).arg(output).arg(workspaceId));
-    return settings.value("path", defaultBackground()).toString();
 }
 
 PersonalizationManagerInterfaceV1::PersonalizationManagerInterfaceV1(QObject *parent)
@@ -1005,18 +849,6 @@ PersonalizationManagerInterfaceV1::PersonalizationManagerInterfaceV1(QObject *pa
 PersonalizationManagerInterfaceV1::~PersonalizationManagerInterfaceV1()
 {
     Q_CLEANUP_RESOURCE(default_background);
-}
-
-void PersonalizationManagerInterfaceV1::onWallpaperContextCreated(PersonalizationWallpaperContextV1 *context)
-{
-    connect(context,
-            &PersonalizationWallpaperContextV1::commit,
-            this,
-            &PersonalizationManagerInterfaceV1::onWallpaperCommit);
-    connect(context,
-            &PersonalizationWallpaperContextV1::getWallpapers,
-            this,
-            &PersonalizationManagerInterfaceV1::onGetWallpapers);
 }
 
 void PersonalizationManagerInterfaceV1::onCursorContextCreated(PersonalizationCursorContextV1 *context)
@@ -1058,25 +890,25 @@ void PersonalizationManagerInterfaceV1::onAppearanceContextCreated(Personalizati
 {
     connect(context, &PersonalizationAppearanceContextV1::roundCornerRadiusChanged, this, [](int32_t radius) {
         Helper::instance()->config()->setWindowRadius(radius);
-        for (auto *c : s_appearanceContexts) {
+        for (auto *c : std::as_const(s_appearanceContexts)) {
             c->sendRoundCornerRadius(radius);
         }
     });
     connect(context, &PersonalizationAppearanceContextV1::iconThemeChanged, this, [](const QString &theme) {
         Helper::instance()->config()->setIconThemeName(theme);
-        for (auto *c : s_appearanceContexts) {
+        for (auto *c : std::as_const(s_appearanceContexts)) {
             c->sendIconTheme(theme);
         }
     });
     connect(context, &PersonalizationAppearanceContextV1::activeColorChanged, this, [](const QString &color) {
         Helper::instance()->config()->setActiveColor(color);
-        for (auto *c : s_appearanceContexts) {
+        for (auto *c : std::as_const(s_appearanceContexts)) {
             c->sendActiveColor(color);
         }
     });
     connect(context, &PersonalizationAppearanceContextV1::windowOpacityChanged, this, [](uint32_t opacity) {
         Helper::instance()->config()->setWindowOpacity(opacity);
-        for (auto *c : s_appearanceContexts) {
+        for (auto *c : std::as_const(s_appearanceContexts)) {
             c->sendWindowOpacity(opacity);
         }
     });
@@ -1084,14 +916,15 @@ void PersonalizationManagerInterfaceV1::onAppearanceContextCreated(Personalizati
         const auto dconfigType = protocolWindowThemeTypeToDConfig(type);
         if (dconfigType.has_value()) {
             Helper::instance()->config()->setWindowThemeType(*dconfigType);
+            Helper::syncPaletteTypeWithWindowThemeType(*dconfigType);
         }
-        for (auto *c : s_appearanceContexts) {
+        for (auto *c : std::as_const(s_appearanceContexts)) {
             c->sendWindowThemeType(type);
         }
     });
     connect(context, &PersonalizationAppearanceContextV1::titlebarHeightChanged, this, [](uint32_t height) {
         Helper::instance()->config()->setWindowTitlebarHeight(height);
-        for (auto *c : s_appearanceContexts) {
+        for (auto *c : std::as_const(s_appearanceContexts)) {
             c->sendWindowTitlebarHeight(height);
         }
     });
@@ -1170,71 +1003,6 @@ void PersonalizationManagerInterfaceV1::onFontContextCreated(PersonalizationFont
     context->blockSignals(false);
 }
 
-void PersonalizationManagerInterfaceV1::saveImage(PersonalizationWallpaperContextV1 *context,
-                                   const QString &prefix)
-{
-    if (!context || context->fd() == -1 || d->settingFile.isEmpty()) {
-        return;
-    }
-
-    QDir dir(d->cacheDirectory);
-    if (!dir.exists()) {
-        dir.mkpath(d->cacheDirectory);
-    }
-
-    QString output = context->outputName();
-    if (output.isEmpty()) {
-        for (QScreen *screen : QGuiApplication::screens()) {
-            output = screen->name();
-            break;
-        }
-    }
-
-    QString dest = d->cacheDirectory + prefix + "_" + output + "_"
-        + QDateTime::currentDateTime().toString("yyyyMMddhhmmss");
-
-    QFile src_file;
-    if (!src_file.open(context->fd(), QIODevice::ReadOnly))
-        return;
-
-    QByteArray data = src_file.readAll();
-    src_file.close();
-
-    QFile dest_file(dest);
-    if (dest_file.open(QIODevice::WriteOnly)) {
-        dest_file.write(data);
-        dest_file.close();
-    }
-
-    QSettings settings(d->settingFile, QSettings::IniFormat);
-
-    int workspaceId = 1;
-    settings.beginGroup(QString("%1.%2.%3").arg(prefix).arg(output).arg(workspaceId));
-
-    const QString &old_path = settings.value("path").toString();
-    QFile::remove(old_path);
-
-    settings.setValue("path", dest);
-    settings.setValue("isdark", context->isDark());
-    settings.endGroup();
-
-    settings.setValue("metadata", context->metaData());
-    d->iniMetaData = context->metaData();
-}
-
-void PersonalizationManagerInterfaceV1::onWallpaperCommit(PersonalizationWallpaperContextV1 *context)
-{
-    if (context->options() & TREELAND_PERSONALIZATION_WALLPAPER_CONTEXT_V1_OPTIONS_BACKGROUND) {
-        saveImage(context, "background");
-        Q_EMIT backgroundChanged(context->outputName(), context->isDark());
-    }
-
-    if (context->options() & TREELAND_PERSONALIZATION_WALLPAPER_CONTEXT_V1_OPTIONS_LOCKSCREEN) {
-        saveImage(context, "lockscreen");
-        Q_EMIT lockscreenChanged();
-    }
-}
-
 void PersonalizationManagerInterfaceV1::onCursorCommit(PersonalizationCursorContextV1 *context)
 {
     if (!context->size().isValid() || context->theme().isEmpty()) {
@@ -1245,15 +1013,6 @@ void PersonalizationManagerInterfaceV1::onCursorCommit(PersonalizationCursorCont
     setCursorSize(context->size());
 
     context->verify(true);
-}
-
-void PersonalizationManagerInterfaceV1::onGetWallpapers(PersonalizationWallpaperContextV1 *context)
-{
-    QDir dir(d->cacheDirectory);
-    if (!dir.exists())
-        return;
-
-    context->setMetaData(d->iniMetaData);
 }
 
 uid_t PersonalizationManagerInterfaceV1::userId()
@@ -1268,7 +1027,6 @@ void PersonalizationManagerInterfaceV1::setUserId(uid_t uid)
     }
 
     d->userId = uid;
-    updateCacheWallpaperPath(uid);
     Q_EMIT userIdChanged(uid);
 }
 
@@ -1308,32 +1066,6 @@ QString PersonalizationManagerInterfaceV1::iconTheme() const
     return Helper::instance()->config()->iconThemeName();
 }
 
-QString PersonalizationManagerInterfaceV1::background(const QString &output, int workspaceId)
-{
-    return readWallpaperSettings("background", output, workspaceId);
-}
-
-QString PersonalizationManagerInterfaceV1::lockscreen(const QString &output, int workspaceId)
-{
-    return readWallpaperSettings("lockscreen", output, workspaceId);
-}
-
-bool PersonalizationManagerInterfaceV1::backgroundIsDark(const QString &output, int workspaceId)
-{
-    if (d->settingFile.isEmpty())
-        return DEFAULT_WALLPAPER_ISDARK;
-
-    QSettings settings(d->settingFile, QSettings::IniFormat);
-    settings.beginGroup(QString("background.%1.%2").arg(output).arg(workspaceId));
-    return settings.value("isdark", DEFAULT_WALLPAPER_ISDARK).toBool();
-}
-
-bool PersonalizationManagerInterfaceV1::isAnimagedImage(const QString &source)
-{
-    QImageReader reader(source);
-    return reader.imageCount() > 1;
-}
-
 Personalization::Personalization(WToplevelSurface *target,
                                  PersonalizationManagerInterfaceV1 *manager,
                                  SurfaceWrapper *parent)
@@ -1342,7 +1074,7 @@ Personalization::Personalization(WToplevelSurface *target,
     , m_manager(manager)
 {
     connect(target, &WToplevelSurface::aboutToBeInvalidated, this, [this] {
-        disconnect(m_connection);
+        disconnect(m_manager, &PersonalizationManagerInterfaceV1::windowContextCreated, this, nullptr);
     });
 
     auto update = [this](PersonalizationWindowContextV1 *context) {
@@ -1352,53 +1084,61 @@ Personalization::Personalization(WToplevelSurface *target,
             return;
         }
 
-        disconnect(m_connection);
-
         connect(context,
                 &PersonalizationWindowContextV1::backgroundTypeChanged,
                 this,
                 [this, context] {
-                    m_backgroundType = context->backgroundType();
-                    Q_EMIT backgroundTypeChanged();
+                    setBackgroundType(static_cast<Personalization::BackgroundType>(context->backgroundType()));
                 });
         connect(context,
                 &PersonalizationWindowContextV1::cornerRadiusChanged,
                 this,
                 [this, context] {
-                    m_cornerRadius = context->cornerRadius();
-                    Q_EMIT cornerRadiusChanged();
+                    setCornerRadius(context->cornerRadius());
                 });
 
         connect(context, &PersonalizationWindowContextV1::shadowChanged, this, [this, context] {
-            m_shadow = context->shadow();
-            Q_EMIT shadowChanged();
+            setShadow(context->shadow());
+            setShadowState(context->shadowState());
         });
 
         connect(context, &PersonalizationWindowContextV1::borderChanged, this, [this, context] {
-            m_border = context->border();
-            Q_EMIT borderChanged();
+            setBorder(context->border());
+            setBorderState(context->borderState());
         });
 
         connect(context,
                 &PersonalizationWindowContextV1::windowStateChanged,
                 this,
                 [this, context] {
-                    m_states = context->states();
-                    Q_EMIT windowStateChanged();
+                    setWindowStates(context->states());
                 });
 
-        m_backgroundType = context->backgroundType();
-        m_cornerRadius = context->cornerRadius();
-        m_shadow = context->shadow();
-        m_border = context->border();
-        m_states = context->states();
+        setBackgroundType(static_cast<Personalization::BackgroundType>(context->backgroundType()));
+        setCornerRadius(context->cornerRadius());
+        setShadow(context->shadow());
+        setShadowState(context->shadowState());
+        setBorder(context->border());
+        setBorderState(context->borderState());
+        setWindowStates(context->states());
     };
 
-    m_connection = connect(m_manager, &PersonalizationManagerInterfaceV1::windowContextCreated, this, update);
+    connect(m_manager, &PersonalizationManagerInterfaceV1::windowContextCreated, this, update);
 
     if (auto *context = PersonalizationWindowContextV1::getWindowContext(m_target->surface())) {
         update(context);
     }
+}
+
+void Personalization::resetProperties()
+{
+    setBackgroundType(Personalization::BackgroundType::Normal);
+    setCornerRadius(0);
+    setShadow({});
+    setShadowState(PersonalizationWindowContextV1::ShadowState::Unset);
+    setBorder({});
+    setBorderState(PersonalizationWindowContextV1::BorderState::Unset);
+    setWindowStates({});
 }
 
 SurfaceWrapper *Personalization::surfaceWrapper() const
@@ -1408,7 +1148,7 @@ SurfaceWrapper *Personalization::surfaceWrapper() const
 
 Personalization::BackgroundType Personalization::backgroundType() const
 {
-    return static_cast<Personalization::BackgroundType>(m_backgroundType);
+    return m_backgroundType;
 }
 
 bool Personalization::noTitlebar() const
@@ -1418,6 +1158,72 @@ bool Personalization::noTitlebar() const
     }
 
     return m_states.testFlag(PersonalizationWindowContextV1::NoTitleBar);
+}
+
+bool Personalization::shadowEnabled() const
+{
+    return m_shadowState == PersonalizationWindowContextV1::ShadowState::Enabled;
+}
+
+bool Personalization::borderEnabled() const
+{
+    return m_borderState == PersonalizationWindowContextV1::BorderState::Enabled;
+}
+
+void Personalization::setBackgroundType(BackgroundType type)
+{
+    if (m_backgroundType == type)
+        return;
+    m_backgroundType = type;
+    Q_EMIT backgroundTypeChanged();
+}
+
+void Personalization::setCornerRadius(int32_t radius)
+{
+    if (m_cornerRadius == radius)
+        return;
+    m_cornerRadius = radius;
+    Q_EMIT cornerRadiusChanged();
+}
+
+void Personalization::setShadow(const Shadow &shadow)
+{
+    if (m_shadow == shadow)
+        return;
+    m_shadow = shadow;
+    Q_EMIT shadowChanged();
+}
+
+void Personalization::setBorder(const Border &border)
+{
+    if (m_border == border)
+        return;
+    m_border = border;
+    Q_EMIT borderChanged();
+}
+
+void Personalization::setWindowStates(PersonalizationWindowContextV1::WindowStates states)
+{
+    if (m_states == states)
+        return;
+    m_states = states;
+    Q_EMIT windowStateChanged();
+}
+
+void Personalization::setShadowState(PersonalizationWindowContextV1::ShadowState state)
+{
+    if (m_shadowState == state)
+        return;
+    m_shadowState = state;
+    Q_EMIT shadowChanged();
+}
+
+void Personalization::setBorderState(PersonalizationWindowContextV1::BorderState state)
+{
+    if (m_borderState == state)
+        return;
+    m_borderState = state;
+    Q_EMIT borderChanged();
 }
 
 void PersonalizationManagerInterfaceV1::create(WServer *server)
@@ -1438,9 +1244,4 @@ wl_global *PersonalizationManagerInterfaceV1::global() const
 QByteArrayView PersonalizationManagerInterfaceV1::interfaceName() const
 {
     return d->interfaceName();
-}
-
-QString PersonalizationManagerInterfaceV1::defaultWallpaper() const
-{
-    return DEFAULT_WALLPAPER;
 }

--- a/src/modules/personalization/personalizationmanagerinterfacev1.h
+++ b/src/modules/personalization/personalizationmanagerinterfacev1.h
@@ -22,12 +22,14 @@ struct Shadow
     int32_t radius;
     QPoint offset;
     QColor color;
+    bool operator==(const Shadow &other) const = default;
 };
 
 struct Border
 {
     int32_t width;
     QColor color;
+    bool operator==(const Border &other) const = default;
 };
 
 class PersonalizationManagerInterfaceV1Private;
@@ -43,13 +45,31 @@ public:
     Q_ENUM(WindowState)
     Q_DECLARE_FLAGS(WindowStates, WindowState)
 
+    enum class ShadowState
+    {
+        Unset,
+        Disabled,
+        Enabled,
+    };
+    Q_ENUM(ShadowState)
+
+    enum class BorderState
+    {
+        Unset,
+        Disabled,
+        Enabled,
+    };
+    Q_ENUM(BorderState)
+
     ~PersonalizationWindowContextV1() override;
 
     wl_resource *resource() const;
     wlr_surface *surface() const;
     int32_t backgroundType() const;
     int32_t cornerRadius() const;
+    ShadowState shadowState() const;
     Shadow shadow() const;
+    BorderState borderState() const;
     Border border() const;
     WindowStates states() const;
 
@@ -73,39 +93,6 @@ private:
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(PersonalizationWindowContextV1::WindowStates)
-
-class PersonalizationWallpaperContextV1Private;
-class PersonalizationWallpaperContextV1 : public QObject
-{
-    Q_OBJECT
-public:
-    ~PersonalizationWallpaperContextV1() override;
-
-    wl_resource *resource() const;
-    int32_t fd() const;
-    uint32_t uid() const;
-    uint32_t options() const;
-    bool isDark() const;
-    QString metaData() const;
-    QString identifier() const;
-    QString outputName() const;
-
-    void setMetaData(const QString &data);
-
-    static PersonalizationWallpaperContextV1 *get(wl_resource *resource);
-
-Q_SIGNALS:
-    void commit(PersonalizationWallpaperContextV1 *context);
-    void getWallpapers(PersonalizationWallpaperContextV1 *context);
-
-private:
-    explicit PersonalizationWallpaperContextV1(wl_resource *resource);
-
-private:
-    std::unique_ptr<PersonalizationWallpaperContextV1Private> d;
-
-    friend class PersonalizationManagerInterfaceV1Private;
-};
 
 class PersonalizationCursorContextV1Private;
 class PersonalizationCursorContextV1 : public QObject
@@ -228,11 +215,13 @@ class Personalization : public QObject
 {
     Q_OBJECT
     QML_ANONYMOUS
-    Q_PROPERTY(int32_t backgroundType READ backgroundType NOTIFY backgroundTypeChanged)
+    Q_PROPERTY(BackgroundType backgroundType READ backgroundType NOTIFY backgroundTypeChanged)
     Q_PROPERTY(int32_t cornerRadius READ cornerRadius NOTIFY cornerRadiusChanged)
     Q_PROPERTY(Shadow shadow READ shadow NOTIFY shadowChanged)
     Q_PROPERTY(Border border READ border NOTIFY borderChanged)
     Q_PROPERTY(bool noTitlebar READ noTitlebar NOTIFY windowStateChanged)
+    Q_PROPERTY(bool shadowEnabled READ shadowEnabled NOTIFY shadowChanged)
+    Q_PROPERTY(bool borderEnabled READ borderEnabled NOTIFY borderChanged)
 
 public:
     enum BackgroundType
@@ -266,6 +255,8 @@ public:
     }
 
     bool noTitlebar() const;
+    bool shadowEnabled() const;
+    bool borderEnabled() const;
 
 Q_SIGNALS:
     void backgroundTypeChanged();
@@ -274,16 +265,28 @@ Q_SIGNALS:
     void borderChanged();
     void windowStateChanged();
 
+private Q_SLOTS:
+    void resetProperties();
+
+private:
+    void setBackgroundType(BackgroundType type);
+    void setCornerRadius(int32_t radius);
+    void setShadow(const Shadow &shadow);
+    void setBorder(const Border &border);
+    void setWindowStates(PersonalizationWindowContextV1::WindowStates states);
+    void setShadowState(PersonalizationWindowContextV1::ShadowState state);
+    void setBorderState(PersonalizationWindowContextV1::BorderState state);
+
 private:
     WWrapPointer<WToplevelSurface> m_target;
     PersonalizationManagerInterfaceV1 *m_manager = nullptr;
-    int32_t m_backgroundType = Personalization::BackgroundType::Normal;
+    BackgroundType m_backgroundType = BackgroundType::Normal;
     int32_t m_cornerRadius = 0;
     Shadow m_shadow {};
     Border m_border {};
     PersonalizationWindowContextV1::WindowStates m_states {};
-
-    QMetaObject::Connection m_connection;
+    PersonalizationWindowContextV1::ShadowState m_shadowState = PersonalizationWindowContextV1::ShadowState::Unset;
+    PersonalizationWindowContextV1::BorderState m_borderState = PersonalizationWindowContextV1::BorderState::Unset;
 };
 
 class PersonalizationManagerInterfaceV1 : public QObject, public WServerInterface
@@ -298,14 +301,11 @@ public:
     explicit PersonalizationManagerInterfaceV1(QObject *parent = nullptr);
     ~PersonalizationManagerInterfaceV1() override;
 
-    void onWallpaperContextCreated(PersonalizationWallpaperContextV1 *context);
     void onCursorContextCreated(PersonalizationCursorContextV1 *context);
     void onAppearanceContextCreated(PersonalizationAppearanceContextV1 *context);
     void onFontContextCreated(PersonalizationFontContextV1 *context);
 
     void onWindowPersonalizationChanged();
-    void onWallpaperCommit(PersonalizationWallpaperContextV1 *context);
-    void onGetWallpapers(PersonalizationWallpaperContextV1 *context);
 
     void onCursorCommit(PersonalizationCursorContextV1 *context);
 
@@ -324,22 +324,13 @@ public:
 
     QByteArrayView interfaceName() const override;
 
-    QString defaultWallpaper() const;
-
-    static constexpr int InterfaceVersion = 1;
+    static constexpr int InterfaceVersion = 2;
 Q_SIGNALS:
     void userIdChanged(uid_t uid);
-    void backgroundChanged(const QString &output, bool isdark);
     void lockscreenChanged();
     void cursorThemeChanged(const QString &name);
     void cursorSizeChanged(const QSize &size);
     void windowContextCreated(PersonalizationWindowContextV1 *context);
-
-public Q_SLOTS:
-    QString background(const QString &output, int workspaceId = 1);
-    QString lockscreen(const QString &output, int workspaceId = 1);
-    bool backgroundIsDark(const QString &output, int workspaceId = 1);
-    bool isAnimagedImage(const QString &source);
 
 protected:
     void create(WServer *server) override;
@@ -347,9 +338,5 @@ protected:
     wl_global *global() const override;
 
 private:
-    void saveImage(PersonalizationWallpaperContextV1 *context, const QString &prefix);
-    void updateCacheWallpaperPath(uid_t uid);
-    QString readWallpaperSettings(const QString &group, const QString &output, int workspaceId = 1);
-
     std::unique_ptr<PersonalizationManagerInterfaceV1Private> d;
 };

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -8,6 +8,7 @@
 #include <QJsonDocument>
 #include <QJsonArray>
 #include <QJsonObject>
+#include <qnamespace.h>
 #ifdef EXT_SESSION_LOCK_V1
 #include "wsessionlock.h"
 #include "wsessionlockmanager.h"
@@ -24,26 +25,27 @@
 #include "core/treeland.h"
 #include "core/windowpicker.h"
 #include "greeter/greeterproxy.h"
-#include "greeter/usermodel.h"
 #include "greeter/sessionmodel.h"
+#include "greeter/usermodel.h"
 #include "input/inputdevice.h"
+#include "inputmanager.h"
 #include "interfaces/multitaskviewinterface.h"
 #include "modules/capture/capture.h"
 #include "modules/dde-shell/ddeshellattached.h"
 #include "modules/dde-shell/ddeshellmanagerinterfacev1.h"
 #include "modules/ddm/ddminterfacev1.h"
+#include "modules/input-manager/inputmanagerinterfacev1.h"
+#include "modules/keyboard-state-notify/keyboardstatenotifymanagerinterfacev1.h"
 #include "modules/output-manager/outputmanagement.h"
 #include "modules/personalization/personalizationmanagerinterfacev1.h"
+#include "modules/resource/treelandremotesource.h"
 #include "modules/screensaver/screensaverinterfacev1.h"
 #include "modules/shortcut/shortcutcontroller.h"
 #include "modules/shortcut/shortcutmanager.h"
 #include "modules/shortcut/shortcutrunner.h"
 #include "modules/wallpaper-color/wallpapercolorinterfacev1.h"
-#include "modules/input-manager/inputmanagerinterfacev1.h"
-#include "modules/keyboard-state-notify/keyboardstatenotifymanagerinterfacev1.h"
-#include "modules/resource/treelandremotesource.h"
-#include "output/outputconfigstate.h"
 #include "output/output.h"
+#include "output/outputconfigstate.h"
 #include "output/outputlifecyclemanager.h"
 #include "session/session.h"
 #include "surface/surfacecontainer.h"
@@ -52,20 +54,24 @@
 #include "treelanduserconfig.hpp"
 #include "utils/cmdline.h"
 #include "utils/fpsdisplaymanager.h"
-#include "workspace/workspace.h"
 #include "wallpaper/wallpapermanager.h"
 #include "wallpapershellinterfacev1.h"
-#include "inputmanager.h"
+#include "workspace/workspace.h"
 
+#include <rhi/qrhi.h>
 #include <xcb/xcb.h>
 #include <xcb/xproto.h>
 
 #include <WBackend>
+#include <WForeignToplevel>
+#include <WOutput>
+#include <WServer>
+#include <WSurfaceItem>
+#include <WXdgOutput>
+#include <wayland-util.h>
 #include <wcursorshapemanagerv1.h>
 #include <wextimagecapturesourcev1impl.h>
-#include <WForeignToplevel>
 #include <wlayersurface.h>
-#include <WOutput>
 #include <woutputhelper.h>
 #include <woutputitem.h>
 #include <woutputlayout.h>
@@ -77,11 +83,8 @@
 #include <wrenderhelper.h>
 #include <wseat.h>
 #include <wsecuritycontextmanager.h>
-#include <WServer>
 #include <wsocket.h>
-#include <WSurfaceItem>
 #include <wtoplevelsurface.h>
-#include <WXdgOutput>
 #include <wxdgshell.h>
 #include <wxdgtoplevelsurface.h>
 #include <wxdgtopleveltagmanager.h>
@@ -121,6 +124,8 @@
 #include <qwxwayland.h>
 #include <qwxwaylandsurface.h>
 
+#include <DGuiApplicationHelper>
+
 #include <QAction>
 #include <QDBusConnection>
 #include <QDBusInterface>
@@ -130,14 +135,12 @@
 #include <QMouseEvent>
 #include <QQmlContext>
 #include <QQuickWindow>
-#include <QtConcurrent>
-#include <rhi/qrhi.h>
+#include <QThreadPool>
 
 #include <functional>
 #include <pwd.h>
 #include <unistd.h>
 #include <utility>
-#include <wayland-util.h>
 
 #define EXT_DATA_CONTROL_MANAGER_V1_VERSION 1
 #define WLR_FRACTIONAL_SCALE_V1_VERSION 1
@@ -203,6 +206,10 @@ Helper::Helper(QObject *parent)
 #endif
 
     m_shellHandler = new ShellHandler(m_rootSurfaceContainer, m_server);
+    connect(m_shellHandler->workspace(),
+            &Workspace::workspaceAdded,
+            m_wallpaperManager,
+            &WallpaperManager::syncAddWorkspace);
     tryInitRemoteSource();
 
     m_outputConfigState = new OutputConfigState(this);
@@ -237,7 +244,8 @@ Helper::Helper(QObject *parent)
         if (!wrapper) {
             // Qt focus lost (e.g. focus item became null) — clear Wayland keyboard focus
             // on all seats to avoid stale focus state.
-            for (auto *seat : m_seatManager->seats()) {
+            const auto seats = m_seatManager->seats();
+            for (auto *seat : seats) {
                 if (auto *seatContainer = m_rootSurfaceContainer->getSeatContainer(seat)) {
                     seatContainer->setKeyboardFocusSurface(nullptr);
                 }
@@ -252,7 +260,8 @@ Helper::Helper(QObject *parent)
                 seatContainer->setKeyboardFocusSurface(wrapper);
             }
         } else {
-            for (auto *seat : m_seatManager->seats()) {
+            const auto seats = m_seatManager->seats();
+            for (auto *seat : seats) {
                 if (!seat || !seat->isValid()) {
                     continue;
                 }
@@ -279,9 +288,9 @@ Helper::Helper(QObject *parent)
     );
 
     if (!connected) {
-        qCWarning(treelandCore) << "Failed to connect to systemd-logind PrepareForSleep signal";
+        qCWarning(lcTlCore) << "Failed to connect to systemd-logind PrepareForSleep signal";
     } else {
-        qCInfo(treelandCore) << "Successfully connected to systemd-logind PrepareForSleep signal";
+        qCInfo(lcTlCore) << "Successfully connected to systemd-logind PrepareForSleep signal";
     }
 
     // Also connect to SessionNew signal for logging purposes
@@ -311,7 +320,7 @@ Helper::~Helper()
     // destroy before m_rootSurfaceContainer
     delete m_shellHandler;
     if (m_rootSurfaceContainer) {
-        for (auto s : m_rootSurfaceContainer->surfaces()) {
+        for (auto s : std::as_const(m_rootSurfaceContainer->surfaces())) {
             if (auto c = s->container())
                 c->removeSurface(s);
         }
@@ -334,6 +343,32 @@ TreelandConfig *Helper::globalConfig()
     return m_globalConfig.get();
 }
 
+void Helper::syncPaletteTypeWithWindowThemeType(int32_t themeType)
+{
+    auto *guiHelper = DTK_GUI_NAMESPACE::DGuiApplicationHelper::instance();
+    if (!guiHelper) {
+        qCCritical(lcTlConfig) << "DGuiApplicationHelper instance not available, cannot sync "
+                                      "palette type with window theme type.";
+        return;
+    }
+
+    qCDebug(lcTlConfig) << "Syncing palette type with window theme type:" << themeType;
+
+    switch (themeType) {
+    case 2:
+        guiHelper->setPaletteType(Dtk::Gui::DGuiApplicationHelper::DarkType);
+        break;
+    case 1:
+        guiHelper->setPaletteType(Dtk::Gui::DGuiApplicationHelper::LightType);
+        break;
+    default:
+        qCWarning(lcTlConfig) << "Unknown windowThemeType:" << themeType
+                                  << ", fallback to light.";
+        guiHelper->setPaletteType(Dtk::Gui::DGuiApplicationHelper::LightType);
+        break;
+    }
+}
+
 void Helper::tryInitRemoteSource()
 {
     if (m_treelandRemoteSource)
@@ -351,14 +386,14 @@ bool Helper::isNvidiaCardPresent()
         return false;
 
     QString deviceName = rhi->driverInfo().deviceName;
-    qCDebug(treelandCore) << "Graphics Device:" << deviceName;
+    qCDebug(lcTlCore) << "Graphics Device:" << deviceName;
 
     return deviceName.contains("NVIDIA", Qt::CaseInsensitive);
 }
 
 void Helper::setWorkspaceVisible(bool visible)
 {
-    for (auto *surface : m_rootSurfaceContainer->surfaces()) {
+    for (auto *surface : std::as_const(m_rootSurfaceContainer->surfaces())) {
         if (surface->type() == SurfaceWrapper::Type::Layer) {
             surface->setHideByLockScreen(m_currentMode == CurrentMode::LockScreen);
         }
@@ -431,7 +466,7 @@ void Helper::onOutputAdded(WOutput *output)
     if (shouldRestoreCopyMode) {
         Output *primaryOutput = m_rootSurfaceContainer->primaryOutput();
         if (!primaryOutput) {
-            qCWarning(treelandCore) << "Cannot restore Copy Mode: no primary output available";
+            qCWarning(lcTlCore) << "Cannot restore Copy Mode: no primary output available";
             o = createNormalOutput(output);
         } else {
             const auto &allSurfaces = getWorkspaceSurfaces();
@@ -453,10 +488,6 @@ void Helper::onOutputAdded(WOutput *output)
     }
 
     o->enable();
-    m_outputManager->newOutput(output);
-
-    m_wallpaperColorV1->updateWallpaperColor(output->name(),
-                                             m_personalizationInterfaceV1->backgroundIsDark(output->name()));
 
     QString cache_location = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
     QSettings settings(cache_location + "/output.ini", QSettings::IniFormat);
@@ -487,10 +518,11 @@ void Helper::onOutputAdded(WOutput *output)
         newState.set_transform(static_cast<wl_output_transform>(settings.value("transform").toInt()));
         newState.set_scale(settings.value("scale").toFloat());
         if (!output->handle()->commit_state(newState)) {
-            qCCritical(treelandCore) << "commit failed on output" << output->name();
+            qCCritical(lcTlCore) << "commit failed on output" << output->name();
         }
     }
     settings.endGroup();
+    m_outputManager->newOutput(output);
     m_wallpaperManager->ensureWallpaperConfigForOutput(o);
 }
 
@@ -548,7 +580,7 @@ void Helper::onOutputRemoved(WOutput *output)
             m_rootSurfaceContainer->removeOutput(o);
         }
 
-        for (auto oldOutput : oldOutputsToDelete) {
+        for (auto oldOutput : std::as_const(oldOutputsToDelete)) {
             m_rootSurfaceContainer->removeOutput(oldOutput);
             delete oldOutput;
         }
@@ -596,8 +628,8 @@ void Helper::setGamma(struct wlr_gamma_control_manager_v1_set_gamma_event *event
     qw_output_state newState;
     newState.set_gamma_lut(ramp_size, r, g, b);
     if (!qwOutput->commit_state(newState)) {
-        qCCritical(treelandCore, "commit failed on output  %s", qwOutput->handle()->name);
-        qCWarning(treelandCore) << "Failed to set gamma lut!";
+        qCCritical(lcTlCore, "commit failed on output  %s", qwOutput->handle()->name);
+        qCWarning(lcTlCore) << "Failed to set gamma lut!";
         // TODO: use software impl it.
         qw_gamma_control_v1::from(gamma_control)->send_failed_and_destroy();
     }
@@ -607,7 +639,7 @@ void Helper::handleCopyModeOutputDisable(Output *affectedOutput)
 {
     int affectedIndex = m_outputList.indexOf(affectedOutput);
     if (affectedIndex < 0) {
-        qCWarning(treelandCore) << "Disabled output not found in m_outputList";
+        qCWarning(lcTlCore) << "Disabled output not found in m_outputList";
         return;
     }
 
@@ -745,7 +777,7 @@ void Helper::onOutputTestOrApply(qw_output_configuration_v1 *config, bool onlyTe
 
         WOutputRenderWindow *renderWindow = viewport->outputRenderWindow();
         if (!renderWindow) {
-            qCWarning(treelandCore) << "No renderWindow for output" << state.output->name();
+            qCWarning(lcTlCore) << "No renderWindow for output" << state.output->name();
             m_outputManager->sendResult(config, false);
             m_pendingOutputConfig = {};
             return;
@@ -760,7 +792,7 @@ void Helper::onOutputTestOrApply(qw_output_configuration_v1 *config, bool onlyTe
 
         auto outputHelper = renderWindow->getOutputHelper(viewport);
         if (!outputHelper) {
-            qCWarning(treelandCore) << "No output helper for viewport" << viewport;
+            qCWarning(lcTlCore) << "No output helper for viewport" << viewport;
             m_outputManager->sendResult(config, false);
             m_pendingOutputConfig = {};
             return;
@@ -796,7 +828,7 @@ void Helper::onOutputTestOrApply(qw_output_configuration_v1 *config, bool onlyTe
         }
 
         if (!outputHelper->setExtraState(extraState)) {
-            qCWarning(treelandCore) << "Failed to set extra state for output" << state.output->name();
+            qCWarning(lcTlCore) << "Failed to set extra state for output" << state.output->name();
             m_outputManager->sendResult(config, false);
             m_pendingOutputConfig = {};
             return;
@@ -823,7 +855,7 @@ void Helper::onOutputTestOrApply(qw_output_configuration_v1 *config, bool onlyTe
                         }
                     }
                 } else {
-                    qCWarning(treelandCore) << "Commit callback received unexpected state pointer!"
+                    qCWarning(lcTlCore) << "Commit callback received unexpected state pointer!"
                                             << "Expected:" << extraState.get()
                                             << "Got:" << committedState.get();
                     self->onOutputCommitFinished(config, false);
@@ -870,7 +902,7 @@ void Helper::onOutputCommitFinished(qw_output_configuration_v1 *config, bool suc
                 // Reason: When disabled, mode/scale/transform are not committed to wlroots,
                 // so we should not save uncommitted values
                 if (!state.enabled) {
-                    qCDebug(treelandCore) << "Skipping config save for disabled output:" << state.output->name();
+                    qCDebug(lcTlCore) << "Skipping config save for disabled output:" << state.output->name();
                     continue;
                 }
 
@@ -901,7 +933,7 @@ void Helper::onSetOutputPowerMode(wlr_output_power_v1_set_mode_event *event)
         }
         newState.set_enabled(false);
         if (!output->commit_state(newState)) {
-            qCCritical(treelandCore, "commit failed on output %s", output->handle()->name);
+            qCCritical(lcTlCore, "commit failed on output %s", output->handle()->name);
         }
         break;
     case ZWLR_OUTPUT_POWER_V1_MODE_ON:
@@ -910,7 +942,7 @@ void Helper::onSetOutputPowerMode(wlr_output_power_v1_set_mode_event *event)
         }
         newState.set_enabled(true);
         if (!output->commit_state(newState)) {
-            qCCritical(treelandCore, "commit failed on output %s", output->handle()->name);
+            qCCritical(lcTlCore, "commit failed on output %s", output->handle()->name);
         }
         break;
     }
@@ -919,13 +951,13 @@ void Helper::onSetOutputPowerMode(wlr_output_power_v1_set_mode_event *event)
 void Helper::onNewIdleInhibitor(wlr_idle_inhibitor_v1 *wlr_inhibitor)
 {
     if (!wlr_inhibitor->surface) {
-        qCInfo(treelandCore) << "Ignoring idle inhibitor with null surface";
+        qCInfo(lcTlCore) << "Ignoring idle inhibitor with null surface";
         return;
     }
 
     auto wsurface = WSurface::fromHandle(wlr_inhibitor->surface);
     if (!wsurface) {
-        qCWarning(treelandCore) << "No WSurface found for idle inhibitor surface"
+        qCWarning(lcTlCore) << "No WSurface found for idle inhibitor surface"
                                 << wlr_inhibitor->surface;
         return;
     }
@@ -1000,7 +1032,7 @@ void Helper::onShowDesktop()
 void Helper::onSetCopyOutput(VirtualOutputInterfaceV1 *interface)
 {
     Output *mirrorOutput = nullptr;
-    for (Output *output : m_outputList) {
+    for (Output *output : std::as_const(m_outputList)) {
         if (!interface->outputList().contains(output->output()->name())) {
             QString screen = output->output()->name() + " does not exist!";
             interface->sendError(VirtualOutputInterfaceV1::INVALID_OUTPUT, screen);
@@ -1066,13 +1098,18 @@ void Helper::onRestoreCopyOutput(VirtualOutputInterfaceV1 *interface)
 
 void Helper::onSurfaceWrapperAdded(SurfaceWrapper *wrapper)
 {
+    if (wrapper->isIMCandidatePanel())
+        return;
+
     bool isXdgToplevel = wrapper->type() == SurfaceWrapper::Type::XdgToplevel;
     bool isXdgPopup = wrapper->type() == SurfaceWrapper::Type::XdgPopup;
     bool isXwayland = wrapper->type() == SurfaceWrapper::Type::XWayland;
     bool isLayer = wrapper->type() == SurfaceWrapper::Type::Layer;
 
-    connect(m_sessionManager->activeSession().lock().get(), &Session::aboutToBeDestroyed,
-            wrapper, &SurfaceWrapper::requestClose);
+    connect(m_sessionManager->activeSession().lock().get(),
+            &Session::aboutToBeDestroyed,
+            wrapper,
+            &SurfaceWrapper::closeSurface);
 
     if (isXdgToplevel || isXdgPopup || isLayer) {
         auto *attached =
@@ -1080,18 +1117,41 @@ void Helper::onSurfaceWrapperAdded(SurfaceWrapper *wrapper)
         connect(wrapper, &SurfaceWrapper::aboutToBeInvalidated,
                 attached, &Personalization::deleteLater);
 
-        auto updateNoTitlebar = [this, attached] {
+        auto updateDecorationParams = [attached] {
+            auto wrapper = attached->surfaceWrapper();
+            auto shadow = attached->shadow();
+            auto border = attached->border();
+            wrapper->setShadowParams(SurfaceWrapper::ShadowParams{
+                shadow.radius,
+                shadow.offset.y(),
+                shadow.color
+            });
+            wrapper->setBorderParams(SurfaceWrapper::BorderParams{
+                border.width,
+                border.color
+            });
+        };
+
+        auto updateNoTitlebar = [this, attached, isLayer, updateDecorationParams] {
             auto wrapper = attached->surfaceWrapper();
             if (attached->noTitlebar()) {
                 wrapper->setNoTitleBar(true);
-                auto layer = qobject_cast<WLayerSurface *>(wrapper->shellSurface());
-                if (!isLaunchpad(layer)) {
-                    wrapper->setNoDecoration(false);
+                if (isLayer) {
+                    bool needsDecoration = attached->shadowEnabled() || attached->borderEnabled();
+                    if (needsDecoration && wrapper->noDecoration()) {
+                        wrapper->setNoDecoration(false);
+                        updateDecorationParams();
+                    }
+                } else {
+                    wrapper->setNoDecoration(m_xdgDecorationManager->modeBySurface(wrapper->surface())
+                                         != WXdgDecorationManager::Server);
                 }
             } else {
                 wrapper->setNoTitleBar(false);
-                wrapper->setNoDecoration(m_xdgDecorationManager->modeBySurface(wrapper->surface())
-                                     != WXdgDecorationManager::Server);
+                if (!isLayer) {
+                    wrapper->setNoDecoration(m_xdgDecorationManager->modeBySurface(wrapper->surface())
+                                         != WXdgDecorationManager::Server);
+                }
             }
         };
 
@@ -1116,11 +1176,30 @@ void Helper::onSurfaceWrapperAdded(SurfaceWrapper *wrapper)
             attached->surfaceWrapper()->setBlur(attached->backgroundType() == Personalization::BackgroundType::Blur);
         };
         connect(attached, &Personalization::backgroundTypeChanged, this, updateBlur);
+        auto updateCornerRadius = [attached] {
+            attached->surfaceWrapper()->setRadius(attached->cornerRadius());
+        };
+        connect(attached, &Personalization::cornerRadiusChanged, this, updateCornerRadius);
+        updateCornerRadius();
         updateBlur();
         if (isLayer) {
             auto layer = qobject_cast<WLayerSurface *>(wrapper->shellSurface());
             if (isLaunchpad(layer))
                 wrapper->setCoverEnabled(true);
+
+            connect(attached, &Personalization::shadowChanged, this, [attached, wrapper, updateDecorationParams]() {
+                if (attached->shadowEnabled() && wrapper->noDecoration()) {
+                    wrapper->setNoDecoration(false);
+                }
+                updateDecorationParams();
+            });
+
+            connect(attached, &Personalization::borderChanged, this, [attached, wrapper, updateDecorationParams]() {
+                if (attached->borderEnabled() && wrapper->noDecoration()) {
+                    wrapper->setNoDecoration(false);
+                }
+                updateDecorationParams();
+            });
         }
     }
 
@@ -1218,6 +1297,9 @@ void Helper::onSurfaceWrapperAdded(SurfaceWrapper *wrapper)
 
 void Helper::onSurfaceWrapperAboutToRemove(SurfaceWrapper *wrapper)
 {
+    if (wrapper->isIMCandidatePanel())
+        return;
+
     if (!wrapper->skipDockPreView()) {
         m_foreignToplevel->removeSurface(wrapper->shellSurface());
         m_extForeignToplevelListV1->removeSurface(wrapper->shellSurface());
@@ -1314,6 +1396,10 @@ void Helper::init(Treeland::Treeland *treeland)
             &RootSurfaceContainer::primaryOutputChanged,
             m_outputManagerV1,
             &OutputManagerV1::onPrimaryOutputChanged);
+    connect(m_rootSurfaceContainer,
+            &RootSurfaceContainer::primaryOutputChanged,
+            m_sessionManager,
+            &SessionManager::syncActiveSessionXWaylandPrimaryOutput);
     m_wallpaperColorV1 = m_server->attach<WallpaperColorInterfaceV1>();
     m_windowManagementInterfaceV1 = m_server->attach<WindowManagementInterfaceV1>();
     m_virtualOutputInterfaceV1 = m_server->attach<VirtualOutputManagerInterfaceV1>();
@@ -1339,6 +1425,17 @@ void Helper::init(Treeland::Treeland *treeland)
         m_config.reset(TreelandUserConfig::createByName("org.deepin.dde.treeland.user",
                                                   "org.deepin.dde.treeland",
                                                   "/" + m_userModel->currentUserName()));
+        // Notify QML that the config pointer has changed so bindings (e.g. sourceSize
+        // on WQuickCursor) reconnect their notifiers to the new TreelandUserConfig object.
+        Q_EMIT configChanged();
+        connect(m_config.get(),
+                &TreelandUserConfig::cursorThemeNameChanged,
+                m_sessionManager,
+                &SessionManager::syncActiveSessionCursorSettings);
+        connect(m_config.get(),
+                &TreelandUserConfig::cursorSizeChanged,
+                m_sessionManager,
+                &SessionManager::syncActiveSessionCursorSettings);
         auto user = m_userModel->currentUser();
         m_personalizationInterfaceV1->setUserId(user ? user->UID() : getuid());
         // TODO(YaoBing Xiao): remove "dde"
@@ -1347,41 +1444,29 @@ void Helper::init(Treeland::Treeland *treeland)
         }
 
         m_inputManager->setupSeatUserConfig(m_userModel->currentUserName());
+        auto onConfigInitialized = [this] {
+            m_sessionManager->syncActiveSessionCursorSettings();
+            syncPaletteTypeWithWindowThemeType(m_config->windowThemeType());
+            m_wallpaperManager->updateWallpaperConfig();
+            tryInitRemoteSource();
+        };
         // TODO(YaoBing Xiao): pre-initialize dconfig, remove isInitializeSucceeded
 #if TREELANDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
         if (m_config->isInitializeSucceeded()) {
 #else
         if (m_config->isInitializeSucceed()) {
 #endif
-            m_wallpaperManager->updateWallpaperConfig();
-            tryInitRemoteSource();
+            onConfigInitialized();
         } else {
             connect(m_config.get(),
                     &TreelandUserConfig::configInitializeSucceed,
-                    m_wallpaperManager,
-                    &WallpaperManager::updateWallpaperConfig);
-            connect(m_config.get(),
-                    &TreelandUserConfig::configInitializeSucceed,
                     this,
-                    &Helper::tryInitRemoteSource);
+                    onConfigInitialized);
         }
     };
     connect(m_userModel, &UserModel::currentUserNameChanged, this, updateCurrentUser);
 
     updateCurrentUser();
-
-    connect(m_personalizationInterfaceV1,
-            &PersonalizationManagerInterfaceV1::backgroundChanged,
-            this,
-            [this](const QString &output, bool isdark) {
-                m_wallpaperColorV1->updateWallpaperColor(output, isdark);
-            });
-
-    for (auto output : m_rootSurfaceContainer->outputs()) {
-        const QString &outputName = output->output()->name();
-        m_wallpaperColorV1->updateWallpaperColor(outputName,
-                                                 m_personalizationInterfaceV1->backgroundIsDark(outputName));
-    }
 
     connect(m_windowManagementInterfaceV1,
             &WindowManagementInterfaceV1::desktopStateChanged,
@@ -1432,7 +1517,7 @@ void Helper::init(Treeland::Treeland *treeland)
     // Initialize seats from configuration
     m_seat = m_seatManager->initializeFromConfig("/etc/deepin/treeland/seats.json", m_server);
     if (!m_seat) {
-        qCCritical(treelandCore) << "Failed to initialize seats!";
+        qCCritical(lcTlCore) << "Failed to initialize seats!";
         return;
     }
 
@@ -1447,11 +1532,11 @@ void Helper::init(Treeland::Treeland *treeland)
     connect(m_seatManager, &SeatsManager::deviceAdded, this, [this](WInputDevice *device) {
         m_seatManager->assignDevice(device, m_renderWindow,
                                    m_rootSurfaceContainer->outputLayout(), m_seat);
-        InputDevice::instance()->initTouchPad(device);
     });
 
     // Setup drag request handling for all seats
-    for (auto *seat : m_seatManager->seats()) {
+    const auto seats = m_seatManager->seats();
+    for (auto *seat : seats) {
         disconnect(seat, &WSeat::requestDrag, this, nullptr);
         connect(seat, &WSeat::requestDrag, this, [this, seat](WSurface *surface) {
             handleRequestDragForSeat(seat, surface);
@@ -1466,7 +1551,7 @@ void Helper::init(Treeland::Treeland *treeland)
     }
 
     if (!m_seat) {
-        qCCritical(treelandCore) << "No seat available after initialization, cannot continue";
+        qCCritical(lcTlCore) << "No seat available after initialization, cannot continue";
         return;
     }
     m_shellHandler->init(m_server, m_seat);
@@ -1477,7 +1562,7 @@ void Helper::init(Treeland::Treeland *treeland)
 
     m_renderer = WRenderHelper::createRenderer(m_backend->handle());
     if (!m_renderer) {
-        qCFatal(treelandCore) << "Failed to create renderer";
+        qCFatal(lcTlCore) << "Failed to create renderer";
     }
 
     m_allocator = qw_allocator::autocreate(*m_backend->handle(), *m_renderer);
@@ -1505,7 +1590,7 @@ void Helper::init(Treeland::Treeland *treeland)
     static const auto isXWaylandClient =
         [sessionManager = QPointer(m_sessionManager)](WClient *client) {
             if (sessionManager) {
-                for (auto session : sessionManager->sessions()) {
+                for (const auto &session : std::as_const(sessionManager->sessions())) {
                     if (session && session->xwayland() && session->xwayland()->waylandClient() == client)
                         return true;
                 }
@@ -1571,11 +1656,18 @@ void Helper::init(Treeland::Treeland *treeland)
             [this](ActivationManagerInterfaceV1::TokenDisposition disposition, WSurface *wsurface) {
                 auto wrapper = m_rootSurfaceContainer->getSurface(wsurface);
                 if (!wrapper) {
-                    qCWarning(treelandCore) << "Activation request for unknown surface!";
+                    qCWarning(lcTlCore) << "Activation request for unknown surface!";
                     return;
                 }
+                // Don't use hasActiveCapability() here — it also checks UnMinimized,
+                // but minimized windows should be allowed to activate (which unminimizes them).
                 if (!wsurface->mapped()) {
-                    qCWarning(treelandCore) << "Activation request for unmapped surface!";
+                    qCWarning(lcTlCore) << "Activation request for unmapped surface!";
+                    return;
+                }
+                if (!wrapper->hasInitializeContainer()) {
+                    qCWarning(lcTlCore) << "Activation request for surface without initialized container:"
+                                       << "container =" << wrapper->container();
                     return;
                 }
                 switch (disposition) {
@@ -1682,6 +1774,9 @@ WSeat *Helper::getSeatForEvent(QInputEvent *event) const
 
 void Helper::activateSurface(SurfaceWrapper *wrapper, Qt::FocusReason reason)
 {
+    if (wrapper && wrapper->isIMCandidatePanel())
+        return;
+
     WSeat *interactingSeat = m_currentEventSeat ? m_currentEventSeat : getLastInteractingSeat(wrapper);
     if (m_blockActivateSurface && wrapper && wrapper->type() != SurfaceWrapper::Type::LockScreen) {
         auto sh = wrapper->shellSurface();
@@ -1700,7 +1795,7 @@ void Helper::activateSurface(SurfaceWrapper *wrapper, Qt::FocusReason reason)
             if (wrapper->hasActiveCapability()) {
                 setActivatedSurface(wrapper);
             } else {
-                qCCritical(treelandShell) << "Trying to activate a surface which doesn't have ActiveCapability!";
+                qCCritical(lcTlShell) << "Trying to activate a surface which doesn't have ActiveCapability!";
             }
         }
     }
@@ -1736,23 +1831,23 @@ void Helper::activateSurface(SurfaceWrapper *wrapper, Qt::FocusReason reason)
 void Helper::forceActivateSurface(SurfaceWrapper *wrapper, Qt::FocusReason reason)
 {
     if (!wrapper) {
-        qCCritical(treelandShell) << "Don't force activate to empty surface! do you want `Helper::activeSurface(nullptr)`?";
+        qCCritical(lcTlShell) << "Don't force activate to empty surface! do you want `Helper::activeSurface(nullptr)`?";
         return;
     }
     if (!wrapper->shellSurface()) {
-        qCWarning(treelandShell) << "Try to force activate a destroyed surface!";
+        qCWarning(lcTlShell) << "Try to force activate a destroyed surface!";
         return;
     }
 
     restoreFromShowDesktop(wrapper);
 
     if (wrapper->isMinimized()) {
-        wrapper->requestCancelMinimize(
+        wrapper->restoreFromMinimized(
             !(reason == Qt::TabFocusReason || reason == Qt::BacktabFocusReason));
     }
 
     if (!wrapper->surface()->mapped()) {
-        qCWarning(treelandShell) << "Can't activate unmapped surface: " << wrapper;
+        qCWarning(lcTlShell) << "Can't activate unmapped surface: " << wrapper;
         return;
     }
 
@@ -1771,7 +1866,7 @@ void Helper::fakePressSurfaceBottomRightToReszie(SurfaceWrapper *surface)
     auto position = surface->geometry().bottomRight();
     m_fakelastPressedPosition = position;
     m_seat->setCursorPosition(position);
-    Q_EMIT surface->requestResize(Qt::BottomEdge | Qt::RightEdge);
+    Q_EMIT surface->resizeRequested(Qt::BottomEdge | Qt::RightEdge);
 }
 
 bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *targetWindow, QInputEvent *event)
@@ -1797,13 +1892,13 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *targetWindow, QInputEvent 
             if (key >= Qt::Key_F1 && key <= Qt::Key_F12) {
                 const int vtnr = key - Qt::Key_F1 + 1;
                 const bool sessionActive = m_backend->isSessionActive();
-                qCWarning(treelandCore) << "Ctrl+Alt+Fn VT shortcut received"
+                qCWarning(lcTlCore) << "Ctrl+Alt+Fn VT shortcut received"
                                         << vtnr << "sessionActive" << sessionActive;
                 if (!sessionActive) {
                     return true;
                 }
 
-                qCWarning(treelandCore) << "Ctrl+Alt+Fn VT shortcut requested" << vtnr;
+                qCWarning(lcTlCore) << "Ctrl+Alt+Fn VT shortcut requested" << vtnr;
                 m_backend->session()->change_vt(vtnr);
                 return true;
             }
@@ -1816,7 +1911,7 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *targetWindow, QInputEvent 
         if (device) {
             targetSeat = m_seatManager->getSeatForDevice(device);
             if (!targetSeat) {
-                qCWarning(treelandCore) << "Device has no associated seat, using default seat";
+                qCWarning(lcTlCore) << "Device has no associated seat, using default seat";
                 targetSeat = seat;
             }
         }
@@ -1872,13 +1967,10 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *targetWindow, QInputEvent 
 
         if (event->type() == QEvent::KeyRelease && !m_captureSelector) {
             auto kevent = static_cast<QKeyEvent *>(event);
-            if (m_taskSwitch && m_taskSwitch->property("switchOn").toBool()) {
-                if (kevent->key() == Qt::Key_Alt || kevent->key() == Qt::Key_Meta) {
-                    auto filter = Helper::instance()->workspace()->currentFilter();
-                    filter->setFilterAppId("");
-                    setCurrentMode(CurrentMode::Normal);
-                    QMetaObject::invokeMethod(m_taskSwitch, "exit");
-                }
+            const int key = kevent->key();
+            if (key == Qt::Key_Alt || key == Qt::Key_Control || key == Qt::Key_Shift
+                || key == Qt::Key_Meta) {
+                Q_EMIT modifierKeyReleased(kevent);
             }
         }
     }
@@ -1917,6 +2009,10 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *targetWindow, QInputEvent 
             auto increment_pos = ev->globalPosition() - moveResizeState.initialPosition;
             m_rootSurfaceContainer->doMoveResizeForSeat(seat, increment_pos);
 
+            return true;
+        } else if (event->type() == QEvent::KeyPress
+                   && static_cast<QKeyEvent *>(event)->key() == Qt::Key_Escape) {
+            m_rootSurfaceContainer->cancelMoveResizeForSeat(seat);
             return true;
         } else if (event->type() == QEvent::MouseButtonRelease
                    || event->type() == QEvent::TouchEnd) {
@@ -1968,12 +2064,13 @@ bool Helper::afterHandleEvent([[maybe_unused]] WSeat *seat,
 
         WSeat *eventSeat = getSeatForEvent(event);
         if (eventSeat && surface) {
-            // LayerSurface cannot be activated, nor should it be activated.
-            if (surface->type() == SurfaceWrapper::Type::Layer) {
+            // IM candidate panel should not be activated.
+            if (surface->isIMCandidatePanel()) {
                 return false;
             }
 
-            for (auto *seat : m_seatManager->seats()) {
+            const auto seats = m_seatManager->seats();
+            for (auto *seat : seats) {
                 if (seat != eventSeat && surface) {
                     auto *container = m_rootSurfaceContainer->getSeatContainer(seat);
                     if (container && container->moveResizeState().surface == surface) {
@@ -1983,7 +2080,10 @@ bool Helper::afterHandleEvent([[maybe_unused]] WSeat *seat,
                 }
             }
 
-            m_rootSurfaceContainer->setActivatedSurfaceForSeat(eventSeat, surface, Qt::MouseFocusReason);
+            if (surface->shellSurface()->hasCapability(WToplevelSurface::Capability::Activate))
+                m_rootSurfaceContainer->setActivatedSurfaceForSeat(eventSeat,
+                                                                   surface,
+                                                                   Qt::MouseFocusReason);
 
             if (surface->shellSurface()->hasCapability(WToplevelSurface::Capability::Focus)
                 && surface->acceptKeyboardFocus()) {
@@ -2094,11 +2194,9 @@ bool Helper::doGesture(QInputEvent *event)
 Output *Helper::createNormalOutput(WOutput *output)
 {
     Output *o = Output::create(output, qmlEngine(), this);
-    auto future = QtConcurrent::run([o, this]() {
-        if (isNvidiaCardPresent()) {
-            o->outputItem()->setProperty("forceSoftwareCursor", true);
-        }
-    });
+    if (isNvidiaCardPresent()) {
+        o->outputItem()->setProperty("forceSoftwareCursor", true);
+    }
     o->outputItem()->stackBefore(m_rootSurfaceContainer);
     m_rootSurfaceContainer->addOutput(o);
     return o;
@@ -2116,13 +2214,13 @@ WOutputViewport *Helper::getOwnOutputViewport(WOutput *output)
     // but we need the OutputViewport that is a direct child of the OutputItem
     Output *outputObj = getOutput(output);
     if (!outputObj || !outputObj->outputItem()) {
-        qCWarning(treelandCore) << "Invalid output object for" << output->name();
+        qCWarning(lcTlCore) << "Invalid output object for" << output->name();
         return nullptr;
     }
 
     WOutputViewport *viewport = outputObj->outputItem()->findChild<WOutputViewport *>({}, Qt::FindDirectChildrenOnly);
     if (!viewport) {
-        qCWarning(treelandCore) << "No viewport found for output" << output->name()
+        qCWarning(lcTlCore) << "No viewport found for output" << output->name()
                                 << "- OutputItem may not have been fully initialized";
     }
     return viewport;
@@ -2210,7 +2308,8 @@ void Helper::setActivatedSurface(SurfaceWrapper *newActivateSurface)
 
 void Helper::setCursorPosition(const QPointF &position)
 {
-    for (auto *seat : m_seatManager->seats()) {
+    const auto seats = m_seatManager->seats();
+    for (auto *seat : seats) {
         m_rootSurfaceContainer->endMoveResizeForSeat(seat);
     }
     m_seat->setCursorPosition(position);
@@ -2265,7 +2364,7 @@ void Helper::handleLockScreen(LockScreenInterface *lockScreen)
 void Helper::onSessionNew(const QString &sessionId, const QDBusObjectPath &sessionPath)
 {
     const auto path = sessionPath.path();
-    qCDebug(treelandCore) << "Session new, sessionId:" << sessionId << ", sessionPath:" << path;
+    qCDebug(lcTlCore) << "Session new, sessionId:" << sessionId << ", sessionPath:" << path;
     QDBusConnection::systemBus().connect("org.freedesktop.login1", path, "org.freedesktop.login1.Session", "Lock", this, SLOT(onSessionLock()));
     QDBusConnection::systemBus().connect("org.freedesktop.login1", path, "org.freedesktop.login1.Session", "Unlock", this, SLOT(onSessionUnlock()));
 }
@@ -2329,7 +2428,7 @@ void Helper::allowNonDrmOutputAutoChangeMode(WOutput *output)
                             if (newState->state->committed & WLR_OUTPUT_STATE_MODE) {
                                 auto output = qobject_cast<qw_output *>(sender());
                                 if (!output->commit_state(newState->state)) {
-                                    qCCritical(treelandCore, "commit failed on output %s",
+                                    qCCritical(lcTlCore, "commit failed on output %s",
                                                output->handle()->name);
                                 }
                             }
@@ -2531,7 +2630,7 @@ void Helper::setLockScreenImpl(ILockScreen *impl)
 
     m_greeterProxy->setLockScreen(m_lockScreen);
 
-    for (auto *output : m_rootSurfaceContainer->outputs()) {
+    for (auto *output : std::as_const(m_rootSurfaceContainer->outputs())) {
         m_lockScreen->addOutput(output);
     }
 
@@ -2638,7 +2737,7 @@ void Helper::restoreFromShowDesktop(SurfaceWrapper *activeSurface)
         m_showDesktop = WindowManagementInterfaceV1::DesktopState::Normal;
         m_windowManagementInterfaceV1->setDesktopState(WindowManagementInterfaceV1::DesktopState::Normal);
         if (activeSurface) {
-            activeSurface->requestCancelMinimize();
+            activeSurface->restoreFromMinimized();
         }
         const auto &surfaces = getWorkspaceSurfaces();
         for (auto &surface : surfaces) {
@@ -2653,7 +2752,7 @@ void Helper::restoreFromShowDesktop(SurfaceWrapper *activeSurface)
 Output *Helper::getOutputAtCursor() const
 {
     QPoint cursorPos = QCursor::pos();
-    for (auto output : m_outputList) {
+    for (auto output : std::as_const(m_outputList)) {
         QRectF outputGeometry(output->outputItem()->position(), output->outputItem()->size());
         if (outputGeometry.contains(cursorPos)) {
             return output;
@@ -2666,43 +2765,43 @@ Output *Helper::getOutputAtCursor() const
 void Helper::handleNewForeignToplevelCaptureRequest(wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request *request)
 {
     if (!request || !request->toplevel_handle) {
-        qCWarning(treelandCapture) << "Invalid capture request or toplevel handle";
+        qCWarning(lcTlCapture) << "Invalid capture request or toplevel handle";
         return;
     }
 
     auto *qw_handle = qw_ext_foreign_toplevel_handle_v1::from(request->toplevel_handle);
     WToplevelSurface *toplevelSurface = m_extForeignToplevelListV1->findSurfaceByHandle(qw_handle);
     if (!toplevelSurface) {
-        qCWarning(treelandCapture) << "Could not find toplevel surface for handle";
+        qCWarning(lcTlCapture) << "Could not find toplevel surface for handle";
         return;
     }
 
     SurfaceWrapper *surfaceWrapper = m_rootSurfaceContainer->getSurface(toplevelSurface);
     if (!surfaceWrapper) {
-        qCWarning(treelandCapture) << "Could not find SurfaceWrapper for toplevel surface";
+        qCWarning(lcTlCapture) << "Could not find SurfaceWrapper for toplevel surface";
         return;
     }
 
     WSurfaceItem *surfaceItem = surfaceWrapper->surfaceItem();
     if (!surfaceItem) {
-        qCWarning(treelandCapture) << "Could not get WSurfaceItem from SurfaceWrapper";
+        qCWarning(lcTlCapture) << "Could not get WSurfaceItem from SurfaceWrapper";
         return;
     }
 
     WSurfaceItemContent *surfaceContent = surfaceItem->findItemContent();
     if (!surfaceContent) {
-        qCWarning(treelandCapture) << "Could not find WSurfaceItemContent";
+        qCWarning(lcTlCapture) << "Could not find WSurfaceItemContent";
         return;
     }
 
-    qCDebug(treelandCapture) << "Found WSurfaceItemContent for capture:"
+    qCDebug(lcTlCapture) << "Found WSurfaceItemContent for capture:"
              << "size=" << surfaceContent->size()
              << "implicitSize=" << QSizeF(surfaceContent->implicitWidth(), surfaceContent->implicitHeight())
              << "isTextureProvider=" << surfaceContent->isTextureProvider();
 
     auto *output = surfaceWrapper->ownsOutput()->output();
     if (!output) {
-        qCWarning(treelandCapture) << "Could not get WOutput from SurfaceWrapper";
+        qCWarning(lcTlCapture) << "Could not get WOutput from SurfaceWrapper";
         return;
     }
 
@@ -2712,7 +2811,7 @@ void Helper::handleNewForeignToplevelCaptureRequest(wlr_ext_foreign_toplevel_ima
         request, *imageCaptureSource);
 
     if (!success) {
-        qCWarning(treelandCapture) << "Failed to accept foreign toplevel image capture request";
+        qCWarning(lcTlCapture) << "Failed to accept foreign toplevel image capture request";
         delete imageCaptureSource;
     }
 }
@@ -2720,11 +2819,11 @@ void Helper::handleNewForeignToplevelCaptureRequest(wlr_ext_foreign_toplevel_ima
 void Helper::onPrepareForSleep(bool sleep)
 {
     if (sleep) {
-        qCInfo(treelandCore) << "Rendering black frames to all outputs before hibernate";
+        qCInfo(lcTlCore) << "Rendering black frames to all outputs before hibernate";
         disableRender();
         // TODO：should we disable output？
     } else {
-        qCInfo(treelandCore) << "Re-enabled rendering after hibernate";
+        qCInfo(lcTlCore) << "Re-enabled rendering after hibernate";
         enableRender();
     }
 }
@@ -2822,7 +2921,7 @@ void Helper::restoreCopyMode()
 {
     Output *primaryOutput = m_rootSurfaceContainer->primaryOutput();
     if (!primaryOutput) {
-        qCWarning(treelandCore) << "Cannot restore Copy Mode: no primary output available";
+        qCWarning(lcTlCore) << "Cannot restore Copy Mode: no primary output available";
         return;
     }
 
@@ -2843,7 +2942,7 @@ bool Helper::setXWindowPositionRelative(uint wid, WSurface *anchor, wl_fixed_t d
 {
     SurfaceWrapper *ach = m_rootSurfaceContainer->getSurface(anchor);
     if (!ach) {
-        qCWarning(treelandCore) << "setXWindowPositionRelative: Failed to get SurfaceWrapper from WSurface";
+        qCWarning(lcTlCore) << "setXWindowPositionRelative: Failed to get SurfaceWrapper from WSurface";
         return false;
     }
 
@@ -2859,7 +2958,7 @@ bool Helper::setXWindowPositionRelative(uint wid, WSurface *anchor, wl_fixed_t d
         }
     }
     if (!target) {
-        qCWarning(treelandCore) << "setXWindowPositionRelative: XWayland surface corresponding to WID" << wid << "not found!";
+        qCWarning(lcTlCore) << "setXWindowPositionRelative: XWayland surface corresponding to WID" << wid << "not found!";
         return false;
     }
 

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -63,6 +63,9 @@ SurfaceWrapper::SurfaceWrapper(QmlEngine *qmlEngine,
     , m_blur(false)
     , m_isActivated(false)
     , m_attention(false)
+    , m_isIMCandidatePanel(false)
+    , m_resizable(false)
+    , m_maximizable(false)
     , m_appId(appId)
 {
     QQmlEngine::setContextForObject(this, qmlEngine->rootContext());
@@ -96,6 +99,9 @@ SurfaceWrapper::SurfaceWrapper(SurfaceWrapper *original, QQuickItem *parent)
     , m_blur(false)
     , m_isActivated(false)
     , m_attention(false)
+    , m_isIMCandidatePanel(false)
+    , m_resizable(false)
+    , m_maximizable(false)
     , m_appId(original->m_appId)
 {
     QQmlEngine::setContextForObject(this, m_engine->rootContext());
@@ -162,13 +168,16 @@ SurfaceWrapper::SurfaceWrapper(QmlEngine *qmlEngine,
     , m_blur(false)
     , m_isActivated(false)
     , m_attention(false)
+    , m_isIMCandidatePanel(false)
+    , m_resizable(false)
+    , m_maximizable(false)
     , m_appId(appId)
 {
     QQmlEngine::setContextForObject(this, qmlEngine->rootContext());
     if (initialSize.isValid() && initialSize.width() > 0 && initialSize.height() > 0) {
         // Also set implicit size to keep QML layout consistent
         setImplicitSize(initialSize.width(), initialSize.height());
-        qCDebug(treelandSurface) << "Prelaunch Splash: set initial size to" << initialSize;
+        qCDebug(lcTlSurface) << "Prelaunch Splash: set initial size to" << initialSize;
     } else {
         setImplicitSize(800, 600);
     }
@@ -213,7 +222,7 @@ SurfaceWrapper::~SurfaceWrapper()
 {
     if (!m_wrapperAboutToRemove) {
         if (isWindowAnimationRunning()) {
-            qCWarning(treelandSurface)
+            qCWarning(lcTlSurface)
                 << "SurfaceWrapper is being destroyed without destroy(); expected external"
                    " destroy() rather than QObject parent-child destruction";
         }
@@ -289,37 +298,37 @@ void SurfaceWrapper::setup()
 
     if (!m_isProxy) {
         m_shellSurface->safeConnect(&WToplevelSurface::requestMinimize, this, [this]() {
-            requestMinimize();
+            minimize();
         });
         m_shellSurface->safeConnect(&WToplevelSurface::requestCancelMinimize, this, [this]() {
-            requestCancelMinimize();
+            restoreFromMinimized();
         });
         m_shellSurface->safeConnect(&WToplevelSurface::requestMaximize,
                                     this,
-                                    &SurfaceWrapper::requestMaximize);
+                                    &SurfaceWrapper::maximize);
         m_shellSurface->safeConnect(&WToplevelSurface::requestCancelMaximize,
                                     this,
-                                    &SurfaceWrapper::requestCancelMaximize);
-        m_shellSurface->safeConnect(&WToplevelSurface::requestMove,
-                                    this,
-                                    &SurfaceWrapper::requestMove);
+                                    &SurfaceWrapper::unmaximize);
+        m_shellSurface->safeConnect(&WToplevelSurface::requestMove, this, [this]() {
+            Q_EMIT moveRequested();
+        });
         m_shellSurface->safeConnect(&WToplevelSurface::requestResize,
                                     this,
                                     [this](WSeat *, Qt::Edges edge, quint32) {
-                                        Q_EMIT requestResize(edge);
+                                        Q_EMIT resizeRequested(edge);
                                     });
         m_shellSurface->safeConnect(&WToplevelSurface::requestFullscreen,
                                     this,
-                                    &SurfaceWrapper::requestFullscreen);
+                                    &SurfaceWrapper::enterFullscreen);
         m_shellSurface->safeConnect(&WToplevelSurface::requestCancelFullscreen,
                                     this,
-                                    &SurfaceWrapper::requestCancelFullscreen);
+                                    &SurfaceWrapper::leaveFullscreen);
 
         if (m_type == Type::XdgToplevel) {
             m_shellSurface->safeConnect(&WToplevelSurface::requestShowWindowMenu,
                                         this,
                                         [this](WSeat *, QPoint pos, quint32) {
-                                            Q_EMIT requestShowWindowMenu(
+                                            Q_EMIT windowMenuRequested(
                                                 m_surfaceItem->mapFromSurface(pos).toPoint());
                                         });
         }
@@ -336,6 +345,16 @@ void SurfaceWrapper::setup()
             Q_EMIT appIdChanged();
         });
     }
+
+    if (m_type == Type::XdgToplevel || m_type == Type::XWayland) {
+        m_shellSurface->safeConnect(&WToplevelSurface::minimumSizeChanged,
+                                    this,
+                                    &SurfaceWrapper::updateSizeCapabilities);
+        m_shellSurface->safeConnect(&WToplevelSurface::maximumSizeChanged,
+                                    this,
+                                    &SurfaceWrapper::updateSizeCapabilities);
+    }
+    updateSizeCapabilities();
 
     if (!m_prelaunchSplash) {
         setImplicitSize(m_surfaceItem->implicitWidth(), m_surfaceItem->implicitHeight());
@@ -424,12 +443,29 @@ void SurfaceWrapper::setup()
         connect(xwaylandSurface,
                 &WXWaylandSurface::bypassManagerChanged,
                 this,
-                updateX11shouldSkipDock);
+                [this, updateX11shouldSkipDock]() {
+                    updateX11shouldSkipDock();
+                    updateSizeCapabilities();
+                });
         connect(xwaylandSurface,
                 &WXWaylandSurface::windowTypesChanged,
                 this,
-                updateX11shouldSkipDock);
+                [this, updateX11shouldSkipDock]() {
+                    updateX11shouldSkipDock();
+                    updateSizeCapabilities();
+                });
         updateX11shouldSkipDock();
+    }
+    // Connect DConfig windowRadius change so QML bindings re-evaluate radius()
+    if (m_type == Type::XdgToplevel || m_type == Type::XWayland) {
+        if (auto *helper = Helper::instance()) {
+            if (auto *config = helper->config()) {
+                connect(config,
+                        &TreelandUserConfig::windowRadiusChanged,
+                        this,
+                        &SurfaceWrapper::radiusChanged);
+            }
+        }
     }
 }
 
@@ -437,7 +473,7 @@ void SurfaceWrapper::convertToNormalSurface(WToplevelSurface *shellSurface, Type
 {
     // Conversion only allowed from prelaunch (SplashScreen) state
     if (m_type != Type::SplashScreen || m_shellSurface != nullptr) {
-        qCCritical(treelandSurface)
+        qCCritical(lcTlSurface)
             << "convertToNormalSurface can only be called on prelaunch surfaces";
         return;
     }
@@ -488,24 +524,15 @@ void SurfaceWrapper::setActivate(bool activate)
 void SurfaceWrapper::updateActiveState()
 {
     if (!m_shellSurface) {
-        qCCritical(treelandSurface) << "updateActiveState called without a valid shellSurface";
+        qCCritical(lcTlSurface) << "updateActiveState called without a valid shellSurface";
         return;
     }
     if (!m_shellSurface->isInitialized()) {
-        qCWarning(treelandSurface)
+        qCWarning(lcTlSurface)
             << "updateActiveState called with shellSurface not yet initialized";
         return;
     }
     m_shellSurface->setActivate(m_isActivated);
-    auto parent = parentSurface();
-    while (parent) {
-        if (!parent->hasActiveCapability()) {
-            // Maybe it's parent is Minimized or Unmapped
-            break;
-        }
-        parent->setActivate(m_isActivated);
-        parent = parent->parentSurface();
-    }
 }
 
 void SurfaceWrapper::setFocus(bool focus, Qt::FocusReason reason)
@@ -534,14 +561,14 @@ void SurfaceWrapper::startPrelaunchSplashHideSequence()
 {
     Q_ASSERT(m_surfaceItem != nullptr);
     if (m_windowAnimation) {
-        qCDebug(treelandSurface) << "prelaunch splash transition is starting while window "
+        qCDebug(lcTlSurface) << "prelaunch splash transition is starting while window "
                                     "animation is still running,"
                                     "this may cause visual glitches, will delay the transition "
                                     "until window animation finishes";
         return;
     }
     if (m_geometryAnimation) {
-        qCDebug(treelandSurface) << "prelaunch splash transition already prepared or running, skip";
+        qCDebug(lcTlSurface) << "prelaunch splash transition already prepared or running, skip";
         return;
     }
 
@@ -564,7 +591,7 @@ void SurfaceWrapper::startPrelaunchSplashHideSequence()
     const bool hasValidTargetImplicitSize =
         targetImplicitSize.width() > 0 && targetImplicitSize.height() > 0;
     if (!hasValidTargetImplicitSize) {
-        qCCritical(treelandSurface) << "Invalid target implicit size, skip transition animation"
+        qCCritical(lcTlSurface) << "Invalid target implicit size, skip transition animation"
                                     << "targetImplicit=" << targetImplicitSize;
     }
 
@@ -692,20 +719,20 @@ QString SurfaceWrapper::appId() const
     return QString();
 }
 
-bool SurfaceWrapper::resize(const QSizeF &size)
+bool SurfaceWrapper::resize(const QSizeF &size, bool tryExec)
 {
     // No surfaceItem in prelaunch mode -> return false
     if (!m_surfaceItem)
         return false;
 
-    return m_surfaceItem->resizeSurface(size);
+    return m_surfaceItem->resizeSurface(size, tryExec);
 }
 
 void SurfaceWrapper::close()
 {
     if (m_type == Type::SplashScreen) {
         // For splash screens, emit a signal to request closure
-        Q_EMIT requestCloseSplash();
+        Q_EMIT splashCloseRequested();
     } else if (m_shellSurface) {
         // For normal surfaces, call the shell surface's close method
         m_shellSurface->close();
@@ -899,11 +926,11 @@ void SurfaceWrapper::setOutputs(const QList<WOutput *> &outputs)
         return;
     }
     if (!surface()) {
-        qCDebug(treelandSurface) << "SurfaceWrapper::setOutputs called but surface() is null!";
+        qCDebug(lcTlSurface) << "SurfaceWrapper::setOutputs called but surface() is null!";
         return;
     }
-    auto oldOutputs = surface()->outputs();
-    for (auto output : oldOutputs) {
+    const auto oldOutputs = surface()->outputs();
+    for (auto output : std::as_const(oldOutputs)) {
         if (outputs.contains(output)) {
             continue;
         }
@@ -1055,12 +1082,30 @@ bool SurfaceWrapper::setAttention(bool attention)
     if (m_attention == attention)
         return true;
     if (attention && m_isActivated) {
-        qCWarning(treelandSurface) << "setAttention(true) ignored: surface is already activated";
+        qCWarning(lcTlSurface) << "setAttention(true) ignored: surface is already activated";
         return false;
     }
     m_attention = attention;
     Q_EMIT attentionChanged();
     return true;
+}
+
+bool SurfaceWrapper::isInputPopupLike() const
+{
+    return m_type == Type::InputPopup || m_isIMCandidatePanel;
+}
+
+bool SurfaceWrapper::isIMCandidatePanel() const
+{
+    return m_isIMCandidatePanel;
+}
+
+void SurfaceWrapper::setIMCandidatePanel(bool isIMCandidatePanel)
+{
+    if (m_isIMCandidatePanel == isIMCandidatePanel)
+        return;
+    m_isIMCandidatePanel = isIMCandidatePanel;
+    Q_EMIT isIMCandidatePanelChanged();
 }
 
 void SurfaceWrapper::setNoDecoration(bool newNoDecoration)
@@ -1340,8 +1385,8 @@ void SurfaceWrapper::doSetSurfaceState(State newSurfaceState)
         m_shellSurface->setMaximize(true);
         break;
     case State::Minimized:
-        m_shellSurface->setMinimize(true);
         updateHasActiveCapability(ActiveControlState::UnMinimized, false);
+        m_shellSurface->setMinimize(true);
         break;
     case State::Fullscreen:
         m_shellSurface->setFullScreen(true);
@@ -1363,8 +1408,8 @@ void SurfaceWrapper::onAnimationReady()
     Q_ASSERT(m_pendingState != m_surfaceState);
     Q_ASSERT(m_pendingGeometry.isValid());
 
-    if (!resize(m_pendingGeometry.size())) {
-        // abort change state if resize failed
+    if (!resize(m_pendingGeometry.size(), true)) {
+        // abort change state if cannot resize
         m_geometryAnimation->disconnect(this);
         m_geometryAnimation->deleteLater();
         m_geometryAnimation = nullptr;
@@ -1374,6 +1419,7 @@ void SurfaceWrapper::onAnimationReady()
     QPointF alignedPos = alignToPixelGrid(m_pendingGeometry.topLeft());
     setPosition(alignedPos);
     doSetSurfaceState(m_pendingState);
+    resize(m_pendingGeometry.size());
 }
 
 void SurfaceWrapper::onAnimationFinished()
@@ -1560,16 +1606,14 @@ void SurfaceWrapper::startShowDesktopAnimation(bool show)
 
 qreal SurfaceWrapper::radius() const
 {
-    // TODO: move to dconfig
-    if (m_type == Type::InputPopup)
+    if (isInputPopupLike())
         return 0;
     if (m_type == Type::XdgPopup)
         return 8;
 
     qreal radius = m_radius;
-
-    // TODO: Handle: XdgToplevel, popup, InputPopup, XWayland (bypass, window type:
-    // menu/normal/popup)
+    // m_radius > 1 means radius was explicitly set via Personalization protocol;
+    // m_radius <= 1 means no per-window override, fall back to DConfig.
     if (radius < 1 && m_type != Type::Layer) {
         radius = Helper::instance()->config()->windowRadius();
     }
@@ -1585,7 +1629,33 @@ void SurfaceWrapper::setRadius(qreal newRadius)
     Q_EMIT radiusChanged();
 }
 
-void SurfaceWrapper::requestMinimize(bool onAnimation)
+ShadowParams SurfaceWrapper::shadowParams() const
+{
+    return m_shadowParams;
+}
+
+void SurfaceWrapper::setShadowParams(const ShadowParams &params)
+{
+    if (m_shadowParams == params)
+        return;
+    m_shadowParams = params;
+    Q_EMIT shadowParamsChanged();
+}
+
+BorderParams SurfaceWrapper::borderParams() const
+{
+    return m_borderParams;
+}
+
+void SurfaceWrapper::setBorderParams(const BorderParams &params)
+{
+    if (m_borderParams == params)
+        return;
+    m_borderParams = params;
+    Q_EMIT borderParamsChanged();
+}
+
+void SurfaceWrapper::minimize(bool onAnimation)
 {
     if (m_surfaceState == State::Minimized)
         return;
@@ -1594,7 +1664,7 @@ void SurfaceWrapper::requestMinimize(bool onAnimation)
         startMinimizeAnimation(iconGeometry(), CLOSE_ANIMATION);
 }
 
-void SurfaceWrapper::requestCancelMinimize(bool onAnimation)
+void SurfaceWrapper::restoreFromMinimized(bool onAnimation)
 {
     if (m_surfaceState != State::Minimized && m_hideByshowDesk)
         return;
@@ -1606,15 +1676,16 @@ void SurfaceWrapper::requestCancelMinimize(bool onAnimation)
         startMinimizeAnimation(iconGeometry(), OPEN_ANIMATION);
 }
 
-void SurfaceWrapper::requestMaximize()
+void SurfaceWrapper::maximize()
 {
-    if (m_surfaceState == State::Minimized || m_surfaceState == State::Fullscreen)
+    if (m_surfaceState == State::Minimized || m_surfaceState == State::Fullscreen
+        || !isMaximizable())
         return;
 
     setSurfaceState(State::Maximized);
 }
 
-void SurfaceWrapper::requestCancelMaximize()
+void SurfaceWrapper::unmaximize()
 {
     if (m_surfaceState != State::Maximized)
         return;
@@ -1622,15 +1693,15 @@ void SurfaceWrapper::requestCancelMaximize()
     setSurfaceState(State::Normal);
 }
 
-void SurfaceWrapper::requestToggleMaximize()
+void SurfaceWrapper::toggleMaximized()
 {
     if (m_surfaceState == State::Maximized)
-        requestCancelMaximize();
+        unmaximize();
     else
-        requestMaximize();
+        maximize();
 }
 
-void SurfaceWrapper::requestFullscreen()
+void SurfaceWrapper::enterFullscreen()
 {
     if (m_surfaceState == State::Minimized)
         return;
@@ -1638,7 +1709,7 @@ void SurfaceWrapper::requestFullscreen()
     setSurfaceState(State::Fullscreen);
 }
 
-void SurfaceWrapper::requestCancelFullscreen()
+void SurfaceWrapper::leaveFullscreen()
 {
     if (m_surfaceState != State::Fullscreen)
         return;
@@ -1646,7 +1717,7 @@ void SurfaceWrapper::requestCancelFullscreen()
     setSurfaceState(m_previousSurfaceState);
 }
 
-void SurfaceWrapper::requestClose()
+void SurfaceWrapper::closeSurface()
 {
     // No shellSurface in prelaunch mode -> early return
     if (!m_shellSurface)
@@ -1966,8 +2037,7 @@ void SurfaceWrapper::setAlwaysOnTop(bool alwaysOnTop)
 
 bool SurfaceWrapper::showOnAllWorkspace() const
 {
-    if (m_type == Type::Layer || m_type == Type::XdgPopup || m_type == Type::InputPopup)
-        [[unlikely]]
+    if (m_type == Type::Layer || m_type == Type::XdgPopup || isInputPopupLike()) [[unlikely]]
         return true;
     return m_workspaceId == Workspace::ShowOnAllWorkspaceId;
 }
@@ -1977,6 +2047,16 @@ bool SurfaceWrapper::showOnWorkspace(int workspaceIndex) const
     if (m_workspaceId == workspaceIndex)
         return true;
     return showOnAllWorkspace();
+}
+
+bool SurfaceWrapper::isResizable() const
+{
+    return m_resizable;
+}
+
+bool SurfaceWrapper::isMaximizable() const
+{
+    return m_maximizable;
 }
 
 bool SurfaceWrapper::blur() const
@@ -2073,15 +2153,35 @@ void SurfaceWrapper::updateExplicitAlwaysOnTop()
         sub->updateExplicitAlwaysOnTop();
 }
 
+void SurfaceWrapper::updateSizeCapabilities()
+{
+    if (!m_shellSurface) {
+        return;
+    }
+
+    const bool resizable = m_shellSurface->hasCapability(WToplevelSurface::Capability::Resize);
+    const bool maximizable = m_shellSurface->hasCapability(WToplevelSurface::Capability::Maximized);
+
+    if (m_resizable != resizable) {
+        m_resizable = resizable;
+        Q_EMIT resizableChanged();
+    }
+
+    if (m_maximizable != maximizable) {
+        m_maximizable = maximizable;
+        Q_EMIT maximizableChanged();
+    }
+}
+
 void SurfaceWrapper::updateHasActiveCapability(ActiveControlState state, bool value)
 {
     bool oldValue = hasActiveCapability();
     m_hasActiveCapability.setFlag(state, value);
     if (oldValue != hasActiveCapability()) {
         if (hasActiveCapability())
-            Q_EMIT requestActive();
+            Q_EMIT activationRequested();
         else
-            Q_EMIT requestInactive();
+            Q_EMIT inactivationRequested();
     }
 }
 
@@ -2124,7 +2224,7 @@ bool SurfaceWrapper::skipDockPreView() const
 void SurfaceWrapper::setSkipDockPreView(bool skip)
 {
     if (!skip && (m_type != Type::XdgToplevel && m_type != Type::XWayland)) {
-        qCWarning(treelandSurface) << "Only XdgToplevel or XWayland surfaces are allowed to set "
+        qCWarning(lcTlSurface) << "Only XdgToplevel or XWayland surfaces are allowed to set "
                                       "`skipDockPreView` to false.";
         return;
     }

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -11,6 +11,7 @@
 #include <QQuickItem>
 #include <QString>
 #include <QColor>
+#include <QMetaType>
 
 Q_MOC_INCLUDE(<woutput.h>)
 Q_MOC_INCLUDE(<output / output.h>)
@@ -23,6 +24,30 @@ class SurfaceContainer;
 QW_BEGIN_NAMESPACE
 class qw_buffer;
 QW_END_NAMESPACE
+
+struct ShadowParams
+{
+    Q_GADGET
+    Q_PROPERTY(int radius MEMBER radius)
+    Q_PROPERTY(int offsetY MEMBER offsetY)
+    Q_PROPERTY(QColor color MEMBER color)
+public:
+    int radius = 40;
+    int offsetY = 10;
+    QColor color = QColor(0, 0, 0, 102);
+    bool operator==(const ShadowParams &other) const = default;
+};
+
+struct BorderParams
+{
+    Q_GADGET
+    Q_PROPERTY(int width MEMBER width)
+    Q_PROPERTY(QColor color MEMBER color)
+public:
+    int width = 0;
+    QColor color = Qt::transparent;
+    bool operator==(const BorderParams &other) const = default;
+};
 
 class SurfaceWrapper : public QQuickItem
 {
@@ -81,6 +106,11 @@ class SurfaceWrapper : public QQuickItem
     Q_PROPERTY(bool coverEnabled READ coverEnabled NOTIFY coverEnabledChanged FINAL)
     Q_PROPERTY(bool acceptKeyboardFocus READ acceptKeyboardFocus NOTIFY acceptKeyboardFocusChanged FINAL)
     Q_PROPERTY(bool isActivated READ isActivated NOTIFY isActivatedChanged FINAL)
+    Q_PROPERTY(bool isIMCandidatePanel READ isIMCandidatePanel NOTIFY isIMCandidatePanelChanged FINAL)
+    Q_PROPERTY(bool isResizable READ isResizable NOTIFY resizableChanged FINAL)
+    Q_PROPERTY(bool isMaximizable READ isMaximizable NOTIFY maximizableChanged FINAL)
+    Q_PROPERTY(ShadowParams shadowParams READ shadowParams NOTIFY shadowParamsChanged FINAL)
+    Q_PROPERTY(BorderParams borderParams READ borderParams NOTIFY borderParamsChanged FINAL)
 
 public:
     enum class Type
@@ -148,7 +178,7 @@ public:
     WSurfaceItem *surfaceItem() const;
     QQuickItem *prelaunchSplash() const;
     QString appId() const;
-    bool resize(const QSizeF &size);
+    bool resize(const QSizeF &size, bool tryExec = false);
     void close();
 
     QRectF titlebarGeometry() const;
@@ -237,6 +267,11 @@ public:
     bool showOnAllWorkspace() const;
     bool showOnWorkspace(int workspaceIndex) const;
 
+    // Keep this policy on SurfaceWrapper so future window rules can override it
+    // without pushing policy into waylib or QML.
+    bool isResizable() const;
+    bool isMaximizable() const;
+
     bool hasActiveCapability() const;
     bool hasCapability(WToplevelSurface::Capability cap) const;
 
@@ -277,20 +312,27 @@ public:
     void setAcceptKeyboardFocus(bool accept);
 
     bool isActivated() const;
+    bool isIMCandidatePanel() const;
+    void setIMCandidatePanel(bool isIMCandidatePanel);
+    bool isInputPopupLike() const;
 
     bool attention() const;
     bool setAttention(bool attention);
 
+    ShadowParams shadowParams() const;
+    void setShadowParams(const ShadowParams &params);
+    BorderParams borderParams() const;
+    void setBorderParams(const BorderParams &params);
+
 public Q_SLOTS:
-    // for titlebar
-    void requestMinimize(bool onAnimation = true);
-    void requestCancelMinimize(bool onAnimation = true);
-    void requestMaximize();
-    void requestCancelMaximize();
-    void requestToggleMaximize();
-    void requestFullscreen();
-    void requestCancelFullscreen();
-    void requestClose();
+    void minimize(bool onAnimation = true);
+    void restoreFromMinimized(bool onAnimation = true);
+    void maximize();
+    void unmaximize();
+    void toggleMaximized();
+    void enterFullscreen();
+    void leaveFullscreen();
+    void closeSurface();
     void onMappedChanged();
     void onSocketEnabledChanged();
 
@@ -313,9 +355,9 @@ Q_SIGNALS:
     void previousSurfaceStateChanged();
     void surfaceStateChanged();
     void radiusChanged();
-    void requestMove(); // for titlebar
-    void requestResize(Qt::Edges edges);
-    void requestShowWindowMenu(QPointF pos);
+    void moveRequested();
+    void resizeRequested(Qt::Edges edges);
+    void windowMenuRequested(QPointF pos);
     void geometryChanged();
     void containerChanged();
     void visibleDecorationChanged();
@@ -327,9 +369,9 @@ Q_SIGNALS:
     void workspaceIdChanged();
     void alwaysOnTopChanged();
     void showOnAllWorkspaceChanged();
-    void requestActive();
-    void requestInactive();
-    void requestCloseSplash();
+    void activationRequested();
+    void inactivationRequested();
+    void splashCloseRequested();
     void skipSwitcherChanged();
     void skipDockPreViewChanged();
     void skipMutiTaskViewChanged();
@@ -343,10 +385,15 @@ Q_SIGNALS:
     void aboutToBeInvalidated();
     void acceptKeyboardFocusChanged();
     void isActivatedChanged();
+    void isIMCandidatePanelChanged();
+    void resizableChanged();
+    void maximizableChanged();
     void attentionChanged();
     void surfaceItemCreated(); // Emitted once after surfaceItem is constructed
     void prelaunchSplashChanged();
     void typeChanged();
+    void shadowParamsChanged();
+    void borderParamsChanged();
 
 private:
     ~SurfaceWrapper() override;
@@ -389,6 +436,7 @@ private:
     Q_SLOT void onShowAnimationFinished();
     Q_SLOT void onHideAnimationFinished();
     void updateExplicitAlwaysOnTop();
+    void updateSizeCapabilities();
     void startMinimizeAnimation(const QRectF &iconGeometry, uint direction);
     Q_SLOT void onMinimizeAnimationFinished();
     void startShowDesktopAnimation(bool show);
@@ -464,6 +512,9 @@ private:
     uint m_blur : 1;
     uint m_isActivated : 1;
     uint m_attention : 1;
+    uint m_isIMCandidatePanel : 1;
+    uint m_resizable : 1;
+    uint m_maximizable : 1;
     SurfaceRole m_surfaceRole = SurfaceRole::Normal;
     quint32 m_autoPlaceYOffset = 0;
     QPoint m_clientRequstPos;
@@ -472,6 +523,11 @@ private:
     bool m_windowAnimationEnabled{ true };
     bool m_acceptKeyboardFocus{ true };
     const QString m_appId;
+    ShadowParams m_shadowParams;
+    BorderParams m_borderParams;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(SurfaceWrapper::ActiveControlStates)
+
+Q_DECLARE_METATYPE(SurfaceWrapper::ShadowParams)
+Q_DECLARE_METATYPE(SurfaceWrapper::BorderParams)


### PR DESCRIPTION
## Summary

Implement the Personalization protocol v2 changes: explicit enable/disable requests for shadow and border, with proper state management.

## Changes

1. **Protocol Implementation** (`personalizationmanagerinterfacev1.cpp/h`)
   - Add `ShadowState`/`BorderState` enums for explicit state management (Unset/Enabled/Disabled)
   - Implement `enable_shadow`/`disable_shadow`/`enable_border`/`disable_border` requests
   - Add `shadow_configured`/`border_configured` events to notify client about actual parameters
   - Add `shadowParams`/`borderParams` properties for QML parameter passing
   - Add `shadowEnabled()`/`borderEnabled()` methods to check enabled state

2. **Layer Shell Decoration Logic** (`helper.cpp`)
   - Change decoration creation to on-demand when `shadowEnabled() || borderEnabled()`
   - Add `updateDecorationParams` lambda to avoid code duplication
   - Connect `shadowChanged`/`borderChanged` signals to update decoration dynamically

3. **Surface Wrapper** (`surfacewrapper.h/cpp`)
   - Add `ShadowParams`/`BorderParams` structs with `Q_GADGET` for signal/slot passing
   - Add `Q_DECLARE_METATYPE` declarations
   - Add `shadowParams`/`borderParams` property getters

4. **QML Components** (`XdgShadow.qml`, `Decoration.qml`, `Border.qml`)
   - Update to use `shadowParams`/`borderParams` for personalization parameters

## Semantics

| Request | State | Description |
|---------|-------|-------------|
| `enable_shadow` | Enabled | Use system default parameters |
| `set_shadow(...)` | Enabled | Use client-specified parameters (even if radius=0) |
| `disable_shadow` | Disabled | Explicitly disable |
| `enable_border` | Enabled | Use system default parameters |
| `set_border(...)` | Enabled | Use client-specified parameters |
| `disable_border` | Disabled | Explicitly disable |

## Related

- Protocol: https://github.com/linuxdeepin/treeland-protocols/pull/76
- Issue: [WM-70](https://agentapi-dev.uniontech.com/issues/82806d03-e4d6-4dce-b987-712deb9b030b)

PMS: BUG-367541