### PR TITLE
fix(gestures): separate unregister from delete to avoid use-after-free

### DIFF
--- a/src/input/gestures.cpp
+++ b/src/input/gestures.cpp
@@ -192,6 +192,11 @@ void GestureRecognizer::unregisterSwipeGesture(SwipeGesture *gesture)
     if (m_activeSwipeGestures.removeOne(gesture)) {
         Q_EMIT gesture->cancelled();
     }
+}
+
+void GestureRecognizer::removeSwipeGesture(SwipeGesture *gesture)
+{
+    unregisterSwipeGesture(gesture);
     gesture->deleteLater();
 }
 
@@ -404,6 +409,11 @@ void GestureRecognizer::unregisterHoldGesture(HoldGesture *gesture)
     if (m_activeHoldGestures.removeOne(gesture)) {
         Q_EMIT gesture->cancelled();
     }
+}
+
+void GestureRecognizer::removeHoldGesture(HoldGesture *gesture)
+{
+    unregisterHoldGesture(gesture);
     gesture->deleteLater();
 }
 

--- a/src/input/gestures.h
+++ b/src/input/gestures.h
@@ -134,9 +134,11 @@ public:
 
     void registerSwipeGesture(SwipeGesture *gesture);
     void unregisterSwipeGesture(SwipeGesture *gesture);
+    void removeSwipeGesture(SwipeGesture *gesture);
 
     void registerHoldGesture(HoldGesture *gesture);
     void unregisterHoldGesture(HoldGesture *gesture);
+    void removeHoldGesture(HoldGesture *gesture);
 
     int startSwipeGesture(uint fingerCount);
     int startSwipeGesture(const QPointF &startPos);

--- a/src/input/inputdevice.cpp
+++ b/src/input/inputdevice.cpp
@@ -419,12 +419,12 @@ InputDevice *InputDevice::instance()
 
 void InputDevice::unregisterTouchpadSwipe(SwipeGesture *gesture)
 {
-    m_touchpadRecognizer->unregisterSwipeGesture(gesture);
+    m_touchpadRecognizer->removeSwipeGesture(gesture);
 }
 
 void InputDevice::unregisterTouchpadHold(HoldGesture *gesture)
 {
-    m_touchpadRecognizer->unregisterHoldGesture(gesture);
+    m_touchpadRecognizer->removeHoldGesture(gesture);
 }
 
 void InputDevice::processSwipeStart(uint finger)


### PR DESCRIPTION
unregisterSwipeGesture/unregisterHoldGesture previously called deleteLater() on the gesture object. This is dangerous because:
1. The QObject::destroyed signal handler also calls unregister, creating a circular dependency.
2. Callers may still reference the gesture after unregister.

Add removeSwipeGesture/removeHoldGesture that call unregister then deleteLater, and update InputDevice callers to use the new methods.

Extracted from #1046. Ref: WM-29

## Summary by Sourcery

Separate gesture unregistration from object deletion to avoid use-after-free issues in gesture handling.

Bug Fixes:
- Fix potential use-after-free by ensuring swipe and hold gestures are only deleted after being cleanly unregistered from the recognizer.

Enhancements:
- Introduce removeSwipeGesture and removeHoldGesture helpers that unregister and then schedule deletion of gesture objects, updating InputDevice to use these safer APIs.