### PR TITLE
fix(activation): validate seat in set_serial and pass seat to trusted…

### DIFF
--- a/src/modules/activation/activationmanagerinterfacev1.cpp
+++ b/src/modules/activation/activationmanagerinterfacev1.cpp
@@ -6,9 +6,11 @@
 #include "qwayland-server-xdg-activation-v1.h"
 
 #include <wserver.h>
+#include <wseat.h>
 #include <wsurface.h>
 
 #include <qwdisplay.h>
+#include <qwseat.h>
 
 #include <QDeadlineTimer>
 #include <QPointer>
@@ -16,10 +18,6 @@
 
 #include <algorithm>
 #include <optional>
-
-extern "C" {
-#include <wlr/types/wlr_compositor.h>
-}
 
 WAYLIB_SERVER_USE_NAMESPACE
 using namespace Qt::StringLiterals;
@@ -64,12 +62,29 @@ protected:
 
     void set_serial(Resource * /*resource*/,
                     uint32_t serial,
-                    struct ::wl_resource * /*seat*/) override
+                    struct ::wl_resource *seat) override
     {
-        // TODO: validate serial/seat pair and support multi-seat
         if (m_committed)
             return;
+
+        auto *seatClient = seat ? wlr_seat_client_from_resource(seat) : nullptr;
+        if (!seatClient) {
+            qCWarning(lcTlActivation) << "set_serial: invalid seat resource, ignoring serial" << serial;
+            m_serial.reset();
+            m_seat.clear();
+            return;
+        }
+
+        auto *wseat = WSeat::fromHandle(qw_seat::from(seatClient->seat));
+        if (!wseat) {
+            qCWarning(lcTlActivation) << "set_serial: no WSeat for seat resource, ignoring serial" << serial;
+            m_serial.reset();
+            m_seat.clear();
+            return;
+        }
+
         m_serial = serial;
+        m_seat = wseat;
     }
 
     void set_surface(Resource * /*resource*/,
@@ -89,6 +104,7 @@ private:
     QString m_appId;
     std::optional<uint32_t> m_serial;
     bool m_committed = false;
+    QPointer<WSeat> m_seat; // set by set_serial; null if not called or seat destroyed
     QPointer<WSurface> m_surface; // set by set_surface; null if not called or surface destroyed
 };
 
@@ -111,7 +127,7 @@ class ActivationManagerInterfaceV1Private
 {
 public:
     explicit ActivationManagerInterfaceV1Private(ActivationManagerInterfaceV1 *q,
-                                                 std::function<bool(WSurface *)> trustedSurfaceChecker)
+                                                 std::function<bool(WSurface *, WSeat *)> trustedSurfaceChecker)
         : QtWaylandServer::xdg_activation_v1()
         , q(q)
         , m_trustedSurfaceChecker(std::move(trustedSurfaceChecker))
@@ -141,10 +157,10 @@ public:
         return token;
     }
 
-    bool isTrustedSurface(WSurface *surface) const
+    bool isTrustedSurface(WSurface *surface, WSeat *seat) const
     {
-        if (m_trustedSurfaceChecker)
-            return m_trustedSurfaceChecker(surface);
+        if (m_trustedSurfaceChecker && seat)
+            return m_trustedSurfaceChecker(surface, seat);
         return false; // conservative: no checker → treat as inactive
     }
 
@@ -239,7 +255,7 @@ private:
 
     ActivationManagerInterfaceV1 *q;
     QList<TokenInfo> m_tokens;
-    std::function<bool(WSurface *)> m_trustedSurfaceChecker;
+    std::function<bool(WSurface *, WSeat *)> m_trustedSurfaceChecker;
 
     static constexpr int TokenLifetimeMs = 60'000;
 };
@@ -267,7 +283,7 @@ void TokenContext::commit(Resource *resource)
     m_committed = true;
 
     // fromTrustedSurface: set_surface was called, surface still alive, and currently active
-    const bool fromTrustedSurface = m_surface && m_manager->isTrustedSurface(m_surface);
+    const bool fromTrustedSurface = m_surface && m_manager->isTrustedSurface(m_surface, m_seat);
     const QString token = m_manager->registerToken(m_appId, resource->client(), m_serial, fromTrustedSurface);
     send_done(token);
 }
@@ -277,7 +293,7 @@ void TokenContext::commit(Resource *resource)
 // ---------------------------------------------------------------------------
 
 ActivationManagerInterfaceV1::ActivationManagerInterfaceV1(
-    std::function<bool(WSurface *)> trustedSurfaceChecker,
+    std::function<bool(WAYLIB_SERVER_NAMESPACE::WSurface *, WAYLIB_SERVER_NAMESPACE::WSeat *)> trustedSurfaceChecker,
     QObject *parent)
     : QObject(parent)
     , WServerInterface()

--- a/src/modules/activation/activationmanagerinterfacev1.h
+++ b/src/modules/activation/activationmanagerinterfacev1.h
@@ -12,6 +12,7 @@
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 class WSurface;
+class WSeat;
 WAYLIB_SERVER_END_NAMESPACE
 
 class ActivationManagerInterfaceV1Private;
@@ -29,7 +30,7 @@ public:
     Q_ENUM(TokenDisposition)
 
     explicit ActivationManagerInterfaceV1(
-        std::function<bool(WAYLIB_SERVER_NAMESPACE::WSurface *)> trustedSurfaceChecker,
+        std::function<bool(WAYLIB_SERVER_NAMESPACE::WSurface *, WAYLIB_SERVER_NAMESPACE::WSeat *)> trustedSurfaceChecker,
         QObject *parent = nullptr);
     ~ActivationManagerInterfaceV1() override;
 

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1598,19 +1598,30 @@ void Helper::init(Treeland::Treeland *treeland)
     connect(m_idleInhibitManager, &qw_idle_inhibit_manager_v1::notify_new_inhibitor, this, &Helper::onNewIdleInhibitor);
 
     m_activationManagerV1 = m_server->attach<ActivationManagerInterfaceV1>(
-        [this](WSurface *surface) -> bool {
-            // Determine whether the Surface can be trusted to transfer its active state.
+        [this](WSurface *surface, WSeat *seat) -> bool {
+            // Determine whether the surface can transfer activation for the same seat
+            // that produced the serial in set_serial.
+            if (!seat || !seat->isValid()) {
+                return false;
+            }
+
             auto wrapper = m_rootSurfaceContainer->getSurface(surface);
             if (!wrapper) {
                 return false;
             }
-            if (wrapper->isActivated()) {
+
+            if (seat->keyboardFocusSurface() == surface) {
                 return true;
             }
-            if (keyboardFocusSurface() == wrapper) {
-                // Special windows, such as Layer Shell, do not have the concept of "activation."
+
+            if (seat->pointerFocusSurface() == surface) {
                 return true;
             }
+
+            if (wrapper->isActivated() && getLastInteractingSeat(wrapper) == seat) {
+                return true;
+            }
+
             return false;
         });
     connect(m_activationManagerV1,
@@ -1635,6 +1646,7 @@ void Helper::init(Treeland::Treeland *treeland)
                 }
                 switch (disposition) {
                 case ActivationManagerInterfaceV1::TokenDisposition::Active:
+                    // TODO: activate the surface on the seat associated with the token
                     forceActivateSurface(wrapper, Qt::OtherFocusReason);
                     break;
                 case ActivationManagerInterfaceV1::TokenDisposition::Attention:


### PR DESCRIPTION
…SurfaceChecker

Previously, xdg_activation_v1::set_serial silently ignored the seat resource parameter, leaving a TODO for multi-seat support. This meant:

1. No validation that the seat resource was valid — a client could pass a bogus or null seat and still obtain a trusted activation token.
2. The trustedSurfaceChecker had no seat context, so it could not distinguish which seat originated the serial, making multi-seat trust decisions impossible.

Changes:
- In TokenContext::set_serial: validate the seat wl_resource via wlr_seat_client_from_resource, look up the corresponding WSeat through qw_seat::from + WSeat::fromHandle, and store it as a QPointer<WSeat> (auto-nulls on seat destruction). Reject invalid/null seat resources by clearing the serial and seat, matching the conservative "no checker" fallback.
- Extend trustedSurfaceChecker signature from (WSurface*) to (WSurface*, WSeat*) so callers can make seat-aware trust decisions. Update isTrustedSurface, TokenContext::commit, the private constructor, and the public ActivationManagerInterfaceV1 constructor accordingly.
- In Helper::init trustedSurfaceChecker lambda: check that the surface holds keyboard focus, pointer focus, or is activated with the last interacting seat matching the token's seat, instead of the previous seat-agnostic check.

The activateRequested signal and forceActivateSurface call site are not yet seat-aware; a TODO has been added for future work to activate on the correct seat.

PMS: 368491