### PR TITLE
fix(popup): stop forcing submenu position to parent side

### DIFF
--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -867,13 +867,11 @@ void Output::handleLayerShellPopup(SurfaceWrapper *surface, const QRectF &normal
     surface->moveNormalGeometryInOutput(pos);
 }
 
-void Output::handleRegularPopup(SurfaceWrapper *surface, const QRectF &normalGeo, bool isSubMenu, WOutputItem *targetOutput)
+void Output::handleRegularPopup(SurfaceWrapper *surface, const QRectF &normalGeo, WOutputItem *targetOutput)
 {
     if (normalGeo.isEmpty()) {
         return;
     }
-
-    auto parentSurfaceWrapper = surface->parentSurface();
 
     auto dPos = popupDPos(surface);
     if (!dPos.has_value())
@@ -886,18 +884,12 @@ void Output::handleRegularPopup(SurfaceWrapper *surface, const QRectF &normalGeo
 
     QRectF outputRect(targetOutput->position(), targetOutput->size());
 
-    if (isSubMenu) {
-        pos.setX(parentSurfaceWrapper->x() + parentSurfaceWrapper->width());
-        if (pos.x() + normalGeo.width() > outputRect.right()) {
-            pos.setX(parentSurfaceWrapper->x() - normalGeo.width());
-        }
-    } else {
-        if (pos.x() < outputRect.left()) {
-            pos.setX(outputRect.left());
-        }
-        if (pos.x() + normalGeo.width() > outputRect.right()) {
-            pos.setX(outputRect.right() - normalGeo.width());
-        }
+    // TODO: Use xdg_positioner::constraint_adjustment to properly respect client's positioning constraints
+    if (pos.x() < outputRect.left()) {
+        pos.setX(outputRect.left());
+    }
+    if (pos.x() + normalGeo.width() > outputRect.right()) {
+        pos.setX(outputRect.right() - normalGeo.width());
     }
 
     adjustToOutputBounds(pos, normalGeo, outputRect);
@@ -955,8 +947,7 @@ void Output::arrangePopupSurface(SurfaceWrapper *surface)
     if (parentSurfaceWrapper->type() == SurfaceWrapper::Type::Layer) {
         handleLayerShellPopup(surface, normalGeo);
     } else {
-        bool isSubMenu = (parentSurfaceWrapper->type() == SurfaceWrapper::Type::XdgPopup);
-        handleRegularPopup(surface, normalGeo, isSubMenu, targetOutput);
+        handleRegularPopup(surface, normalGeo, targetOutput);
     }
 }
 

--- a/src/output/output.h
+++ b/src/output/output.h
@@ -144,7 +144,7 @@ private:
 
     QPointF calculateBasePosition(SurfaceWrapper *surface, const QPointF &dPos) const;
     void handleLayerShellPopup(SurfaceWrapper *surface, const QRectF &normalGeo);
-    void handleRegularPopup(SurfaceWrapper *surface, const QRectF &normalGeo, bool isSubMenu, WOutputItem *targetOutput);
+    void handleRegularPopup(SurfaceWrapper *surface, const QRectF &normalGeo, WOutputItem *targetOutput);
     void clearPopupCache(SurfaceWrapper *surface);
 
     Type m_type;


### PR DESCRIPTION
handleRegularPopup previously overrode the client-requested position for submenu popups by anchoring them to the right side of their parent popup and flipping to the left when out of bounds. This ignored the client's xdg_positioner placement request.

Now all popups (including submenus) use the client-requested position from calculateBasePosition, with only output-boundary clamping as a fallback. Added TODO to use constraint_adjustment for proper future handling.

PMS: 365899 339275