### PR TITLE
fix(shortcut): clear app filter for all-app task switch

### DIFF
--- a/src/modules/shortcut/shortcutrunner.cpp
+++ b/src/modules/shortcut/shortcutrunner.cpp
@@ -373,12 +373,13 @@ void ShortcutRunner::taskswitchAction(bool isRepeat, bool isSameApp, bool isPrev
         m_quickSwitchPending = false;
     }
 
-    if (isSameApp)
+    if (isSameApp) {
         QMetaObject::invokeMethod(helper->m_taskSwitch, isPrev ? "previousSameApp" : "nextSameApp");
-    else if (isPrev)
-        QMetaObject::invokeMethod(helper->m_taskSwitch, "previous");
-    else
-        QMetaObject::invokeMethod(helper->m_taskSwitch, "next");
+    } else {
+        auto filter = helper->workspace()->currentFilter();
+        filter->setFilterAppId({});
+        QMetaObject::invokeMethod(helper->m_taskSwitch, isPrev ? "previous" : "next");
+    }
 }
 
 void ShortcutRunner::onQuickSwitchTimeout()


### PR DESCRIPTION
Clear the same-app filter before handling normal task switch navigation in the active task switcher. This lets users move back from same-app switching to all-app Alt-Tab while holding the modifier.

Log: Fix task switch filter reset for all-app navigation

PMS: BUG-368117

Influence: Affects Alt-Tab and same-app task switch behavior

## Summary by Sourcery

Bug Fixes:
- Ensure Alt-Tab all-app navigation clears any same-app filter so users can move from same-app switching back to full task switching while holding the modifier.