### PR TITLE
fix(greeter): remove redundant translator loading on user switch

### DIFF
--- a/src/greeter/usermodel.cpp
+++ b/src/greeter/usermodel.cpp
@@ -61,36 +61,6 @@ UserModel::UserModel(QObject *parent)
     connect(&d->manager, &DAccountsManager::UserAdded, this, &UserModel::onUserAdded);
     connect(&d->manager, &DAccountsManager::UserDeleted, this, &UserModel::onUserDeleted);
 
-    connect(this, &UserModel::currentUserNameChanged, [this] {
-        auto user = getUser(d->currentUserName);
-        if (!user) {
-            qCWarning(lcTlGreeter) << "Couldn't find user:" << d->currentUserName;
-            return;
-        }
-
-        auto locale = user->locale();
-        qCInfo(lcTlGreeter) << "Current locale:" << locale.language();
-        auto *newTrans = new QTranslator{ this };
-        auto dirs = QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation);
-        for (const auto &dir : dirs) {
-            if (newTrans->load(locale, "greeter", ".", dir + "/treeland/translations", ".qm")) {
-                if (d->lastTrans) {
-                    QGuiApplication::removeTranslator(d->lastTrans);
-                    d->lastTrans->deleteLater();
-                }
-                d->lastTrans = newTrans;
-                QGuiApplication::installTranslator(d->lastTrans);
-                Q_EMIT updateTranslations(locale);
-                Q_EMIT dataChanged(createIndex(0, 0), createIndex(rowCount(), 0));
-                qmlEngine(this)->retranslate();
-                return;
-            }
-        }
-
-        newTrans->deleteLater();
-        qCWarning(lcTlGreeter) << "Failed to load new translator under" << dirs.last();
-    });
-
     auto userList = d->manager.userList();
     if (!userList) {
         qFatal() << userList.error();


### PR DESCRIPTION
Remove redundant logic for dynamically loading translators when switching users. The translation loading logic in the greeter part is completely overridden by the plugin translation mechanism at lines 216–219 in src/core/treeland.cpp, and it attempts to load a translation named "greeter" which does not exist.

移除切换用户时动态加载翻译器的冗余逻辑，greeter部分的翻译加载逻辑完全被src/core/treeland.cpp第 216–219 行的插件翻译机制覆盖了，且它加载的还是一个不存在的 "greeter" 翻译名。

Log: 移除切换用户时冗余的翻译器加载逻辑
PMS: BUG-332581

## Summary by Sourcery

Bug Fixes:
- Eliminate duplicate translator loading on user switch that attempted to load a non-existent 'greeter' translation and could override plugin-based translations.