### PR TITLE
refactor: consolidate surface capability init

### DIFF
--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -391,9 +391,6 @@ void SurfaceWrapper::setup()
         onSocketEnabledChanged();
     }
 
-    updateActivateCapability();
-    updateFocusCapability();
-
     if (m_type == Type::XdgToplevel && !m_isProxy) // x11 will set later
         setSkipDockPreView(false);
 
@@ -490,6 +487,25 @@ void SurfaceWrapper::setup()
             }
         }
     }
+
+    updateActivateCapability();
+    updateFocusCapability();
+    if (m_prelaunchSplash) {
+        m_surfaceItem->setVisible(false);
+
+        // Check if surface is still valid before accessing
+        WSurface *surf = surface();
+        if (surf && surf->mapped()) {
+            updateFocusControlState(FocusControlState::Mapped, true);
+            // ActiveControlState::MappedOrSplash is already true
+            syncPrelaunchMappedState();
+            startPrelaunchSplashHideSequence();
+        }
+    } else {
+        updateFocusControlState(FocusControlState::Mapped, surface() && surface()->mapped());
+        updateHasActiveCapability(ActiveControlState::MappedOrSplash,
+                                  surface() && surface()->mapped());
+    }
 }
 
 void SurfaceWrapper::convertToNormalSurface(WToplevelSurface *shellSurface, Type type)
@@ -508,16 +524,6 @@ void SurfaceWrapper::convertToNormalSurface(WToplevelSurface *shellSurface, Type
 
     // Call setup() to initialize surfaceItem related features
     setup();
-    m_surfaceItem->setVisible(false);
-
-    // Check if surface is still valid before accessing
-    WSurface *surf = surface();
-    if (surf && surf->mapped()) {
-        updateFocusControlState(FocusControlState::Mapped, true);
-        // ActiveControlState::MappedOrSplash is already true
-        syncPrelaunchMappedState();
-        startPrelaunchSplashHideSequence();
-    }
 }
 
 void SurfaceWrapper::setParent(QQuickItem *item)
@@ -2215,16 +2221,6 @@ void SurfaceWrapper::setHasInitializeContainer(bool value)
         // Start open animation when container initialized
         // m_prelaunchSplash can't get mapped signal
         createNewOrClose(OPEN_ANIMATION);
-    }
-
-    // If the surface was already mapped before the wrapper could connect to
-    // mappedChanged (e.g. wrapper created after the surface's initial map),
-    // onMappedChanged was never triggered. Make up for it here so that
-    // MappedOrSplash gets set and hasActiveCapability() can turn true,
-    // otherwise the window would be drawn but never activated/focused.
-    if (!m_prelaunchSplash && value && surface() && surface()->mapped()
-        && !m_hasActiveCapability.testFlag(ActiveControlState::MappedOrSplash)) {
-        onMappedChanged();
     }
 }
 


### PR DESCRIPTION
1. Move updateActivateCapability and updateFocusCapability calls to the end of setup() function to ensure all initialization is complete before updating capabilities
2. Consolidate prelaunch splash mapped state handling from convertToNormalSurface into setup() for better code organization
3. Add proper mapped state and active capability updates for both prelaunch splash and normal surfaces in setup()
4. Remove redundant workaround in setHasInitializeContainer that handled late mapping detection since setup now properly checks mapped state

Influence:
1. Test normal window creation and verify focus/activation works correctly
2. Test prelaunch splash window creation and verify splash to window transition
3. Test window creation when surface is already mapped before wrapper initialization
4. Verify that window activation and focus capabilities are properly set in all scenarios
5. Test X11 and Wayland surface creation paths

refactor: 整合 surface 能力初始化逻辑

1. 将 updateActivateCapability 和 updateFocusCapability 调用移至 setup() 函数末尾，确保在更新能力之前完成所有初始化
2. 将 convertToNormalSurface 中的预启动闪屏映射状态处理整合到 setup() 中，改善代码组织
3. 在 setup() 中为预启动闪屏和普通 surface 添加正确的映射状态和活动能力 更新
4. 移除 setHasInitializeContainer 中处理延迟映射检测的冗余变通方案，因为 setup 现在会正确检查映射状态

Influence:
1. 测试普通窗口创建，验证焦点/激活功能正常工作
2. 测试预启动闪屏窗口创建，验证闪屏到窗口的过渡
3. 测试在 wrapper 初始化之前 surface 已映射的窗口创建场景
4. 验证在所有场景下窗口激活和焦点能力是否正确设置
5. 测试 X11 和 Wayland surface 创建路径

## Summary by Sourcery

Consolidate surface capability initialization into setup() to correctly handle mapped state and activation/focus across normal and prelaunch splash surfaces.

Bug Fixes:
- Ensure activation and focus capabilities are updated after full setup to avoid windows that cannot be activated or focused when already mapped.

Enhancements:
- Move prelaunch splash mapped-state handling from convertToNormalSurface into setup() for centralized initialization of both splash and normal surfaces.
- Simplify initialization by removing the late-mapping workaround in setHasInitializeContainer now that setup() correctly handles mapped surfaces.