### PR TITLE
fix(wallpaper): resend all wallpapers after output reconnect

### DIFF
--- a/src/wallpaper/wallpapermanager.cpp
+++ b/src/wallpaper/wallpapermanager.cpp
@@ -147,11 +147,7 @@ void WallpaperManager::ensureWallpaperConfigForOutput(Output *output)
         return;
     }
 
-    QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> beforeWallpapers =
-        globalValidWallpaper(output->output()->nativeHandle());
-
     bool update = false;
-    bool isNewOutput = false;
     if (!configContainsOutput(output)) {
         WallpaperOutputConfig refConfig = m_wallpaperConfig.last();
         WallpaperWorkspaceConfig refWorkspaceConfig = refConfig.workspaces.first();
@@ -171,7 +167,6 @@ void WallpaperManager::ensureWallpaperConfigForOutput(Output *output)
         }
         m_wallpaperConfig.append(outputConfig);
         update = true;
-        isNewOutput = true;
     } else {
         QString outputId = getOutputId(output);
         Workspace *workspace = Helper::instance()->workspace();
@@ -200,45 +195,16 @@ void WallpaperManager::ensureWallpaperConfigForOutput(Output *output)
         QString json = wallpaperConfigToJsonString();
         Helper::instance()->m_config->setWallpaperConfig(json);
 
-        if (isNewOutput) {
-            Workspace *workspace = Helper::instance()->workspace();
-            Q_ASSERT(workspace);
-
-            sendMissingWallpapersForNewOutput(getOutputConfig(output), workspace, beforeWallpapers);
-        } else {
-            QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> afterWallpapers =
-                globalValidWallpaper();
-            for (auto it = afterWallpapers.constBegin(); it != afterWallpapers.constEnd(); ++it) {
-                if (!beforeWallpapers.contains(it.key())) {
-                    Helper::instance()->m_wallpaperNotifierInterfaceV1->sendAdd(it.value(), it.key());
-                }
-            }
+        WallpaperOutputConfig outputConfig = getOutputConfig(output);
+        for (auto &workspaceConfig : std::as_const(outputConfig.workspaces)) {
+            Helper::instance()->m_wallpaperNotifierInterfaceV1->sendAdd(workspaceConfig.desktopWallpapertype,
+                                                                        workspaceConfig.desktopWallpaper);
         }
+
+        Helper::instance()->m_wallpaperNotifierInterfaceV1->sendAdd(outputConfig.lockScreenWallpapertype,
+                                                                    outputConfig.lockscreenWallpaper);
 
         Q_EMIT updateWallpaper();
-    }
-}
-
-void WallpaperManager::sendMissingWallpapersForNewOutput(
-    const WallpaperOutputConfig &outputConfig,
-    Workspace *workspace,
-    const QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> &beforeWallpapers)
-{
-    QString currentDesktopWallpaper;
-    const int currentIndex = workspace->currentIndex();
-    if (currentIndex >= 0 && currentIndex < outputConfig.workspaces.size()) {
-        const WallpaperWorkspaceConfig &workspaceConfig = outputConfig.workspaces[currentIndex];
-        currentDesktopWallpaper = workspaceConfig.desktopWallpaper;
-        if (!beforeWallpapers.contains(workspaceConfig.desktopWallpaper)) {
-            Helper::instance()->m_wallpaperNotifierInterfaceV1->sendAdd(workspaceConfig.desktopWallpapertype,
-                                                                         workspaceConfig.desktopWallpaper);
-        }
-    }
-
-    if (!beforeWallpapers.contains(outputConfig.lockscreenWallpaper)
-        && currentDesktopWallpaper != outputConfig.lockscreenWallpaper) {
-        Helper::instance()->m_wallpaperNotifierInterfaceV1->sendAdd(outputConfig.lockScreenWallpapertype,
-                                                                     outputConfig.lockscreenWallpaper);
     }
 }
 

--- a/src/wallpaper/wallpapermanager.h
+++ b/src/wallpaper/wallpapermanager.h
@@ -60,12 +60,6 @@ public Q_SLOTS:
     void handleWallpaperSurfaceAdded(TreelandWallpaperSurfaceInterfaceV1 *interface);
 
 private:
-    void sendMissingWallpapersForNewOutput(
-        const WallpaperOutputConfig &outputConfig,
-        Workspace *workspace,
-        const QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> &beforeWallpapers);
-
-private:
     bool m_wallpaperConfigUpdated { false };
     QList<WallpaperOutputConfig> m_wallpaperConfig;
 };

--- a/wallpaper-factory/treelandwallpapernotifierclient.cpp
+++ b/wallpaper-factory/treelandwallpapernotifierclient.cpp
@@ -74,6 +74,12 @@ void TreelandWallpaperNotifierClientV1::instantiate()
 
 void TreelandWallpaperNotifierClientV1::treeland_wallpaper_notifier_v1_add(uint32_t source_type, const QString &file_source)
 {
+    foreach (auto window, m_windows) {
+        if (window->property(WALLPAPERSOURCE).toString() == file_source) {
+            return;
+        }
+    }
+
     QQuickView *wallpaperWindow = new QQuickView;
     WallpaperWindow *window = WallpaperWindow::get(wallpaperWindow);
     window->setSource(file_source);


### PR DESCRIPTION
Resend wallpaper additions for every workspace and the lockscreen whenever an output configuration changes. Remove the missing-wallpaper comparison and dedicated new-output path, ensuring wallpaper-factory receives every configured wallpaper and reliably recreates its surfaces.

Log: resend all wallpapers after switching back from TTY
PMS: BUG-369961
Influence: Wallpaper restoration after output reconnect

## Summary by Sourcery

Ensure all configured wallpapers are re-sent and surfaces recreated when outputs change or reconnect.

Bug Fixes:
- Always resend wallpapers for every workspace and the lockscreen after output configuration updates instead of only sending missing ones.
- Prevent duplicate wallpaper windows from being created in the wallpaper factory when the same wallpaper source is re-announced.

Enhancements:
- Simplify wallpaper resend logic by removing the special new-output path and previous wallpaper comparison.