### PR TITLE
fix(backlight): replace Q_ASSERT with error handling and guard division by zero

### DIFF
--- a/src/output/backlight.cpp
+++ b/src/output/backlight.cpp
@@ -11,23 +11,40 @@
 QW_USE_NAMESPACE
 
 Backlight::Backlight(const QString &name)
-    : m_name(name)
+    : m_maxBrightness(0)
+    , m_brightnessLevel(0)
+    , m_name(name)
 {
     QFile maxBrightnessFile(QString("/sys/class/backlight/%1/max_brightness").arg(name));
-    Q_ASSERT(maxBrightnessFile.open(QIODevice::ReadOnly));
+    if (!maxBrightnessFile.open(QIODevice::ReadOnly)) {
+        qCWarning(lcTlOutput) << "Backlight: Failed to open max_brightness for" << name;
+        return;
+    }
 
     bool ok = false;
     m_maxBrightness = maxBrightnessFile.readLine().trimmed().toLongLong(&ok);
     maxBrightnessFile.close();
-    Q_ASSERT(ok);
-    Q_ASSERT(m_maxBrightness > 0);
+    if (!ok || m_maxBrightness <= 0) {
+        qCWarning(lcTlOutput) << "Backlight: Invalid max_brightness for" << name;
+        m_maxBrightness = 0;
+        return;
+    }
 
     QFile brightnessFile(QString("/sys/class/backlight/%1/brightness").arg(name));
-    Q_ASSERT(brightnessFile.open(QIODevice::ReadOnly));
+    if (!brightnessFile.open(QIODevice::ReadOnly)) {
+        qCWarning(lcTlOutput) << "Backlight: Failed to open brightness for" << name;
+        m_maxBrightness = 0;
+        return;
+    }
 
     m_brightnessLevel = brightnessFile.readLine().trimmed().toLongLong(&ok);
     brightnessFile.close();
-    Q_ASSERT(ok);
+    if (!ok) {
+        qCWarning(lcTlOutput) << "Backlight: Invalid brightness for" << name;
+        m_maxBrightness = 0;
+        m_brightnessLevel = 0;
+        return;
+    }
 }
 
 Backlight::~Backlight()
@@ -37,6 +54,8 @@ Backlight::~Backlight()
 
 qreal Backlight::brightness() const
 {
+    if (m_maxBrightness <= 0)
+        return 0.0;
     return m_brightnessLevel / static_cast<qreal>(m_maxBrightness);
 }
 
@@ -57,7 +76,10 @@ qreal Backlight::setBrightness(qreal brightness)
     QByteArray brightnessStr = QByteArray::number(brightnessLevel);
     qint64 written = brightnessFile.write(brightnessStr);
     brightnessFile.close();
-    Q_ASSERT(written == brightnessStr.size());
+    if (written != brightnessStr.size()) {
+        qCWarning(lcTlOutput) << "Output" << m_name << ": Failed to write backlight brightness.";
+        return this->brightness();
+    }
 
     m_brightnessLevel = brightnessLevel;
     return this->brightness();    


### PR DESCRIPTION
Q_ASSERT crashes in release builds. Replace with proper error handling that logs warnings and returns safely. Add division-by-zero guard in brightness() for the case where max_brightness is invalid.

Extracted from #1046. Ref: WM-29