### PR TITLE
feat: add SystemDConfigManager for dconfig init

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -186,6 +186,8 @@ qt_add_qml_module(libtreeland
         seat/helper.h
         seat/seatsmanager.cpp
         seat/seatsmanager.h
+        seat/systemdconfigmanager.cpp
+        seat/systemdconfigmanager.h
         session/session.cpp
         session/session.h
         surface/surfacecontainer.cpp

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -3,6 +3,7 @@
 
 #include "helper.h"
 #include "seatsmanager.h"
+#include "systemdconfigmanager.h"
 #include <QScopeGuard>
 #include <QFile>
 #include <QRandomGenerator>
@@ -276,12 +277,10 @@ Helper::Helper(QObject *parent)
     Q_ASSERT(!m_instance);
     m_instance = this;
 
-    Q_ASSERT(!m_config);
-    m_config.reset(TreelandUserConfig::createByName("org.deepin.dde.treeland.user",
-                                              "org.deepin.dde.treeland",
-                                              "/dde")); // will update user path in Helper::init
-    m_globalConfig.reset(TreelandConfig::create("org.deepin.dde.treeland",
-                                                      QString()));
+    m_systemConfigManager = new SystemDConfigManager(this);
+    // Block on the global config after the pointer is stored, so any nested-loop
+    // callback reaching Helper::config()/globalConfig() sees a valid pointer.
+    m_systemConfigManager->initialize();
 
     m_renderWindow->setColor(Qt::black);
     m_rootSurfaceContainer->setFlag(QQuickItem::ItemIsFocusScope, true);
@@ -404,12 +403,12 @@ Helper *Helper::instance()
 
 TreelandUserConfig *Helper::config()
 {
-    return m_config.get();
+    return m_systemConfigManager->userConfig();
 }
 
 TreelandConfig *Helper::globalConfig()
 {
-    return m_globalConfig.get();
+    return m_systemConfigManager->globalConfig();
 }
 
 void Helper::syncPaletteTypeWithWindowThemeType(int32_t themeType)
@@ -442,7 +441,7 @@ void Helper::tryInitRemoteSource()
 {
     if (m_treelandRemoteSource)
         return;
-    if (m_globalConfig->debugSource()) {
+    if (m_systemConfigManager->globalConfig()->debugSource()) {
         m_treelandRemoteSource = new TreelandRemoteSource(this);
     }
 }
@@ -574,7 +573,7 @@ void Helper::onOutputAdded(WOutput *output)
 
         auto *config = outputObject->config();
         const QString outputId = WallpaperManager::getOutputId(outputObject);
-        const QString primaryOutputId = m_globalConfig->primaryOutputId();
+        const QString primaryOutputId = m_systemConfigManager->globalConfig()->primaryOutputId();
         if (config->enabled() && primaryOutputId == outputId) {
             m_rootSurfaceContainer->setPrimaryOutput(outputObject);
         } else if (config->enabled()
@@ -670,7 +669,7 @@ void Helper::onOutputAdded(WOutput *output)
                                        [this,
                                         restoreOutputConfig = std::move(restoreOutputConfig),
                                         outputObject = QPointer<Output>(o)]() mutable {
-                                           runWhenTreelandConfigInitialized(m_globalConfig.get(),
+                                           runWhenTreelandConfigInitialized(m_systemConfigManager->globalConfig(),
                                                                            outputObject,
                                                                            std::move(restoreOutputConfig));
                                        });
@@ -1559,17 +1558,15 @@ void Helper::init(Treeland::Treeland *treeland)
     m_personalizationInterfaceV1 = m_server->attach<PersonalizationManagerInterfaceV1>();
 
     auto updateCurrentUser = [this] {
-        m_config.reset(TreelandUserConfig::createByName("org.deepin.dde.treeland.user",
-                                                  "org.deepin.dde.treeland",
-                                                  "/" + m_userModel->currentUserName()));
+        m_systemConfigManager->resetUserConfig(m_userModel->currentUserName());
         // Notify QML that the config pointer has changed so bindings (e.g. sourceSize
         // on WQuickCursor) reconnect their notifiers to the new TreelandUserConfig object.
         Q_EMIT configChanged();
-        connect(m_config.get(),
+        connect(m_systemConfigManager->userConfig(),
                 &TreelandUserConfig::cursorThemeNameChanged,
                 m_sessionManager,
                 &SessionManager::syncActiveSessionCursorSettings);
-        connect(m_config.get(),
+        connect(m_systemConfigManager->userConfig(),
                 &TreelandUserConfig::cursorSizeChanged,
                 m_sessionManager,
                 &SessionManager::syncActiveSessionCursorSettings);
@@ -1581,25 +1578,12 @@ void Helper::init(Treeland::Treeland *treeland)
         }
 
         m_inputManager->setupSeatUserConfig(m_userModel->currentUserName());
-        auto onConfigInitialized = [this] {
-            m_sessionManager->syncActiveSessionCursorSettings();
-            syncPaletteTypeWithWindowThemeType(m_config->windowThemeType());
-            m_wallpaperManager->updateWallpaperConfig();
-            tryInitRemoteSource();
-        };
-        // TODO(YaoBing Xiao): pre-initialize dconfig, remove isInitializeSucceeded
-#if TREELANDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
-        if (m_config->isInitializeSucceeded()) {
-#else
-        if (m_config->isInitializeSucceed()) {
-#endif
-            onConfigInitialized();
-        } else {
-            connect(m_config.get(),
-                    &TreelandUserConfig::configInitializeSucceed,
-                    this,
-                    onConfigInitialized);
-        }
+        // resetUserConfig() blocks until the user config is ready, so the
+        // follow-up sync can run directly without a deferred signal connection.
+        m_sessionManager->syncActiveSessionCursorSettings();
+        syncPaletteTypeWithWindowThemeType(m_systemConfigManager->userConfig()->windowThemeType());
+        m_wallpaperManager->updateWallpaperConfig();
+        tryInitRemoteSource();
     };
     connect(m_userModel, &UserModel::currentUserNameChanged, this, updateCurrentUser);
 
@@ -1900,18 +1884,10 @@ void Helper::init(Treeland::Treeland *treeland)
 
     m_keyboardStateNotifyManagerInterfaceV1 = m_server->attach<TreelandKeyboardStateNotifyManagerInterfaceV1>();
 
-#if TREELANDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
-    if (m_globalConfig->isInitializeSucceeded()) {
-#else
-    if (m_globalConfig->isInitializeSucceed()) {
-#endif
-    } else {
-    }
-
     m_backend->handle()->start();
 
     // If the stored primary output is no longer present, select a random one as primary
-    const QString primaryOutputId = m_globalConfig->primaryOutputId();
+    const QString primaryOutputId = m_systemConfigManager->globalConfig()->primaryOutputId();
     if (!currentPrimaryMatchesId(m_rootSurfaceContainer, primaryOutputId)) {
         const auto &outputs = m_rootSurfaceContainer->outputs();
         if (!outputs.isEmpty()) {

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -123,6 +123,7 @@ class ShortcutManagerV2;
 class ShortcutRunner;
 class SurfaceContainer;
 class SurfaceWrapper;
+class SystemDConfigManager;
 class TreelandConfig;
 class TreelandUserConfig;
 class TreelandRemoteSource;
@@ -363,8 +364,7 @@ private:
     WSeat *m_currentEventSeat = nullptr;
 
     static Helper *m_instance;
-    std::unique_ptr<TreelandUserConfig> m_config;
-    std::unique_ptr<TreelandConfig> m_globalConfig;
+    SystemDConfigManager *m_systemConfigManager = nullptr;
     Treeland::Treeland *m_treeland = nullptr;
     FpsDisplayManager *m_fpsManager = nullptr;
     SessionManager *m_sessionManager = nullptr;

--- a/src/seat/systemdconfigmanager.cpp
+++ b/src/seat/systemdconfigmanager.cpp
@@ -1,0 +1,154 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "systemdconfigmanager.h"
+
+#include "common/treelandlogging.h"
+#include "treelandconfig.hpp"
+#include "treelanduserconfig.hpp"
+
+#include <QEventLoop>
+#include <QTimer>
+
+namespace {
+// The generated config classes renamed isInitializeSucceed() to
+// isInitializeSucceeded() once the dconfig file minor version became > 0, so
+// guard the call site the same way the rest of the codebase does.
+bool globalConfigReady(TreelandConfig *config)
+{
+#if TREELANDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
+    return config->isInitializeSucceeded();
+#else
+    return config->isInitializeSucceed();
+#endif
+}
+
+bool userConfigReady(TreelandUserConfig *config)
+{
+#if TREELANDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
+    return config->isInitializeSucceeded();
+#else
+    return config->isInitializeSucceed();
+#endif
+}
+} // namespace
+
+SystemDConfigManager::SystemDConfigManager(QObject *parent)
+    : QObject(parent)
+{
+    m_globalConfig.reset(TreelandConfig::create("org.deepin.dde.treeland", QString()));
+    // Stand-in config used before a real session path is known; the real path
+    // is applied in resetUserConfig() and only that one is awaited.
+    m_userConfig.reset(TreelandUserConfig::createByName("org.deepin.dde.treeland.user",
+                                                        "org.deepin.dde.treeland",
+                                                        "/dde"));
+    // The blocking wait lives in initialize() so Helper can store the pointer
+    // first; see initialize() and the class doc on isInitializeSucceeded().
+}
+
+SystemDConfigManager::~SystemDConfigManager() = default;
+
+void SystemDConfigManager::initialize()
+{
+    m_globalConfigInitialized = waitForGlobalConfigInitialized();
+    checkInitialized();
+}
+
+bool SystemDConfigManager::isInitializeSucceeded() const
+{
+    return m_globalConfigInitialized && m_userConfigInitialized;
+}
+
+TreelandConfig *SystemDConfigManager::globalConfig() const
+{
+    return m_globalConfig.get();
+}
+
+TreelandUserConfig *SystemDConfigManager::userConfig() const
+{
+    return m_userConfig.get();
+}
+
+void SystemDConfigManager::resetUserConfig(const QString &userName)
+{
+    m_userConfig.reset(TreelandUserConfig::createByName("org.deepin.dde.treeland.user",
+                                                        "org.deepin.dde.treeland",
+                                                        "/" + userName));
+    m_userConfigInitialized = false;
+
+    // The "dde" path is only a placeholder for the greeter, so do not block on
+    // it; only a real session config is awaited.
+    if (userName != "dde") {
+        m_userConfigInitialized = waitForUserConfigInitialized();
+    }
+
+    checkInitialized();
+}
+
+bool SystemDConfigManager::waitForGlobalConfigInitialized()
+{
+    // Already loaded successfully or already reported failure: either way the
+    // wait is done, and only success counts as initialized.
+    if (globalConfigReady(m_globalConfig.get())) {
+        return true;
+    }
+    if (m_globalConfig->isInitializeFailed()) {
+        return false;
+    }
+
+    bool success = false;
+    QEventLoop loop;
+    connect(m_globalConfig.get(), &TreelandConfig::configInitializeSucceed, &loop, [&success, &loop] {
+        success = true;
+        loop.quit();
+    });
+    connect(m_globalConfig.get(), &TreelandConfig::configInitializeFailed, &loop, [&success, &loop] {
+        success = false;
+        loop.quit();
+    });
+    QTimer::singleShot(5000, &loop, [&success, &loop] {
+        qCWarning(lcTlConfig) << "Global dconfig initialization timed out after 5s, using defaults";
+        success = false;
+        loop.quit();
+    });
+    loop.exec();
+    return success;
+}
+
+bool SystemDConfigManager::waitForUserConfigInitialized()
+{
+    // Mirror the global path: succeed, fail, or timeout all terminate the
+    // wait instead of forcing a full 5s timeout on failure.
+    if (userConfigReady(m_userConfig.get())) {
+        return true;
+    }
+    if (m_userConfig->isInitializeFailed()) {
+        return false;
+    }
+
+    bool success = false;
+    QEventLoop loop;
+    connect(m_userConfig.get(), &TreelandUserConfig::configInitializeSucceed, &loop, [&success, &loop] {
+        success = true;
+        loop.quit();
+    });
+    connect(m_userConfig.get(), &TreelandUserConfig::configInitializeFailed, &loop, [&success, &loop] {
+        success = false;
+        loop.quit();
+    });
+    QTimer::singleShot(5000, &loop, [&success, &loop] {
+        qCWarning(lcTlConfig) << "User dconfig initialization timed out after 5s, using defaults";
+        success = false;
+        loop.quit();
+    });
+    loop.exec();
+    return success;
+}
+
+void SystemDConfigManager::checkInitialized()
+{
+    if (m_globalConfigInitialized && m_userConfigInitialized && !m_initializeSucceedEmitted) {
+        m_initializeSucceedEmitted = true;
+        Q_EMIT initializeSucceed();
+    }
+}

--- a/src/seat/systemdconfigmanager.h
+++ b/src/seat/systemdconfigmanager.h
@@ -1,0 +1,57 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <memory>
+
+class TreelandConfig;
+class TreelandUserConfig;
+
+class SystemDConfigManager : public QObject
+{
+    Q_OBJECT
+public:
+    explicit SystemDConfigManager(QObject *parent = nullptr);
+    ~SystemDConfigManager() override;
+
+    // Block until the global config finishes initializing (success, failure,
+    // or timeout). Call once after construction, before the global config is
+    // consumed. Splitting the wait out of the constructor lets Helper assign the
+    // manager pointer first, so any nested-loop callback reaching
+    // Helper::config()/globalConfig() sees a valid pointer instead of null.
+    void initialize();
+
+    // True only when both configs finished initializing *successfully*. A
+    // failure or timeout is intentionally not counted as success, so the
+    // initializeSucceed signal is not emitted for degraded configs. In the
+    // greeter ("dde" placeholder) scenario the user config is deliberately not
+    // awaited, so this stays false by design and the signal does not fire.
+    bool isInitializeSucceeded() const;
+
+    TreelandConfig *globalConfig() const;
+    TreelandUserConfig *userConfig() const;
+
+    // Rebuild the user-scoped config for the given user and block until it
+    // finishes initializing (real user only; the "dde" placeholder is not
+    // awaited). See isInitializeSucceeded() for the greeter contract.
+    void resetUserConfig(const QString &userName);
+
+Q_SIGNALS:
+    void initializeSucceed();
+
+private:
+    // Returns true when the config initialized successfully, false on failure
+    // or timeout (defaults are then in effect, which is still safe to read).
+    bool waitForGlobalConfigInitialized();
+    bool waitForUserConfigInitialized();
+    void checkInitialized();
+
+    std::unique_ptr<TreelandConfig> m_globalConfig;
+    std::unique_ptr<TreelandUserConfig> m_userConfig;
+    bool m_globalConfigInitialized = false;
+    bool m_userConfigInitialized = false;
+    bool m_initializeSucceedEmitted = false;
+};

--- a/src/wallpaper/wallpapermanager.cpp
+++ b/src/wallpaper/wallpapermanager.cpp
@@ -88,8 +88,8 @@ WallpaperOutputConfig WallpaperManager::getOutputConfig(const QString &id)
 void WallpaperManager::updateWallpaperConfig()
 {
     m_wallpaperConfig.clear();
-    if (!Helper::instance()->m_config->wallpaperConfig().isEmpty()) {
-        QJsonDocument doc = QJsonDocument::fromJson(Helper::instance()->m_config->wallpaperConfig().toUtf8());
+    if (!Helper::instance()->config()->wallpaperConfig().isEmpty()) {
+        QJsonDocument doc = QJsonDocument::fromJson(Helper::instance()->config()->wallpaperConfig().toUtf8());
         if (doc.isArray()) {
             QJsonArray jsonArray = doc.array();
             for (const QJsonValue& value : jsonArray) {
@@ -111,7 +111,7 @@ void WallpaperManager::defaultWallpaperConfig()
     Q_ASSERT(workspace);
     for (Output *output : std::as_const(Helper::instance()->m_outputList)) {
         WallpaperOutputConfig outputConfig;
-        outputConfig.lockscreenWallpaper = Helper::instance()->m_config->defaultBackground();
+        outputConfig.lockscreenWallpaper = Helper::instance()->config()->defaultBackground();
         outputConfig.outputName = WallpaperManager::getOutputId(output);
         outputConfig.enable = output->output()->nativeHandle()->enabled;
         WallpaperType type = detectWallpaperType(outputConfig.lockscreenWallpaper);
@@ -124,7 +124,7 @@ void WallpaperManager::defaultWallpaperConfig()
 
         for (int i = 0; i < workspace->count(); i++) {
             WallpaperWorkspaceConfig workspaceConfig;
-            workspaceConfig.desktopWallpaper = Helper::instance()->m_config->defaultBackground();
+            workspaceConfig.desktopWallpaper = Helper::instance()->config()->defaultBackground();
             workspaceConfig.workspaceId = i;
             workspaceConfig.enable = true;
             WallpaperType type = detectWallpaperType(workspaceConfig.desktopWallpaper);
@@ -140,7 +140,7 @@ void WallpaperManager::defaultWallpaperConfig()
     }
 
     QString json = wallpaperConfigToJsonString();
-    Helper::instance()->m_config->setWallpaperConfig(json);
+    Helper::instance()->config()->setWallpaperConfig(json);
 }
 
 void WallpaperManager::ensureWallpaperConfigForOutput(Output *output)
@@ -207,7 +207,7 @@ void WallpaperManager::ensureWallpaperConfigForOutput(Output *output)
 
     if (update) {
         QString json = wallpaperConfigToJsonString();
-        Helper::instance()->m_config->setWallpaperConfig(json);
+        Helper::instance()->config()->setWallpaperConfig(json);
 
         if (isNewOutput) {
             Workspace *workspace = Helper::instance()->workspace();
@@ -307,7 +307,7 @@ void WallpaperManager::setOutputWallpaper(wlr_output *output, [[maybe_unused]] i
     }
 
     if (update) {
-        Helper::instance()->m_config->setWallpaperConfig(wallpaperConfigToJsonString());
+        Helper::instance()->config()->setWallpaperConfig(wallpaperConfigToJsonString());
     }
 }
 
@@ -379,7 +379,7 @@ void WallpaperManager::syncAddWorkspace()
     }
 
     if (update) {
-        Helper::instance()->m_config->setWallpaperConfig(wallpaperConfigToJsonString());
+        Helper::instance()->config()->setWallpaperConfig(wallpaperConfigToJsonString());
         Q_EMIT updateWallpaper();
     }
 }


### PR DESCRIPTION
## Summary

Encapsulate a `SystemDConfigManager` class to unify ownership and initialization of system-level dconfig (`TreelandConfig` + `TreelandUserConfig`). The compositor now blocks until the global config finishes initializing (success, failure, or 5s timeout) before proceeding with business logic, ensuring configuration values are ready before they are consumed.

## Changes

- **New**: `src/seat/systemdconfigmanager.h` / `systemdconfigmanager.cpp` — owns both dconfig objects, provides `initialize()` (blocking wait), `isInitializeSucceeded()`, `initializeSucceed` signal, and `resetUserConfig()`.
- **`src/seat/helper.h` / `helper.cpp`** — replace `m_config`/`m_globalConfig` members with a single `SystemDConfigManager *m_systemConfigManager`; `config()`/`globalConfig()` delegate to the manager; call `initialize()` after storing the pointer to avoid null-pointer reentry during the nested event loop.
- **`src/wallpaper/wallpapermanager.cpp`** — switch 8 friend-access sites from `Helper::instance()->m_config->` to `Helper::instance()->config()->`.
- **`src/CMakeLists.txt`** — register the two new source files.

## Design notes

- Blocking wait is split out of the constructor into `initialize()` so `Helper` can store the manager pointer first — any nested-loop callback reaching `Helper::config()/globalConfig()` sees a valid pointer.
- `isInitializeSucceeded()` returns true only when both configs initialized *successfully*; failures/timeouts fall back to defaults (still safe to read).
- Greeter ("dde" placeholder path) deliberately does not block on user config; the signal stays false by design.

Multica issue: WM-9
