### PR TITLE
fix(greeter): activate DDM user sessions atomically

### DIFF
--- a/src/greeter/greeterproxy.cpp
+++ b/src/greeter/greeterproxy.cpp
@@ -487,7 +487,8 @@ void GreeterProxy::readyRead()
                 break;
             }
 
-            userModel()->setCurrentUserName(user);
+            if (!Helper::instance()->activateUserSession(user, sessionId))
+                break;
 
             qCInfo(lcTlGreeter) << "activate successfully: " << user << ", XDG_SESSION_ID: " << sessionId;
         } break;

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2999,6 +2999,20 @@ void Helper::activateSession() {
         m_backend->activateSession();
 }
 
+bool Helper::activateUserSession(const QString &username, int sessionId)
+{
+    if (!m_userModel->getUser(username))
+        return false;
+
+    const auto update = m_sessionManager->prepareActiveUserSession(username, sessionId);
+    if (!update)
+        return false;
+
+    m_userModel->setCurrentUserName(username);
+    m_sessionManager->commitActiveUserSession(update);
+    return true;
+}
+
 void Helper::deactivateSession() {
     if (m_backend->isSessionActive())
         m_backend->deactivateSession();

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -261,6 +261,7 @@ public:
     DDMInterfaceV1 *ddmInterfaceV1() const;
 
     void activateSession();
+    bool activateUserSession(const QString &username, int sessionId);
     void deactivateSession();
     void enableRender();
     void disableRender();

--- a/src/session/session.cpp
+++ b/src/session/session.cpp
@@ -523,29 +523,49 @@ void SessionManager::syncActiveSessionCursorSettings()
  */
 void SessionManager::updateActiveUserSession(const QString &username, int id)
 {
+    commitActiveUserSession(prepareActiveUserSession(username, id));
+}
+
+SessionManager::ActiveSessionUpdate SessionManager::prepareActiveUserSession(const QString &username,
+                                                                             int id)
+{
     // Get previous active session
     auto previous = m_activeSession.lock();
     // Get new session for uid, creating if necessary
     auto session = ensureSession(id, username);
     if (!session) {
         qCWarning(lcTlInput) << "Failed to ensure session for user" << username;
-        return;
+        return {};
     }
-    if (previous != session) {
+
+    const bool activeSessionChanged = previous != session;
+    if (activeSessionChanged) {
         // Update active session
         m_activeSession = session;
         // Clear activated surface
         // TODO: Each Wayland socket's active surface needs to be cleaned up individually.
         Helper::instance()->activateSurface(nullptr);
-        // Emit signal and update socket enabled state
+        // Update socket enabled state before publishing activation notifications.
         if (previous && previous->m_socket)
             previous->m_socket->setEnabled(false, globalSession()->socket());
         session->m_socket->setEnabled(true);
+    }
+
+    return { session, activeSessionChanged };
+}
+
+void SessionManager::commitActiveUserSession(const ActiveSessionUpdate &update)
+{
+    if (!update)
+        return;
+
+    if (update.activeSessionChanged) {
         Q_EMIT socketFileChanged();
         // Notify session changed through DBus, treeland-sd will listen it to update envs
         Q_EMIT sessionChanged();
         syncActiveSessionXWaylandPrimaryOutput();
     }
-    qCInfo(lcTlCore) << "Listening on:" << session->m_socket->fullServerName();
+
+    qCInfo(lcTlCore) << "Listening on:" << update.session->m_socket->fullServerName();
     syncActiveSessionCursorSettings();
 }

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -62,6 +62,19 @@ public:
     bool activeSocketEnabled() const;
     void setActiveSocketEnabled(bool newEnabled);
 
+    struct ActiveSessionUpdate
+    {
+        std::shared_ptr<Session> session;
+        bool activeSessionChanged = false;
+
+        explicit operator bool() const noexcept
+        {
+            return session != nullptr;
+        }
+    };
+
+    ActiveSessionUpdate prepareActiveUserSession(const QString &username, int id);
+    void commitActiveUserSession(const ActiveSessionUpdate &update);
     void updateActiveUserSession(const QString &username, int id);
     void removeSession(std::shared_ptr<Session> session);
     std::shared_ptr<Session> sessionForId(int id) const;


### PR DESCRIPTION
DDM socket 的 UserActivateMessage 同时携带认证后的目标用户和 logind session id。 Treeland 先准备目标 SessionManager::activeSession，再更新UserModel::currentUserName，最 后统一发布 sessionChanged，避免多用户切换登录时观察到 activeSession/currentUserName 不一致。 原有 updateActiveUserSession 仍保留旧调用语义，DDM 激活路径改为通过
Helper::activateUserSession 统一处理。

Log: 修复 DDM 激活用户时 activeSession 与 currentUserName 不一致
PMS: BUG-346587
Influence: 影响 DDM 用户激活、登录和多用户切换时的会话状态同步

## Summary by Sourcery

Ensure DDM-driven user activation updates the active session and current user atomically to keep session state consistent during logins and user switches.

Bug Fixes:
- Fix a race where activeSession and currentUserName could become temporarily inconsistent when DDM activates or switches users.

Enhancements:
- Introduce a two-step active session update flow (prepare/commit) in SessionManager to coordinate socket and signal updates.
- Add Helper::activateUserSession API and route greeter DDM activation through it for coordinated user and session updates.