### PR TITLE
fix(input): keep num lock synchronized across keyboard devices

### DIFF
--- a/misc/dconfig/org.deepin.dde.treeland.json
+++ b/misc/dconfig/org.deepin.dde.treeland.json
@@ -78,6 +78,17 @@
             "description[zh_CN]": "记录为主屏幕的输出 ID。空字符串表示未保存主屏幕。",
             "permissions": "readwrite",
             "visibility": "public"
+        },
+        "keyboardNumLock": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "Keyboard Num Lock",
+            "name[zh_CN]": "键盘数字锁定",
+            "description": "Whether the Num Lock state is enabled by default on keyboards that have a numeric keypad. When enabled, the numeric keypad inputs numbers.",
+            "description[zh_CN]": "是否默认在带有数字小键盘的键盘上启用数字锁定。启用时数字小键盘输入数字。",
+            "permissions": "readwrite",
+            "visibility": "public"
         }
     }
 }

--- a/misc/dconfig/org.deepin.dde.treeland.user.seat.json
+++ b/misc/dconfig/org.deepin.dde.treeland.user.seat.json
@@ -144,17 +144,6 @@
             "description[zh_CN]": "按住按键后开始重复输入前的等待时间（以毫秒为单位）。值越低等待时间越短。有效范围通常为 0 到 1000 毫秒。",
             "permissions": "readwrite",
             "visibility": "public"
-        },
-        "keyboardNumLock": {
-            "value": true,
-            "serial": 0,
-            "flags": [],
-            "name": "Keyboard Num Lock",
-            "name[zh_CN]": "键盘数字锁定",
-            "description": "Whether the Num Lock state is enabled by default on keyboards that have a numeric keypad. When enabled, the numeric keypad inputs numbers.",
-            "description[zh_CN]": "是否默认在带有数字小键盘的键盘上启用数字锁定。启用时数字小键盘输入数字。",
-            "permissions": "readwrite",
-            "visibility": "public"
         }
     }
 }

--- a/src/input/inputmanager.cpp
+++ b/src/input/inputmanager.cpp
@@ -3,6 +3,7 @@
 
 #include "inputmanager.h"
 #include "seatuserconfig.hpp"
+#include "treelandconfig.hpp"
 #include "helper.h"
 #include "inputdevice.h"
 #include "modules/input-manager/inputmanagerinterfacev1.h"
@@ -14,10 +15,42 @@
 
 #include <qwseat.h>
 
+extern "C" {
+#include <wlr/interfaces/wlr_keyboard.h>
+}
+
 #include <wbackend.h>
 #include <wcursor.h>
 #include <winputdevice.h>
+#include <wseat.h>
 
+namespace {
+
+bool isSeatDConfigInitialized(SeatUserDConfig *config)
+{
+    if (!config)
+        return false;
+
+#if SEATUSERDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
+    return config->isInitializeSucceeded();
+#else
+    return config->isInitializeSucceed();
+#endif
+}
+
+bool isTreelandConfigInitialized(TreelandConfig *config)
+{
+    if (!config)
+        return false;
+
+#if TREELANDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
+    return config->isInitializeSucceeded();
+#else
+    return config->isInitializeSucceed();
+#endif
+}
+
+}
 
 InputManager::InputManager(QObject *parent)
     : QObject(parent)
@@ -41,11 +74,7 @@ void InputManager::setupSeatUserConfig(const QString &userName)
                                                    "org.deepin.dde.treeland",
                                                    "/" + userName);
 
-#if SEATUSERDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
-    if (m_seatDConfig->isInitializeSucceeded()) {
-#else
-    if (m_seatDConfig->isInitializeSucceed()) {
-#endif
+    if (isSeatDConfigInitialized(m_seatDConfig)) {
         onConfigInitializeSucceed();
     } else {
         connect(m_seatDConfig,
@@ -76,6 +105,17 @@ void InputManager::onConfigInitializeSucceed()
     for (WInputDevice *device : inputDevices) {
         onInputAdded(device);
     }
+
+    auto *globalConfig = Helper::instance()->globalConfig();
+    if (isTreelandConfigInitialized(globalConfig)) {
+        applyNumLockToKeyboards();
+    } else {
+        connect(globalConfig,
+                &TreelandConfig::configInitializeSucceed,
+                this,
+                &InputManager::applyNumLockToKeyboards,
+                Qt::SingleShotConnection);
+    }
 }
 
 void InputManager::onMouseSettingsCreated(MouseSettingsInterfaceV1 *interface)
@@ -99,12 +139,46 @@ void InputManager::onKeyboardSettingsCreated(KeyboardSettingsInterfaceV1 *interf
     if (!m_seatDConfig)
         return;
 
-#if SEATUSERDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
-    if (!m_seatDConfig->isInitializeSucceeded()) {
-#else
-    if (!m_seatDConfig->isInitializeSucceed()) {
-#endif
+    auto *globalConfig = Helper::instance()->globalConfig();
+    const bool seatConfigReady = isSeatDConfigInitialized(m_seatDConfig);
+    const bool globalConfigReady = isTreelandConfigInitialized(globalConfig);
+    if (!seatConfigReady || !globalConfigReady) {
+        auto retry = [this, interface] {
+            initializeKeyboardSettings(interface);
+        };
+
+        if (!seatConfigReady) {
+            connect(m_seatDConfig,
+                    &SeatUserDConfig::configInitializeSucceed,
+                    interface,
+                    retry,
+                    Qt::SingleShotConnection);
+        }
+
+        if (!globalConfigReady) {
+            connect(globalConfig,
+                    &TreelandConfig::configInitializeSucceed,
+                    interface,
+                    retry,
+                    Qt::SingleShotConnection);
+        }
         return;
+    }
+
+    initializeKeyboardSettings(interface);
+}
+
+bool InputManager::initializeKeyboardSettings(KeyboardSettingsInterfaceV1 *interface)
+{
+    if (interface->property("_treelandKeyboardSettingsInitialized").toBool())
+        return true;
+
+    if (!m_seatDConfig)
+        return false;
+
+    auto *globalConfig = Helper::instance()->globalConfig();
+    if (!isSeatDConfigInitialized(m_seatDConfig) || !isTreelandConfigInitialized(globalConfig)) {
+        return false;
     }
 
     KeyboardSettingsInterfaceV1::FeatureFlags features;
@@ -132,7 +206,7 @@ void InputManager::onKeyboardSettingsCreated(KeyboardSettingsInterfaceV1 *interf
     }
 
     interface->sendFeature(features, true);
-    interface->sendNumLock(m_seatDConfig->keyboardNumLock(), true);
+    interface->sendNumLock(globalConfig->keyboardNumLock(), true);
     interface->sendRepeat(m_seatDConfig->keyboardRate(), m_seatDConfig->keyboardDelay(), true);
     interface->sendDone();
 
@@ -140,6 +214,10 @@ void InputManager::onKeyboardSettingsCreated(KeyboardSettingsInterfaceV1 *interf
             &KeyboardSettingsInterfaceV1::applied,
             this,
             &InputManager::handleKeyboardSettingsApplied);
+
+    interface->setProperty("_treelandKeyboardSettingsInitialized", true);
+
+    return true;
 }
 
 void InputManager::onMousePointerConfigCreated(PointerDeviceConfigurationV1 *config)
@@ -147,11 +225,7 @@ void InputManager::onMousePointerConfigCreated(PointerDeviceConfigurationV1 *con
     if (!m_seatDConfig)
         return;
 
-#if SEATUSERDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
-    if (!m_seatDConfig->isInitializeSucceeded()) {
-#else
-    if (!m_seatDConfig->isInitializeSucceed()) {
-#endif
+    if (!isSeatDConfigInitialized(m_seatDConfig)) {
         return;
     }
 
@@ -227,11 +301,7 @@ void InputManager::handleMousePointerConfigApplied(PointerDeviceConfigurationV1:
         return;
     }
 
-#if SEATUSERDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
-    if (!m_seatDConfig->isInitializeSucceeded()) {
-#else
-    if (!m_seatDConfig->isInitializeSucceed()) {
-#endif
+    if (!isSeatDConfigInitialized(m_seatDConfig)) {
         interface->sendFailed();
         return;
     }
@@ -344,11 +414,7 @@ void InputManager::onTouchpadPointerConfigCreated(PointerDeviceConfigurationV1 *
     if (!m_seatDConfig)
         return;
 
-#if SEATUSERDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
-    if (!m_seatDConfig->isInitializeSucceeded()) {
-#else
-    if (!m_seatDConfig->isInitializeSucceed()) {
-#endif
+    if (!isSeatDConfigInitialized(m_seatDConfig)) {
         return;
     }
 
@@ -377,11 +443,7 @@ void InputManager::handleTouchpadPointerConfigApplied(PointerDeviceConfiguration
         return;
     }
 
-#if SEATUSERDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
-    if (!m_seatDConfig->isInitializeSucceeded()) {
-#else
-    if (!m_seatDConfig->isInitializeSucceed()) {
-#endif
+    if (!isSeatDConfigInitialized(m_seatDConfig)) {
         interface->sendFailed();
         return;
     }
@@ -469,17 +531,13 @@ void InputManager::handleKeyboardSettingsApplied(KeyboardSettingsInterfaceV1::Ch
         return;
     }
 
-#if SEATUSERDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
-    if (!m_seatDConfig->isInitializeSucceeded()) {
-#else
-    if (!m_seatDConfig->isInitializeSucceed()) {
-#endif
+    if (!isSeatDConfigInitialized(m_seatDConfig) || !isTreelandConfigInitialized(Helper::instance()->globalConfig())) {
         interface->sendFailed();
         return;
     }
 
     if (changes.testFlag(KeyboardSettingsInterfaceV1::NumLockChanged)) {
-        m_seatDConfig->setKeyboardNumLock(interface->numLock());
+        Helper::instance()->globalConfig()->setKeyboardNumLock(interface->numLock());
     }
 
     if (changes.testFlag(KeyboardSettingsInterfaceV1::RepeatChanged)) {
@@ -497,15 +555,37 @@ void InputManager::handleKeyboardSettingsApplied(KeyboardSettingsInterfaceV1::Ch
         }
     }
 
-    const auto devices = interface->wSeat()->deviceList();
-    for (WInputDevice *device : devices) {
-        if (device->type() != WInputDevice::Type::Keyboard)
-            continue;
+    if (changes.testFlag(KeyboardSettingsInterfaceV1::NumLockChanged))
+        setNumLockForSeat(interface->wSeat(), interface->numLock());
+}
 
-        if (changes.testFlag(KeyboardSettingsInterfaceV1::NumLockChanged)) {
-            setNumLockForDevice(device, interface->numLock());
+void InputManager::applyNumLockToKeyboards()
+{
+    auto *globalConfig = Helper::instance()->globalConfig();
+    if (!isTreelandConfigInitialized(globalConfig))
+        return;
+
+    auto *seatManager = Helper::instance()->seatManager();
+    if (seatManager) {
+        const auto seats = seatManager->seats();
+        for (WSeat *seat : seats) {
+            setNumLockForSeat(seat, globalConfig->keyboardNumLock());
         }
     }
+}
+
+void InputManager::setNumLockForSeat(WSeat *seat, bool enabled)
+{
+    if (!seat)
+        return;
+
+    const auto devices = seat->deviceList();
+    for (auto *device : devices) {
+        if (device->type() == WInputDevice::Type::Keyboard)
+            setNumLockForDevice(device, enabled);
+    }
+
+    setNumLockForDevice(seat->keyboardGroupKeyboard(), enabled);
 }
 
 void InputManager::setNumLockForDevice(WInputDevice *device, bool enabled)
@@ -530,18 +610,10 @@ void InputManager::setNumLockForDevice(WInputDevice *device, bool enabled)
     } else {
         locked &= ~(1u << numlock);
     }
-    xkb_state_update_mask(wlrKeyboard->xkb_state,
-                          xkb_state_serialize_mods(wlrKeyboard->xkb_state, XKB_STATE_MODS_DEPRESSED),
-                          xkb_state_serialize_mods(wlrKeyboard->xkb_state, XKB_STATE_MODS_LATCHED),
-                          locked, 0, 0, 0);
-
-    uint32_t leds = wlrKeyboard->leds;
-    if (enabled) {
-        leds |= WLR_LED_NUM_LOCK;
-    } else {
-        leds &= ~WLR_LED_NUM_LOCK;
-    }
-    wlr_keyboard_led_update(wlrKeyboard, leds);
+    const auto depressed = xkb_state_serialize_mods(wlrKeyboard->xkb_state, XKB_STATE_MODS_DEPRESSED);
+    const auto latched = xkb_state_serialize_mods(wlrKeyboard->xkb_state, XKB_STATE_MODS_LATCHED);
+    const auto group = xkb_state_serialize_layout(wlrKeyboard->xkb_state, XKB_STATE_LAYOUT_EFFECTIVE);
+    wlr_keyboard_notify_modifiers(wlrKeyboard, depressed, latched, locked, group);
 }
 
 void InputManager::onInputAdded(WInputDevice *input)
@@ -549,11 +621,7 @@ void InputManager::onInputAdded(WInputDevice *input)
     if (!m_seatDConfig)
         return;
 
-#if SEATUSERDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
-    if (!m_seatDConfig->isInitializeSucceeded()) {
-#else
-    if (!m_seatDConfig->isInitializeSucceed()) {
-#endif
+    if (!isSeatDConfigInitialized(m_seatDConfig)) {
         return;
     }
 
@@ -569,7 +637,10 @@ void InputManager::onInputAdded(WInputDevice *input)
         if (auto *keyboard = qobject_cast<qw_keyboard *>(input->handle())) {
             keyboard->set_repeat_info(m_seatDConfig->keyboardRate(), m_seatDConfig->keyboardDelay());
         }
-        setNumLockForDevice(input, m_seatDConfig->keyboardNumLock());
+        if (isTreelandConfigInitialized(Helper::instance()->globalConfig())) {
+            if (auto *seat = input->seat())
+                setNumLockForSeat(seat, Helper::instance()->globalConfig()->keyboardNumLock());
+        }
     }
 
     if (udev_device_get_property_value(udevDevice, "ID_INPUT_MOUSE")) {

--- a/src/input/inputmanager.h
+++ b/src/input/inputmanager.h
@@ -10,6 +10,8 @@ Q_MOC_INCLUDE("seatuserconfig.hpp")
 
 #include <qwinputdevice.h>
 
+#include <wseat.h>
+
 #include <QObject>
 #include <QMap>
 
@@ -41,5 +43,9 @@ private Q_SLOTS:
     void onConfigInitializeSucceed();
 
 private:
+    bool initializeKeyboardSettings(KeyboardSettingsInterfaceV1 *interface);
+    void applyNumLockToKeyboards();
+    static void setNumLockForSeat(WSeat *seat, bool enabled);
+
     SeatUserDConfig* m_seatDConfig = nullptr;
 };

--- a/src/modules/keyboard-state-notify/keyboardstatenotifymanagerinterfacev1.cpp
+++ b/src/modules/keyboard-state-notify/keyboardstatenotifymanagerinterfacev1.cpp
@@ -6,6 +6,7 @@
 #include "seat/helper.h"
 #include "seatsmanager.h"
 #include "common/treelandlogging.h"
+#include "treelandconfig.hpp"
 
 #include <qwdisplay.h>
 #include <qwkeyboard.h>
@@ -17,32 +18,83 @@
 
 #include <xkbcommon/xkbcommon.h>
 
+#include <optional>
+
 static QList<KeyboardStateWatcherV1 *> s_watchers;
-static QHash<WSeat *, uint32_t> s_lastLockStates;
+static QHash<WSeat *, wlr_keyboard_modifiers> s_lastModifiers;
+
+
+namespace {
+bool isTreelandConfigInitialized(TreelandConfig *config)
+{
+    if (!config)
+        return false;
+
+#if TREELANDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0
+    return config->isInitializeSucceeded();
+#else
+    return config->isInitializeSucceed();
+#endif
+}
+
+}
 
 struct ModifierInfo {
     uint32_t flag;
-    const char *ledName;
+    const char *modName;
 };
 
 static constexpr ModifierInfo s_modifierInfos[] = {
-    { KeyboardStateWatcherV1::CapsLock, XKB_LED_NAME_CAPS },
-    { KeyboardStateWatcherV1::NumLock, XKB_LED_NAME_NUM },
+    { KeyboardStateWatcherV1::CapsLock, XKB_MOD_NAME_CAPS },
+    { KeyboardStateWatcherV1::NumLock, XKB_MOD_NAME_NUM },
 };
 
-static uint32_t getLockStateBitfield(xkb_state *state)
+static std::optional<wlr_keyboard *> getSeatKeyboard(WSeat *seat)
 {
-    uint32_t locked = 0;
-    auto *keymap = xkb_state_get_keymap(state);
+    if (!seat || !seat->keyboardGroupKeyboard())
+        return std::nullopt;
 
+    auto *keyboard = qobject_cast<qw_keyboard *>(seat->keyboardGroupKeyboard()->handle());
+    if (!keyboard || !keyboard->handle() || !keyboard->handle()->keymap)
+        return std::nullopt;
+
+    return keyboard->handle();
+}
+
+static bool modifiersEqual(const wlr_keyboard_modifiers &a, const wlr_keyboard_modifiers &b)
+{
+    return a.depressed == b.depressed
+        && a.latched == b.latched
+        && a.locked == b.locked
+        && a.group == b.group;
+}
+
+static uint32_t lockStateBitfield(wlr_keyboard *keyboard, xkb_mod_mask_t locked)
+{
+    uint32_t state = 0;
     for (const auto &info : s_modifierInfos) {
-        xkb_led_index_t idx = xkb_keymap_led_get_index(keymap, info.ledName);
-        if (idx != XKB_LED_INVALID
-            && xkb_state_led_index_is_active(state, idx))
-            locked |= info.flag;
+        xkb_mod_index_t idx = xkb_keymap_mod_get_index(keyboard->keymap, info.modName);
+        if (idx != XKB_MOD_INVALID && (locked & (xkb_mod_mask_t(1) << idx)))
+            state |= info.flag;
     }
 
-    return locked;
+    return state;
+}
+
+static std::optional<uint32_t> getSeatLockState(WSeat *seat)
+{
+    const auto keyboard = getSeatKeyboard(seat);
+    if (!keyboard)
+        return std::nullopt;
+
+    return lockStateBitfield(*keyboard, (*keyboard)->modifiers.locked);
+}
+
+static uint32_t changedLockStateBitfield(wlr_keyboard *keyboard,
+                                         const wlr_keyboard_modifiers &previous,
+                                         const wlr_keyboard_modifiers &current)
+{
+    return lockStateBitfield(keyboard, previous.locked ^ current.locked);
 }
 
 struct KeyboardConnection {
@@ -76,6 +128,7 @@ private:
     void connectKeyboardGroup(WSeat *seat, WInputDevice *keyboardDevice);
 
     QList<KeyboardConnection> m_keyboardConnections;
+    bool m_keyboardConnectionsSetup = false;
 };
 
 TreelandKeyboardStateNotifyManagerInterfaceV1Private::TreelandKeyboardStateNotifyManagerInterfaceV1Private(
@@ -91,9 +144,7 @@ wl_global *TreelandKeyboardStateNotifyManagerInterfaceV1Private::global() const
 
 void TreelandKeyboardStateNotifyManagerInterfaceV1Private::bind_resource([[maybe_unused]] Resource *resource)
 {
-    if (resourceMap().isEmpty()) {
-        setupKeyboardConnections();
-    }
+    setupKeyboardConnections();
 }
 
 void TreelandKeyboardStateNotifyManagerInterfaceV1Private::connectKeyboardGroup(WSeat *seat, WInputDevice *keyboardDevice)
@@ -102,6 +153,9 @@ void TreelandKeyboardStateNotifyManagerInterfaceV1Private::connectKeyboardGroup(
         if (conn.seat == seat)
             return;
     }
+
+    if (const auto keyboard = getSeatKeyboard(seat))
+        s_lastModifiers[seat] = (*keyboard)->modifiers;
 
     KeyboardConnection conn;
     conn.seat = seat;
@@ -113,6 +167,10 @@ void TreelandKeyboardStateNotifyManagerInterfaceV1Private::connectKeyboardGroup(
 
 void TreelandKeyboardStateNotifyManagerInterfaceV1Private::setupKeyboardConnections()
 {
+    if (m_keyboardConnectionsSetup)
+        return;
+    m_keyboardConnectionsSetup = true;
+
     auto *helper = Helper::instance();
     const auto seats = helper->seatManager()->seats();
     for (auto *seat : seats) {
@@ -129,34 +187,47 @@ void TreelandKeyboardStateNotifyManagerInterfaceV1Private::setupKeyboardConnecti
 
 void TreelandKeyboardStateNotifyManagerInterfaceV1Private::onModifiersEvent(WSeat *seat)
 {
+    const auto keyboard = getSeatKeyboard(seat);
+    if (!keyboard)
+        return;
+
+    const auto currentModifiers = (*keyboard)->modifiers;
+    const auto previousModifiers = s_lastModifiers.value(seat, currentModifiers);
+    s_lastModifiers[seat] = currentModifiers;
+
+    if (modifiersEqual(previousModifiers, currentModifiers))
+        return;
+
+    const uint32_t changedLocks = changedLockStateBitfield(*keyboard, previousModifiers, currentModifiers);
+    if (changedLocks == 0)
+        return;
+
+    const uint32_t currentLocks = lockStateBitfield(*keyboard, currentModifiers.locked);
+
+    constexpr uint32_t NumLockMask = KeyboardStateWatcherV1::NumLock;
+
+    if (changedLocks & NumLockMask) {
+        const bool isLocked = currentLocks & NumLockMask;
+
+        if (isTreelandConfigInitialized(Helper::instance()->globalConfig())) {
+            Helper::instance()->globalConfig()->setKeyboardNumLock(isLocked);
+        }
+    }
+
     if (s_watchers.isEmpty())
         return;
-
-    qw_keyboard *keyboard = qobject_cast<qw_keyboard*>(seat->keyboardGroupKeyboard()->handle());
-    const auto *wlrKeyboard = keyboard->handle();
-    if (!wlrKeyboard || !wlrKeyboard->xkb_state)
-        return;
-
-    uint32_t currentLocks = getLockStateBitfield(wlrKeyboard->xkb_state);
-    uint32_t prevLocks = s_lastLockStates.value(seat, 0);
-    uint32_t changed = currentLocks ^ prevLocks;
-
-    if (changed == 0)
-        return;
-
-    s_lastLockStates[seat] = currentLocks;
 
     for (auto *watcher : std::as_const(s_watchers)) {
         if (watcher->seat() && watcher->wSeat() != seat)
             continue;
 
-        uint32_t watchMods = watcher->modifiers() & changed;
-        if (watchMods == 0)
+        const uint32_t changed = changedLocks & uint32_t(watcher->modifiers());
+        if (changed == 0)
             continue;
 
         for (int i = 0; i < 2; ++i) {
             uint32_t mod = (1u << i);
-            if (!(watchMods & mod))
+            if (!(changed & mod))
                 continue;
 
             bool isLocked = (currentLocks & mod) != 0;
@@ -178,14 +249,11 @@ void TreelandKeyboardStateNotifyManagerInterfaceV1Private::handleSeatDestroy(WSe
             m_keyboardConnections.removeAt(i);
         }
     }
+    s_lastModifiers.remove(seat);
 }
 
 void TreelandKeyboardStateNotifyManagerInterfaceV1Private::destroy(Resource *resource)
 {
-    if (resourceMap().size() == 1) {
-        m_keyboardConnections.clear();
-    }
-
     wl_resource_destroy(resource->handle);
 }
 
@@ -303,19 +371,16 @@ void KeyboardStateWatcherV1Private::apply([[maybe_unused]] Resource *resource)
     }
 
     for (auto *seat : std::as_const(seats)) {
-        qw_keyboard *keyboard =
-            qobject_cast<qw_keyboard *>(seat->keyboardGroupKeyboard()->handle());
-        if (!keyboard || !keyboard->handle()->xkb_state)
+        const auto currentLocks = getSeatLockState(seat);
+        if (!currentLocks)
             continue;
-
-        uint32_t currentLocks = getLockStateBitfield(keyboard->handle()->xkb_state);
 
         for (int i = 0; i < 2; ++i) {
             uint32_t mod = (1u << i);
             if (!(modifiers & mod))
                 continue;
 
-            bool isLocked = (currentLocks & mod) != 0;
+            bool isLocked = (*currentLocks & mod) != 0;
             if (isLocked && !(flags & KeyboardStateWatcherV1::WatchLocked))
                 continue;
             if (!isLocked && !(flags & KeyboardStateWatcherV1::WatchUnlocked))
@@ -337,6 +402,7 @@ TreelandKeyboardStateNotifyManagerInterfaceV1::~TreelandKeyboardStateNotifyManag
 void TreelandKeyboardStateNotifyManagerInterfaceV1::create(WServer *server)
 {
     d->init(server->handle()->handle(), InterfaceVersion);
+    d->setupKeyboardConnections();
 }
 
 void TreelandKeyboardStateNotifyManagerInterfaceV1::destroy([[maybe_unused]] WServer *server)


### PR DESCRIPTION
Move the Num Lock setting to global treeland config so it is shared across seats and available during keyboard settings initialization.

Apply Num Lock through wlr_keyboard_notify_modifiers() and synchronize the state to every keyboard device in the seat before updating the keyboard group. This keeps physical keyboard state, keyboard group state, and LED state aligned, preventing the first key press after boot or unlock from reverting Num Lock and delaying the state notification until another modifier key is pressed.

Track keyboard-state-notify changes from the keyboard group's wlroots modifier snapshot, and only send watcher updates when the watched lock modifiers actually change.

Log: keep num lock state synchronized with keyboard group state
PMS: BUG-367545
Influence: Num Lock state and keyboard state notifications