### PR TITLE
refactor: remove redundant PrepareForSleep D-Bus handling

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -362,21 +362,6 @@ Helper::Helper(QObject *parent)
     });
 
     // Connect to systemd-logind's PrepareForSleep signal for hibernate blackout
-    bool connected = QDBusConnection::systemBus().connect(
-        "org.freedesktop.login1",           // service
-        "/org/freedesktop/login1",          // path
-        "org.freedesktop.login1.Manager",   // interface
-        "PrepareForSleep",                  // signal name
-        this,                               // receiver
-        SLOT(onPrepareForSleep(bool))       // slot
-    );
-
-    if (!connected) {
-        qCWarning(lcTlCore) << "Failed to connect to systemd-logind PrepareForSleep signal";
-    } else {
-        qCInfo(lcTlCore) << "Successfully connected to systemd-logind PrepareForSleep signal";
-    }
-
     // Also connect to SessionNew signal for logging purposes
     QDBusConnection::systemBus().connect(
         "org.freedesktop.login1",
@@ -2987,18 +2972,6 @@ void Helper::handleNewForeignToplevelCaptureRequest(wlr_ext_foreign_toplevel_ima
     if (!success) {
         qCWarning(lcTlCapture) << "Failed to accept foreign toplevel image capture request";
         delete imageCaptureSource;
-    }
-}
-
-void Helper::onPrepareForSleep(bool sleep)
-{
-    if (sleep) {
-        qCInfo(lcTlCore) << "Rendering black frames to all outputs before hibernate";
-        disableRender();
-        // TODO：should we disable output？
-    } else {
-        qCInfo(lcTlCore) << "Re-enabled rendering after hibernate";
-        enableRender();
     }
 }
 

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -296,7 +296,6 @@ Q_SIGNALS:
 private Q_SLOTS:
     void onShowDesktop();
     void deleteTaskSwitch();
-    void onPrepareForSleep(bool sleep);
     void onSessionNew(const QString &sessionId, const QDBusObjectPath &objectPath);
     void onSessionLock();
     void onSessionUnlock();


### PR DESCRIPTION
1. Remove the D-Bus connection to org.freedesktop.login1 PrepareForSleep signal and the onPrepareForSleep handler, which rendered black frames before hibernate.
2. This logic is redundant because wlroots already handles session active processing for the seatd backend. Duplicate handling may cause unpredictable issues such as longer resume time.

Log: Remove redundant session active handling duplicated with wlroots seatd backend

Influence:
1. Verify system suspend/resume works correctly (no black screen or rendering artifacts after resume)
2. Verify D-Bus login1 PrepareForSleep signal is no longer connected by treeland
3. Verify no crash or unexpected behavior during suspend/resume cycle

refactor: 移除冗余的 PrepareForSleep D-Bus 处理逻辑

1. 删除了到 org.freedesktop.login1 的 PrepareForSleep 信号的 D-Bus 连接， 以及在休眠前渲染黑帧的 onPrepareForSleep 处理函数。
2. 此逻辑为冗余代码，wlroots 已经为 seatd 后端处理了 session active 状态管理，重复处理可能导致不可预测的问题，如待机唤醒时间更长。

Log: 移除与 wlroots seatd 后端重复的 session active 处理

Influence:
1. 验证系统挂起/恢复功能正常（恢复后无黑屏或渲染异常）
2. 验证 treeland 不再连接 D-Bus login1 PrepareForSleep 信号
3. 验证挂起/恢复循环过程中无崩溃或异常行为

PMS: TASK-390751