### PR TITLE
fix(greeter): guard null socket in isConnected

### DIFF
--- a/src/greeter/greeterproxy.cpp
+++ b/src/greeter/greeterproxy.cpp
@@ -390,7 +390,7 @@ void GreeterProxy::onSessionUnlock()
 
 bool GreeterProxy::isConnected() const
 {
-    return m_socket->state() == QLocalSocket::ConnectedState;
+    return m_socket && m_socket->state() == QLocalSocket::ConnectedState;
 }
 
 void GreeterProxy::connected()


### PR DESCRIPTION
m_socket can be null if the DDM socket has not been established yet. Calling m_socket->state() on a null pointer causes a crash.

```cpp
// Before
return m_socket->state() == QLocalSocket::ConnectedState;

// After
return m_socket && m_socket->state() == QLocalSocket::ConnectedState;
```

Extracted from #1046. Ref: WM-29

## Summary by Sourcery

Bug Fixes:
- Fix a potential crash in GreeterProxy::isConnected() when the underlying socket has not been established yet.