### PR TITLE
fix(dconfig): remove global flag from all items

### DIFF
--- a/misc/dconfig/org.deepin.dde.treeland.app.json
+++ b/misc/dconfig/org.deepin.dde.treeland.app.json
@@ -5,7 +5,7 @@
         "enablePrelaunchSplash": {
             "value": true,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Enable Prelaunch Splash",
             "name[zh_CN]": "启用预启动闪屏",
             "description": "Whether to show prelaunch splash for this app",
@@ -16,7 +16,7 @@
         "lastWindowWidth": {
             "value": 800,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Last Window Width",
             "name[zh_CN]": "上次关闭时的窗口宽度",
             "description": "Window width saved when the window was last closed",
@@ -27,7 +27,7 @@
         "lastWindowHeight": {
             "value": 600,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Last Window Height",
             "name[zh_CN]": "上次关闭时的窗口高度",
             "description": "Window height saved when the window was last closed",
@@ -38,7 +38,7 @@
         "splashThemeType": {
             "value": 0,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Splash Theme Type",
             "name[zh_CN]": "闪屏主题类型",
             "description": "Splash theme preference: 0 follow system, 1 light, 2 dark",
@@ -49,7 +49,7 @@
         "splashDarkPalette": {
             "value": "#181818",
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Splash Dark Palette",
             "name[zh_CN]": "闪屏暗色配色",
             "description": "Background color used when splash theme is dark",
@@ -60,7 +60,7 @@
         "splashLightPalette": {
             "value": "#FFFFFF",
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Splash Light Palette",
             "name[zh_CN]": "闪屏亮色配色",
             "description": "Background color used when splash theme is light",

--- a/misc/dconfig/org.deepin.dde.treeland.json
+++ b/misc/dconfig/org.deepin.dde.treeland.json
@@ -5,7 +5,7 @@
         "quickSwitchTimeout": {
             "value": 120,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Quick Switch Timeout (ms)",
             "name[zh_CN]": "快速切换超时（毫秒）",
             "description": "Timeout to distinguish a quick Alt+Tab toggle from the full task switcher",
@@ -16,7 +16,7 @@
         "forceSoftwareCursor": {
             "value": false,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Force Software Cursor",
             "name[zh_CN]": "强制软光标渲染",
             "description": "Force software cursor rendering",
@@ -27,7 +27,7 @@
         "enablePrelaunchSplash": {
             "value": true,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Enable Prelaunch Splash",
             "name[zh_CN]": "启用预启动闪屏",
             "description": "Enable showing prelaunch splash screens during application startup",
@@ -38,7 +38,7 @@
         "prelaunchSplashTimeoutMs": {
             "value": 5000,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Prelaunch Splash Timeout (ms)",
             "name[zh_CN]": "预启动闪屏超时（毫秒）",
             "description": "Timeout before destroying unmatched prelaunch splash wrappers",
@@ -49,7 +49,7 @@
         "debugSource": {
             "value": false,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Debug Remote Source",
             "name[zh_CN]": "调试远程数据源",
             "description": "Enable the Qt Remote Object remote source for window tree debugging tools. Performance impact when enabled.",
@@ -60,7 +60,7 @@
         "showOtherUserOption": {
             "value": false,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Show Other User Option",
             "name[zh_CN]": "显示其他用户选项",
             "description": "Show the 'Other...' entry in the login user list to allow logging in as an unlisted (e.g. LDAP/NSS) user",
@@ -71,7 +71,7 @@
         "primaryOutputId": {
             "value": "",
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Primary Output ID",
             "name[zh_CN]": "主屏幕 ID",
             "description": "Output id recorded as the primary output. Empty means no primary output has been saved.",

--- a/misc/dconfig/org.deepin.dde.treeland.output.json
+++ b/misc/dconfig/org.deepin.dde.treeland.output.json
@@ -5,7 +5,7 @@
         "brightness": {
             "value": 1.0e0,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Brightness",
             "name[zh_CN]": "亮度",
             "description": "Brightness of this Output (in range 0.0 - 1.0)",
@@ -16,7 +16,7 @@
         "colorTemperature": {
             "value": 6600,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Color Temperature",
             "name[zh_CN]": "色温",
             "description": "Color temperature of this Output (in Kelvin)",
@@ -27,7 +27,7 @@
         "enabled": {
             "value": true,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Enabled",
             "name[zh_CN]": "启用",
             "description": "Whether this output was enabled in the last applied wlr-output-management configuration.",
@@ -38,7 +38,7 @@
         "x": {
             "value": 0,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "X Position",
             "name[zh_CN]": "X 坐标",
             "description": "Last applied x position of this output in the global compositor space.",
@@ -49,7 +49,7 @@
         "y": {
             "value": 0,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Y Position",
             "name[zh_CN]": "Y 坐标",
             "description": "Last applied y position of this output in the global compositor space.",
@@ -60,7 +60,7 @@
         "width": {
             "value": 0,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Width",
             "name[zh_CN]": "宽度",
             "description": "Last committed output mode width in pixels. 0 means no output mode has been saved.",
@@ -71,7 +71,7 @@
         "height": {
             "value": 0,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Height",
             "name[zh_CN]": "高度",
             "description": "Last committed output mode height in pixels. 0 means no output mode has been saved.",
@@ -82,7 +82,7 @@
         "refresh": {
             "value": 0,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Refresh Rate",
             "name[zh_CN]": "刷新率",
             "description": "Last committed output refresh rate in mHz. 0 means no output mode has been saved.",
@@ -93,7 +93,7 @@
         "transform": {
             "value": 0,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Transform",
             "name[zh_CN]": "变换",
             "description": "Last committed wl_output_transform enum value for this output.",
@@ -104,7 +104,7 @@
         "scale": {
             "value": 1.0,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Scale",
             "name[zh_CN]": "缩放",
             "description": "Last committed output scale. Values must be greater than 0. The default value means no output mode has been saved.",
@@ -115,7 +115,7 @@
         "adaptiveSyncEnabled": {
             "value": false,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Adaptive Sync Enabled",
             "name[zh_CN]": "启用自适应同步",
             "description": "Whether adaptive sync was enabled in the last committed output state.",

--- a/misc/dconfig/org.deepin.dde.treeland.user.json
+++ b/misc/dconfig/org.deepin.dde.treeland.user.json
@@ -5,7 +5,7 @@
         "showOnLock": {
             "value": false,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Show on lock screen",
             "name[zh_CN]": "显示在锁屏之上",
             "description": "Allow show context on lock screen",
@@ -16,7 +16,7 @@
         "lostScreen": {
             "value": "MoveToPrimary",
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Behaivor when lost screen",
             "name[zh_CN]": "丢失屏幕的行为",
             "description": "Behaivor when lost screen, allow value: MoveToPrimary、Minimize",
@@ -27,7 +27,7 @@
         "font": {
             "value": "Source Han Sans SC",
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Font",
             "name[zh_CN]": "字体",
             "description": "Font Family",
@@ -38,7 +38,7 @@
         "monoFont": {
             "value": "Noto Mono",
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Mono Font",
             "name[zh_CN]": "等宽字体",
             "description": "Mono Font Family",
@@ -49,7 +49,7 @@
         "fontSize": {
             "value": 105,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Font Size",
             "name[zh_CN]": "字体大小",
             "description": "Font Size",
@@ -60,7 +60,7 @@
         "windowRadius": {
             "value": 12,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Round Corner Radius",
             "name[zh_CN]": "窗口圆角大小",
             "description": "Window Corner Round Radius",
@@ -71,7 +71,7 @@
         "preferDark": {
             "value": false,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Prefer Dark",
             "name[zh_CN]": "倾向暗色",
             "description": "Color scheme is prefer dark",
@@ -82,7 +82,7 @@
         "themeName": {
             "value": "",
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Theme Name",
             "name[zh_CN]": "主题名称",
             "description": "Theme Name",
@@ -93,7 +93,7 @@
         "iconThemeName": {
             "value": "nirvana",
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Icon Theme Name",
             "name[zh_CN]": "图标主题名称",
             "description": "Icon Theme Name",
@@ -104,7 +104,7 @@
         "cursorThemeName": {
             "value": "bloom",
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Cursor Theme Name",
             "name[zh_CN]": "光标主题名称",
             "description": "Cursor Theme Name",
@@ -115,7 +115,7 @@
         "cursorSize": {
             "value": 24,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Cursor Size",
             "name[zh_CN]": "光标大小",
             "description": "Cursor Size",
@@ -126,7 +126,7 @@
         "cursorBlink": {
             "value": true,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Cursor Blink",
             "name[zh_CN]": "光标闪烁",
             "description": "Whether the cursor should blink",
@@ -137,7 +137,7 @@
         "cursorBlinkTime": {
             "value": 1200,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Cursor Blink Time",
             "name[zh_CN]": "光标闪烁时间",
             "description": "Length of the cursor blink cycle, in milleseconds",
@@ -148,7 +148,7 @@
         "doubleClickTime": {
             "value": 250,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Double Click Time",
             "name[zh_CN]": "双击时间",
             "description": "Maximum time allowed between two clicks for them to be considered a double click (in milliseconds)",
@@ -159,7 +159,7 @@
         "doubleClickDistance": {
             "value": 5,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Double Click Distance",
             "name[zh_CN]": "双击距离",
             "description": "Maximum distance allowed between two clicks for them to be considered a double click (in pixels)",
@@ -170,7 +170,7 @@
         "dndDragThreshold": {
             "value": 8,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Dnd Drag Threshold",
             "name[zh_CN]": "拖动阈值",
             "description": "Number of pixels the cursor can move before dragging",
@@ -181,7 +181,7 @@
         "maxWorkspace": {
             "value": 6,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Max Workspace Count",
             "name[zh_CN]": "工作区最大数量",
             "description": "Maximum number of workspaces",
@@ -192,7 +192,7 @@
         "numWorkspace": {
             "value": 2,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Number of workspaces",
             "name[zh_CN]": "工作区数量",
             "description": "Current number of workspaces",
@@ -203,7 +203,7 @@
         "currentWorkspace": {
             "value": 0,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Current workspace",
             "name[zh_CN]": "当前工作区",
             "description": "Current index of workspace",
@@ -214,7 +214,7 @@
         "activeColor": {
             "value": "#1F6EE7",
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Global Window Active Color",
             "name[zh_CN]": "全局窗口活动色",
             "description": "Set window active color",
@@ -225,7 +225,7 @@
         "windowOpacity": {
             "value": 40,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Global Window Opacity",
             "name[zh_CN]": "全局窗口不透明度",
             "description": "Set all window opacity",
@@ -236,7 +236,7 @@
         "windowThemeType": {
             "value": 1,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Global Window Theme Type",
             "name[zh_CN]": "全局窗口主题类型",
             "description": "System theme type: 1 light, 2 dark",
@@ -247,7 +247,7 @@
         "windowTitlebarHeight": {
             "value": 40,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Global Window titlebar height",
             "name[zh_CN]": "全局标题栏高度",
             "description": "Set all window default titlebar height",
@@ -258,7 +258,7 @@
         "defaultBackground": {
             "value": "/usr/share/backgrounds/default_background.jpg",
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Default background",
             "name[zh_CN]": "默认壁纸",
             "description": "Set the default displayed wallpaper, when no wallpaper is set",
@@ -270,7 +270,7 @@
         "workspaceThumbHeight": {
             "value": 144,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Workspace thumbnail height",
             "name[zh_CN]": "工作区缩略图高度",
             "description": "Workspace thumbnail height",
@@ -281,7 +281,7 @@
         "workspaceThumbMargin": {
             "value": 20,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Workspace thumbnail margin",
             "name[zh_CN]": "工作区缩略图边距",
             "description": "Workspace thumbnail margin",
@@ -292,7 +292,7 @@
         "workspaceThumbCornerRadius": {
             "value": 8,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Workspace thumbnail corner radius",
             "name[zh_CN]": "工作区缩略图圆角弧度",
             "description": "Workspace thumbnail corner radius",
@@ -303,7 +303,7 @@
         "highlightBorderWidth": {
             "value": 4,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Highlight border width",
             "name[zh_CN]": "高亮边框宽度",
             "description": "Highlight border width",
@@ -314,7 +314,7 @@
         "minMultitaskviewSurfaceHeight": {
             "value": 232,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Multitask view surface minimal height",
             "name[zh_CN]": "多任务视图表面最小高度",
             "description": "Multitask view surface minimal height",
@@ -325,7 +325,7 @@
         "titleBoxCornerRadius": {
             "value": 8,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Title box corner radius",
             "name[zh_CN]": "标题框圆角弧度",
             "description": "Title box corner radius",
@@ -336,7 +336,7 @@
         "normalWindowHeight": {
             "value": 720,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Normal window height",
             "name[zh_CN]": "正常窗口高度",
             "description": "Normal window height",
@@ -347,7 +347,7 @@
         "windowHeightStep": {
             "value": 15,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Window height step",
             "name[zh_CN]": "窗口高度梯度",
             "description": "Window height step",
@@ -358,7 +358,7 @@
         "multitaskviewPaddingOpacity": {
             "value": 0.1,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Multitaskview padding opacity",
             "name[zh_CN]": "多任务视图内边距不透明度",
             "description": "Multitask view padding opacity",
@@ -369,7 +369,7 @@
         "multitaskviewAnimationDuration": {
             "value": 300,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Multitaskview animation duration",
             "name[zh_CN]": "多任务视图动画时长",
             "description": "Multitaskview animation duration",
@@ -380,7 +380,7 @@
         "multitaskviewEasingCurveType": {
             "value": 22,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Multitaskview easing curve type",
             "name[zh_CN]": "多任务视图缓动曲线类型",
             "description": "Multitaskview easing curve type, enumerate value of QEasingCurve::Type",
@@ -391,7 +391,7 @@
         "multitaskviewTopContentMargin": {
             "value": 40,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Multitaskview top content margin",
             "name[zh_CN]": "多任务视图内容顶边距",
             "description": "Multitaskview top content margin",
@@ -402,7 +402,7 @@
         "multitaskviewBottomContentMargin": {
             "value": 60,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Multitaskview bottom content margin",
             "name[zh_CN]": "多任务视图内容底边距",
             "description": "Multitaskview bottom content margin",
@@ -413,7 +413,7 @@
         "multitaskviewHorizontalMargin": {
             "value": 20,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Multitaskview horizontal margin",
             "name[zh_CN]": "多任务视图横向边距",
             "description": "Multitaskview horizontal margin",
@@ -424,7 +424,7 @@
         "multitaskviewCellPadding": {
             "value": 12,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Multitaskview cell padding",
             "name[zh_CN]": "多任务视图单元格间距",
             "description": "Multitaskview cell padding",
@@ -435,7 +435,7 @@
         "multitaskviewLoadFactor": {
             "value": 0.6,
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Multitaskview load factor",
             "name[zh_CN]": "多任务视图加载因子",
             "description": "Multitaskview load factor",
@@ -446,7 +446,7 @@
         "wallpaperConfig": {
             "value": "",
             "serial": 0,
-            "flags": ["global"],
+            "flags": [],
             "name": "Wallpaper Config",
             "name[zh_CN]": "壁纸配置",
             "description": "A configuration to manage wallpapers used by the system, including desktop and lockscreen wallpapers for each screen and workspace.",


### PR DESCRIPTION
## Summary

Remove the `global` flag from all 65 dconfig configuration items under `misc/dconfig/` (4 files) so treeland configuration is writable only by the `dde` user. This prevents non-dde processes from modifying treeland configuration.

## Changes

- `misc/dconfig/org.deepin.dde.treeland.app.json`
- `misc/dconfig/org.deepin.dde.treeland.json`
- `misc/dconfig/org.deepin.dde.treeland.output.json`
- `misc/dconfig/org.deepin.dde.treeland.user.json`

Each affected item: `"flags": ["global"]` -> `"flags": []` (65 items total).

## Verification

- Exactly 65 `global` flags removed; no other lines changed.
- All JSON files validated as well-formed.

## Testing

- Verify the `dde` user can still read/write treeland dconfig items.
- Verify non-dde processes cannot modify treeland configuration.
- Verify treeland loads config values correctly after the flag removal.

Multica issue: WM-74
