### PR TITLE
fix: improve shortcut event dispatch and Alt+Tab task switch reliability

### DIFF
--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -1037,10 +1037,11 @@ void ShellHandler::setupSurfaceWindowMenu(SurfaceWrapper *wrapper)
             &SurfaceWrapper::windowMenuRequested,
             m_windowMenu,
             [this, wrapper](QPointF pos) {
-                QMetaObject::invokeMethod(m_windowMenu,
+                bool ok = QMetaObject::invokeMethod(m_windowMenu,
                                           "showWindowMenu",
                                           QVariant::fromValue(wrapper),
                                           QVariant::fromValue(pos));
+                qCDebug(lcTlShortcut) << "showWindowMenu invokeMethod result=" << ok;
             });
 }
 

--- a/src/modules/shortcut/shortcutcontroller.cpp
+++ b/src/modules/shortcut/shortcutcontroller.cpp
@@ -74,6 +74,15 @@ uint ShortcutController::registerKey(const QString &name, const QString& key, Sh
         m_keyMap[combined].remove(action);
         m_actionCombinedMap.remove(action);
     };
+    if (lcTlShortcut().isInfoEnabled()) {
+        QStringList flagNames;
+        if (keybindFlags.testFlag(ShortcutController::KeyPress)) flagNames << "KeyPress";
+        if (keybindFlags.testFlag(ShortcutController::KeyRelease)) flagNames << "KeyRelease";
+        if (keybindFlags.testFlag(ShortcutController::Repeat)) flagNames << "Repeat";
+        if (flagNames.isEmpty()) flagNames << "None";
+        qCInfo(lcTlShortcut).noquote() << "register shortcut:" << key << "->" << name
+            << "flags:" << flagNames.join('|');
+    }
     return 0;
 }
 
@@ -195,17 +204,30 @@ bool ShortcutController::dispatchKeyEvent(const QKeyEvent *kevent)
     ShortcutController::KeyFlags keyFlags = (kevent->isAutoRepeat() ? ShortcutController::Repeat : ShortcutController::None)
         | (kevent->type() == QEvent::KeyPress ? ShortcutController::KeyPress : ShortcutController::None)
         | (kevent->type() == QEvent::KeyRelease ? ShortcutController::KeyRelease : ShortcutController::None);
-    if (m_keyMap.contains(combined)) {
-        for (const auto &[action, keybind] : std::as_const(m_keyMap[combined]).asKeyValueRange()) {
-            const auto& [name, bindFlags] = keybind;
-            if ((bindFlags & keyFlags) != keyFlags) {
-                continue;
-            }
-            emit actionTriggered(action, name, false, keyFlags);
-        }
-        return true;
+
+    bool matched = m_keyMap.contains(combined);
+    if (matched) {
+        qCInfo(lcTlShortcut).noquote()
+            << "shortcut match:" << QKeySequence(kevent->keyCombination()).toString(QKeySequence::PortableText)
+            << (kevent->type() == QEvent::KeyPress ? "press" : "release")
+            << (kevent->isAutoRepeat() ? "repeat" : "");
     }
-    return false;
+    if (!matched)
+        return false;
+
+    for (const auto &[action, keybind] : std::as_const(m_keyMap[combined]).asKeyValueRange()) {
+        const auto& [name, bindFlags] = keybind;
+        // Match if the event flags are a subset of the binding flags.
+        // Each shortcut's behavior is determined by its registration flags:
+        // KeyPress-only → triggers on press,
+        // KeyRelease-only → triggers on release,
+        // Both → triggers on both.
+        if ((bindFlags & keyFlags) != keyFlags) {
+            continue;
+        }
+        Q_EMIT actionTriggered(action, name, false, keyFlags);
+    }
+    return true;
 }
 
 Qt::KeyboardModifiers ShortcutController::modifierForAction(ShortcutAction action) const

--- a/src/modules/shortcut/shortcutmanager.cpp
+++ b/src/modules/shortcut/shortcutmanager.cpp
@@ -573,17 +573,16 @@ ShortcutCaptureV1 *ShortcutManagerV2Private::resetCaptureState()
 //                                      ShortcutController::isValidShortcutCombination().
 bool ShortcutManagerV2Private::tryHandleCaptureEvent(WSeat *seat, QInputEvent *event)
 {
-    // Post-capture drain: consume residual KeyRelease events from the captured session.
-    // This prevents the release of the captured key from immediately firing a newly
-    // bound shortcut that uses KeyRelease trigger semantics.
+    // Drain the captured key's residual KeyRelease to avoid triggering
+    // a newly bound shortcut with KeyRelease trigger semantics.
     if (m_drainKey != Qt::Key_unknown && seat == m_drainSeat
         && event->type() == QEvent::KeyRelease) {
         auto *ke = static_cast<QKeyEvent *>(event);
         if (static_cast<Qt::Key>(ke->key()) == m_drainKey) {
             m_drainKey = Qt::Key_unknown;
             m_drainSeat = nullptr;
+            return true;
         }
-        return true; // consume all key releases until the captured key is released
     }
 
     if (!m_pendingCapture)
@@ -694,6 +693,11 @@ wl_global *ShortcutManagerV2::global() const
 bool ShortcutManagerV2::tryHandleCaptureEvent(WSeat *seat, QInputEvent *event)
 {
     return d->tryHandleCaptureEvent(seat, event);
+}
+
+bool ShortcutManagerV2::isCaptureActive()
+{
+    return d->m_pendingCapture || d->m_drainKey != Qt::Key_unknown;
 }
 
 QByteArrayView ShortcutManagerV2::interfaceName() const

--- a/src/modules/shortcut/shortcutmanager.h
+++ b/src/modules/shortcut/shortcutmanager.h
@@ -68,6 +68,7 @@ public:
     void sendActivated(const QString& name, ShortcutController::KeyFlags keyFlags);
 
     bool tryHandleCaptureEvent(WAYLIB_SERVER_NAMESPACE::WSeat *seat, QInputEvent *event);
+    bool isCaptureActive();
 
 public Q_SLOTS:
     void onSessionChanged();

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2050,15 +2050,12 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *targetWindow, QInputEvent 
     [[maybe_unused]] auto clearEventSeat = qScopeGuard([this] { m_currentEventSeat = nullptr; });
 
     if (seat == m_primarySeat) {
-        // NOTE: Unable to distinguish meta from other key combinations
-        //       For example, Meta+S will still receive Meta release after
-        //       fully releasing the key, actively detect whether there are
-        //       other keys, and reset the state.
         if (event->type() == QEvent::KeyPress) {
             auto kevent = static_cast<QKeyEvent *>(event);
             switch (kevent->key()) {
             case Qt::Key_Meta:
             case Qt::Key_Super_L:
+            case Qt::Key_Super_R:
                 if (auto *seatContainer = m_rootSurfaceContainer->getSeatContainer(seat))
                     seatContainer->setMetaKeyPressed(true);
                 break;
@@ -2146,24 +2143,28 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *targetWindow, QInputEvent 
         }
     }
 
-    // handle shortcut
-    if (m_shortcutManager->tryHandleCaptureEvent(seat, event))
+    // Capture mode: intercept key events before dispatchKeyEvent
+    if (m_shortcutManager->isCaptureActive() && m_shortcutManager->tryHandleCaptureEvent(seat, event))
         return true;
 
     if (seat == m_primarySeat && !m_captureSelector && m_currentMode != CurrentMode::LockScreen
         && (event->type() == QEvent::KeyPress || event->type() == QEvent::KeyRelease)) {
-        do {
-            auto kevent = static_cast<QKeyEvent *>(event);
-            // SKIP Meta+Meta
-            auto *seatContainer = m_rootSurfaceContainer->getSeatContainer(seat);
-            if (kevent->key() == Qt::Key_Meta && kevent->modifiers() == Qt::NoModifier
-                && seatContainer && !seatContainer->metaKeyPressed()) {
-                break;
-            }
+        auto kevent = static_cast<QKeyEvent *>(event);
+        auto *seatContainer = m_rootSurfaceContainer->getSeatContainer(seat);
 
-            if (m_shortcutManager->controller()->dispatchKeyEvent(kevent))
+        // Meta: consume press as modifier; suppress release when used in combo
+        if (kevent->key() == Qt::Key_Meta || kevent->key() == Qt::Key_Super_L || kevent->key() == Qt::Key_Super_R) {
+            if (kevent->type() == QEvent::KeyPress) {
                 return true;
-        } while (false);
+            }
+            if (kevent->type() == QEvent::KeyRelease && seatContainer && !seatContainer->metaKeyPressed()) {
+                return false;
+            }
+        }
+
+        if (m_shortcutManager->controller()->dispatchKeyEvent(kevent)) {
+            return true;
+        }
     }
 
     return false;


### PR DESCRIPTION
1. Add debug logging for window menu invokeMethod result
2. Add shortcut register/dispatch logging with human-readable flag names
3. Fix task switch show() race with Qt::QueuedConnection
4. Refactor Meta key handling: support Super_R, simplify Meta+Meta skip

Log: Fix Alt+Tab task switch UI not showing on long press; improve shortcut debugging with readable flag logs

Influence:
1. Verify Alt+Tab long press (>120ms) shows task switch UI immediately
2. Verify Alt+Shift+Tab also works correctly
3. Verify Meta/Super key combos (Meta+S, Super_L/R) still work
4. Verify window menu right-click works on client surfaces

fix: 改进快捷键事件分发和 Alt+Tab 任务切换可靠性

1. 增加窗口菜单 invokeMethod 返回值的调试日志
2. 增加快捷键注册/分派日志，flag 改为可读字符串
3. 修复 task switch show() 的竞态问题，改用 QueuedConnection
4. 重构 Meta 键处理：支持 Super_R，简化 Meta+Meta 跳过逻辑

Log: 修复长按 Alt+Tab 不显示任务切换 UI 的问题；改进快捷键调试日志，flag 显示为可读字符串

Influence:
1. 验证长按 Alt+Tab（>120ms）立即显示任务切换界面
2. 验证 Alt+Shift+Tab 也能正常工作
3. 验证 Meta/Super 键组合（Meta+S、Super_L/R）仍然正常
4. 验证客户端窗口右键菜单正常弹出

PMS: TASK-390751

## Summary by Sourcery

Improve keyboard shortcut handling reliability and observability, particularly for Alt+Tab window switching and Meta/Super key behavior.

New Features:
- Add human-readable logging for shortcut registration and dispatch, including key flags and matched sequences.

Bug Fixes:
- Fix race condition when showing the task switcher UI by invoking its show method via a queued connection.
- Correct Meta/Super key handling so Meta combos do not incorrectly trigger standalone Meta shortcuts and support Super_R in meta state tracking.
- Ensure window menu invocation logs success to aid in diagnosing right-click menu issues.

Enhancements:
- Refine shortcut dispatch flow to early-return on non-matching shortcuts and provide detailed match logs for debugging.