### PR TITLE
fix: auto-wake DPMS-off outputs on input events

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -681,6 +681,8 @@ void Helper::onOutputRemoved(WOutput *output)
     m_outputManager->removeOutput(output);
     m_wallpaperManager->removeOutputWallpaper(output->handle()->handle());
 
+    m_powerOffOutputs.remove(output->nativeHandle());
+
     delete o;
 }
 
@@ -1030,21 +1032,25 @@ void Helper::onSetOutputPowerMode(wlr_output_power_v1_set_mode_event *event)
 
     switch (event->mode) {
     case ZWLR_OUTPUT_POWER_V1_MODE_OFF:
-        if (!output->handle()->enabled) {
-            return;
-        }
+        if (m_powerOffOutputs.contains(event->output))
+            return; // already disabled by output_power
+        if (!output->handle()->enabled)
+            return; // already disabled by output_management, not ours
         newState.set_enabled(false);
         if (!output->commit_state(newState)) {
             qCCritical(lcTlCore, "commit failed on output %s", output->handle()->name);
-        }
-        break;
-    case ZWLR_OUTPUT_POWER_V1_MODE_ON:
-        if (output->handle()->enabled) {
             return;
         }
+        m_powerOffOutputs.insert(event->output);
+        break;
+    case ZWLR_OUTPUT_POWER_V1_MODE_ON:
+        if (!m_powerOffOutputs.remove(event->output))
+            return; // not disabled by output_power, nothing to do
         newState.set_enabled(true);
         if (!output->commit_state(newState)) {
             qCCritical(lcTlCore, "commit failed on output %s", output->handle()->name);
+            m_powerOffOutputs.insert(event->output);
+            return;
         }
         break;
     }
@@ -1980,6 +1986,21 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *targetWindow, QInputEvent 
 
     if (event->isInputEvent()) {
         m_idleNotifier->notify_activity(seat->nativeHandle());
+
+        // Wake DPMS-off outputs on any input event
+        // Only re-enable outputs disabled by output_power, not user-disabled outputs
+        for (auto *out : std::as_const(m_outputList)) {
+            auto *wlr_out = out->output()->nativeHandle();
+            if (!wlr_out->enabled && wlr_out->current_mode && m_powerOffOutputs.contains(wlr_out)) {
+                qw_output_state state;
+                state.set_enabled(true);
+                if (!out->output()->handle()->commit_state(state)) {
+                    qCWarning(lcTlCore) << "Failed to wake output" << wlr_out->name;
+                } else {
+                    m_powerOffOutputs.remove(wlr_out);
+                }
+            }
+        }
     }
 
     if (event->type() == QEvent::KeyPress) {

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -23,6 +23,7 @@
 #include <wxdgdialogmanagerv1.h>
 #include <wxdgtopleveltagmanager.h>
 
+#include <QSet>
 #include <QList>
 #include <QMap>
 #include <qevent.h>
@@ -141,6 +142,7 @@ class InputManager;
 
 struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request;
 struct wlr_idle_inhibitor_v1;
+struct wlr_output;
 struct wlr_output_power_v1_set_mode_event;
 namespace Treeland {
 class Treeland;
@@ -447,6 +449,9 @@ private:
     // private data
     QList<Output *> m_outputList;
     OutputConfigState *m_outputConfigState = nullptr;
+    // outputs disabled by output_power (should be re-enabled on input)
+    QSet<wlr_output *> m_powerOffOutputs;
+
     OutputLifecycleManager *m_outputLifecycleManager = nullptr;
     QPointer<QQuickItem> m_taskSwitch;
     QList<qw_idle_inhibitor_v1 *> m_idleInhibitors;


### PR DESCRIPTION
1. Add DPMS wake-up logic in Helper::beforeDisposeEvent: when any input
2. event arrives, traverse all outputs and re-enable those that are DPMS-off
3. but still connected (has current_mode).

Log: Fix display not waking up when client sets DPMS off and user provides input

Influence:
1. Verify monitor turns on when moving mouse after a client turns off DPMS
2. Verify monitor turns on when pressing any key after DPMS off
3. Verify physically disconnected outputs are not affected

fix: 输入事件时自动唤醒 DPMS 关闭的显示器

1. 在 Helper::beforeDisposeEvent 中增加 DPMS 唤醒逻辑：收到输入事件后
2. 遍历所有输出，对因 DPMS 关闭但仍连接（有 current_mode）的显示器执行
3. 重新点亮。

Log: 修复客户端关闭显示器 DPMS 后，输入事件无法自动唤醒显示器的问题

Influence:
1. 验证客户端设置 DPMS OFF 后，移动鼠标可自动点亮显示器
2. 验证客户端设置 DPMS OFF 后，按键可自动点亮显示器
3. 验证物理断开的显示器不会被错误唤醒

PMS: BUG-367531