### PR TITLE
fix: correct shadow rendering during layer shell window animations

### DIFF
--- a/src/core/qml/Animations/LayerShellAnimation.qml
+++ b/src/core/qml/Animations/LayerShellAnimation.qml
@@ -3,7 +3,6 @@
 
 import QtQuick
 import Waylib.Server
-import QtQuick.Effects
 
 Item {
     id: root
@@ -24,10 +23,12 @@ Item {
     property var position: WaylandLayerSurface.AnchorType.Bottom
     property var enableBlur: false
 
-    x: target.x
-    y: target.y
-    width: target.width
-    height: target.height
+    readonly property rect sourceRect: target.boundingRect
+
+    x: target.x + sourceRect.x
+    y: target.y + sourceRect.y
+    width: sourceRect.width
+    height: sourceRect.height
 
     function start() {
         visible = true;
@@ -42,20 +43,13 @@ Item {
 
     Loader {
         active: root.enableBlur
-        anchors.fill: effect
-        sourceComponent: RenderBufferBlitter {
-            id: blitter
+        x: effect.x - root.sourceRect.x
+        y: effect.y - root.sourceRect.y
+        width: root.target.width
+        height: root.target.height
+        sourceComponent: Blur {
             anchors.fill: parent
-            MultiEffect {
-                id: blur
-                anchors.fill: parent
-                source: blitter.content
-                autoPaddingEnabled: false
-                blurEnabled: true
-                blur: 1.0
-                blurMax: 64
-                saturation: 0.2
-            }
+            radius: root.target.radius
         }
     }
 
@@ -64,8 +58,9 @@ Item {
         live: root.direction === LayerShellAnimation.Direction.Show
         hideSource: true
         sourceItem: root.target
-        width: root.target.width
-        height: root.target.height
+        sourceRect: root.sourceRect
+        width: root.width
+        height: root.height
     }
 
     ParallelAnimation {


### PR DESCRIPTION
The animation item's geometry was incorrectly set to the parent target's
full extents, causing rectangular shadows to appear during layering
animations. Fixed by using the target's bounding rect to properly clip
the shadow area to the window's content region.

Additionally, replaced the outdated `RenderBufferBlitter`+`MultiEffect`
blur implementation with a more performant and correct `Blur` component,
and adjusted the `ShaderEffectSource` to use the proper source
rectangle.

Log: Fixed rectangular shadow artifacts during layer shell window show/
hide animations

Influence:
1. Verify that layer shell windows (e.g., application launchers, popups)
display correctly during show animations without rectangular shadow
artifacts
2. Test hover/popup animations across different anchor positions
(Bottom, Top, Left, Right)
3. Confirm that the blur effect still functions correctly when
`enableBlur` is enabled
4. Test window transitions with and without blur to ensure no regression
in shadow appearance
5. Verify that the animation bounds match the actual window content
bounds, especially for non-rectangular windows (e.g., rounded corners)

fix: 修复图层化窗口动画中的阴影显示为直角的问题

动画元素的几何尺寸被错误地设置为父目标元素的完整尺寸，导致在显示动画时出
现直角阴影。通过使用目标的边界矩形来正确裁剪阴影区域到窗口内容区域。

同时，将过时的 `RenderBufferBlitter`+`MultiEffect` 模糊实现替换为更高
效、更正确的 `Blur` 组件，并调整 `ShaderEffectSource` 使用正确的源矩形。

Log: 修复图层化窗口显示/隐藏动画中的直角阴影伪像

Influence:
1. 验证图层化窗口（如应用启动器、弹出窗口）在显示动画期间正确显示，无直
角阴影伪像
2. 测试不同锚点位置的悬停/弹出动画（Bottom、Top、Left、Right）
3. 确认当启用 `enableBlur` 时模糊效果仍能正常工作
4. 测试带模糊和不带模糊的窗口过渡，确保阴影外观无回归
5. 验证动画边界与实际窗口内容边界一致，特别是非矩形窗口（如圆角窗口）

## Summary by Sourcery

Fix shadow clipping and blur behavior for layer shell window animations.

Bug Fixes:
- Correct shadow clipping during layer shell animations by aligning the animation item bounds with the target content's bounding rect.

Enhancements:
- Replace the legacy RenderBufferBlitter + MultiEffect blur pipeline with a Blur component wired to the correct source rect and radius.