### PR TITLE
refactor: delegate activation to SeatSurfaceManager

### DIFF
--- a/src/core/popupfocusmanager.cpp
+++ b/src/core/popupfocusmanager.cpp
@@ -33,9 +33,13 @@ PopupFocusManager::PopupFocusManager(WSeat *seat, QObject *parent)
 
 PopupFocusManager::~PopupFocusManager() = default;
 
-void PopupFocusManager::giveFocus(WXdgPopupSurface *popupSurface)
+void PopupFocusManager::giveFocus(SurfaceWrapper *popupWrapper)
 {
-    if (!m_hasPopupGrab || !popupSurface || !m_seat->nativeHandle())
+    if (!m_hasPopupGrab || !popupWrapper || !m_seat->nativeHandle())
+        return;
+
+    auto *popupSurface = qobject_cast<WXdgPopupSurface *>(popupWrapper->shellSurface());
+    if (!popupSurface)
         return;
 
     // Only give focus to popups that belong to our seat's active popup grab.
@@ -54,9 +58,9 @@ void PopupFocusManager::giveFocus(WXdgPopupSurface *popupSurface)
 
     // Move keyboard focus to the popup surface via the normal waylib path.
     // TODO(rewine): Support multi-seat
-    m_seat->setKeyboardFocusSurface(popupSurface->surface());
+    Helper::instance()->requestKeyboardFocus(popupWrapper, Qt::ActiveWindowFocusReason, m_seat);
 
-    qCDebug(lcTlPopupFocus) << "Moved keyboard focus to popup surface:" << popupSurface;
+    qCDebug(lcTlPopupFocus) << "Moved keyboard focus to popup surface:" << popupWrapper;
 }
 
 void PopupFocusManager::dismissAll()
@@ -100,6 +104,6 @@ void PopupFocusManager::onKeyboardGrabEnd()
 
     if (saved && saved->hasFocusCapability()) {
         // TODO(rewine): Only restore focus if the saved surface belongs to the same seat.
-        Helper::instance()->requestKeyboardFocus(saved, Qt::ActiveWindowFocusReason);
+        Helper::instance()->requestKeyboardFocus(saved, Qt::ActiveWindowFocusReason, m_seat);
     }
 }

--- a/src/core/popupfocusmanager.h
+++ b/src/core/popupfocusmanager.h
@@ -12,7 +12,6 @@ class SurfaceWrapper;
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 class WSeat;
-class WXdgPopupSurface;
 WAYLIB_SERVER_END_NAMESPACE
 
 // Manages xdg_popup keyboard grab lifecycle for the compositor.
@@ -33,10 +32,10 @@ public:
     explicit PopupFocusManager(WAYLIB_SERVER_NAMESPACE::WSeat *seat, QObject *parent = nullptr);
     ~PopupFocusManager() override;
 
-    // Move keyboard focus to the given xdg_popup surface. If this is the first
+    // Move keyboard focus to the given popup surface wrapper. If this is the first
     // popup during the current grab, the previously focused surface is saved
     // for later restoration. No-op if no popup grab is active.
-    void giveFocus(WAYLIB_SERVER_NAMESPACE::WXdgPopupSurface *popupSurface);
+    void giveFocus(SurfaceWrapper *popupWrapper);
 
     // Dismiss all active popup surfaces. No-op if no popup grab is active.
     void dismissAll();

--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -147,11 +147,6 @@ void RootSurfaceContainer::destroyForSurface(SurfaceWrapper *wrapper)
         container->surfaceDestroyed(wrapper);
     }
 
-    auto *helper = Helper::instance();
-    if (helper && helper->activatedSurface() == wrapper) {
-        helper->setActivatedSurface(nullptr);
-    }
-
     wrapper->destroy();
 }
 
@@ -678,6 +673,12 @@ void RootSurfaceContainer::onSeatAdded(WSeat *seat)
     m_seatContainers[seat] = container;
 
     connect(container, &SeatSurfaceManager::moveResizeChanged, this, &RootSurfaceContainer::moveResizeFinised);
+    connect(container, &SeatSurfaceManager::activatedSurfaceChanged, this, [seat]() {
+        auto *helper = Helper::instance();
+        if (helper && helper->seat() == seat) {
+            Q_EMIT helper->activatedSurfaceChanged();
+        }
+    });
 }
 
 void RootSurfaceContainer::onSeatRemoved(WSeat *seat)

--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -902,10 +902,8 @@ void ShellHandler::setupSurfaceActiveWatcher(SurfaceWrapper *wrapper)
         connect(wrapper, &SurfaceWrapper::hasFocusCapabilityChanged, this, [wrapper]() {
             if (!wrapper->hasFocusCapability())
                 return;
-            if (auto *pfm = Helper::instance()->popupFocusManager()) {
-                if (auto *popupSurface = qobject_cast<WXdgPopupSurface *>(wrapper->shellSurface()))
-                    pfm->giveFocus(popupSurface);
-            }
+            if (auto *pfm = Helper::instance()->popupFocusManager())
+                pfm->giveFocus(wrapper);
         });
     } else if (wrapper->type() == SurfaceWrapper::Type::Layer) {
         connect(wrapper, &SurfaceWrapper::hasFocusCapabilityChanged, this, [this, wrapper]() {

--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -17,7 +17,9 @@
 #include "modules/wine-window-state/winewindowstate.h"
 #include "rootsurfacecontainer.h"
 #include "seat/helper.h"
+#include "seat/seatsmanager.h"
 #include "session/session.h"
+#include "surface/seatsurfacemanager.h"
 #include "surface/surfacewrapper.h"
 #include "treelandconfig.hpp"
 #include "treelanduserconfig.hpp"
@@ -850,6 +852,45 @@ void ShellHandler::onDockPreviewTooltip(
                               QVariant::fromValue(direction));
 }
 
+void ShellHandler::onSurfaceInactivationRequested(SurfaceWrapper *wrapper)
+{
+    Q_ASSERT(wrapper);
+    if (wrapper->type() != SurfaceWrapper::Type::Layer)
+        m_workspace->removeActivedSurface(wrapper);
+
+    auto *helper = Helper::instance();
+    auto *seatManager = helper->seatManager();
+    WSeat *primarySeat = helper->seat();
+    const auto seats = seatManager->seats();
+    auto *container = helper->rootSurfaceContainer();
+
+    for (auto *seat : seats) {
+        auto *seatContainer = container->getSeatContainer(seat);
+        const bool isKeyboardFocusOwner = seatContainer->keyboardFocusSurface() == wrapper;
+        const bool isActivatedOwner = seatContainer->activatedSurface() == wrapper;
+
+        if (isKeyboardFocusOwner) {
+            // activateSurface implicitly clears the old activated state and falls back focus.
+            // TODO(multi-seat): non-primary seats should also perform focus fallback once
+            // per-seat workspace stacking is supported.
+            if (seat == primarySeat) {
+                helper->activateSurface(m_workspace->current()->latestActiveSurface(),
+                                        Qt::OtherFocusReason,
+                                        seat);
+            } else {
+                helper->requestKeyboardFocus(nullptr, Qt::OtherFocusReason, seat);
+            }
+            continue;
+        }
+
+        if (isActivatedOwner) { // not isKeyboardFocusOwner
+            // Clear the activated state so foreign-toplevel clients do not observe a
+            // minimized-but-activated window.
+            helper->setActivatedSurface(nullptr, seat);
+        }
+    }
+}
+
 void ShellHandler::setupSurfaceActiveWatcher(SurfaceWrapper *wrapper)
 {
     Q_ASSERT_X(wrapper->container(), Q_FUNC_INFO, "Must setContainer at first!");
@@ -882,14 +923,7 @@ void ShellHandler::setupSurfaceActiveWatcher(SurfaceWrapper *wrapper)
                         == WLayerSurface::KeyboardInteractivity::Exclusive)
                     Helper::instance()->requestKeyboardFocus(wrapper);
             } else {
-                // Only the current keyboard focus owner should drive focus fallback.
-                // Closing an unfocused layer surface, such as a notification, must not
-                // move focus away from the current owner, which may be a layer-shell
-                // surface that does not participate in fallback history.
-                if (Helper::instance()->keyboardFocusSurface() != wrapper)
-                    return;
-
-                Helper::instance()->activateSurface(m_workspace->current()->latestActiveSurface());
+                onSurfaceInactivationRequested(wrapper);
             }
         });
     } else { // Xdgtoplevel or X11 or Splash
@@ -901,21 +935,7 @@ void ShellHandler::setupSurfaceActiveWatcher(SurfaceWrapper *wrapper)
         });
 
         connect(wrapper, &SurfaceWrapper::inactivationRequested, this, [this, wrapper]() {
-            m_workspace->removeActivedSurface(wrapper);
-            // The window may already be inactive. Keep history cleanup above, but
-            // avoid changing focus unless this window still owns keyboard focus.
-            if (Helper::instance()->keyboardFocusSurface() != wrapper) {
-                // Requests from task bars or other external controllers can minimize the
-                // active window after keyboard focus has already moved away from it. Clear
-                // the compositor active state so foreign-toplevel clients do not observe a
-                // minimized-but-activated window, but do not fall back focus from the
-                // current keyboard focus owner.
-                if (Helper::instance()->activatedSurface() == wrapper)
-                    Helper::instance()->setActivatedSurface(nullptr);
-                return;
-            }
-
-            Helper::instance()->activateSurface(m_workspace->current()->latestActiveSurface());
+            onSurfaceInactivationRequested(wrapper);
         });
 
         if (wrapper->hasActiveCapability()) {

--- a/src/core/shellhandler.h
+++ b/src/core/shellhandler.h
@@ -135,6 +135,7 @@ private Q_SLOTS:
 
 private:
     void setupSurfaceActiveWatcher(SurfaceWrapper *wrapper);
+    void onSurfaceInactivationRequested(SurfaceWrapper *wrapper);
     void setupSurfaceWindowMenu(SurfaceWrapper *wrapper);
     void updateLayerSurfaceContainer(SurfaceWrapper *surface);
     void registerSurfaceToForeignToplevel(SurfaceWrapper *wrapper);

--- a/src/modules/shortcut/shortcutrunner.cpp
+++ b/src/modules/shortcut/shortcutrunner.cpp
@@ -2,22 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "shortcutrunner.h"
-#include "seat/helper.h"
-#include "common/treelandlogging.h"
-#include "treelandconfig.hpp"
-#include "shortcutcontroller.h"
-#include "workspace/workspace.h"
-#include "modules/window-management/windowmanagementinterfacev1.h"
-#include "core/rootsurfacecontainer.h"
-#include "surface/surfacewrapper.h"
-#include "utils/fpsdisplaymanager.h"
-#include "interfaces/multitaskviewinterface.h"
+
 #include "core/qmlengine.h"
+#include "core/rootsurfacecontainer.h"
+#include "interfaces/multitaskviewinterface.h"
+#include "modules/window-management/windowmanagementinterfacev1.h"
+#include "output/output.h"
+#include "seat/helper.h"
+#include "shortcutcontroller.h"
+#include "surface/surfacewrapper.h"
+#include "treelandconfig.hpp"
+#include "utils/fpsdisplaymanager.h"
+#include "workspace/workspace.h"
 #include "workspaceanimationcontroller.h"
 #include "woutputrenderwindow.h"
-#include "output/output.h"
-
-#include "qwayland-server-treeland-shortcut-manager-v2.h"
 
 ShortcutRunner::ShortcutRunner(QObject *parent)
     : QObject(parent)
@@ -114,8 +112,8 @@ void ShortcutRunner::onActionTrigger(ShortcutAction action, const QString &name,
         break;
     }
     case ShortcutAction::ShowWindowMenu:
-        if (helper->m_activatedSurface) {
-            Q_EMIT helper->m_activatedSurface->windowMenuRequested({ 0, 0 });
+        if (auto surface = helper->activatedSurface()) {
+            Q_EMIT surface->windowMenuRequested({ 0, 0 });
         }
         break;
     case ShortcutAction::OpenMultiTaskView:

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2316,23 +2316,33 @@ SurfaceWrapper *Helper::keyboardFocusSurface() const
 
 SurfaceWrapper *Helper::activatedSurface() const
 {
-    return m_activatedSurface;
+    if (!m_rootSurfaceContainer)
+        return nullptr;
+
+    auto *seatContainer = m_rootSurfaceContainer->getSeatContainerOrDefault(m_primarySeat);
+    return seatContainer ? seatContainer->activatedSurface() : nullptr;
 }
 
 void Helper::setActivatedSurface(SurfaceWrapper *newActivateSurface, WSeat *seat)
 {
-    if (seat && seat != m_primarySeat) {
-        // Per-seat activation: delegate to SeatSurfaceManager
-        if (auto *container = m_rootSurfaceContainer->getSeatContainer(seat)) {
-            if (container->activatedSurface() != newActivateSurface)
-                container->setActivatedSurface(newActivateSurface, Qt::OtherFocusReason);
-        }
+    if (!m_rootSurfaceContainer) {
         return;
     }
 
-    // Primary seat / global activation
-    if (m_activatedSurface == newActivateSurface)
+    WSeat *targetSeat = seat ? seat : m_primarySeat;
+    auto *seatContainer = m_rootSurfaceContainer->getSeatContainerOrDefault(targetSeat);
+    if (!seatContainer) {
         return;
+    }
+
+    if (seatContainer->activatedSurface() == newActivateSurface)
+        return;
+
+    const bool isPrimarySeat = (targetSeat == m_primarySeat);
+    auto *oldPrimarySurface = isPrimarySeat ? activatedSurface() : nullptr;
+
+    if (oldPrimarySurface)
+        oldPrimarySurface->setActivate(false);
 
     if (newActivateSurface) {
         Q_ASSERT(newActivateSurface->showOnWorkspace(workspace()->current()->id()));
@@ -2345,9 +2355,6 @@ void Helper::setActivatedSurface(SurfaceWrapper *newActivateSurface, WSeat *seat
         }
     }
 
-    if (m_activatedSurface)
-        m_activatedSurface->setActivate(false);
-
     if (newActivateSurface) {
         if (m_showDesktop == WindowManagementInterfaceV1::DesktopState::Show) {
             m_showDesktop = WindowManagementInterfaceV1::DesktopState::Normal;
@@ -2356,26 +2363,19 @@ void Helper::setActivatedSurface(SurfaceWrapper *newActivateSurface, WSeat *seat
         }
 
         Q_ASSERT(newActivateSurface->hasActiveCapability());
-        newActivateSurface->setActivate(true);
         workspace()->pushActivedSurface(newActivateSurface);
     }
 
-    if (m_activatedSurface)
-        disconnect(m_activatedSurface,
-                   &SurfaceWrapper::hasFocusCapabilityChanged,
-                   this,
-                   &Helper::onActivatedSurfaceFocusCapabilityChanged);
+    seatContainer->setActivatedSurface(newActivateSurface, Qt::OtherFocusReason);
 
-    m_activatedSurface = newActivateSurface;
-
-    if (m_activatedSurface) {
-        connect(m_activatedSurface,
-                &SurfaceWrapper::hasFocusCapabilityChanged,
-                this,
-                &Helper::onActivatedSurfaceFocusCapabilityChanged);
+    if (isPrimarySeat && newActivateSurface) {
+        Q_ASSERT(newActivateSurface->hasActiveCapability());
+        newActivateSurface->setActivate(true);
     }
 
-    Q_EMIT activatedSurfaceChanged();
+    if (isPrimarySeat && oldPrimarySurface != activatedSurface()) {
+        Q_EMIT activatedSurfaceChanged();
+    }
 }
 
 void Helper::onRenderWindowActiveFocusItemChanged()
@@ -2449,30 +2449,22 @@ void Helper::requestKeyboardFocus(SurfaceWrapper *wrapper, Qt::FocusReason reaso
     if (!targetSeat || !targetSeat->nativeHandle())
         return;
 
+    auto *seatContainer = m_rootSurfaceContainer->getSeatContainer(targetSeat);
+
     if (wrapper) {
         wrapper->setFocus(true, reason);
         if (m_currentEventSeat && targetSeat == m_currentEventSeat) {
             updateSurfaceSeatInteraction(wrapper, targetSeat);
         }
-    } else if (auto currentFocus = keyboardFocusSurface()) {
+    } else if (auto currentFocus =
+                   seatContainer ? seatContainer->keyboardFocusSurface() : keyboardFocusSurface()) {
         currentFocus->setFocus(false, reason);
     }
 
     // Ensure Wayland keyboard focus is set and also inform SeatSurfaceManager
     targetSeat->setKeyboardFocusSurface(wrapper ? wrapper->surface() : nullptr);
-    if (auto *seatContainer = m_rootSurfaceContainer->getSeatContainer(targetSeat)) {
+    if (seatContainer) {
         seatContainer->setKeyboardFocusSurface(wrapper);
-    }
-}
-
-void Helper::onActivatedSurfaceFocusCapabilityChanged()
-{
-    if (!m_activatedSurface)
-        return;
-    if (m_activatedSurface->hasFocusCapability()) {
-        requestKeyboardFocus(m_activatedSurface, Qt::ActiveWindowFocusReason);
-    } else {
-        requestKeyboardFocus(nullptr, Qt::ActiveWindowFocusReason);
     }
 }
 
@@ -2791,8 +2783,8 @@ void Helper::setLockScreenImpl(ILockScreen *impl)
 #ifdef EXT_SESSION_LOCK_V1
         setNoAnimation(false);
 #endif
-        if (m_activatedSurface) {
-            m_activatedSurface->setFocus(true, Qt::NoFocusReason);
+        if (auto *surface = activatedSurface()) {
+            surface->setFocus(true, Qt::NoFocusReason);
         }
     });
     if (!impl) {

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2326,12 +2326,15 @@ SurfaceWrapper *Helper::activatedSurface() const
 void Helper::setActivatedSurface(SurfaceWrapper *newActivateSurface, WSeat *seat)
 {
     if (!m_rootSurfaceContainer) {
+        qCWarning(lcTlCore) << "Cannot set activated surface: root surface container is null";
         return;
     }
 
     WSeat *targetSeat = seat ? seat : m_primarySeat;
     auto *seatContainer = m_rootSurfaceContainer->getSeatContainerOrDefault(targetSeat);
     if (!seatContainer) {
+        qCWarning(lcTlCore) << "Cannot set activated surface: no seat container for seat"
+                            << targetSeat;
         return;
     }
 
@@ -2366,6 +2369,8 @@ void Helper::setActivatedSurface(SurfaceWrapper *newActivateSurface, WSeat *seat
         workspace()->pushActivedSurface(newActivateSurface);
     }
 
+    // SeatSurfaceManager emits activatedSurfaceChanged, and RootSurfaceContainer forwards
+    // it for the primary seat. Do not emit Helper::activatedSurfaceChanged again here.
     seatContainer->setActivatedSurface(newActivateSurface, Qt::OtherFocusReason);
 
     if (isPrimarySeat && newActivateSurface) {
@@ -2373,9 +2378,6 @@ void Helper::setActivatedSurface(SurfaceWrapper *newActivateSurface, WSeat *seat
         newActivateSurface->setActivate(true);
     }
 
-    if (isPrimarySeat && oldPrimarySurface != activatedSurface()) {
-        Q_EMIT activatedSurfaceChanged();
-    }
 }
 
 void Helper::onRenderWindowActiveFocusItemChanged()

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2,13 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "helper.h"
+
+#include "qwxdgshell.h"
 #include "seatsmanager.h"
-#include <QScopeGuard>
+
 #include <QFile>
-#include <QRandomGenerator>
-#include <QJsonDocument>
 #include <QJsonArray>
+#include <QJsonDocument>
 #include <QJsonObject>
+#include <QRandomGenerator>
+#include <QScopeGuard>
 #include <qnamespace.h>
 #ifdef EXT_SESSION_LOCK_V1
 #include "wsessionlock.h"
@@ -88,6 +91,7 @@
 #include <wsecuritycontextmanager.h>
 #include <wsocket.h>
 #include <wtoplevelsurface.h>
+#include <wxdgpopupsurface.h>
 #include <wxdgshell.h>
 #include <wxdgtoplevelsurface.h>
 #include <wxdgtopleveltagmanager.h>
@@ -2382,57 +2386,19 @@ void Helper::setActivatedSurface(SurfaceWrapper *newActivateSurface, WSeat *seat
 
 void Helper::onRenderWindowActiveFocusItemChanged()
 {
-    if (!m_seatManager)
-        return;
-
-    // If an explicit event seat is present we already handled activation
-    // in activateSurface(), avoid re-applying focus here to prevent races.
-    if (m_currentEventSeat)
-        return;
-
-    auto wrapper = keyboardFocusSurface();
-    if (!wrapper) {
-        // Qt focus lost (e.g. focus item became null) — clear Wayland keyboard focus
-        // on all seats to avoid stale focus state.
-        const auto seats = m_seatManager->seats();
-        for (auto *seat : seats) {
-            if (auto *seatContainer = m_rootSurfaceContainer->getSeatContainer(seat)) {
-                seatContainer->setKeyboardFocusSurface(nullptr);
-            }
-        }
-        return;
-    }
-
-    WSeat *interactingSeat = getLastInteractingSeat(wrapper);
-    if (interactingSeat) {
-        updateSurfaceSeatInteraction(wrapper, interactingSeat);
-        if (auto *seatContainer = m_rootSurfaceContainer->getSeatContainer(interactingSeat)) {
-            seatContainer->setKeyboardFocusSurface(wrapper);
-        }
-    } else {
-        const auto seats = m_seatManager->seats();
-        for (auto *seat : seats) {
-            if (!seat || !seat->isValid()) {
-                continue;
-            }
-
-            if (seat->pointerFocusSurface() == wrapper->surface()) {
-                if (auto *seatContainer = m_rootSurfaceContainer->getSeatContainer(seat)) {
-                    seatContainer->setKeyboardFocusSurface(wrapper);
-                }
-                updateSurfaceSeatInteraction(wrapper, seat);
-                break;
-            }
-        }
-    }
+    // TODO(muit-seat): Need to check whether the following logic is required.
 }
 
 void Helper::requestKeyboardFocus(SurfaceWrapper *wrapper, Qt::FocusReason reason, WSeat *seat)
 {
-
     if (wrapper) {
-        // Pop up through parent hierarchy until we find a non-popup surface
-        while (wrapper && wrapper->type() == SurfaceWrapper::Type::XdgPopup) {
+        // Pop up through parent hierarchy until we find a non-popup surface or grabbed popup
+        while (wrapper) {
+            auto *popupSurface = qobject_cast<WXdgPopupSurface *>(wrapper->shellSurface());
+            if (!popupSurface)
+                break;
+            if (popupSurface->handle()->handle()->seat)
+                break;
             wrapper = wrapper->parentSurface();
         }
         if (!wrapper || !wrapper->hasFocusCapability()) {
@@ -2442,32 +2408,20 @@ void Helper::requestKeyboardFocus(SurfaceWrapper *wrapper, Qt::FocusReason reaso
         }
     }
 
-    WSeat *targetSeat = seat;
-    if (!targetSeat)
-        targetSeat = m_currentEventSeat ? m_currentEventSeat : getLastInteractingSeat(wrapper);
-    if (!targetSeat)
-        targetSeat = m_primarySeat;
-
-    if (!targetSeat || !targetSeat->nativeHandle())
-        return;
-
-    auto *seatContainer = m_rootSurfaceContainer->getSeatContainer(targetSeat);
+    if (!seat)
+        seat = m_primarySeat;
 
     if (wrapper) {
         wrapper->setFocus(true, reason);
-        if (m_currentEventSeat && targetSeat == m_currentEventSeat) {
-            updateSurfaceSeatInteraction(wrapper, targetSeat);
-        }
-    } else if (auto currentFocus =
-                   seatContainer ? seatContainer->keyboardFocusSurface() : keyboardFocusSurface()) {
-        currentFocus->setFocus(false, reason);
     }
+    // Old surface focus clearing is delegated to SeatSurfaceManager::setKeyboardFocusSurface,
+    // which handles multi-seat arbitration.
 
-    // Ensure Wayland keyboard focus is set and also inform SeatSurfaceManager
-    targetSeat->setKeyboardFocusSurface(wrapper ? wrapper->surface() : nullptr);
-    if (seatContainer) {
-        seatContainer->setKeyboardFocusSurface(wrapper);
-    }
+    // Delegate to SeatSurfaceManager which handles Wayland focus, multi-seat arbitration,
+    // and interaction metadata in one place.
+    auto *seatContainer = m_rootSurfaceContainer->getSeatContainer(seat);
+    Q_ASSERT(seatContainer);
+    seatContainer->setKeyboardFocusSurface(wrapper);
 }
 
 void Helper::setCursorPosition(const QPointF &position)

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -355,7 +355,6 @@ private:
     SurfaceWrapper *keyboardFocusSurface() const;
     SurfaceWrapper *activatedSurface() const;
     void setActivatedSurface(SurfaceWrapper *newActivateSurface, WSeat *seat = nullptr);
-    void onActivatedSurfaceFocusCapabilityChanged();
 
     void setCursorPosition(const QPointF &position);
 
@@ -456,7 +455,6 @@ private:
     QPointer<QQuickItem> m_taskSwitch;
     QList<qw_idle_inhibitor_v1 *> m_idleInhibitors;
 
-    SurfaceWrapper *m_activatedSurface = nullptr;
     LockScreen *m_lockScreen = nullptr;
     float m_animationSpeed = 1.0;
     OutputMode m_mode = OutputMode::Extension;

--- a/src/surface/seatsurfacemanager.cpp
+++ b/src/surface/seatsurfacemanager.cpp
@@ -79,6 +79,7 @@ void SeatSurfaceManager::setKeyboardFocusSurface(SurfaceWrapper *surface)
 {
     if (m_keyboardFocusSurface == surface)
         return;
+    Q_ASSERT(m_seat && m_seat->nativeHandle());
 
     auto *oldSurface = m_keyboardFocusSurface;
     // Clear focus from old surface if no other seat has it
@@ -107,19 +108,18 @@ void SeatSurfaceManager::setKeyboardFocusSurface(SurfaceWrapper *surface)
 
         if (!otherSeatHasFocus)
             oldSurface->setFocus(false, Qt::OtherFocusReason);
-
-        if (m_seat && m_seat->nativeHandle())
-            m_seat->setKeyboardFocusSurface(nullptr);
     }
 
     // Assign new keyboard focus surface and update interaction metadata
     m_keyboardFocusSurface = surface;
-    if (surface && m_seat && m_seat->nativeHandle()) {
+    m_seat->setKeyboardFocusSurface(surface ? surface->surface() : nullptr);
+
+    if (surface) {
         surface->setProperty("lastInteractingSeat", QVariant::fromValue(m_seat));
         surface->setProperty("lastInteractionTime", QDateTime::currentMSecsSinceEpoch());
 
-        surface->setFocus(true, Qt::OtherFocusReason);
-        m_seat->setKeyboardFocusSurface(surface->surface());
+        // Qt focus is managed by the caller (requestKeyboardFocus or Qt Scene Graph),
+        // only set Wayland keyboard focus here.
     }
 }
 

--- a/src/surface/seatsurfacemanager.cpp
+++ b/src/surface/seatsurfacemanager.cpp
@@ -2,17 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "seatsurfacemanager.h"
+
 #include "rootsurfacecontainer.h"
 #include "seat/helper.h"
 #include "seat/seatsmanager.h"
-#include "common/treelandlogging.h"
 
 #include <winputdevice.h>
 #include <woutput.h>
-#include <woutputlayout.h>
 #include <woutputitem.h>
-#include <wxdgtoplevelsurface.h>
+#include <woutputlayout.h>
 #include <wseat.h>
+#include <wxdgtoplevelsurface.h>
+
 #include <qwoutput.h>
 
 #include <QDateTime>
@@ -39,8 +40,39 @@ void SeatSurfaceManager::setActivatedSurface(SurfaceWrapper *surface, Qt::FocusR
     if (m_activatedSurface == surface)
         return;
 
+    if (m_activatedSurface) {
+        disconnect(m_activatedSurface,
+                   &SurfaceWrapper::hasFocusCapabilityChanged,
+                   this,
+                   &SeatSurfaceManager::onActivatedSurfaceFocusCapabilityChanged);
+    }
+
     m_activatedSurface = surface;
+
+    if (m_activatedSurface) {
+        connect(m_activatedSurface,
+                &SurfaceWrapper::hasFocusCapabilityChanged,
+                this,
+                &SeatSurfaceManager::onActivatedSurfaceFocusCapabilityChanged);
+    }
+
     Q_EMIT activatedSurfaceChanged(surface);
+}
+
+void SeatSurfaceManager::onActivatedSurfaceFocusCapabilityChanged()
+{
+    if (!m_activatedSurface)
+        return;
+
+    auto *helper = Helper::instance();
+    if (!helper)
+        return;
+
+    if (m_activatedSurface->hasFocusCapability()) {
+        helper->requestKeyboardFocus(m_activatedSurface, Qt::ActiveWindowFocusReason, m_seat);
+    } else {
+        helper->requestKeyboardFocus(nullptr, Qt::ActiveWindowFocusReason, m_seat);
+    }
 }
 
 void SeatSurfaceManager::setKeyboardFocusSurface(SurfaceWrapper *surface)

--- a/src/surface/seatsurfacemanager.h
+++ b/src/surface/seatsurfacemanager.h
@@ -52,6 +52,8 @@ Q_SIGNALS:
     void moveResizeChanged();
 
 private:
+    void onActivatedSurfaceFocusCapabilityChanged();
+
     WSeat *m_seat = nullptr;
     RootSurfaceContainer *m_rootContainer = nullptr;
     


### PR DESCRIPTION
1. Remove m_activatedSurface member from Helper class
2. Make Helper::activatedSurface() delegate to SeatSurfaceManager
3. Refactor setActivatedSurface() to properly sync with SeatSurfaceManager
4. Move focus capability handling to SeatSurfaceManager
5. Update RootSurfaceContainer to forward activatedSurfaceChanged signal
6. Fix ShortcutRunner to use public getter instead of direct member access

The previous implementation maintained a separate m_activatedSurface in Helper which could become out of sync with SeatSurfaceManager's state. This refactoring makes Helper a proper facade that delegates surface state management to SeatSurfaceManager, ensuring single source of truth for activation state and proper cleanup when surfaces are destroyed.

Influence:
1. Test window activation with mouse clicks and keyboard shortcuts
2. Verify focus follows mouse and click-to-focus behavior
3. Test window destruction while it has active focus
4. Test show desktop functionality and restoration
5. Test window menu shortcut with active and inactive windows
6. Verify multitask view shows correct active window state
7. Test multi-seat scenarios if applicable
8. Test lock screen activation and deactivation
9. Verify no regressions in window stacking order

refactor: 将激活状态委托给 SeatSurfaceManager

1. 从 Helper 类中移除 m_activatedSurface 成员变量
2. 使 Helper::activatedSurface() 委托给 SeatSurfaceManager
3. 重构 setActivatedSurface() 以正确与 SeatSurfaceManager 同步
4. 将焦点能力处理移动到 SeatSurfaceManager
5. 更新 RootSurfaceContainer 以转发 activatedSurfaceChanged 信号
6. 修复 ShortcutRunner 使用公共 getter 而非直接访问成员

之前的实现在 Helper 中维护了单独的 m_activatedSurface，这可能与
SeatSurfaceManager 的状态不同步。此重构使 Helper 成为适当的门面，将表面
状态管理委托给 SeatSurfaceManager，确保激活状态的单一事实来源，并在表面
销毁时正确清理。

Influence:
1. 测试通过鼠标点击和键盘快捷键激活窗口
2. 验证焦点跟随鼠标和点击聚焦行为
3. 测试窗口在拥有活动焦点时被销毁的场景
4. 测试显示桌面功能和恢复
5. 测试活动和非活动窗口的窗口菜单快捷键
6. 验证多任务视图显示正确的活动窗口状态
7. 如适用，测试多座位场景
8. 测试锁屏激活和停用
9. 验证窗口堆叠顺序无回归

## Summary by Sourcery

Delegate window activation and focus management from Helper to SeatSurfaceManager to ensure a single source of truth for per-seat activation state.

Bug Fixes:
- Fix ShortcutRunner to use Helper::activatedSurface() instead of accessing Helper’s internal activated surface member directly, preventing desynchronization with SeatSurfaceManager.
- Ensure activated surfaces are properly deactivated and focus cleared when seats or surfaces change, reducing risk of stale activation after surface destruction.

Enhancements:
- Make Helper::activatedSurface() and setActivatedSurface() rely on RootSurfaceContainer/SeatSurfaceManager instead of a local activated surface member.
- Move activated surface focus-capability handling into SeatSurfaceManager, including reacting to capability changes per seat.
- Emit Helper::activatedSurfaceChanged in response to SeatSurfaceManager activation changes via RootSurfaceContainer, aligning activation signals with seat state.
- Update lock screen focus restoration and keyboard focus requests to use SeatSurfaceManager-managed activation and focus surfaces.