### PR TITLE
refactor(greeter): add testMode constructor with early-return in lock

### DIFF
--- a/src/greeter/greeterproxy.cpp
+++ b/src/greeter/greeterproxy.cpp
@@ -121,6 +121,12 @@ GreeterProxy::GreeterProxy(QObject *parent)
     updateAuthSocket();
 }
 
+GreeterProxy::GreeterProxy(bool testMode, QObject *parent)
+    : QObject(parent)
+    , m_testMode(testMode)
+{
+}
+
 GreeterProxy::~GreeterProxy() { }
 
 ////////////////////////
@@ -234,6 +240,10 @@ void GreeterProxy::logout()
 
 void GreeterProxy::lock()
 {
+    if (m_testMode) {
+        setLock(true);
+        return;
+    }
     auto session = Helper::instance()->sessionManager()->activeSession().lock();
     if (!session || session->username() == "dde") {
         qCInfo(lcTlGreeter) << "Trying to lock when no user session active, show lockscreen directly.";

--- a/src/greeter/greeterproxy.h
+++ b/src/greeter/greeterproxy.h
@@ -41,6 +41,7 @@ class GreeterProxy
 
 public:
     explicit GreeterProxy(QObject *parent = nullptr);
+    explicit GreeterProxy(bool testMode, QObject *parent = nullptr);
     ~GreeterProxy();
 
     //////////////////////
@@ -314,6 +315,7 @@ private:
 
     QLocalSocket *m_socket{ nullptr };
     LockScreen *m_lockScreen{ nullptr };
+    bool m_testMode{ false };
 
     QString m_hostName{};
 


### PR DESCRIPTION
Add a testMode constructor that skips DDM initialization and socket setup. When testMode is active, lock() directly sets the lock state instead of communicating with DDM, allowing unit tests to exercise the lock path without a running daemon.

Extracted from #1046. Ref: WM-29