### PR TITLE
feat: implement simplified decoration state management

### DIFF
--- a/src/modules/personalization/personalizationmanagerinterfacev1.cpp
+++ b/src/modules/personalization/personalizationmanagerinterfacev1.cpp
@@ -213,6 +213,8 @@ public:
     Shadow shadow;
     Border border;
     PersonalizationWindowContextV1::WindowStates states;
+    PersonalizationWindowContextV1::DecorationState shadowState = PersonalizationWindowContextV1::DecorationState::NotSet;
+    PersonalizationWindowContextV1::DecorationState borderState = PersonalizationWindowContextV1::DecorationState::NotSet;
 
 protected:
     void destroy_resource(Resource *resource) override;
@@ -222,6 +224,8 @@ protected:
     void set_shadow(Resource *resource, int32_t radius, int32_t offset_x, int32_t offset_y, int32_t r, int32_t g, int32_t b, int32_t a) override;
     void set_border(Resource *resource, int32_t width, int32_t r, int32_t g, int32_t b, int32_t a) override;
     void set_titlebar(Resource *resource, int32_t mode) override;
+    void set_shadow_enabled(Resource *resource, uint32_t enabled) override;
+    void set_border_enabled(Resource *resource, uint32_t enabled) override;
 };
 
 PersonalizationWindowContextV1Private::PersonalizationWindowContextV1Private(
@@ -266,6 +270,7 @@ void PersonalizationWindowContextV1Private::set_shadow([[maybe_unused]] Resource
                                                         int32_t a)
 {
     shadow = Shadow{ radius, QPoint{ offset_x, offset_y }, QColor{ r, g, b, a } };
+    shadowState = PersonalizationWindowContextV1::DecorationState::Custom;
     Q_EMIT q->shadowChanged();
 }
 
@@ -277,6 +282,7 @@ void PersonalizationWindowContextV1Private::set_border([[maybe_unused]] Resource
                                                         int32_t a)
 {
     border = Border{ width, QColor{ r, g, b, a } };
+    borderState = PersonalizationWindowContextV1::DecorationState::Custom;
     Q_EMIT q->borderChanged();
 }
 
@@ -286,6 +292,48 @@ void PersonalizationWindowContextV1Private::set_titlebar([[maybe_unused]] Resour
         PersonalizationWindowContextV1::WindowState::NoTitleBar,
         mode == TREELAND_PERSONALIZATION_WINDOW_CONTEXT_V1_ENABLE_MODE_DISABLE);
     Q_EMIT q->windowStateChanged();
+}
+
+void PersonalizationWindowContextV1Private::set_shadow_enabled([[maybe_unused]] Resource *resource, uint32_t enabled)
+{
+    if (enabled) {
+        if (shadowState == PersonalizationWindowContextV1::DecorationState::NotSet) {
+            shadow = Shadow{ 40, QPoint{ 0, 10 }, QColor{ 0, 0, 0, 102 } };
+            shadowState = PersonalizationWindowContextV1::DecorationState::EnabledDefault;
+            Q_EMIT q->shadowChanged();
+        }
+        auto oldState = shadowState;
+        shadowState = PersonalizationWindowContextV1::DecorationState::EnabledDefault;
+        if (oldState != shadowState) {
+            Q_EMIT q->shadowStateChanged();
+        }
+    } else {
+        shadow = Shadow{};
+        shadowState = PersonalizationWindowContextV1::DecorationState::NotSet;
+        Q_EMIT q->shadowChanged();
+        Q_EMIT q->shadowStateChanged();
+    }
+}
+
+void PersonalizationWindowContextV1Private::set_border_enabled([[maybe_unused]] Resource *resource, uint32_t enabled)
+{
+    if (enabled) {
+        if (borderState == PersonalizationWindowContextV1::DecorationState::NotSet) {
+            border = Border{ 1, QColor{ 255, 255, 255, 26 } };
+            borderState = PersonalizationWindowContextV1::DecorationState::EnabledDefault;
+            Q_EMIT q->borderChanged();
+        }
+        auto oldState = borderState;
+        borderState = PersonalizationWindowContextV1::DecorationState::EnabledDefault;
+        if (oldState != borderState) {
+            Q_EMIT q->borderStateChanged();
+        }
+    } else {
+        border = Border{};
+        borderState = PersonalizationWindowContextV1::DecorationState::NotSet;
+        Q_EMIT q->borderChanged();
+        Q_EMIT q->borderStateChanged();
+    }
 }
 
 PersonalizationWindowContextV1::PersonalizationWindowContextV1(
@@ -326,6 +374,16 @@ Shadow PersonalizationWindowContextV1::shadow() const
 Border PersonalizationWindowContextV1::border() const
 {
     return d->border;
+}
+
+PersonalizationWindowContextV1::DecorationState PersonalizationWindowContextV1::shadowState() const
+{
+    return d->shadowState;
+}
+
+PersonalizationWindowContextV1::DecorationState PersonalizationWindowContextV1::borderState() const
+{
+    return d->borderState;
 }
 
 PersonalizationWindowContextV1 *PersonalizationWindowContextV1::get(wl_resource *resource)
@@ -1103,6 +1161,16 @@ bool Personalization::noTitlebar() const
     return m_states.testFlag(PersonalizationWindowContextV1::NoTitleBar);
 }
 
+bool Personalization::shadowEnabled() const
+{
+    return m_shadowState != PersonalizationWindowContextV1::DecorationState::NotSet;
+}
+
+bool Personalization::borderEnabled() const
+{
+    return m_borderState != PersonalizationWindowContextV1::DecorationState::NotSet;
+}
+
 void Personalization::setBackgroundType(BackgroundType type)
 {
     if (m_backgroundType == type)
@@ -1141,6 +1209,22 @@ void Personalization::setWindowStates(PersonalizationWindowContextV1::WindowStat
         return;
     m_states = states;
     Q_EMIT windowStateChanged();
+}
+
+void Personalization::setShadowState(PersonalizationWindowContextV1::DecorationState state)
+{
+    if (m_shadowState == state)
+        return;
+    m_shadowState = state;
+    Q_EMIT shadowStateChanged();
+}
+
+void Personalization::setBorderState(PersonalizationWindowContextV1::DecorationState state)
+{
+    if (m_borderState == state)
+        return;
+    m_borderState = state;
+    Q_EMIT borderStateChanged();
 }
 
 void PersonalizationManagerInterfaceV1::create(WServer *server)

--- a/src/modules/personalization/personalizationmanagerinterfacev1.h
+++ b/src/modules/personalization/personalizationmanagerinterfacev1.h
@@ -45,6 +45,14 @@ public:
     Q_ENUM(WindowState)
     Q_DECLARE_FLAGS(WindowStates, WindowState)
 
+    enum class DecorationState
+    {
+        NotSet,
+        EnabledDefault,
+        Custom
+    };
+    Q_ENUM(DecorationState)
+
     ~PersonalizationWindowContextV1() override;
 
     wl_resource *resource() const;
@@ -54,6 +62,8 @@ public:
     Shadow shadow() const;
     Border border() const;
     WindowStates states() const;
+    DecorationState shadowState() const;
+    DecorationState borderState() const;
 
     static PersonalizationWindowContextV1 *get(wl_resource *resource);
     static PersonalizationWindowContextV1 *getWindowContext(WSurface *surface);
@@ -202,6 +212,8 @@ class Personalization : public QObject
     Q_PROPERTY(Shadow shadow READ shadow NOTIFY shadowChanged)
     Q_PROPERTY(Border border READ border NOTIFY borderChanged)
     Q_PROPERTY(bool noTitlebar READ noTitlebar NOTIFY windowStateChanged)
+    Q_PROPERTY(bool shadowEnabled READ shadowEnabled NOTIFY shadowStateChanged)
+    Q_PROPERTY(bool borderEnabled READ borderEnabled NOTIFY borderStateChanged)
 
 public:
     enum BackgroundType
@@ -235,6 +247,8 @@ public:
     }
 
     bool noTitlebar() const;
+    bool shadowEnabled() const;
+    bool borderEnabled() const;
 
 Q_SIGNALS:
     void backgroundTypeChanged();
@@ -242,6 +256,8 @@ Q_SIGNALS:
     void shadowChanged();
     void borderChanged();
     void windowStateChanged();
+    void shadowStateChanged();
+    void borderStateChanged();
 
 private Q_SLOTS:
     void resetProperties();
@@ -252,6 +268,8 @@ private:
     void setShadow(const Shadow &shadow);
     void setBorder(const Border &border);
     void setWindowStates(PersonalizationWindowContextV1::WindowStates states);
+    void setShadowState(PersonalizationWindowContextV1::DecorationState state);
+    void setBorderState(PersonalizationWindowContextV1::DecorationState state);
 
 private:
     WWrapPointer<WToplevelSurface> m_target;
@@ -261,6 +279,8 @@ private:
     Shadow m_shadow {};
     Border m_border {};
     PersonalizationWindowContextV1::WindowStates m_states {};
+    PersonalizationWindowContextV1::DecorationState m_shadowState = PersonalizationWindowContextV1::DecorationState::NotSet;
+    PersonalizationWindowContextV1::DecorationState m_borderState = PersonalizationWindowContextV1::DecorationState::NotSet;
 };
 
 class PersonalizationManagerInterfaceV1 : public QObject, public WServerInterface

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1117,18 +1117,41 @@ void Helper::onSurfaceWrapperAdded(SurfaceWrapper *wrapper)
         connect(wrapper, &SurfaceWrapper::aboutToBeInvalidated,
                 attached, &Personalization::deleteLater);
 
-        auto updateNoTitlebar = [this, attached] {
+        auto updateDecorationParams = [attached] {
+            auto wrapper = attached->surfaceWrapper();
+            auto shadow = attached->shadow();
+            auto border = attached->border();
+            wrapper->setShadowParams(SurfaceWrapper::ShadowParams{
+                shadow.radius,
+                shadow.offset.y(),
+                shadow.color
+            });
+            wrapper->setBorderParams(SurfaceWrapper::BorderParams{
+                border.width,
+                border.color
+            });
+        };
+
+        auto updateNoTitlebar = [this, attached, isLayer, updateDecorationParams] {
             auto wrapper = attached->surfaceWrapper();
             if (attached->noTitlebar()) {
                 wrapper->setNoTitleBar(true);
-                auto layer = qobject_cast<WLayerSurface *>(wrapper->shellSurface());
-                if (!isLaunchpad(layer)) {
-                    wrapper->setNoDecoration(false);
+                if (isLayer) {
+                    bool needsDecoration = attached->shadowEnabled() || attached->borderEnabled();
+                    if (needsDecoration && wrapper->noDecoration()) {
+                        wrapper->setNoDecoration(false);
+                        updateDecorationParams();
+                    }
+                } else {
+                    wrapper->setNoDecoration(m_xdgDecorationManager->modeBySurface(wrapper->surface())
+                                         != WXdgDecorationManager::Server);
                 }
             } else {
                 wrapper->setNoTitleBar(false);
-                wrapper->setNoDecoration(m_xdgDecorationManager->modeBySurface(wrapper->surface())
-                                     != WXdgDecorationManager::Server);
+                if (!isLayer) {
+                    wrapper->setNoDecoration(m_xdgDecorationManager->modeBySurface(wrapper->surface())
+                                         != WXdgDecorationManager::Server);
+                }
             }
         };
 
@@ -1163,6 +1186,23 @@ void Helper::onSurfaceWrapperAdded(SurfaceWrapper *wrapper)
             auto layer = qobject_cast<WLayerSurface *>(wrapper->shellSurface());
             if (isLaunchpad(layer))
                 wrapper->setCoverEnabled(true);
+
+            connect(attached, &Personalization::shadowStateChanged, this, [attached, wrapper, updateDecorationParams]() {
+                if (attached->shadowEnabled() && wrapper->noDecoration()) {
+                    wrapper->setNoDecoration(false);
+                }
+                updateDecorationParams();
+            });
+
+            connect(attached, &Personalization::borderStateChanged, this, [attached, wrapper, updateDecorationParams]() {
+                if (attached->borderEnabled() && wrapper->noDecoration()) {
+                    wrapper->setNoDecoration(false);
+                }
+                updateDecorationParams();
+            });
+
+            connect(attached, &Personalization::shadowChanged, this, updateDecorationParams);
+            connect(attached, &Personalization::borderChanged, this, updateDecorationParams);
         }
     }
 


### PR DESCRIPTION
Implement Layer Shell decoration on-demand creation with simplified DecorationState enum.

Changes:
- `personalizationmanagerinterfacev1.h`: Add DecorationState enum (NotSet/EnabledDefault/Custom), shadowState()/borderState() getters, shadowEnabled/borderEnabled properties
- `personalizationmanagerinterfacev1.cpp`: Implement set_shadow_enabled/set_border_enabled request handling, state transition logic
- `helper.cpp`: Layer Shell decoration created on-demand when shadowEnabled/borderEnabled, updateDecorationParams lambda

State transition rules:
- `set_shadow_enabled(1)`: NotSet → EnabledDefault with default params; Custom keeps params
- `set_shadow_enabled(0)`: → NotSet, clear params
- `set_shadow(...)`: → Custom, implies enabled

Related: WM-70