### PR TITLE
fix: remove redundant partialFactor reset in MultitaskviewProxy

### DIFF
--- a/src/plugins/multitaskview/qml/MultitaskviewProxy.qml
+++ b/src/plugins/multitaskview/qml/MultitaskviewProxy.qml
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import QtQuick
@@ -69,7 +69,6 @@ Multitaskview {
 
         if (exited) {
             root.visible = false;
-            partialFactor = 0;
 
             return "initial";
         }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent unintended partialFactor reset when the multitask view exits.