### PR TITLE
fix(im-candidate): correct position offset with contentGeometry

### DIFF
--- a/src/core/imcandidatepanelmanager.cpp
+++ b/src/core/imcandidatepanelmanager.cpp
@@ -163,9 +163,12 @@ void IMCandidatePanelManager::applyInitialPositionAtCursor()
 
     QPointF pos;
     auto wrapperPos = focusWrapper->mapToGlobal(QPointF(0, 0));
-    pos.setX(wrapperPos.x() + cursorRect.x());
-    pos.setY(wrapperPos.y() + cursorRect.y() + cursorRect.height()
-             + focusWrapper->titlebarGeometry().height());
+    auto *shellSurface = focusWrapper->shellSurface();
+    const QPointF contentOffset = shellSurface
+        ? shellSurface->getContentGeometry().topLeft() : QPointF(0, 0);
+    pos.setX(wrapperPos.x() + cursorRect.x() - contentOffset.x());
+    pos.setY(wrapperPos.y() + cursorRect.y() - contentOffset.y()
+             + cursorRect.height() + focusWrapper->titlebarGeometry().height());
 
     arrangeIMCandidatePanels(output, pos);
 }
@@ -194,7 +197,6 @@ void IMCandidatePanelManager::onIMCandidatePanelGeometryChanged()
     auto *focusWrapper = focusSurface ? rootContainer->getSurface(focusSurface) : nullptr;
     if (!focusWrapper)
         return;
-
     auto *output = focusWrapper->ownsOutput();
     if (!output)
         return;
@@ -202,9 +204,12 @@ void IMCandidatePanelManager::onIMCandidatePanelGeometryChanged()
     QPointF pos;
     auto wrapperPos = focusWrapper->mapToGlobal(QPointF(0, 0));
     auto cursorRect = m_inputMethodHelper->textInputCursorRect();
-    pos.setX(wrapperPos.x() + cursorRect.x());
-    pos.setY(wrapperPos.y() + cursorRect.y() + cursorRect.height()
-             + focusWrapper->titlebarGeometry().height());
+    auto *shellSurface = focusWrapper->shellSurface();
+    const QPointF contentOffset = shellSurface
+        ? shellSurface->getContentGeometry().topLeft() : QPointF(0, 0);
+    pos.setX(wrapperPos.x() + cursorRect.x() - contentOffset.x());
+    pos.setY(wrapperPos.y() + cursorRect.y() - contentOffset.y()
+             + cursorRect.height() + focusWrapper->titlebarGeometry().height());
 
     arrangeIMCandidatePanels(output, pos);
 }


### PR DESCRIPTION
Subtract contentGeometry topLeft offset when computing IMCandidatePanel position from cursor rect, matching the InputPopup behavior for CSD windows.

修正IM候选框位置计算时未减去contentGeometry偏移的问题，
与InputPopup的定位逻辑保持一致。

Log: 修正IM候选框contentGeometry偏移
Influence: CSD窗口下IM候选框位置更准确，不再偏移。

## Summary by Sourcery

Bug Fixes:
- Fix IM candidate panel offset by subtracting content geometry top-left when positioning relative to the cursor.