### PR TITLE
fix: allow Video Bus brightness shortcuts

### DIFF
--- a/src/seat/seatsmanager.cpp
+++ b/src/seat/seatsmanager.cpp
@@ -680,7 +680,7 @@ void SeatsManager::assignDevice(WInputDevice *device,
     // Filter out system buttons
     if (deviceType == WInputDevice::Type::Keyboard &&
         (deviceName.contains("Power Button") || deviceName.contains("Sleep Button") ||
-         deviceName.contains("Lid Switch") || deviceName.contains("Video Bus"))) {
+         deviceName.contains("Lid Switch"))) {
         return;
     }
 


### PR DESCRIPTION
## Summary

- Keep Video Bus keyboard devices assigned to seats.
- Restore physical brightness shortcut activation under Wayland.

## Test plan

- Verify brightness up/down keys activate shortcuts under Treeland.
- Verify power, sleep, and lid switch devices remain filtered.
