### PR TITLE
fix(wallpaper): add default member initializers to config structs

### DIFF
--- a/src/wallpaper/wallpaperconfig.h
+++ b/src/wallpaper/wallpaperconfig.h
@@ -11,10 +11,10 @@
 
 class WallpaperWorkspaceConfig {
 public:
-    int workspaceId;
+    int workspaceId = 0;
     QString desktopWallpaper;
-    TreelandWallpaperInterfaceV1::WallpaperType desktopWallpapertype;
-    bool enable;
+    TreelandWallpaperInterfaceV1::WallpaperType desktopWallpapertype = TreelandWallpaperInterfaceV1::Image;
+    bool enable = true;
 
     QJsonObject toJson() const;
 
@@ -26,8 +26,8 @@ public:
     QString outputName;
     QString lockscreenWallpaper;
     QList<WallpaperWorkspaceConfig> workspaces;
-    TreelandWallpaperInterfaceV1::WallpaperType lockScreenWallpapertype;
-    bool enable;
+    TreelandWallpaperInterfaceV1::WallpaperType lockScreenWallpapertype = TreelandWallpaperInterfaceV1::Image;
+    bool enable = true;
 
     QJsonObject toJson() const;
     bool containsWorkspace(int id) const;


### PR DESCRIPTION
WallpaperWorkspaceConfig and WallpaperOutputConfig had uninitialized members (workspaceId, desktopWallpapertype, enable, etc.) which led to undefined behavior when default-constructed.

Extracted from #1046. Ref: WM-29