### PR TITLE
feat(lockscreen): add keyboard focus navigation for power buttons

### DIFF
--- a/src/plugins/lockscreen/qml/ControlAction.qml
+++ b/src/plugins/lockscreen/qml/ControlAction.qml
@@ -91,11 +91,20 @@ RowLayout {
             x: 0
             y: rootItem.height / 5 * 2
             modal: true
-            contentItem: PowerList { }
+            contentItem: PowerList {
+                id: innerPowerList
+            }
             background: MouseArea {
                 onClicked: powerItem.closePopup()
             }
-            onClosed: powerItem.expand = false
+            onOpened: {
+                innerPowerList.focusPowerOff()
+                innerPowerList.enableLoopInside()
+            }
+            onClosed: {
+                innerPowerList.loopInside = false
+                powerItem.expand = false
+            }
         }
         onClicked: {
             powerItem.expand = true

--- a/src/plugins/lockscreen/qml/PowerList.qml
+++ b/src/plugins/lockscreen/qml/PowerList.qml
@@ -13,9 +13,26 @@ FocusScope {
     property alias modelChildren: objModel.children
     property alias leftModelChildren: leftObjeModel.children
 
+    property alias listPowerOffBtn: powerOffBtn
+    property alias listHibernateBtn: hibernateBtn
+
+    property bool loopInside: false
+
+    signal tabOutForward()                                                                                                                                                 
+    signal tabOutBackward()  
+
     implicitWidth: layout.width
     implicitHeight: layout.height
 
+    function focusPowerOff() {
+        powerOffBtn.forceActiveFocus()
+    }
+    function focusHibernate() {
+        hibernateBtn.forceActiveFocus()
+    }
+    function enableLoopInside() {
+        loopInside = true
+    }
     RowLayout {
         id: layout
         spacing: 100
@@ -30,35 +47,68 @@ FocusScope {
                 id: objModel
 
                 ShutdownButton {
-                    id: powerOff
+                    id: powerOffBtn
                     enabled: GreeterProxy.canPowerOff
                     text: qsTr("Shut Down")
                     icon.name: "login_shutdown"
                     onClicked: GreeterProxy.powerOff()
+                    KeyNavigation.tab: rebootBtn
+                    KeyNavigation.backtab: hibernateBtn
+                    Keys.onBacktabPressed :function(event) {
+                        if(root.loopInside)
+                        {
+                            event.accepted = false
+                        }
+                        else
+                        {
+                            root.tabOutBackward() 
+                            event.accepted = true
+                        }
+                    }
                 }
 
                 ShutdownButton {
+                    id:rebootBtn
                     enabled: GreeterProxy.canReboot
                     text: qsTr("Reboot")
                     icon.name: "login_reboot"
                     onClicked: GreeterProxy.reboot()
+                    KeyNavigation.tab: suspendBtn
+                    KeyNavigation.backtab: powerOffBtn
                 }
 
                 ShutdownButton {
+                    id: suspendBtn
                     enabled: GreeterProxy.canSuspend
                     text: qsTr("Suspend")
                     icon.name: "login_suspend"
                     onClicked: {
                         GreeterProxy.suspend()
                     }
+                    KeyNavigation.tab: hibernateBtn
+                    KeyNavigation.backtab: rebootBtn
                 }
 
                 ShutdownButton {
+                    id: hibernateBtn
                     enabled: GreeterProxy.canHibernate
                     text: qsTr("Hibernate")
                     icon.name: "login_hibernate"
                     onClicked: {
                         GreeterProxy.hibernate()
+                    }
+                    KeyNavigation.tab: powerOffBtn
+                    KeyNavigation.backtab: suspendBtn
+                    Keys.onTabPressed :function(event) {
+                        if(root.loopInside)
+                        {
+                            event.accepted = false
+                        }
+                        else
+                        {
+                            root.tabOutForward() 
+                            event.accepted = true
+                        }
                     }
                 }
             }

--- a/src/plugins/lockscreen/qml/ShutdownButton.qml
+++ b/src/plugins/lockscreen/qml/ShutdownButton.qml
@@ -46,14 +46,18 @@ D.Button {
                 RoundBlur {
                     anchors.fill: parent
                     radius: btn.width / 2
-                    color: root.D.ColorSelector.backgroundColor
+                    color: root.activeFocus && !root.hovered && !root.pressed
+                           ? Qt.rgba(1.0, 1.0, 1.0, 0.2)
+                           : root.D.ColorSelector.backgroundColor
                 }
                 D.OutsideBoxBorder {
                     anchors.fill: parent
-                    visible: root.pressed || root.activeFocus
-                    borderWidth: 3
+                    visible: root.activeFocus || root.pressed
+                    borderWidth: root.activeFocus ? 2 : 3
                     radius: width / 2
-                    color: Qt.rgba(1.0, 1.0, 1.0, 0.3)
+                    color: root.activeFocus
+                           ? "#FFFFFF"
+                           : Qt.rgba(1.0, 1.0, 1.0, 0.3)
                 }
             }
         }
@@ -73,18 +77,22 @@ D.Button {
             color: root.D.ColorSelector.textColor
 
             background: Item {
-                visible: root.pressed || root.hovered
+                visible: root.activeFocus || root.hovered || root.pressed
                 RoundBlur {
                     anchors.fill: parent
                     radius: 6
-                    color: root.D.ColorSelector.backgroundColor
+                    color: root.activeFocus && !root.hovered && !root.pressed
+                           ? Qt.rgba(1.0, 1.0, 1.0, 0.2)
+                           : root.D.ColorSelector.backgroundColor
                 }
                 D.OutsideBoxBorder {
-                    visible: root.pressed
+                    visible: root.activeFocus || root.pressed
                     anchors.fill: parent
                     borderWidth: 2
                     radius: 6
-                    color: Qt.rgba(1.0, 1.0, 1.0, 0.3)
+                    color: root.activeFocus
+                           ? "#FFFFFF"
+                           : Qt.rgba(1.0, 1.0, 1.0, 0.3)
                 }
             }
         }

--- a/src/plugins/lockscreen/qml/ShutdownButton.qml
+++ b/src/plugins/lockscreen/qml/ShutdownButton.qml
@@ -50,7 +50,7 @@ D.Button {
                 }
                 D.OutsideBoxBorder {
                     anchors.fill: parent
-                    visible: root.pressed
+                    visible: root.pressed || root.activeFocus
                     borderWidth: 3
                     radius: width / 2
                     color: Qt.rgba(1.0, 1.0, 1.0, 0.3)

--- a/src/plugins/lockscreen/qml/ShutdownView.qml
+++ b/src/plugins/lockscreen/qml/ShutdownView.qml
@@ -9,6 +9,10 @@ FocusScope {
     id: root
 
     signal switchUser()
+    Component.onCompleted: {
+        lockBtn.forceActiveFocus()
+    }
+        
 
     MouseArea {
         anchors.fill: parent
@@ -17,6 +21,10 @@ FocusScope {
     }
 
     PowerList {
+        id:powerList
+        onTabOutForward: lockBtn.forceActiveFocus()                                                                                                                                              
+        onTabOutBackward: logoutBtn.forceActiveFocus()
+
         width: parent.width
         height: 140
         anchors {
@@ -27,23 +35,32 @@ FocusScope {
 
         modelChildren: [
             ShutdownButton {
+                id:lockBtn
                 visible: !GreeterProxy.isLocked
                 text: qsTr("lock")
                 icon.name: "login_lock"
                 onClicked: GreeterProxy.lock()
+                KeyNavigation.tab: switchBtn
+                KeyNavigation.backtab: powerList.listHibernateBtn
             },
             ShutdownButton {
+                id:switchBtn
                 visible: !GreeterProxy.isLocked
                 text: qsTr("switch user")
                 icon.name: "login_switchuser"
                 enabled: UserModel.count > 1
                 onClicked: root.switchUser()
+                KeyNavigation.tab: logoutBtn
+                KeyNavigation.backtab: lockBtn
             },
             ShutdownButton {
+                id:logoutBtn
                 visible: !GreeterProxy.isLocked
                 text: qsTr("Logout")
                 icon.name: "login_logout"
                 onClicked: GreeterProxy.logout()
+                KeyNavigation.tab: powerList.listPowerOffBtn
+                KeyNavigation.backtab: switchBtn
             }
         ]
     }


### PR DESCRIPTION
Add circular Tab/BackTab focus chain across lock, switch user, logout and power action buttons. Loop inside PowerList when opened as popup, break out to surrounding buttons when closed.

添加锁屏界面电源操作按钮的键盘焦点循环导航功能。

Log: 添加锁屏界面电源按钮键盘焦点导航
PMS: BUG-300951
Influence: 用户可通过Tab/Shift+Tab在锁屏界面所有电源操作按钮间切换焦点，
焦点按钮显示高亮边框。