### PR TITLE
fix: Skip keyboard focus assignment for XdgPopup surfaces

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2438,6 +2438,19 @@ void Helper::onRenderWindowActiveFocusItemChanged()
 
 void Helper::requestKeyboardFocus(SurfaceWrapper *wrapper, Qt::FocusReason reason, WSeat *seat)
 {
+
+    if (wrapper) {
+        // Pop up through parent hierarchy until we find a non-popup surface
+        while (wrapper && wrapper->type() == SurfaceWrapper::Type::XdgPopup) {
+            wrapper = wrapper->parentSurface();
+        }
+        if (!wrapper || !wrapper->hasFocusCapability()) {
+            qCDebug(lcTlShell) << "Request keyboard focus for surface without focus capability!"
+                                 << "surface =" << wrapper;
+            return;
+        }
+    }
+
     WSeat *targetSeat = seat;
     if (!targetSeat)
         targetSeat = m_currentEventSeat ? m_currentEventSeat : getLastInteractingSeat(wrapper);


### PR DESCRIPTION
When requesting keyboard focus for a non-grabbed popup (e.g. Chrome context menu), bypass the popup layer and assign focus to its parent toplevel surface instead. This prevents the parent from losing focus when the popup is clicked, which would cause the client to prematurely close the popup before the user can interact with menu items.

Fixes the issue where clicking popup menu items would close the menu without executing the requested action.

修复无 grab 的 popup (如 Chrome 右键菜单) 点击时导致 parent 失焦从而关闭 popup 的问题。现在会跳过 popup 层级，直接给其父 toplevel surface 设置焦点，避免
parent 失焦导致客户端提前关闭 popup，用户无法点击菜单项。