### PR TITLE
fix(wallpaper): restore wallpapers after output reconnect

### DIFF
--- a/src/wallpaper/wallpaperconfig.cpp
+++ b/src/wallpaper/wallpaperconfig.cpp
@@ -10,7 +10,6 @@
 #define DESKTOP_WALLPAPER "desktopWallpaper"
 #define LOCK_SCREEN_WALLPAPER "lockScreenWallpaper"
 #define WORKSPACES "workspaces"
-#define ENABLE "enable"
 
 QJsonObject WallpaperWorkspaceConfig::toJson() const
 {
@@ -18,7 +17,6 @@ QJsonObject WallpaperWorkspaceConfig::toJson() const
     obj[WORKSPACE_INDEX] = workspaceId;
     obj[DESKTOP_WALLPAPER] = desktopWallpaper;
     obj[DESKTOP_WALLAPER_TYPE] = desktopWallpapertype;
-    obj[ENABLE] = enable;
     return obj;
 }
 
@@ -28,7 +26,6 @@ WallpaperWorkspaceConfig WallpaperWorkspaceConfig::fromJson(const QJsonObject &o
     ws.workspaceId = obj[WORKSPACE_INDEX].toInt();
     ws.desktopWallpaper = obj[DESKTOP_WALLPAPER].toString();
     ws.desktopWallpapertype = static_cast<TreelandWallpaperInterfaceV1::WallpaperType>(obj[DESKTOP_WALLAPER_TYPE].toInt());
-    ws.enable = obj[ENABLE].toBool();
     return ws;
 }
 
@@ -38,7 +35,6 @@ QJsonObject WallpaperOutputConfig::toJson() const
     obj[OUTPUT_NAME] = outputName;
     obj[LOCK_SCREEN_WALLPAPER] = lockscreenWallpaper;
     obj[LOCK_SCREEN_WALLAPER_TYPE] = lockScreenWallpapertype;
-    obj[ENABLE] = enable;
     QJsonArray workspacesArray;
     for (const WallpaperWorkspaceConfig& ws : std::as_const(workspaces)) {
         workspacesArray.append(ws.toJson());
@@ -65,7 +61,6 @@ WallpaperOutputConfig WallpaperOutputConfig::fromJson(const QJsonObject &obj)
     out.outputName = obj[OUTPUT_NAME].toString();
     out.lockscreenWallpaper = obj[LOCK_SCREEN_WALLPAPER].toString();
     out.lockScreenWallpapertype = static_cast<TreelandWallpaperInterfaceV1::WallpaperType>(obj[LOCK_SCREEN_WALLAPER_TYPE].toInt());
-    out.enable = obj[ENABLE].toBool();
     QJsonArray workspacesArray = obj[WORKSPACES].toArray();
     for (const QJsonValue& value : std::as_const(workspacesArray)) {
         out.workspaces.append(WallpaperWorkspaceConfig::fromJson(value.toObject()));

--- a/src/wallpaper/wallpaperconfig.h
+++ b/src/wallpaper/wallpaperconfig.h
@@ -14,7 +14,6 @@ public:
     int workspaceId;
     QString desktopWallpaper;
     TreelandWallpaperInterfaceV1::WallpaperType desktopWallpapertype;
-    bool enable;
 
     QJsonObject toJson() const;
 
@@ -27,7 +26,6 @@ public:
     QString lockscreenWallpaper;
     QList<WallpaperWorkspaceConfig> workspaces;
     TreelandWallpaperInterfaceV1::WallpaperType lockScreenWallpapertype;
-    bool enable;
 
     QJsonObject toJson() const;
     bool containsWorkspace(int id) const;

--- a/src/wallpaper/wallpapermanager.cpp
+++ b/src/wallpaper/wallpapermanager.cpp
@@ -113,7 +113,6 @@ void WallpaperManager::defaultWallpaperConfig()
         WallpaperOutputConfig outputConfig;
         outputConfig.lockscreenWallpaper = Helper::instance()->m_config->defaultBackground();
         outputConfig.outputName = WallpaperManager::getOutputId(output);
-        outputConfig.enable = output->output()->nativeHandle()->enabled;
         WallpaperType type = detectWallpaperType(outputConfig.lockscreenWallpaper);
         if (type == WallpaperType::Unknown) {
             outputConfig.lockscreenWallpaper = DEFAULT_WALLPAPER;
@@ -126,7 +125,6 @@ void WallpaperManager::defaultWallpaperConfig()
             WallpaperWorkspaceConfig workspaceConfig;
             workspaceConfig.desktopWallpaper = Helper::instance()->m_config->defaultBackground();
             workspaceConfig.workspaceId = i;
-            workspaceConfig.enable = true;
             WallpaperType type = detectWallpaperType(workspaceConfig.desktopWallpaper);
             if (type == WallpaperType::Unknown) {
                 workspaceConfig.desktopWallpaper = DEFAULT_WALLPAPER;
@@ -150,7 +148,7 @@ void WallpaperManager::ensureWallpaperConfigForOutput(Output *output)
     }
 
     QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> beforeWallpapers =
-        globalValidWallpaper(nullptr, -1);
+        globalValidWallpaper(output->output()->nativeHandle());
 
     bool update = false;
     bool isNewOutput = false;
@@ -164,13 +162,11 @@ void WallpaperManager::ensureWallpaperConfigForOutput(Output *output)
         outputConfig.lockscreenWallpaper = refConfig.lockscreenWallpaper;
         outputConfig.lockScreenWallpapertype = refConfig.lockScreenWallpapertype;
         outputConfig.outputName = getOutputId(output);
-        outputConfig.enable = output->output()->nativeHandle()->enabled;
         for (int i = 0; i < workspace->count(); i++) {
             WallpaperWorkspaceConfig workspaceConfig;
             workspaceConfig.desktopWallpaper = refWorkspaceConfig.desktopWallpaper;
             workspaceConfig.desktopWallpapertype = refWorkspaceConfig.desktopWallpapertype;
             workspaceConfig.workspaceId = i;
-            workspaceConfig.enable = true;
             outputConfig.workspaces.append(workspaceConfig);
         }
         m_wallpaperConfig.append(outputConfig);
@@ -183,10 +179,6 @@ void WallpaperManager::ensureWallpaperConfigForOutput(Output *output)
 
         for (WallpaperOutputConfig &outputConfig : m_wallpaperConfig) {
             if (outputConfig.outputName == outputId) {
-                outputConfig.enable = true;
-                for (WallpaperWorkspaceConfig &wsConfig : outputConfig.workspaces) {
-                    wsConfig.enable = true;
-                }
                 const WallpaperWorkspaceConfig refConfig = outputConfig.workspaces.first();
                 for (int i = 0; i < workspace->count(); i++) {
                     const int workspaceId = workspace->modelAt(i)->id();
@@ -195,7 +187,6 @@ void WallpaperManager::ensureWallpaperConfigForOutput(Output *output)
                         wsConfig.desktopWallpaper = refConfig.desktopWallpaper;
                         wsConfig.desktopWallpapertype = refConfig.desktopWallpapertype;
                         wsConfig.workspaceId = workspaceId;
-                        wsConfig.enable = true;
                         outputConfig.workspaces.append(wsConfig);
                     }
                 }
@@ -216,7 +207,7 @@ void WallpaperManager::ensureWallpaperConfigForOutput(Output *output)
             sendMissingWallpapersForNewOutput(getOutputConfig(output), workspace, beforeWallpapers);
         } else {
             QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> afterWallpapers =
-                globalValidWallpaper(nullptr, -1);
+                globalValidWallpaper();
             for (auto it = afterWallpapers.constBegin(); it != afterWallpapers.constEnd(); ++it) {
                 if (!beforeWallpapers.contains(it.key())) {
                     Helper::instance()->m_wallpaperNotifierInterfaceV1->sendAdd(it.value(), it.key());
@@ -311,7 +302,7 @@ void WallpaperManager::setOutputWallpaper(wlr_output *output, [[maybe_unused]] i
     }
 }
 
-QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> WallpaperManager::globalValidWallpaper(wlr_output *exclusiveOutput, int exclusiveworkspaceId)
+QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> WallpaperManager::globalValidWallpaper(wlr_output *excludedOutput)
 {
     QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> wallpapers;
     for (const WallpaperOutputConfig& output : std::as_const(m_wallpaperConfig)) {
@@ -322,23 +313,15 @@ QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> WallpaperManager::glo
                 break;
             }
         }
-        if (!outputConnected) {
+        if (!outputConnected ||
+            (excludedOutput && output.outputName == getOutputId(excludedOutput))) {
             continue;
         }
 
         if (!wallpapers.contains(output.lockscreenWallpaper)) {
-            if (!(exclusiveOutput &&
-                  output.outputName == getOutputId(exclusiveOutput))) {
-                wallpapers.insert(output.lockscreenWallpaper, output.lockScreenWallpapertype);
-            }
+            wallpapers.insert(output.lockscreenWallpaper, output.lockScreenWallpapertype);
         }
         for (const WallpaperWorkspaceConfig& workspace : std::as_const(output.workspaces)) {
-            if (exclusiveOutput &&
-                output.outputName == getOutputId(exclusiveOutput) &&
-                workspace.workspaceId == exclusiveworkspaceId) {
-                continue;
-            }
-
             if (!wallpapers.contains(workspace.desktopWallpaper)) {
                 wallpapers.insert(workspace.desktopWallpaper, workspace.desktopWallpapertype);
             }
@@ -371,7 +354,6 @@ void WallpaperManager::syncAddWorkspace()
                 workspaceConfig.desktopWallpaper = refConfig.desktopWallpaper;
                 workspaceConfig.desktopWallpapertype = refConfig.desktopWallpapertype;
                 workspaceConfig.workspaceId = workspaceId;
-                workspaceConfig.enable = true;
                 outputConfig.workspaces.append(workspaceConfig);
                 update = true;
             }
@@ -389,12 +371,7 @@ void WallpaperManager::removeOutputWallpaper(wlr_output *output)
     for (int i = 0; i < m_wallpaperConfig.size(); ++i) {
         if (m_wallpaperConfig[i].outputName == getOutputId(output)) {
             WallpaperOutputConfig &outputConfig = m_wallpaperConfig[i];
-            outputConfig.enable = false;
-            for (WallpaperWorkspaceConfig &workspace : outputConfig.workspaces) {
-                workspace.enable = false;
-            }
-
-            QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> globalWallpapers = globalValidWallpaper(nullptr, -1);
+            QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> globalWallpapers = globalValidWallpaper(output);
             if (!globalWallpapers.contains(outputConfig.lockscreenWallpaper)) {
                 Helper::instance()->m_wallpaperNotifierInterfaceV1->sendRemove(outputConfig.lockscreenWallpaper);
             }
@@ -489,7 +466,7 @@ void WallpaperManager::onImageChanged(int workspaceIndex, const QString &fileSou
     if (!output)
         return;
 
-    QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> globalWallpapers = globalValidWallpaper(nullptr, -1);
+    QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> globalWallpapers = globalValidWallpaper();
     setOutputWallpaper(output->nativeHandle(),
                        workspaceIndex,
                        fileSource,
@@ -511,7 +488,7 @@ void WallpaperManager::onVideoChanged(int workspaceIndex, const QString &fileSou
     if (!output)
         return;
 
-    QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> globalWallpapers = globalValidWallpaper(nullptr, -1);
+    QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> globalWallpapers = globalValidWallpaper();
     setOutputWallpaper(output->nativeHandle(),
                        workspaceIndex,
                        fileSource,
@@ -527,7 +504,7 @@ void WallpaperManager::onVideoChanged(int workspaceIndex, const QString &fileSou
 
 void WallpaperManager::onWallpaperNotifierBound(wl_resource *resource)
 {
-    QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> globalWallpapers = globalValidWallpaper(nullptr, -1);
+    QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> globalWallpapers = globalValidWallpaper();
     QMapIterator<QString, TreelandWallpaperInterfaceV1::WallpaperType> i(globalWallpapers);
     while (i.hasNext()) {
         i.next();
@@ -538,7 +515,7 @@ void WallpaperManager::onWallpaperNotifierBound(wl_resource *resource)
 void WallpaperManager::handleWallpaperSurfaceAdded([[maybe_unused]] TreelandWallpaperSurfaceInterfaceV1 *interface)
 {
     QList<QString> wallpapers = Helper::instance()->shellHandler()->wallpaperShell()->producedWallpapers();
-    QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> globalWallpapers = globalValidWallpaper(nullptr, -1);
+    QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> globalWallpapers = globalValidWallpaper();
     foreach (auto wallpaper, std::as_const(wallpapers)) {
         if (!globalWallpapers.contains(wallpaper)) {
             Helper::instance()->m_wallpaperNotifierInterfaceV1->sendRemove(wallpaper);

--- a/src/wallpaper/wallpapermanager.h
+++ b/src/wallpaper/wallpapermanager.h
@@ -37,7 +37,7 @@ public:
                             const QString &fileSource,
                             TreelandWallpaperInterfaceV1::WallpaperRoles roles,
                             TreelandWallpaperInterfaceV1::WallpaperType type);
-    QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> globalValidWallpaper(wlr_output *exclusiveOutput, int exclusiveworkspaceId);
+    QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> globalValidWallpaper(wlr_output *excludedOutput = nullptr);
     void syncAddWorkspace();
     void removeOutputWallpaper(wlr_output *output);
     QString currentWorkspaceWallpaper(WOutput *output);


### PR DESCRIPTION
Remove persisted output and workspace enabled states from wallpaper configurations. Exclude a removed output when collecting valid wallpapers and resend missing wallpaper additions when it reconnects, allowing wallpaper-factory to recreate the corresponding surfaces.

Log: restore wallpapers after switching back from TTY
PMS: BUG-369961
Influence: Wallpaper restoration after output reconnect