### PR TITLE
fix(shortcut): keep same-app task switch filter in QML

### DIFF
--- a/src/core/qml/SwitchViewHighlightDelegate.qml
+++ b/src/core/qml/SwitchViewHighlightDelegate.qml
@@ -8,10 +8,11 @@ Rectangle {
     property ListView sourceView: ListView.view
     readonly property int aniDuration: 400
 
-    x: sourceView.currentItem.x + sourceView.borderMargin
-    y: sourceView.currentItem.y + (sourceView.vMargin / 2 - 2 * sourceView.borderMargin)
-    height: sourceView.currentItem.height - 2 * (sourceView.vMargin / 2 - 2 * sourceView.borderMargin)
-    width: sourceView.currentItem.width - 2 * sourceView.vSpacing + 2 * sourceView.borderMargin
+    visible: sourceView.currentItem
+    x: sourceView.currentItem ? sourceView.currentItem.x + sourceView.borderMargin : 0
+    y: sourceView.currentItem ? sourceView.currentItem.y + (sourceView.vMargin / 2 - 2 * sourceView.borderMargin) : 0
+    height: sourceView.currentItem ? sourceView.currentItem.height - 2 * (sourceView.vMargin / 2 - 2 * sourceView.borderMargin) : 0
+    width: sourceView.currentItem ? sourceView.currentItem.width - 2 * sourceView.vSpacing + 2 * sourceView.borderMargin : 0
     color: "transparent"
     radius: sourceView.radius
     border {

--- a/src/core/qml/TaskSwitcher.qml
+++ b/src/core/qml/TaskSwitcher.qml
@@ -111,7 +111,7 @@ Item {
                 id: currentContext
                 visible: previewWindows.count === 0
 
-                sourceSurface: switchView.currentItem.surface
+                sourceSurface: switchView.currentItem ? switchView.currentItem.surface : null
                 anchors.centerIn: previewItem
                 sourceComponent: undefined
 
@@ -482,6 +482,20 @@ Item {
 
         focusReason = Qt.TabFocusReason
         switchIndex(nextIndex)
+    }
+
+    function previousSameApp() {
+        if (switchView.currentItem && switchView.currentItem.surface)
+            root.model.setFilterAppId(switchView.currentItem.surface.appId)
+
+        previous()
+    }
+
+    function nextSameApp() {
+        if (switchView.currentItem && switchView.currentItem.surface)
+            root.model.setFilterAppId(switchView.currentItem.surface.appId)
+
+        next()
     }
 
     function show() {

--- a/src/core/qml/TaskWindowPreview.qml
+++ b/src/core/qml/TaskWindowPreview.qml
@@ -16,16 +16,16 @@ Loader {
     property alias previewComponent: sourceComponent
 
     transformOrigin: Item.Center
-    property real preferredHeight: sourceSurface.height < (parent.height - 2 * vSpacing) ?
+    property real preferredHeight: !sourceSurface ? 0 : sourceSurface.height < (parent.height - 2 * vSpacing) ?
                                        sourceSurface.height : (parent.height - 2 * vSpacing)
-    property real preferredWidth: sourceSurface.width < (parent.width - 2 * hSpacing) ?
+    property real preferredWidth: !sourceSurface ? 0 : sourceSurface.width < (parent.width - 2 * hSpacing) ?
                                       sourceSurface.width : (parent.width - 2 * hSpacing)
-    property bool refHeight: preferredHeight * sourceSurface.width / sourceSurface.height < (parent.width - 2 * hSpacing)
+    property bool refHeight: sourceSurface && preferredHeight * sourceSurface.width / sourceSurface.height < (parent.width - 2 * hSpacing)
     readonly property real hSpacing: 20
     readonly property real vSpacing: 20
 
-    height: refHeight ? preferredHeight : preferredWidth * sourceSurface.height / sourceSurface.width
-    width: refHeight ? preferredHeight * sourceSurface.width / sourceSurface.height : preferredWidth
+    height: !sourceSurface ? 0 : refHeight ? preferredHeight : preferredWidth * sourceSurface.height / sourceSurface.width
+    width: !sourceSurface ? 0 : refHeight ? preferredHeight * sourceSurface.width / sourceSurface.height : preferredWidth
 
     onLoaderStatusChanged: {
         if (loaderStatus === -1) {

--- a/src/modules/shortcut/shortcutrunner.cpp
+++ b/src/modules/shortcut/shortcutrunner.cpp
@@ -341,11 +341,12 @@ void ShortcutRunner::finishWorkspaceSwipe()
 void ShortcutRunner::taskswitchAction(bool isRepeat, bool isSameApp, bool isPrev)
 {
     auto *helper = Helper::instance();
-    if (helper->currentMode() != Helper::CurrentMode::Normal && helper->currentMode() != Helper::CurrentMode::WindowSwitch)
+    const auto modeBefore = helper->currentMode();
+    if (modeBefore != Helper::CurrentMode::Normal && modeBefore != Helper::CurrentMode::WindowSwitch)
         return;
 
-    if (!isRepeat && helper->currentMode() == Helper::CurrentMode::Normal) {
-        auto current = helper->workspace()->current();
+    if (!isRepeat && !isSameApp && modeBefore == Helper::CurrentMode::Normal) {
+        auto *current = helper->workspace()->current();
         if (current) {
             auto nextSurface = current->findNextActivedSurface();
             if (nextSurface)
@@ -380,30 +381,26 @@ void ShortcutRunner::taskswitchAction(bool isRepeat, bool isSameApp, bool isPrev
     m_taskAltCount = 0;
     helper->setCurrentMode(Helper::CurrentMode::WindowSwitch);
 
-    QString appid;
-    if (isSameApp) {
-        auto surface = Helper::instance()->activatedSurface();
-        if (surface) {
-            appid = surface->shellSurface()->appId();
-        }
+    if (m_quickSwitchPending) {
+        m_quickSwitchTimer->stop();
+        m_quickSwitchPending = false;
     }
-    auto filter = Helper::instance()->workspace()->currentFilter();
-    filter->setFilterAppId(appid);
-    if (isPrev) {
+
+    if (isSameApp)
+        QMetaObject::invokeMethod(helper->m_taskSwitch, isPrev ? "previousSameApp" : "nextSameApp");
+    else if (isPrev)
         QMetaObject::invokeMethod(helper->m_taskSwitch, "previous");
-    } else {
+    else
         QMetaObject::invokeMethod(helper->m_taskSwitch, "next");
-    }
-    qCWarning(lcTlShortcut) << "TaskSwitch: navigating in full task switcher";
 }
 
 void ShortcutRunner::onQuickSwitchTimeout()
 {
-    m_quickSwitchPending = false;
-
     auto *helper = Helper::instance();
-    if (helper->currentMode() != Helper::CurrentMode::Normal)
+    if (helper->currentMode() != Helper::CurrentMode::Normal) {
+        m_quickSwitchPending = false;
         return;
+    }
 
     if (helper->m_taskSwitch.isNull()) {
         auto contentItem = helper->window()->contentItem();
@@ -476,6 +473,7 @@ void ShortcutRunner::onModifierReleased(QKeyEvent *event)
             auto filter = helper->workspace()->currentFilter();
             filter->setFilterAppId("");
             helper->setCurrentMode(Helper::CurrentMode::Normal);
+            m_quickSwitchPending = false;
             QMetaObject::invokeMethod(helper->m_taskSwitch, "exit");
         }
     }


### PR DESCRIPTION
Move same-app task switch filtering to the task switcher so it usesthe currently highlighted surface instead of the activated surface. Also guard task switch preview and highlight bindings when there is no current item.

Log: Fix same-app task switch filtering and empty current item handling
PMS: BUG-368117
Influence: Affects Alt-Tab and same-app task switch behavior