### PR TITLE
fix(xwayland): X11 apps cannot connect after treeland restart

### DIFF
--- a/misc/systemd/dde-session-pre.target.wants/treeland-xwayland.service.in
+++ b/misc/systemd/dde-session-pre.target.wants/treeland-xwayland.service.in
@@ -19,5 +19,6 @@ Sockets=treeland-xwayland.socket
 UnsetEnvironment=DISPLAY
 ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/treeland-sd --type xwayland
 ExecStop=-/usr/bin/systemctl --user unset-environment DISPLAY
-Slice=session.slice
+Restart=on-failure
 RestartSec=3s
+Slice=session.slice

--- a/misc/systemd/treeland.service.in
+++ b/misc/systemd/treeland.service.in
@@ -20,6 +20,10 @@ Environment=ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
 Environment=ASAN_OPTIONS=log_path=/tmp/treeland-asan:detect_leaks=0:abort_on_error=1:symbolize=1
 Environment=DDM_DISPLAY_MANAGER=1
 Environment=TREELAND_INPUT_ENHANCE=1
+# Kill orphaned Xwayland processes from previous treeland instance.
+# When treeland crashes, its Xwayland child processes may become orphans
+# because the cleanup code in Session::~Session() is not executed.
+ExecStartPre=-/usr/bin/pkill -9 -u dde -f '^Xwayland[[:space:]]+:[0-9]+'
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/treeland.sh --lockscreen
 Restart=on-failure
 RestartSec=1s

--- a/src/systemd-socket.cpp
+++ b/src/systemd-socket.cpp
@@ -16,12 +16,17 @@
 #include <QDir>
 #include <QFile>
 #include <QLoggingCategory>
-#include <QTemporaryFile>
+#include <QSaveFile>
+#include <QTimer>
 #include <QtEnvironmentVariables>
 
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
+
+#include <memory>
+#include <optional>
+#include <utility>
 
 Q_DECLARE_LOGGING_CATEGORY(lcSdSocket)
 Q_LOGGING_CATEGORY(lcSdSocket, "treeland.systemd.socket")
@@ -29,19 +34,331 @@ Q_LOGGING_CATEGORY(lcSdSocket, "treeland.systemd.socket")
 typedef QMap<QString, QString> StringMap;
 Q_DECLARE_METATYPE(StringMap)
 
-class SignalReceiver : public QObject
+class SocketActivator : public QObject
 {
     Q_OBJECT
 public:
-    SignalReceiver(std::function<void()> activateFdFunc, QObject *parent = nullptr)
-        : QObject(parent), activateFd(activateFdFunc) {
+    SocketActivator(QDBusUnixFileDescriptor unixFileDescriptor,
+                     QString type,
+                     QObject *parent = nullptr)
+        : QObject(parent)
+        , m_unixFileDescriptor(std::make_shared<QDBusUnixFileDescriptor>(std::move(unixFileDescriptor)))
+        , m_type(std::move(type))
+        , m_started(false) {
     }
+
+    bool tryStart(const QDBusConnection &connection) {
+        watchService(connection);
+
+        QDBusInterface test("org.deepin.Compositor1",
+                            "/org/deepin/Compositor1",
+                            "org.deepin.Compositor1",
+                            connection);
+        if (!test.isValid())
+            return false;
+
+        if (m_type == "xwayland") {
+            m_compositorBus = busFromConnection(connection);
+            return true;
+        }
+
+        return connectActivationSignal(connection);
+    }
+
+    void start() {
+        if (tryStart(QDBusConnection::sessionBus()) || tryStart(QDBusConnection::systemBus())) {
+            m_started = true;
+            clearPendingRetry(StartRetry);
+            activate();
+            return;
+        }
+        scheduleStartRetry();
+    }
+
 public Q_SLOTS:
-    void onSessionChanged() {
-        activateFd();
+    void activate() {
+        if (!m_started)
+            return;
+
+        if (!m_compositorBus.has_value())
+            return;
+
+        auto connection = dbusConnection(*m_compositorBus);
+
+        QDBusInterface updateFd("org.deepin.Compositor1",
+                                "/org/deepin/Compositor1",
+                                "org.deepin.Compositor1",
+                                connection);
+
+        if (updateFd.isValid()) {
+            if (m_type == "wayland") {
+                if (!callDBus(updateFd,
+                              QStringLiteral("ActivateWayland"),
+                              QStringLiteral("Failed to activate Wayland socket"),
+                              QVariant::fromValue(*m_unixFileDescriptor))) {
+                    return;
+                }
+
+                QDBusInterface dbus("org.freedesktop.DBus",
+                                    "/org/freedesktop/DBus",
+                                    "org.freedesktop.DBus",
+                                    QDBusConnection::sessionBus());
+                StringMap env;
+                env["WAYLAND_DISPLAY"] = "treeland.socket";
+
+                const auto extraEnvs = qgetenv("TREELAND_SESSION_ENVIRONMENTS");
+                if (!extraEnvs.isEmpty()) {
+                    const auto envs = extraEnvs.split('\n');
+                    for (const auto &i : envs) {
+                        const auto pair = i.split('=');
+                        if (pair.size() == 2) {
+                            env[QString::fromLocal8Bit(pair[0])] = QString::fromLocal8Bit(pair[1]);
+                        }
+                    }
+                }
+
+                if (!callDBus(dbus,
+                              QStringLiteral("UpdateActivationEnvironment"),
+                              QStringLiteral("Failed to update Wayland activation environment"),
+                              QVariant::fromValue(env))) {
+                    return;
+                }
+
+                sd_notify(0, "READY=1");
+            } else if (m_type == "xwayland") {
+                QDBusMessage reply = updateFd.call("XWaylandName");
+                if (reply.type() == QDBusMessage::ReplyMessage) {
+                    QVariantList values = reply.arguments();
+                    if (values.size() < 2) {
+                        qCWarning(lcSdSocket) << "Invalid XWaylandName reply";
+                        scheduleActivateRetry();
+                        return;
+                    }
+                    QString xwaylandName = values.at(0).toString();
+                    QByteArray auth = values.at(1).toByteArray();
+
+                    if (m_lastXwaylandAuth == auth) {
+                        sd_notify(0, "READY=1");
+                        clearPendingRetry(ActivateRetry);
+                        return;
+                    }
+
+                    const QString authFileName = xauthorityFileName();
+                    if (!writeXAuthority(authFileName, auth)) {
+                        scheduleActivateRetry();
+                        return;
+                    }
+
+                    QDBusInterface dbus("org.freedesktop.DBus",
+                                        "/org/freedesktop/DBus",
+                                        "org.freedesktop.DBus",
+                                        QDBusConnection::sessionBus());
+                    StringMap env;
+                    env["DISPLAY"] = xwaylandName;
+                    env["XAUTHORITY"] = authFileName;
+                    if (!callDBus(dbus,
+                                  QStringLiteral("UpdateActivationEnvironment"),
+                                  QStringLiteral("Failed to update XWayland activation environment"),
+                                  QVariant::fromValue(env))) {
+                        scheduleActivateRetry();
+                        return;
+                    }
+
+                    sd_notify(0, "READY=1");
+                    m_lastXwaylandAuth = auth;
+                    clearPendingRetry(ActivateRetry);
+                } else {
+                    scheduleActivateRetry();
+                }
+            }
+        }
+        if (m_type == "xwayland" && !updateFd.isValid()) {
+            scheduleActivateRetry();
+        }
     }
+
 private:
-    std::function<void()> activateFd;
+    enum class Bus {
+        Session,
+        System,
+    };
+
+    enum RetryFlag {
+        StartRetry = 1 << 0,
+        ActivateRetry = 1 << 1,
+    };
+
+    bool isRetryPending(RetryFlag flag) const {
+        return m_pendingRetries & flag;
+    }
+
+    void setPendingRetry(RetryFlag flag) {
+        m_pendingRetries |= flag;
+    }
+
+    void clearPendingRetry(RetryFlag flag) {
+        m_pendingRetries &= ~flag;
+    }
+
+    Bus busFromConnection(const QDBusConnection &connection) const {
+        return connection.name() == QDBusConnection::sessionBus().name()
+            ? Bus::Session
+            : Bus::System;
+    }
+
+    QDBusConnection dbusConnection(Bus bus) const {
+        return bus == Bus::Session
+            ? QDBusConnection::sessionBus()
+            : QDBusConnection::systemBus();
+    }
+
+    QString runtimeFileName(const QString &fileName) const {
+        QByteArray runtimeDir = qgetenv("XDG_RUNTIME_DIR");
+        if (runtimeDir.isEmpty())
+            runtimeDir = QDir::tempPath().toLocal8Bit();
+
+        return QStringLiteral("%1/%2").arg(QString::fromLocal8Bit(runtimeDir), fileName);
+    }
+
+    QString xauthorityFileName() const {
+        return runtimeFileName(QStringLiteral("treeland-xauthority"));
+    }
+
+    bool writeXAuthority(const QString &fileName, const QByteArray &auth) const {
+        QSaveFile file(fileName);
+        if (!file.open(QFile::WriteOnly)) {
+            qCWarning(lcSdSocket) << "Failed to open xauth file" << fileName << file.errorString();
+            return false;
+        }
+
+        file.setPermissions(QFile::ReadOwner | QFile::WriteOwner);
+        if (file.write(auth) != auth.size()) {
+            qCWarning(lcSdSocket) << "Failed to write xauth file" << fileName << file.errorString();
+            return false;
+        }
+
+        if (!file.commit()) {
+            qCWarning(lcSdSocket) << "Failed to commit xauth file" << fileName << file.errorString();
+            return false;
+        }
+
+        return true;
+    }
+
+    template<typename... Args>
+    std::optional<QDBusMessage> callDBus(QDBusInterface &interface,
+                                         const QString &method,
+                                         const QString &errorMessage,
+                                         Args &&...args) {
+        QDBusMessage reply = interface.call(method, std::forward<Args>(args)...);
+        if (reply.type() == QDBusMessage::ErrorMessage) {
+            qCWarning(lcSdSocket) << errorMessage << reply.errorMessage();
+            return std::nullopt;
+        }
+
+        return reply;
+    }
+
+    bool connectActivationSignal(QDBusConnection connection) {
+        const auto bus = busFromConnection(connection);
+        if (m_compositorBus == bus)
+            return true;
+
+        if (m_compositorBus.has_value()) {
+            auto oldConnection = dbusConnection(*m_compositorBus);
+            oldConnection.disconnect("org.deepin.Compositor1",
+                                     "/org/deepin/Compositor1",
+                                     "org.deepin.Compositor1",
+                                     QStringLiteral("SessionChanged"),
+                                     this,
+                                     SLOT(activate()));
+            m_compositorBus.reset();
+        }
+
+        if (connection.connect("org.deepin.Compositor1",
+                               "/org/deepin/Compositor1",
+                               "org.deepin.Compositor1",
+                               QStringLiteral("SessionChanged"),
+                               this,
+                               SLOT(activate()))) {
+            m_compositorBus = bus;
+            return true;
+        }
+
+        return false;
+    }
+
+    void watchService(const QDBusConnection &connection) {
+        if (findChild<QDBusServiceWatcher *>(connection.name()))
+            return;
+
+        const auto bus = busFromConnection(connection);
+        auto *watcher = new QDBusServiceWatcher(QStringLiteral("org.deepin.Compositor1"),
+                                                connection,
+                                                QDBusServiceWatcher::WatchForRegistration
+                                                    | QDBusServiceWatcher::WatchForUnregistration,
+                                                this);
+        watcher->setObjectName(connection.name());
+        connect(watcher, &QDBusServiceWatcher::serviceRegistered, this, [this, bus](const QString &service) {
+            Q_UNUSED(service)
+            if (!m_started || m_compositorBus == bus) {
+                start();
+            }
+        });
+        connect(watcher, &QDBusServiceWatcher::serviceUnregistered, this, [this, bus](const QString &service) {
+            Q_UNUSED(service)
+            if (m_compositorBus == bus) {
+                m_started = false;
+                resetXwaylandActivationState();
+                scheduleStartRetry();
+            }
+        });
+    }
+
+    void scheduleStartRetry() {
+        if (isRetryPending(StartRetry))
+            return;
+
+        setPendingRetry(StartRetry);
+        QTimer::singleShot(RetryIntervalMs, this, [this] {
+            if (!isRetryPending(StartRetry))
+                return;
+
+            clearPendingRetry(StartRetry);
+            start();
+        });
+    }
+
+    void scheduleActivateRetry() {
+        if (m_type != "xwayland" || isRetryPending(ActivateRetry))
+            return;
+
+        setPendingRetry(ActivateRetry);
+        QTimer::singleShot(RetryIntervalMs, this, [this] {
+            if (!isRetryPending(ActivateRetry))
+                return;
+
+            clearPendingRetry(ActivateRetry);
+            activate();
+        });
+    }
+
+    void resetXwaylandActivationState() {
+        if (m_type != "xwayland")
+            return;
+
+        m_lastXwaylandAuth.clear();
+        clearPendingRetry(ActivateRetry);
+    }
+
+    static constexpr int RetryIntervalMs = 500;
+
+    std::shared_ptr<QDBusUnixFileDescriptor> m_unixFileDescriptor;
+    QString m_type;
+    bool m_started = false;
+    int m_pendingRetries = 0;
+    QByteArray m_lastXwaylandAuth;
+    std::optional<Bus> m_compositorBus;
 };
 
 int main(int argc, char *argv[])
@@ -70,100 +387,12 @@ int main(int argc, char *argv[])
         exit(1);
     }
 
-    QList<QTemporaryFile *> tmpFiles;
     QDBusUnixFileDescriptor unixFileDescriptor(SD_LISTEN_FDS_START);
 
-    auto active = [unixFileDescriptor, type, &tmpFiles](QDBusConnection connection) {
-        auto activateFd = [unixFileDescriptor, type, &connection, &tmpFiles] {
-            QDBusInterface updateFd("org.deepin.Compositor1",
-                                    "/org/deepin/Compositor1",
-                                    "org.deepin.Compositor1",
-                                    connection);
+    auto *activator = new SocketActivator(unixFileDescriptor, type, &app);
+    activator->start();
 
-            if (updateFd.isValid()) {
-                if (type == "wayland") {
-                    updateFd.call("ActivateWayland", QVariant::fromValue(unixFileDescriptor));
-
-                    QDBusInterface dbus("org.freedesktop.DBus",
-                                        "/org/freedesktop/DBus",
-                                        "org.freedesktop.DBus",
-                                        QDBusConnection::sessionBus());
-                    StringMap env;
-                    env["WAYLAND_DISPLAY"] = "treeland.socket";
-
-                    const auto extraEnvs = qgetenv("TREELAND_SESSION_ENVIRONMENTS");
-                    if (!extraEnvs.isEmpty()) {
-                        const auto envs = extraEnvs.split('\n');
-                        for (const auto &i : envs) {
-                            const auto pair = i.split('=');
-                            if (pair.size() == 2) {
-                                env[QString::fromLocal8Bit(pair[0])] = QString::fromLocal8Bit(pair[1]);
-                            }
-                        }
-                    }
-
-                    auto reply = dbus.call("UpdateActivationEnvironment", QVariant::fromValue(env));
-
-                    sd_notify(0, "READY=1");
-                } else if (type == "xwayland") {
-                    QDBusMessage reply = updateFd.call("XWaylandName");
-                    if (reply.type() == QDBusMessage::ReplyMessage) {
-                        QVariantList values = reply.arguments();
-                        if (values.size() < 2) {
-                            qCWarning(lcSdSocket) << "Invalid XWaylandName reply";
-                            return;
-                        }
-                        QString xwaylandName = values.at(0).toString();
-                        QByteArray auth = values.at(1).toByteArray();
-
-                        QByteArray runtimeDir = qgetenv("XDG_RUNTIME_DIR");
-                        if (runtimeDir.isEmpty())
-                            runtimeDir = QDir::tempPath().toLocal8Bit();
-                        QTemporaryFile *authFile = new QTemporaryFile();
-                        authFile->setFileTemplate(QStringLiteral("%1/.xauth_XXXXXX").arg(runtimeDir));
-                        if (!authFile->open()) {
-                            qCWarning(lcSdSocket) << "Failed to create temporary xauth file";
-                            return;
-                        }
-                        QString authFileName = authFile->fileName();
-                        tmpFiles.append(authFile);
-                        authFile->setPermissions(QFile::ReadOwner | QFile::WriteOwner);
-                        authFile->write(auth);
-                        authFile->flush();
-                        authFile->close();
-
-                        QDBusInterface dbus("org.freedesktop.DBus",
-                                            "/org/freedesktop/DBus",
-                                            "org.freedesktop.DBus",
-                                            QDBusConnection::sessionBus());
-                        StringMap env;
-                        env["DISPLAY"] = xwaylandName;
-                        env["XAUTHORITY"] = authFileName;
-                        auto reply =
-                            dbus.call("UpdateActivationEnvironment", QVariant::fromValue(env));
-
-                        sd_notify(0, "READY=1");
-                    }
-                }
-            }
-        };
-
-        connection.connect("org.deepin.Compositor1",
-                           "/org/deepin/Compositor1",
-                           "org.deepin.Compositor1",
-                           "SessionChanged",
-                           new SignalReceiver(activateFd),
-                           SLOT(onSessionChanged()));
-        activateFd();
-    };
-
-    active(QDBusConnection::sessionBus());
-    active(QDBusConnection::systemBus());
-
-    int ret = app.exec();
-    for (auto i : std::as_const(tmpFiles))
-        delete i;
-    return ret;
+    return app.exec();
 }
 
 #include "systemd-socket.moc"


### PR DESCRIPTION
When treeland restarts, Xwayland prepares new Xauthority data, but treeland-sd may still keep the old auth data in the user's XAUTHORITY file. New X11 clients then present stale MIT-MAGIC-COOKIE-1 data and fail to connect to Xwayland.

Do not rely on an extra Xwayland-ready D-Bus signal to refresh the user environment. Instead, make treeland-sd actively synchronize Xwayland state: retry finding treeland on D-Bus while the compositor is not registered, retry XWaylandName() while Xwayland or its auth file is not ready, and refresh DISPLAY/XAUTHORITY after the latest auth data is available.

问题

treeland 重启后，X11 应用报 Invalid MIT-MAGIC-COOKIE-1 key，无法连接 Xwayland。

原因

Xwayland 使用 MIT-MAGIC-COOKIE-1 认证。正常连接流程是：

1. treeland-xwayland helper 准备 Xauthority 数据，并写入 /tmp/.xauth_<display>
2. treeland-sd 通过 D-Bus 调用 XWaylandName()，从 treeland 读取 display 和 auth 数据
3. treeland-sd 将 auth 数据写入用户的 $XAUTHORITY 文件，并更新 systemd 用户环境变量
4. X11 客户端启动时从 $XAUTHORITY 读取认证数据，再连接 Xwayland

treeland 重启后，新的 Xwayland 会准备新的 auth 数据。旧逻辑通过
WXWayland::ready 转发出 XWaylandReady D-Bus signal，再由 treeland-sd 接收 该 signal 后调用 XWaylandName() 更新用户侧 XAUTHORITY。

这个通知链路存在时序问题：treeland 重启过程中，XWaylandReady 可能早于
treeland-sd 重新连接 signal 发出，也可能因为 D-Bus service owner 变化而丢失。 一旦 treeland-sd 没有收到该一次性通知，就不会重新查询 XWaylandName()，用户 环境中继续保留旧 auth 数据，导致后续 X11 客户端认证失败。

修复

misc/systemd/treeland.service.in
- 添加 ExecStartPre，在 treeland 启动前清理上次异常退出遗留的孤儿 Xwayland 进程

misc/systemd/dde-session-pre.target.wants/treeland-xwayland.service.in
- 添加 Restart=on-failure，使 treeland-sd 异常退出后可自动重启

src/session/session.cpp
src/session/session.h
src/seat/helper.cpp
src/core/treeland.cpp
src/core/treeland.h
- 删除 xwaylandReady / XWaylandReady 通知链路
- WXWayland::ready 回调只保留 treeland 内部初始化逻辑，例如 primary output 同步、X11 atom 初始化和 XSettings 初始化
- 不再通过额外的 D-Bus signal 通知 treeland-sd 更新 XAUTHORITY

src/systemd-socket.cpp
- Xwayland 路径不再连接 activation signal
- treeland 未注册到 D-Bus 时，每 500ms 重试查找 org.deepin.Compositor1
- treeland 已注册后，treeland-sd 直接调用 XWaylandName() 查询当前 Xwayland display 和 auth 数据
- XWaylandName() 暂不可用、auth 文件未就绪、写入 XAUTHORITY 失败、更新 systemd 用户环境失败时，每 500ms 重试
- treeland 从 D-Bus 注销时清理已缓存的 Xwayland auth 状态，并重新进入重试流程
- 使用 $XDG_RUNTIME_DIR/treeland-xauthority 作为稳定的用户侧 XAUTHORITY 文件
- 使用 QSaveFile 原子写入 XAUTHORITY，避免写入中断产生损坏文件
- 缓存上一次 Xwayland auth 内容，auth 未变化时避免重复写入

这样 Xwayland auth 同步不再依赖一次性的 ready 通知。首次启动、treeland 重启、 Xwayland auth 文件延迟生成、以及 D-Bus signal 丢失等场景，都会通过同一套 XWaylandName() 查询和 retry 机制最终刷新用户侧 DISPLAY/XAUTHORITY，避免 X11 客户端继续使用旧认证数据。

ISSUE: 1071