### PR TITLE
feat: implement shadow and border protocol, disable layershell decorations by default

### DIFF
--- a/src/core/qml/Animations/GeometryAnimation.qml
+++ b/src/core/qml/Animations/GeometryAnimation.qml
@@ -28,6 +28,7 @@ Item {
     }
 
     XdgShadow {
+        surface: root.surface
         anchors.fill: parent
         visible: surface.visibleDecoration && !surface.noDecoration
         cornerRadius: surface.radius

--- a/src/core/qml/Border.qml
+++ b/src/core/qml/Border.qml
@@ -1,32 +1,40 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import QtQuick
+import Waylib.Server
+import Treeland
 
 Item {
     id: root
 
+    required property SurfaceWrapper surface
+
     property real radius: 0
-    property color outsideColor: Qt.rgba(0, 0, 0, 0.1)
     property color insideColor: Qt.rgba(255, 255, 255, 0.1)
+
+    readonly property int outsideWidth: surface.border.width
+    readonly property color outsideColor: surface.border.color
 
     Rectangle {
         id: outsideBorder
+        visible: outsideWidth > 0
         anchors {
             fill: parent
-            margins: -border.width
+            margins: -outsideWidth
         }
 
         color: "transparent"
         border {
             color: outsideColor
-            width: 1
+            width: outsideWidth
         }
-        radius: GraphicsInfo.api === GraphicsInfo.Software ? 0 : root.radius + border.width
+        radius: GraphicsInfo.api === GraphicsInfo.Software ? 0 : root.radius + outsideWidth
     }
 
     Rectangle {
         id: insideBorder
+        visible: outsideWidth > 0
         anchors.fill: parent
         color: "transparent"
         border {

--- a/src/core/qml/Decoration.qml
+++ b/src/core/qml/Decoration.qml
@@ -66,6 +66,7 @@ Item {
 
     XdgShadow {
         id: shadow
+        surface: root.surface
         width: surface.width
         height: surface.height
         cornerRadius: surface.radius
@@ -73,7 +74,7 @@ Item {
     }
 
     Border {
-        visible: surface.visibleDecoration
+        surface: root.surface
         parent: surface.surfaceItem ? surface.surfaceItem : surface.prelaunchSplash
         z: SurfaceItem.ZOrder.ContentItem + 1
         anchors.fill: parent

--- a/src/core/qml/XdgShadow.qml
+++ b/src/core/qml/XdgShadow.qml
@@ -1,20 +1,27 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import QtQuick
 import QtQuick.Effects
 import org.deepin.dtk 1.0 as D
+import Waylib.Server
+import Treeland
 
 D.BoxShadow {
     id: shadow
+
+    required property SurfaceWrapper surface
+
     readonly property rect boundingRect: Qt.rect(-shadow.shadowBlur, -shadow.shadowBlur,
                                              width + 2 * shadow.shadowBlur,
                                              height + 2 * shadow.shadowBlur)
 
+    visible: surface.shadow.radius > 0
     width: parent.width
     height: parent.height
-    shadowColor: Qt.rgba(0, 0, 0, 0.4)
-    shadowOffsetY: 10
-    shadowBlur: 40
+    shadowColor: surface.shadow.color
+    shadowOffsetX: surface.shadow.offsetX
+    shadowOffsetY: surface.shadow.offsetY
+    shadowBlur: surface.shadow.radius
     hollow: true
 }

--- a/src/core/qmlengine.cpp
+++ b/src/core/qmlengine.cpp
@@ -105,9 +105,11 @@ QQuickItem *QmlEngine::createTaskBar(Output *output, QQuickItem *parent)
     return createComponent(taskBarComponent, parent, { { "output", QVariant::fromValue(output) } });
 }
 
-QQuickItem *QmlEngine::createXdgShadow(QQuickItem *parent)
+QQuickItem *QmlEngine::createXdgShadow(SurfaceWrapper *surface, QQuickItem *parent)
 {
-    return createComponent(xdgShadowComponent, parent);
+    return createComponent(xdgShadowComponent,
+                           parent,
+                           { { "surface", QVariant::fromValue(surface) } });
 }
 
 QQuickItem *QmlEngine::createTaskSwitcher(Output *output, QQuickItem *parent)

--- a/src/core/qmlengine.h
+++ b/src/core/qmlengine.h
@@ -44,7 +44,7 @@ public:
     QObject *createWindowMenu(QObject *parent);
     QQuickItem *createBorder(SurfaceWrapper *surface, QQuickItem *parent);
     QQuickItem *createTaskBar(Output *output, QQuickItem *parent);
-    QQuickItem *createXdgShadow(QQuickItem *parent);
+    QQuickItem *createXdgShadow(SurfaceWrapper *surface, QQuickItem *parent);
     QQuickItem *createTaskSwitcher(Output *output, QQuickItem *parent);
     QQuickItem *createGeometryAnimation(SurfaceWrapper *surface,
                                         const QRectF &startGeo,

--- a/src/modules/personalization/personalizationmanagerinterfacev1.h
+++ b/src/modules/personalization/personalizationmanagerinterfacev1.h
@@ -19,16 +19,16 @@ WAYLIB_SERVER_USE_NAMESPACE
 
 struct Shadow
 {
-    int32_t radius;
-    QPoint offset;
-    QColor color;
+    int32_t radius = 0;
+    QPoint offset = {};
+    QColor color = Qt::transparent;
     bool operator==(const Shadow &other) const = default;
 };
 
 struct Border
 {
-    int32_t width;
-    QColor color;
+    int32_t width = 0;
+    QColor color = Qt::transparent;
     bool operator==(const Border &other) const = default;
 };
 

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1261,6 +1261,34 @@ void Helper::onSurfaceWrapperAdded(SurfaceWrapper *wrapper)
         connect(attached, &Personalization::cornerRadiusChanged, this, updateCornerRadius);
         updateCornerRadius();
         updateBlur();
+
+        auto updateShadow = [attached] {
+            auto wrapper = attached->surfaceWrapper();
+            auto shadow = attached->shadow();
+
+            wrapper->setShadow(SurfaceShadow{
+                shadow.radius,
+                shadow.offset.x(),
+                shadow.offset.y(),
+                shadow.color
+            });
+        };
+
+        auto updateBorder = [attached] {
+            auto wrapper = attached->surfaceWrapper();
+            auto border = attached->border();
+
+            wrapper->setBorder(SurfaceBorder{
+                border.width,
+                border.color
+            });
+        };
+
+        connect(attached, &Personalization::shadowChanged, this, updateShadow);
+        connect(attached, &Personalization::borderChanged, this, updateBorder);
+        updateShadow();
+        updateBorder();
+
         if (isLayer) {
             auto layer = qobject_cast<WLayerSurface *>(wrapper->shellSurface());
             if (isLaunchpad(layer))

--- a/src/surface/surfaceproxy.cpp
+++ b/src/surface/surfaceproxy.cpp
@@ -51,7 +51,7 @@ void SurfaceProxy::setSurface(SurfaceWrapper *newSurface)
         QQuickItemPrivate::get(m_proxySurface)->culled = true;
         if (!m_fullProxy) {
             if (!m_shadow)
-                m_shadow = m_sourceSurface->m_engine->createXdgShadow(this);
+                m_shadow = m_sourceSurface->m_engine->createXdgShadow(m_sourceSurface, this);
             m_shadow->setProperty("cornerRadius", radius());
             m_shadow->stackBefore(m_proxySurface);
             QQuickItemPrivate::get(m_shadow)->culled = true;
@@ -297,7 +297,7 @@ void SurfaceProxy::setFullProxy(bool newFullProxy)
                 m_shadow = nullptr;
             }
         } else if (!m_shadow) {
-            m_shadow = m_sourceSurface->m_engine->createXdgShadow(this);
+            m_shadow = m_sourceSurface->m_engine->createXdgShadow(m_sourceSurface, this);
             m_shadow->setProperty("cornerRadius", radius());
             m_shadow->stackBefore(m_proxySurface);
             QQuickItemPrivate::get(m_shadow)->culled = true;

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -71,6 +71,11 @@ SurfaceWrapper::SurfaceWrapper(QmlEngine *qmlEngine,
 {
     QQmlEngine::setContextForObject(this, qmlEngine->rootContext());
 
+    if (m_type != Type::Layer) {
+        m_shadow = SurfaceShadow{ 40, 0, 10, QColor(0, 0, 0, 102) };
+        m_border = SurfaceBorder{ 1, QColor(255, 255, 255, 26) };
+    }
+
     setup();
 }
 
@@ -82,7 +87,7 @@ SurfaceWrapper::SurfaceWrapper(SurfaceWrapper *original, QQuickItem *parent)
     , m_positionAutomatic(true)
     , m_visibleDecoration(true)
     , m_clipInOutput(false)
-    , m_noDecoration(true)
+    , m_noDecoration(original->m_noDecoration)
     , m_noTitleBar(true)
     , m_noCornerRadius(false)
     , m_alwaysOnTop(false)
@@ -105,6 +110,8 @@ SurfaceWrapper::SurfaceWrapper(SurfaceWrapper *original, QQuickItem *parent)
     , m_maximizable(false)
     , m_modal(false)
     , m_appId(original->m_appId)
+    , m_shadow(original->m_shadow)
+    , m_border(original->m_border)
 {
     QQmlEngine::setContextForObject(this, m_engine->rootContext());
 
@@ -177,6 +184,12 @@ SurfaceWrapper::SurfaceWrapper(QmlEngine *qmlEngine,
     , m_appId(appId)
 {
     QQmlEngine::setContextForObject(this, qmlEngine->rootContext());
+
+    if (m_type != Type::Layer) {
+        m_shadow = SurfaceShadow{ 40, 0, 10, QColor(0, 0, 0, 102) };
+        m_border = SurfaceBorder{ 1, QColor(255, 255, 255, 26) };
+    }
+
     if (initialSize.isValid() && initialSize.width() > 0 && initialSize.height() > 0) {
         // Also set implicit size to keep QML layout consistent
         setImplicitSize(initialSize.width(), initialSize.height());
@@ -1683,6 +1696,42 @@ void SurfaceWrapper::setRadius(qreal newRadius)
         return;
     m_radius = newRadius;
     Q_EMIT radiusChanged();
+}
+
+SurfaceShadow SurfaceWrapper::shadow() const
+{
+    return m_shadow;
+}
+
+void SurfaceWrapper::setShadow(const SurfaceShadow &shadow)
+{
+    SurfaceShadow newShadow = shadow;
+    if (newShadow.radius == -1) {
+        newShadow = SurfaceShadow{ 40, 0, 10, QColor(0, 0, 0, 102) };
+    }
+
+    if (m_shadow == newShadow)
+        return;
+    m_shadow = newShadow;
+    Q_EMIT shadowChanged();
+}
+
+SurfaceBorder SurfaceWrapper::border() const
+{
+    return m_border;
+}
+
+void SurfaceWrapper::setBorder(const SurfaceBorder &border)
+{
+    SurfaceBorder newBorder = border;
+    if (newBorder.width == -1) {
+        newBorder = SurfaceBorder{ 1, QColor(255, 255, 255, 26) };
+    }
+
+    if (m_border == newBorder)
+        return;
+    m_border = newBorder;
+    Q_EMIT borderChanged();
 }
 
 void SurfaceWrapper::minimize(bool onAnimation)

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -11,6 +11,7 @@
 #include <QQuickItem>
 #include <QString>
 #include <QColor>
+#include <QMetaType>
 
 Q_MOC_INCLUDE(<woutput.h>)
 Q_MOC_INCLUDE(<output / output.h>)
@@ -23,6 +24,32 @@ class SurfaceContainer;
 QW_BEGIN_NAMESPACE
 class qw_buffer;
 QW_END_NAMESPACE
+
+struct SurfaceShadow
+{
+    Q_GADGET
+    Q_PROPERTY(int radius MEMBER radius)
+    Q_PROPERTY(int offsetX MEMBER offsetX)
+    Q_PROPERTY(int offsetY MEMBER offsetY)
+    Q_PROPERTY(QColor color MEMBER color)
+public:
+    int radius = 0;
+    int offsetX = 0;
+    int offsetY = 0;
+    QColor color = Qt::transparent;
+    bool operator==(const SurfaceShadow &other) const = default;
+};
+
+struct SurfaceBorder
+{
+    Q_GADGET
+    Q_PROPERTY(int width MEMBER width)
+    Q_PROPERTY(QColor color MEMBER color)
+public:
+    int width = 0;
+    QColor color = Qt::transparent;
+    bool operator==(const SurfaceBorder &other) const = default;
+};
 
 class SurfaceWrapper : public QQuickItem
 {
@@ -85,6 +112,8 @@ class SurfaceWrapper : public QQuickItem
     Q_PROPERTY(bool isResizable READ isResizable NOTIFY resizableChanged FINAL)
     Q_PROPERTY(bool isMaximizable READ isMaximizable NOTIFY maximizableChanged FINAL)
     Q_PROPERTY(bool modal READ modal NOTIFY modalChanged FINAL)
+    Q_PROPERTY(SurfaceShadow shadow READ shadow NOTIFY shadowChanged FINAL)
+    Q_PROPERTY(SurfaceBorder border READ border NOTIFY borderChanged FINAL)
 
 public:
     enum class Type
@@ -309,6 +338,11 @@ public:
     bool attention() const;
     bool setAttention(bool attention);
 
+    SurfaceShadow shadow() const;
+    void setShadow(const SurfaceShadow &shadow);
+    SurfaceBorder border() const;
+    void setBorder(const SurfaceBorder &border);
+
 public Q_SLOTS:
     void minimize(bool onAnimation = true);
     void restoreFromMinimized(bool onAnimation = true);
@@ -379,6 +413,8 @@ Q_SIGNALS:
     void hasFocusCapabilityChanged();
     void prelaunchSplashChanged();
     void typeChanged();
+    void shadowChanged();
+    void borderChanged();
 
 private:
     ~SurfaceWrapper() override;
@@ -516,7 +552,12 @@ private:
     bool m_socketEnabled{ false };
     bool m_windowAnimationEnabled{ true };
     const QString m_appId;
+    SurfaceShadow m_shadow;
+    SurfaceBorder m_border;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(SurfaceWrapper::ActiveControlStates)
 Q_DECLARE_OPERATORS_FOR_FLAGS(SurfaceWrapper::FocusControlStates)
+
+Q_DECLARE_METATYPE(SurfaceShadow)
+Q_DECLARE_METATYPE(SurfaceBorder)


### PR DESCRIPTION
1. Implement SurfaceShadow and SurfaceBorder structures with Q_PROPERTY
for QML exposure
2. Add shadow and border properties to SurfaceWrapper, with default
values for non-layer surfaces
3. Update XdgShadow QML component to read shadow properties from surface
(radius, offset, color)
4. Update Border QML component to read border properties from surface
(width, color)
5. Connect Personalization signals (shadowChanged, borderChanged) to
update SurfaceWrapper properties
6. Disable shadow and border decorations by default for LayerShell
surfaces (m_type != Type::Layer)
7. Set default shadow: radius 40, offsetX 0, offsetY 10, color
rgba(0,0,0,0.4)
8. Set default border: width 1, color rgba(255,255,255,0.1)
9. Fix noDecoration property inheritance in SurfaceWrapper copy
constructor
10. Pass surface property to XdgShadow and Border QML components for
data binding
11. Update createXdgShadow function signature to accept SurfaceWrapper
parameter

Log: Implement shadow and border protocol for surfaces, disable
layershell decorations by default

Influence:
1. Test shadow rendering for non-layer surfaces (radius, offset, color)
2. Test border rendering for non-layer surfaces (width, color)
3. Verify LayerShell surfaces have no decorations by default
4. Test shadow and border property updates via Personalization interface
5. Verify noDecoration property inheritance in surface cloning
6. Test animations with combined shadow and border effects
7. Verify shadows work with proxy surfaces (minimized windows, etc.)

feat: 实现阴影和边框协议，默认关闭层壳装饰

1. 实现 SurfaceShadow 和 SurfaceBorder 结构体，包含 Q_PROPERTY 以便 QML
使用
2. 为 SurfaceWrapper 添加阴影和边框属性，非层壳表面使用默认值
3. 更新 XdgShadow QML 组件，从 surface 读取阴影属性（半径、偏移、颜色）
4. 更新 Border QML 组件，从 surface 读取边框属性（宽度、颜色）
5. 连接 Personalization 信号（shadowChanged、borderChanged）以更新
SurfaceWrapper 属性
6. 默认禁用 LayerShell 表面的阴影和边框装饰（m_type != Type::Layer）
7. 设置默认阴影：半径 40，偏移 X 0，偏移 Y 10，颜色 rgba(0,0,0,0.4)
8. 设置默认边框：宽度 1，颜色 rgba(255,255,255,0.1)
9. 修复 SurfaceWrapper 拷贝构造函数中的 noDecoration 属性继承
10. 将 surface 属性传递给 XdgShadow 和 Border QML 组件以进行数据绑定
11. 更新 createXdgShadow 函数签名，接受 SurfaceWrapper 参数

Log: 实现表面阴影和边框协议，默认关闭层壳装饰

Influence:
1. 测试非层壳表面的阴影渲染（半径、偏移、颜色）
2. 测试非层壳表面的边框渲染（宽度、颜色）
3. 验证 LayerShell 表面默认无装饰
4. 测试通过 Personalization 接口更新阴影和边框属性
5. 验证表面克隆时的 noDecoration 属性继承
6. 测试结合阴影和边框效果的动画
7. 验证代理表面（最小化窗口等）的阴影效果
