### PR TITLE
fix: emit startedChanged signal on session start

### DIFF
--- a/examples/test_capture/capture.cpp
+++ b/examples/test_capture/capture.cpp
@@ -194,7 +194,7 @@ void TreelandCaptureSession::start()
 {
     QtWayland::treeland_capture_session_v1::start();
     m_started = true;
-    Q_EMIT started();
+    Q_EMIT startedChanged();
 }
 
 void TreelandCaptureSession::doneFrame()


### PR DESCRIPTION
## 修复说明

`TreelandCaptureSession::start()` 中误用 `Q_EMIT started()`，而 `started()` 是 `Q_PROPERTY` 的 getter（普通 const 成员函数），并非信号，调用后未发出任何通知。

本次将 `examples/test_capture/capture.cpp:197` 改为发射真正的 NOTIFY 信号 `Q_EMIT startedChanged()`，使 `started` 属性的变更通知能正确触发。

## Fix Description

In `TreelandCaptureSession::start()`, `Q_EMIT started()` was incorrect — `started()` is the `Q_PROPERTY` getter (a plain const member function), not a signal, so it emitted no notification.

This PR changes `examples/test_capture/capture.cpp:197` to emit the real NOTIFY signal `Q_EMIT startedChanged()`, so the `started` property's change notification fires correctly.

## Scope

- Only one line changed in `examples/test_capture/capture.cpp`
- `capture.h` and server-side `capturev1impl.*` untouched

## Related

- Multica issue: [WM-77](https://agent-dev.uniontech.com/issues/WM-77)

## Summary by Sourcery

Bug Fixes:
- Correct the TreelandCaptureSession start logic to emit startedChanged instead of calling the started getter so session start notifications work as intended.