### PR TITLE
feat: add decoration state management

### DIFF
--- a/src/core/qml/Border.qml
+++ b/src/core/qml/Border.qml
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import QtQuick
@@ -9,9 +9,27 @@ Item {
     property real radius: 0
     property color outsideColor: Qt.rgba(0, 0, 0, 0.1)
     property color insideColor: Qt.rgba(255, 255, 255, 0.1)
+    property int borderWidth: 0
+    property color borderColor: Qt.transparent
+
+    Rectangle {
+        id: personalizationBorder
+        visible: borderWidth > 0
+        anchors {
+            fill: parent
+            margins: -borderWidth
+        }
+        color: "transparent"
+        border {
+            color: borderColor
+            width: borderWidth
+        }
+        radius: GraphicsInfo.api === GraphicsInfo.Software ? 0 : root.radius + borderWidth
+    }
 
     Rectangle {
         id: outsideBorder
+        visible: borderWidth <= 0
         anchors {
             fill: parent
             margins: -border.width
@@ -27,6 +45,7 @@ Item {
 
     Rectangle {
         id: insideBorder
+        visible: borderWidth <= 0
         anchors.fill: parent
         color: "transparent"
         border {

--- a/src/core/qml/Decoration.qml
+++ b/src/core/qml/Decoration.qml
@@ -70,13 +70,18 @@ Item {
         height: surface.height
         cornerRadius: surface.radius
         anchors.centerIn: parent
+        customShadowColor: surface.shadowParams.color
+        customShadowOffsetY: surface.shadowParams.offsetY
+        customShadowBlur: surface.shadowParams.radius
     }
 
     Border {
-        visible: surface.visibleDecoration
+        visible: surface.visibleDecoration && surface.borderParams.width > 0
         parent: surface.surfaceItem ? surface.surfaceItem : surface.prelaunchSplash
         z: SurfaceItem.ZOrder.ContentItem + 1
         anchors.fill: parent
         radius: surface.radius
+        borderWidth: surface.borderParams.width
+        borderColor: surface.borderParams.color
     }
 }

--- a/src/core/qml/XdgShadow.qml
+++ b/src/core/qml/XdgShadow.qml
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import QtQuick
@@ -10,6 +10,10 @@ D.BoxShadow {
     readonly property rect boundingRect: Qt.rect(-shadow.shadowBlur, -shadow.shadowBlur,
                                              width + 2 * shadow.shadowBlur,
                                              height + 2 * shadow.shadowBlur)
+
+    property alias customShadowColor: shadow.shadowColor
+    property alias customShadowOffsetY: shadow.shadowOffsetY
+    property alias customShadowBlur: shadow.shadowBlur
 
     width: parent.width
     height: parent.height

--- a/src/modules/personalization/personalizationmanagerinterfacev1.cpp
+++ b/src/modules/personalization/personalizationmanagerinterfacev1.cpp
@@ -10,6 +10,9 @@
 #include "common/treelandlogging.h"
 #include "treelanduserconfig.hpp"
 
+#include <wlr/types/wlr_xdg_shell.h>
+#include <wlr/types/wlr_layer_shell_v1.h>
+
 #include <wlayersurface.h>
 #include <wxdgpopupsurface.h>
 #include <wxdgshell.h>
@@ -196,6 +199,15 @@ void PersonalizationManagerInterfaceV1Private::get_appearance_context(Resource *
     Q_EMIT q->onAppearanceContextCreated(context);
 }
 
+static bool isXdgToplevelSurface(wlr_surface *surface)
+{
+    if (!surface)
+        return false;
+
+    auto *xdg_surface = wlr_xdg_surface_try_from_wlr_surface(surface);
+    return xdg_surface && xdg_surface->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL;
+}
+
 class PersonalizationWindowContextV1Private
     : public QtWaylandServer::treeland_personalization_window_context_v1
 {
@@ -213,6 +225,8 @@ public:
     Shadow shadow;
     Border border;
     PersonalizationWindowContextV1::WindowStates states;
+    PersonalizationWindowContextV1::DecorationState shadowState = PersonalizationWindowContextV1::DecorationState::NotSet;
+    PersonalizationWindowContextV1::DecorationState borderState = PersonalizationWindowContextV1::DecorationState::NotSet;
 
 protected:
     void destroy_resource(Resource *resource) override;
@@ -222,6 +236,8 @@ protected:
     void set_shadow(Resource *resource, int32_t radius, int32_t offset_x, int32_t offset_y, int32_t r, int32_t g, int32_t b, int32_t a) override;
     void set_border(Resource *resource, int32_t width, int32_t r, int32_t g, int32_t b, int32_t a) override;
     void set_titlebar(Resource *resource, int32_t mode) override;
+    void set_shadow_enabled(Resource *resource, uint32_t enabled) override;
+    void set_border_enabled(Resource *resource, uint32_t enabled) override;
 };
 
 PersonalizationWindowContextV1Private::PersonalizationWindowContextV1Private(
@@ -232,6 +248,12 @@ PersonalizationWindowContextV1Private::PersonalizationWindowContextV1Private(
     , q(_q)
     , surface(_surface)
 {
+    if (isXdgToplevelSurface(_surface)) {
+        shadowState = PersonalizationWindowContextV1::DecorationState::EnabledDefault;
+        shadow = Shadow{ 40, QPoint{ 0, 10 }, QColor{ 0, 0, 0, 102 } };
+        borderState = PersonalizationWindowContextV1::DecorationState::EnabledDefault;
+        border = Border{ 1, QColor{ 255, 255, 255, 26 } };
+    }
 }
 
 void PersonalizationWindowContextV1Private::destroy_resource([[maybe_unused]] Resource *resource)
@@ -266,6 +288,7 @@ void PersonalizationWindowContextV1Private::set_shadow([[maybe_unused]] Resource
                                                         int32_t a)
 {
     shadow = Shadow{ radius, QPoint{ offset_x, offset_y }, QColor{ r, g, b, a } };
+    shadowState = PersonalizationWindowContextV1::DecorationState::Custom;
     Q_EMIT q->shadowChanged();
 }
 
@@ -277,6 +300,7 @@ void PersonalizationWindowContextV1Private::set_border([[maybe_unused]] Resource
                                                         int32_t a)
 {
     border = Border{ width, QColor{ r, g, b, a } };
+    borderState = PersonalizationWindowContextV1::DecorationState::Custom;
     Q_EMIT q->borderChanged();
 }
 
@@ -286,6 +310,48 @@ void PersonalizationWindowContextV1Private::set_titlebar([[maybe_unused]] Resour
         PersonalizationWindowContextV1::WindowState::NoTitleBar,
         mode == TREELAND_PERSONALIZATION_WINDOW_CONTEXT_V1_ENABLE_MODE_DISABLE);
     Q_EMIT q->windowStateChanged();
+}
+
+void PersonalizationWindowContextV1Private::set_shadow_enabled([[maybe_unused]] Resource *resource, uint32_t enabled)
+{
+    if (enabled) {
+        if (shadowState == PersonalizationWindowContextV1::DecorationState::NotSet) {
+            shadow = Shadow{ 40, QPoint{ 0, 10 }, QColor{ 0, 0, 0, 102 } };
+            shadowState = PersonalizationWindowContextV1::DecorationState::EnabledDefault;
+            Q_EMIT q->shadowChanged();
+        }
+        auto oldState = shadowState;
+        shadowState = PersonalizationWindowContextV1::DecorationState::EnabledDefault;
+        if (oldState != shadowState) {
+            Q_EMIT q->shadowStateChanged();
+        }
+    } else {
+        shadow = Shadow{};
+        shadowState = PersonalizationWindowContextV1::DecorationState::NotSet;
+        Q_EMIT q->shadowChanged();
+        Q_EMIT q->shadowStateChanged();
+    }
+}
+
+void PersonalizationWindowContextV1Private::set_border_enabled([[maybe_unused]] Resource *resource, uint32_t enabled)
+{
+    if (enabled) {
+        if (borderState == PersonalizationWindowContextV1::DecorationState::NotSet) {
+            border = Border{ 1, QColor{ 255, 255, 255, 26 } };
+            borderState = PersonalizationWindowContextV1::DecorationState::EnabledDefault;
+            Q_EMIT q->borderChanged();
+        }
+        auto oldState = borderState;
+        borderState = PersonalizationWindowContextV1::DecorationState::EnabledDefault;
+        if (oldState != borderState) {
+            Q_EMIT q->borderStateChanged();
+        }
+    } else {
+        border = Border{};
+        borderState = PersonalizationWindowContextV1::DecorationState::NotSet;
+        Q_EMIT q->borderChanged();
+        Q_EMIT q->borderStateChanged();
+    }
 }
 
 PersonalizationWindowContextV1::PersonalizationWindowContextV1(
@@ -326,6 +392,16 @@ Shadow PersonalizationWindowContextV1::shadow() const
 Border PersonalizationWindowContextV1::border() const
 {
     return d->border;
+}
+
+PersonalizationWindowContextV1::DecorationState PersonalizationWindowContextV1::shadowState() const
+{
+    return d->shadowState;
+}
+
+PersonalizationWindowContextV1::DecorationState PersonalizationWindowContextV1::borderState() const
+{
+    return d->borderState;
 }
 
 PersonalizationWindowContextV1 *PersonalizationWindowContextV1::get(wl_resource *resource)
@@ -1022,6 +1098,11 @@ Personalization::Personalization(WToplevelSurface *target,
     , m_target(target)
     , m_manager(manager)
 {
+    if (!qobject_cast<WLayerSurface *>(target)) {
+        m_shadowState = PersonalizationWindowContextV1::DecorationState::EnabledDefault;
+        m_borderState = PersonalizationWindowContextV1::DecorationState::EnabledDefault;
+    }
+
     connect(target, &WToplevelSurface::aboutToBeInvalidated, this, [this] {
         disconnect(m_manager, &PersonalizationManagerInterfaceV1::windowContextCreated, this, nullptr);
     });
@@ -1061,11 +1142,21 @@ Personalization::Personalization(WToplevelSurface *target,
                     setWindowStates(context->states());
                 });
 
+        connect(context, &PersonalizationWindowContextV1::shadowStateChanged, this, [this, context] {
+            setShadowState(context->shadowState());
+        });
+
+        connect(context, &PersonalizationWindowContextV1::borderStateChanged, this, [this, context] {
+            setBorderState(context->borderState());
+        });
+
         setBackgroundType(static_cast<Personalization::BackgroundType>(context->backgroundType()));
         setCornerRadius(context->cornerRadius());
         setShadow(context->shadow());
         setBorder(context->border());
         setWindowStates(context->states());
+        setShadowState(context->shadowState());
+        setBorderState(context->borderState());
     };
 
     connect(m_manager, &PersonalizationManagerInterfaceV1::windowContextCreated, this, update);
@@ -1101,6 +1192,16 @@ bool Personalization::noTitlebar() const
     }
 
     return m_states.testFlag(PersonalizationWindowContextV1::NoTitleBar);
+}
+
+bool Personalization::shadowEnabled() const
+{
+    return m_shadowState != PersonalizationWindowContextV1::DecorationState::NotSet;
+}
+
+bool Personalization::borderEnabled() const
+{
+    return m_borderState != PersonalizationWindowContextV1::DecorationState::NotSet;
 }
 
 void Personalization::setBackgroundType(BackgroundType type)
@@ -1141,6 +1242,22 @@ void Personalization::setWindowStates(PersonalizationWindowContextV1::WindowStat
         return;
     m_states = states;
     Q_EMIT windowStateChanged();
+}
+
+void Personalization::setShadowState(PersonalizationWindowContextV1::DecorationState state)
+{
+    if (m_shadowState == state)
+        return;
+    m_shadowState = state;
+    Q_EMIT shadowStateChanged();
+}
+
+void Personalization::setBorderState(PersonalizationWindowContextV1::DecorationState state)
+{
+    if (m_borderState == state)
+        return;
+    m_borderState = state;
+    Q_EMIT borderStateChanged();
 }
 
 void PersonalizationManagerInterfaceV1::create(WServer *server)

--- a/src/modules/personalization/personalizationmanagerinterfacev1.h
+++ b/src/modules/personalization/personalizationmanagerinterfacev1.h
@@ -45,6 +45,14 @@ public:
     Q_ENUM(WindowState)
     Q_DECLARE_FLAGS(WindowStates, WindowState)
 
+    enum class DecorationState
+    {
+        NotSet,
+        EnabledDefault,
+        Custom
+    };
+    Q_ENUM(DecorationState)
+
     ~PersonalizationWindowContextV1() override;
 
     wl_resource *resource() const;
@@ -54,6 +62,8 @@ public:
     Shadow shadow() const;
     Border border() const;
     WindowStates states() const;
+    DecorationState shadowState() const;
+    DecorationState borderState() const;
 
     static PersonalizationWindowContextV1 *get(wl_resource *resource);
     static PersonalizationWindowContextV1 *getWindowContext(WSurface *surface);
@@ -63,6 +73,8 @@ Q_SIGNALS:
     void shadowChanged();
     void borderChanged();
     void windowStateChanged();
+    void shadowStateChanged();
+    void borderStateChanged();
 
 private:
     explicit PersonalizationWindowContextV1(wl_resource *resource,
@@ -202,6 +214,8 @@ class Personalization : public QObject
     Q_PROPERTY(Shadow shadow READ shadow NOTIFY shadowChanged)
     Q_PROPERTY(Border border READ border NOTIFY borderChanged)
     Q_PROPERTY(bool noTitlebar READ noTitlebar NOTIFY windowStateChanged)
+    Q_PROPERTY(bool shadowEnabled READ shadowEnabled NOTIFY shadowStateChanged)
+    Q_PROPERTY(bool borderEnabled READ borderEnabled NOTIFY borderStateChanged)
 
 public:
     enum BackgroundType
@@ -235,6 +249,8 @@ public:
     }
 
     bool noTitlebar() const;
+    bool shadowEnabled() const;
+    bool borderEnabled() const;
 
 Q_SIGNALS:
     void backgroundTypeChanged();
@@ -242,6 +258,8 @@ Q_SIGNALS:
     void shadowChanged();
     void borderChanged();
     void windowStateChanged();
+    void shadowStateChanged();
+    void borderStateChanged();
 
 private Q_SLOTS:
     void resetProperties();
@@ -252,6 +270,8 @@ private:
     void setShadow(const Shadow &shadow);
     void setBorder(const Border &border);
     void setWindowStates(PersonalizationWindowContextV1::WindowStates states);
+    void setShadowState(PersonalizationWindowContextV1::DecorationState state);
+    void setBorderState(PersonalizationWindowContextV1::DecorationState state);
 
 private:
     WWrapPointer<WToplevelSurface> m_target;
@@ -261,6 +281,8 @@ private:
     Shadow m_shadow {};
     Border m_border {};
     PersonalizationWindowContextV1::WindowStates m_states {};
+    PersonalizationWindowContextV1::DecorationState m_shadowState = PersonalizationWindowContextV1::DecorationState::NotSet;
+    PersonalizationWindowContextV1::DecorationState m_borderState = PersonalizationWindowContextV1::DecorationState::NotSet;
 };
 
 class PersonalizationManagerInterfaceV1 : public QObject, public WServerInterface
@@ -298,7 +320,7 @@ public:
 
     QByteArrayView interfaceName() const override;
 
-    static constexpr int InterfaceVersion = 1;
+    static constexpr int InterfaceVersion = 2;
 Q_SIGNALS:
     void userIdChanged(uid_t uid);
     void lockscreenChanged();

--- a/src/modules/wine-window-management/winewindowmanagement.cpp
+++ b/src/modules/wine-window-management/winewindowmanagement.cpp
@@ -173,7 +173,7 @@ protected:
         }
 
         qCDebug(lcTlProtocol) << "set_position serial" << x << y << serial << "for window_id"
-                                  << m_windowId;
+                              << m_windowId;
 
         m_wrapper->setPositionAutomatic(false);
         // Suppress only this class's xChanged/yChanged handlers to avoid
@@ -248,51 +248,77 @@ private:
     // Raise to top of current stacking tier (no tier change)
     void applyHwndTop()
     {
-        if (!m_wrapper || !m_wrapper->parentItem())
+        if (!m_wrapper)
             return;
-        auto *parent = m_wrapper->parentItem();
-        const auto children = parent->childItems();
-        if (children.isEmpty() || children.last() == m_wrapper)
-            return;
-        // stackAfter(last) brings this above the last child
-        m_wrapper->QQuickItem::stackAfter(children.last());
+        m_wrapper->stackToLast();
     }
 
-    // Lower to absolute bottom, clear topmost tier
+    // Lower to absolute bottom, clear topmost tier.
     void applyHwndBottom()
     {
         if (!m_wrapper)
             return;
         m_wrapper->setAlwaysOnTop(false);
-        if (!m_wrapper->parentItem())
-            return;
-        auto *parent = m_wrapper->parentItem();
-        const auto children = parent->childItems();
-        if (children.isEmpty() || children.first() == m_wrapper)
-            return;
-        m_wrapper->QQuickItem::stackBefore(children.first());
+        m_wrapper->stackToFirst();
     }
 
-    // Place this window directly below the identified sibling
+    // Place this window directly below the identified sibling.
+    // Matches Windows SetWindowPos semantics: top-level windows may only be
+    // ordered relative to other top-level peers, and child windows only
+    // relative to same-parent siblings. Cross-group requests are ignored.
     void applyHwndInsertAfter(uint32_t siblingId)
     {
         if (!m_manager || !m_wrapper)
             return;
 
         WineWindowControl *sibling = m_manager->controlForId(siblingId);
-        // If sibling not found or in different tier, fall back to hwnd_top
-        if (!sibling || !sibling->wrapper()) {
+        // If sibling is not found, the request has no effect (e.g. the
+        // sibling window was destroyed before this message arrived).
+        if (!sibling || !sibling->wrapper())
             return;
-        }
+        if (sibling == this)
+            return;
 
         SurfaceWrapper *siblingWrapper = sibling->wrapper();
-        // Both must share the same parent container
-        if (!m_wrapper->parentItem() || siblingWrapper->parentItem() != m_wrapper->parentItem()) {
+
+        // Protocol set_z_order: child windows may only be ordered relative to
+        // same-parent siblings. An independent top-level has no parentSurface,
+        // so the check only fires when m_wrapper is a child and its top-level
+        // ancestor differs from the sibling's.
+        if (m_wrapper->parentSurface()
+            && topLevelSurface(m_wrapper) != topLevelSurface(siblingWrapper)) {
+            qCWarning(lcTlProtocol)
+                << "hwnd_insert_after: child window" << m_windowId << "and sibling_id" << siblingId
+                << "belong to different top-level groups; ignoring";
             return;
         }
 
-        // Place this window before the sibling (visually below sibling)
-        m_wrapper->stackBefore(siblingWrapper);
+        // Protocol set_z_order: hwnd_insert_after must not mix tiers.
+        if (m_wrapper->effectiveAlwaysOnTop() != siblingWrapper->effectiveAlwaysOnTop()) {
+            qCWarning(lcTlProtocol) << "hwnd_insert_after: window" << m_windowId << "and sibling_id"
+                                    << siblingId << "belong to different tiers; ignoring";
+            return;
+        }
+
+        // Safety check: both windows must share the same Qt parent container.
+        if (!m_wrapper->parentItem() || siblingWrapper->parentItem() != m_wrapper->parentItem()) {
+            qCWarning(lcTlProtocol) << "hwnd_insert_after: window" << m_windowId << "and sibling_id"
+                                    << siblingId << "do not share a parent container; ignoring";
+            return;
+        }
+
+        // Place this window before the sibling (visually below sibling).
+        if (!m_wrapper->stackBefore(siblingWrapper)) {
+            qCWarning(lcTlProtocol) << "hwnd_insert_after: stackBefore failed for window"
+                                    << m_windowId << "(sibling_id =" << siblingId << ")";
+        }
+    }
+
+    static SurfaceWrapper *topLevelSurface(SurfaceWrapper *wrapper)
+    {
+        while (wrapper && wrapper->parentSurface())
+            wrapper = wrapper->parentSurface();
+        return wrapper;
     }
 
 private:

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1117,18 +1117,41 @@ void Helper::onSurfaceWrapperAdded(SurfaceWrapper *wrapper)
         connect(wrapper, &SurfaceWrapper::aboutToBeInvalidated,
                 attached, &Personalization::deleteLater);
 
-        auto updateNoTitlebar = [this, attached] {
+        auto updateDecorationParams = [attached] {
+            auto wrapper = attached->surfaceWrapper();
+            auto shadow = attached->shadow();
+            auto border = attached->border();
+            wrapper->setShadowParams(ShadowParams{
+                shadow.radius,
+                shadow.offset.y(),
+                shadow.color
+            });
+            wrapper->setBorderParams(BorderParams{
+                border.width,
+                border.color
+            });
+        };
+
+        auto updateNoTitlebar = [this, attached, isLayer, updateDecorationParams] {
             auto wrapper = attached->surfaceWrapper();
             if (attached->noTitlebar()) {
                 wrapper->setNoTitleBar(true);
-                auto layer = qobject_cast<WLayerSurface *>(wrapper->shellSurface());
-                if (!isLaunchpad(layer)) {
-                    wrapper->setNoDecoration(false);
+                if (isLayer) {
+                    bool needsDecoration = attached->shadowEnabled() || attached->borderEnabled();
+                    if (needsDecoration && wrapper->noDecoration()) {
+                        wrapper->setNoDecoration(false);
+                        updateDecorationParams();
+                    }
+                } else {
+                    wrapper->setNoDecoration(m_xdgDecorationManager->modeBySurface(wrapper->surface())
+                                         != WXdgDecorationManager::Server);
                 }
             } else {
                 wrapper->setNoTitleBar(false);
-                wrapper->setNoDecoration(m_xdgDecorationManager->modeBySurface(wrapper->surface())
-                                     != WXdgDecorationManager::Server);
+                if (!isLayer) {
+                    wrapper->setNoDecoration(m_xdgDecorationManager->modeBySurface(wrapper->surface())
+                                         != WXdgDecorationManager::Server);
+                }
             }
         };
 
@@ -1163,6 +1186,23 @@ void Helper::onSurfaceWrapperAdded(SurfaceWrapper *wrapper)
             auto layer = qobject_cast<WLayerSurface *>(wrapper->shellSurface());
             if (isLaunchpad(layer))
                 wrapper->setCoverEnabled(true);
+
+            connect(attached, &Personalization::shadowStateChanged, this, [attached, wrapper, updateDecorationParams]() {
+                if (attached->shadowEnabled() && wrapper->noDecoration()) {
+                    wrapper->setNoDecoration(false);
+                }
+                updateDecorationParams();
+            });
+
+            connect(attached, &Personalization::borderStateChanged, this, [attached, wrapper, updateDecorationParams]() {
+                if (attached->borderEnabled() && wrapper->noDecoration()) {
+                    wrapper->setNoDecoration(false);
+                }
+                updateDecorationParams();
+            });
+
+            connect(attached, &Personalization::shadowChanged, this, updateDecorationParams);
+            connect(attached, &Personalization::borderChanged, this, updateDecorationParams);
         }
     }
 

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -1629,6 +1629,32 @@ void SurfaceWrapper::setRadius(qreal newRadius)
     Q_EMIT radiusChanged();
 }
 
+ShadowParams SurfaceWrapper::shadowParams() const
+{
+    return m_shadowParams;
+}
+
+void SurfaceWrapper::setShadowParams(const ShadowParams &params)
+{
+    if (m_shadowParams == params)
+        return;
+    m_shadowParams = params;
+    Q_EMIT shadowParamsChanged();
+}
+
+BorderParams SurfaceWrapper::borderParams() const
+{
+    return m_borderParams;
+}
+
+void SurfaceWrapper::setBorderParams(const BorderParams &params)
+{
+    if (m_borderParams == params)
+        return;
+    m_borderParams = params;
+    Q_EMIT borderParamsChanged();
+}
+
 void SurfaceWrapper::minimize(bool onAnimation)
 {
     if (m_surfaceState == State::Minimized)

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -11,6 +11,7 @@
 #include <QQuickItem>
 #include <QString>
 #include <QColor>
+#include <QMetaType>
 
 Q_MOC_INCLUDE(<woutput.h>)
 Q_MOC_INCLUDE(<output / output.h>)
@@ -23,6 +24,30 @@ class SurfaceContainer;
 QW_BEGIN_NAMESPACE
 class qw_buffer;
 QW_END_NAMESPACE
+
+struct ShadowParams
+{
+    Q_GADGET
+    Q_PROPERTY(int radius MEMBER radius)
+    Q_PROPERTY(int offsetY MEMBER offsetY)
+    Q_PROPERTY(QColor color MEMBER color)
+public:
+    int radius = 40;
+    int offsetY = 10;
+    QColor color = QColor(0, 0, 0, 102);
+    bool operator==(const ShadowParams &other) const = default;
+};
+
+struct BorderParams
+{
+    Q_GADGET
+    Q_PROPERTY(int width MEMBER width)
+    Q_PROPERTY(QColor color MEMBER color)
+public:
+    int width = 0;
+    QColor color = Qt::transparent;
+    bool operator==(const BorderParams &other) const = default;
+};
 
 class SurfaceWrapper : public QQuickItem
 {
@@ -84,6 +109,8 @@ class SurfaceWrapper : public QQuickItem
     Q_PROPERTY(bool isIMCandidatePanel READ isIMCandidatePanel NOTIFY isIMCandidatePanelChanged FINAL)
     Q_PROPERTY(bool isResizable READ isResizable NOTIFY resizableChanged FINAL)
     Q_PROPERTY(bool isMaximizable READ isMaximizable NOTIFY maximizableChanged FINAL)
+    Q_PROPERTY(ShadowParams shadowParams READ shadowParams NOTIFY shadowParamsChanged FINAL)
+    Q_PROPERTY(BorderParams borderParams READ borderParams NOTIFY borderParamsChanged FINAL)
 
 public:
     enum class Type
@@ -292,6 +319,11 @@ public:
     bool attention() const;
     bool setAttention(bool attention);
 
+    ShadowParams shadowParams() const;
+    void setShadowParams(const ShadowParams &params);
+    BorderParams borderParams() const;
+    void setBorderParams(const BorderParams &params);
+
 public Q_SLOTS:
     void minimize(bool onAnimation = true);
     void restoreFromMinimized(bool onAnimation = true);
@@ -360,6 +392,8 @@ Q_SIGNALS:
     void surfaceItemCreated(); // Emitted once after surfaceItem is constructed
     void prelaunchSplashChanged();
     void typeChanged();
+    void shadowParamsChanged();
+    void borderParamsChanged();
 
 private:
     ~SurfaceWrapper() override;
@@ -489,6 +523,11 @@ private:
     bool m_windowAnimationEnabled{ true };
     bool m_acceptKeyboardFocus{ true };
     const QString m_appId;
+    ShadowParams m_shadowParams;
+    BorderParams m_borderParams;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(SurfaceWrapper::ActiveControlStates)
+
+Q_DECLARE_METATYPE(ShadowParams)
+Q_DECLARE_METATYPE(BorderParams)


### PR DESCRIPTION
Implement Layer Shell decoration on-demand creation with simplified DecorationState enum.

1. Add DecorationState enum (NotSet/EnabledDefault/Custom)
2. Implement set_shadow_enabled/set_border_enabled requests
3. Create Layer Shell decoration on-demand when enabled

添加装饰状态管理

1. 新增 DecorationState 枚举 (NotSet/EnabledDefault/Custom)
2. 实现 set_shadow_enabled/set_border_enabled 请求处理
3. Layer Shell 窗口按需创建装饰

Log: Layer Shell 窗口装饰按需创建
Influence: 无影响
PMS: BUG-367541

Related: WM-70
