### PR TITLE
fix(capture): restore mask surface before ending selection

### DIFF
--- a/src/modules/capture/capture.cpp
+++ b/src/modules/capture/capture.cpp
@@ -606,9 +606,8 @@ void CaptureSourceSelector::doneSelection()
 void CaptureSourceSelector::cancelSelection()
 {
     if (captureManager() && captureManager()->contextInSelection()) {
-        releaseMaskSurface();
         captureManager()->contextInSelection()->sendSourceFailed(CaptureContextV1::UserCancel);
-        captureManager()->clearContextInSelection(captureManager()->contextInSelection());
+        finishSelection();
     }
 }
 
@@ -684,17 +683,17 @@ void CaptureSourceSelector::createImage()
     if (m_selectedSource) {
         m_selectedSource->createImage();
         if (m_selectedSource->imageValid()) {
-            releaseMaskSurface();
+            finishSelection();
         } else {
             connect(m_selectedSource,
                     &CaptureSource::imageReady,
                     this,
-                    &CaptureSourceSelector::releaseMaskSurface);
+                    &CaptureSourceSelector::finishSelection,
+                    Qt::UniqueConnection);
         }
     } else {
-        releaseMaskSurface();
+        finishSelection();
     }
-    captureManager()->clearContextInSelection(captureManager()->contextInSelection());
 }
 
 CaptureManagerV1 *CaptureSourceSelector::captureManager() const
@@ -1211,14 +1210,30 @@ ToolBarModel *CaptureSourceSelector::toolBarModel() const
     return m_toolBarModel;
 }
 
+void CaptureSourceSelector::finishSelection()
+{
+    releaseMaskSurface();
+
+    if (captureManager() && captureManager()->contextInSelection()) {
+        captureManager()->clearContextInSelection(captureManager()->contextInSelection());
+    }
+}
+
 void CaptureSourceSelector::releaseMaskSurface()
 {
+    if (m_maskSurfaceReleased)
+        return;
+
+    m_maskSurfaceReleased = true;
+
     // Mask surface should be reparented before destruction.
     // If reparent in destructor, it's already marked as deleted in qml
-    disconnect(m_selectedSource,
-               &CaptureSource::imageReady,
-               this,
-               &CaptureSourceSelector::releaseMaskSurface);
+    if (m_selectedSource) {
+        disconnect(m_selectedSource,
+                   &CaptureSource::imageReady,
+                   this,
+                   &CaptureSourceSelector::finishSelection);
+    }
     if (m_savedContainer) {
         QQueue<WWrapPointer<SurfaceWrapper>> q;
         q.enqueue(m_canvas);

--- a/src/modules/capture/capture.h
+++ b/src/modules/capture/capture.h
@@ -425,6 +425,7 @@ private:
     void handleItemSelectorSelectionRegionChanged();
     WOutputRenderWindow *renderWindow() const;
     void createImage();
+    void finishSelection();
     void releaseMaskSurface();
 
     void updateItemSelectorItemTypes();
@@ -440,6 +441,7 @@ private:
     bool m_itemSelectionMode{ true };
     SelectionMode m_selectionMode = SelectionMode::SelectRegion;
     bool m_doNotFinish{ false };
+    bool m_maskSurfaceReleased{ false };
     QPointer<SurfaceContainer> m_savedContainer{};
     WWrapPointer<SurfaceWrapper> m_canvas{};
     ToolBarModel *m_toolBarModel{ nullptr };


### PR DESCRIPTION
Delay clearing the capture selection context until the mask surface has been released back to its original container. This keeps the selector alive for async image capture completion and avoids leaving stale surface wrappers in the root container.