### PR TITLE
fix(surface): guard null parentContainer in ensureQmlContext

### DIFF
--- a/src/surface/surfacecontainer.cpp
+++ b/src/surface/surfacecontainer.cpp
@@ -203,8 +203,11 @@ void SurfaceContainer::removeOutput(Output *output)
 
 void SurfaceContainer::ensureQmlContext()
 {
-    if (QQmlEngine *engine = qmlEngine(parentContainer())) {
-        parentContainer()->setQmlEngine(engine);
+    auto *pc = parentContainer();
+    if (!pc)
+        return;
+    if (QQmlEngine *engine = qmlEngine(pc)) {
+        pc->setQmlEngine(engine);
     }
 }
 


### PR DESCRIPTION
parentContainer() can return null when the container has no parent. Calling qmlEngine() or setQmlEngine() on null leads to a crash.

Extracted from #1048. Ref: WM-29

## Summary by Sourcery

Bug Fixes:
- Prevent crashes by avoiding qmlEngine and setQmlEngine calls when the parent container is null.