### PR TITLE
优化 Treeland 全部 QML 代码以支持 Qt6 类型标注 C++ 编译优化

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,6 +116,10 @@ qt_add_qml_module(libtreeland
     URI Treeland
     VERSION "2.0"
 
+    IMPORTS
+        Waylib.Server
+        Treeland.Capture
+
     SOURCES
         ${DDM_DBUS_SOURCES}
         ${DBUS_INTERFACE}

--- a/src/core/qml/.qmllint.ini
+++ b/src/core/qml/.qmllint.ini
@@ -1,0 +1,15 @@
+[qmllint]
+unused-imports=warning
+type=error
+unqualified=error
+with=warning
+import-name=warning
+import-version=warning
+deprecated=warning
+syntax=warning
+inheritance-cycle=warning
+non-list-type=warning
+missing-property=warning
+binding-in-loop=warning
+attached-property-reuse=info
+compiler=error

--- a/src/core/qml/Animations/GeometryAnimation.qml
+++ b/src/core/qml/Animations/GeometryAnimation.qml
@@ -1,6 +1,8 @@
 // Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import Treeland
 import Waylib.Server
@@ -13,7 +15,7 @@ Item {
     required property rect fromGeometry
     required property rect toGeometry
     property int duration: 200 * Helper.animationSpeed
-    property var enableBlur: false
+    property bool enableBlur: false
 
     signal ready
     signal finished
@@ -23,7 +25,7 @@ Item {
     width: fromGeometry.width
     height: fromGeometry.height
 
-    function start() {
+    function start(): void {
         animation.start();
     }
 
@@ -37,8 +39,10 @@ Item {
         active: root.enableBlur
         anchors.fill: parent
         sourceComponent: Blur {
+            // qmllint disable unqualified: qmllint directive — root.surface is outer scope, accessed from inline Component
             anchors.fill: parent
-            radius: surface.radius
+            radius: root.surface.radius
+            // qmllint enable unqualified
         }
     }
 

--- a/src/core/qml/Animations/LaunchpadAnimation.qml
+++ b/src/core/qml/Animations/LaunchpadAnimation.qml
@@ -1,5 +1,7 @@
-// Copyright (C) 2024 justforlxz <justforlxz@gmail.com>.
+// Copyright (C) 2024-2026 justforlxz <justforlxz@gmail.com>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Effects
@@ -18,20 +20,20 @@ Item {
     visible: false
     clip: true
 
-    required property var target
-    required property var direction
+    required property Item target
+    required property int direction
     property int duration: 400 * Helper.animationSpeed
 
     width: target.width
     height: target.height
     state: "None"
 
-    function start() {
+    function start(): void {
         visible = true;
         root.state = direction === LaunchpadAnimation.Direction.Show ? "Show" : "Hide"
     }
 
-    function stop() {
+    function stop(): void {
         visible = false;
         effect.sourceItem = null;
         finished();

--- a/src/core/qml/Animations/LayerShellAnimation.qml
+++ b/src/core/qml/Animations/LayerShellAnimation.qml
@@ -1,5 +1,7 @@
-// Copyright (C) 2024 justforlxz <justforlxz@gmail.com>.
+// Copyright (C) 2024-2026 justforlxz <justforlxz@gmail.com>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import Waylib.Server
@@ -17,11 +19,11 @@ Item {
     visible: false
     clip: true
 
-    required property var target
-    required property var direction
+    required property Item target
+    required property int direction
 
-    property var position: WaylandLayerSurface.AnchorType.Bottom
-    property var enableBlur: false
+    property int position: WaylandLayerSurface.AnchorType.Bottom
+    property bool enableBlur: false
 
     readonly property rect sourceRect: target.boundingRect
 
@@ -30,12 +32,12 @@ Item {
     width: sourceRect.width
     height: sourceRect.height
 
-    function start() {
+    function start(): void {
         visible = true;
         sideAnimation.start();
     }
 
-    function stop() {
+    function stop(): void {
         visible = false;
         effect.sourceItem = null;
         finished();

--- a/src/core/qml/Animations/MinimizeAnimation.qml
+++ b/src/core/qml/Animations/MinimizeAnimation.qml
@@ -1,6 +1,8 @@
 // Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Effects
 import Treeland
@@ -17,12 +19,12 @@ Item {
 
     clip: false
 
-    required property var target
+    required property SurfaceWrapper target
     required property rect position
-    required property var direction
+    required property int direction
     property int duration: 400 * Helper.animationSpeed
 
-    function start() {
+    function start(): void {
         mainAnimation.start();
     }
 

--- a/src/core/qml/Animations/NewAnimation.qml
+++ b/src/core/qml/Animations/NewAnimation.qml
@@ -1,6 +1,8 @@
 // Copyright (C) 2023-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import Treeland
 import Waylib.Server
@@ -17,9 +19,9 @@ Item {
     signal finished
 
     required property SurfaceWrapper target
-    required property var direction
+    required property int direction
     property int duration: 400 * Helper.animationSpeed
-    property var enableBlur: false
+    property bool enableBlur: false
 
     x: target.x
     y: target.y
@@ -39,7 +41,7 @@ Item {
         }
     ]
 
-    function start() {
+    function start(): void {
         animation.start();
     }
 
@@ -47,8 +49,10 @@ Item {
         active: root.enableBlur
         anchors.fill: parent
         sourceComponent: Blur {
+            // qmllint disable unqualified: qmllint directive — root.target is outer scope, accessed from inline Component
             anchors.fill: parent
             radius: root.target.radius
+            // qmllint enable unqualified
         }
     }
 

--- a/src/core/qml/Animations/ShowDesktopAnimation.qml
+++ b/src/core/qml/Animations/ShowDesktopAnimation.qml
@@ -1,6 +1,8 @@
 // Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Effects
 import Treeland
@@ -12,11 +14,11 @@ Item {
 
     clip: false
 
-    required property var target
+    required property SurfaceWrapper target
     required property bool showDesktop
     property int duration: 500 * Helper.animationSpeed //500: Initial design requirements
 
-    function start() {
+    function start(): void {
         animation.start();
     }
 

--- a/src/core/qml/Border.qml
+++ b/src/core/qml/Border.qml
@@ -1,5 +1,7 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
 
 import QtQuick
 

--- a/src/core/qml/CaptureSelectorLayer.qml
+++ b/src/core/qml/CaptureSelectorLayer.qml
@@ -1,5 +1,7 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Controls

--- a/src/core/qml/CopyOutput.qml
+++ b/src/core/qml/CopyOutput.qml
@@ -1,5 +1,7 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import Waylib.Server
@@ -112,12 +114,12 @@ OutputItem {
 
         Timer {
             id: transformTimer
-            property var scheduleTransform
+            property int scheduleTransform
             onTriggered: viewport.rotateOutput(scheduleTransform)
             interval: rotationAnimator.duration / 2
         }
 
-        function rotationOutput(orientation) {
+        function rotationOutput(orientation: int): void {
             transformTimer.scheduleTransform = orientation
             transformTimer.start()
 
@@ -141,15 +143,15 @@ OutputItem {
         }
     }
 
-    function setTransform(transform) {
+    function setTransform(transform: int): void {
         viewport.rotationOutput(transform)
     }
 
-    function setScale(scale) {
+    function setScale(scale: real): void {
         viewport.setOutputScale(scale)
     }
 
-    function invalidate() {
+    function invalidate(): void {
         viewport.invalidate()
     }
 }

--- a/src/core/qml/Decoration.qml
+++ b/src/core/qml/Decoration.qml
@@ -1,6 +1,8 @@
 // Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Effects
 import Waylib.Server

--- a/src/core/qml/DockPreview.qml
+++ b/src/core/qml/DockPreview.qml
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -21,7 +23,7 @@ Item {
     // set by States
     property bool isHorizontal
     // set by show()
-    property var target
+    property var target // mixed type: PrimaryOutput or Output, keep as var
     property point pos
     property int direction
     // auto update by binding
@@ -54,12 +56,12 @@ Item {
             Qt.callLater(()=> { lastSize = count })
         }
 
-        property var desiredSurfaces: []
+        property var desiredSurfaces: [] // JS array of SurfaceWrapper, keep as var
         onDesiredSurfacesChanged:  {
             updateModel();
         }
 
-        function updateModel() {
+        function updateModel(): void {
             var newSize = desiredSurfaces.length;
             var oldSize = filterSurfaceModel.count;
             root.isNewDockPreview = oldSize === 0 && newSize !== 0;
@@ -76,7 +78,7 @@ Item {
             }
         }
 
-        function removeSurface(surfaceWrapper) {
+        function removeSurface(surfaceWrapper: SurfaceWrapper): void {
             if (!surfaceWrapper)
                 return;
 
@@ -88,24 +90,24 @@ Item {
             updateModel();
         }
 
-        function activateWindow(surfaceWrapper) {
+        function activateWindow(surfaceWrapper: SurfaceWrapper): void {
             console.debug(qLcDockPreview, "activate preview window: ", surfaceWrapper)
             Helper.forceActivateSurface(surfaceWrapper)
             ForeignToplevelManagerInterfaceV1.leaveDockPreview(root.target.shellSurface.surface)
             root.close();
         }
 
-        function previewWindow(surfaceWrapper) {
+        function previewWindow(surfaceWrapper: SurfaceWrapper): void {
             console.debug(qLcDockPreview, "start preview window: ", surfaceWrapper)
             Helper.workspace.startPreviewing(surfaceWrapper);
         }
 
-        function stopPreviewWindow() {
+        function stopPreviewWindow(): void {
             console.debug(qLcDockPreview, "stop preview window")
             Helper.workspace.stopPreviewing();
         }
 
-        function closeAllWindow() {
+        function closeAllWindow(): void {
             console.debug(qLcDockPreview, "close all preview windows")
             var tmp = filterSurfaceModel.desiredSurfaces;
             filterSurfaceModel.desiredSurfaces = [ ];
@@ -115,7 +117,7 @@ Item {
             root.close();
         }
 
-        function closeSpecialWindow(surfaceId) {
+        function closeSpecialWindow(surfaceId: int): void {
             let surfaceWrapper = filterSurfaceModel.get(surfaceId)?.wrapper
             console.debug(qLcDockPreview, "close a special window: ", surfaceWrapper)
             filterSurfaceModel.remove(surfaceId)
@@ -123,7 +125,7 @@ Item {
         }
     }
 
-    function show(surfaces, target, pos, direction) {
+    function show(surfaces: var, target: var, pos: point, direction: int): void {
         console.info(qLcDockPreview, "start show windows: ", surfaces)
         root.parent = target.parent;
 
@@ -148,7 +150,7 @@ Item {
         root.isShowing = true;
     }
 
-    function showTooltip(tooltip, target, pos, direction) {
+    function showTooltip(tooltip: string, target: var, pos: point, direction: int): void {
         console.info(qLcDockPreview, "start show tooltip: ", tooltip, target, pos, direction)
         root.parent = target.parent;
         if (root.isShowing && !root.isTooltip)
@@ -170,7 +172,7 @@ Item {
         root.isShowing = true;
     }
 
-    function close() {
+    function close(): void {
         console.info(qLcDockPreview, "stop dock preview")
         root.isShowing = false;
     }
@@ -337,7 +339,7 @@ Item {
         text: root.tooltip
     }
 
-    function getWidth(removing) {
+    function getWidth(removing: bool): real {
         let tooltipWidth = Math.min(tooltipMetrics.width + listview.spacing * 2, root.outPutSize.width);
         if (removing && root.isTooltip)
             return tooltipWidth;
@@ -366,7 +368,7 @@ Item {
         return width
     }
 
-    function getHeight(removing) {
+    function getHeight(removing: bool): real {
         if (removing && root.isTooltip)
             return tooltipMetrics.height;
 
@@ -476,8 +478,8 @@ Item {
             radius: listview.radius
             color: Qt.rgba(0, 0, 0, 0.05) // TODO: dark mode
 
-            required property var index
-            required property var wrapper // from filterSurfaceModel
+            required property int index
+            required property SurfaceWrapper wrapper // from filterSurfaceModel
             property bool isRemoving: false
 
             implicitHeight: root.isHorizontal ? 120 : Math.max(80, Math.min(120, 240 * wrapper.height / wrapper.width))

--- a/src/core/qml/Effects/Blur.qml
+++ b/src/core/qml/Effects/Blur.qml
@@ -1,6 +1,8 @@
 // Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Effects
 import QtQuick.Shapes
@@ -36,6 +38,7 @@ RenderBufferBlitter {
     Component {
         id: glassComponent
         GlassEffect {
+            // qmllint disable unqualified: qmllint directive — blitter properties needed in effect component
             anchors.fill: parent
             source: blitter.content
             radius: blitter.radius
@@ -63,6 +66,7 @@ RenderBufferBlitter {
             rimReflectionEnabled: true
             lightPower: 3.0
             reflectionOffset: Helper.config.glassReflectionOffset
+            // qmllint enable unqualified
         }
     }
 
@@ -73,6 +77,7 @@ RenderBufferBlitter {
 
             MultiEffect {
                 id: blur
+                // qmllint disable unqualified: qmllint directive — blitter properties needed in effect component
                 anchors.fill: parent
                 layer.enabled: blitter.radiusEnabled
                 smooth: blitter.radiusEnabled
@@ -84,13 +89,16 @@ RenderBufferBlitter {
                 blurMax: blitter.blurMax
                 blurMultiplier: blitter.multiplier
                 saturation: 0.2
+                // qmllint enable unqualified
             }
 
             Loader {
                 x: blur.x
                 y: blur.y
                 active: blitter.radiusEnabled
+                // qmllint disable unqualified: qmllint directive — blitter is outer scope
                 sourceComponent: Shape {
+                    // qmllint disable unqualified: qmllint directive — blitter and blur are outer scope
                     anchors.fill: parent
                     preferredRendererType: Shape.CurveRenderer
                     ShapePath {
@@ -102,6 +110,7 @@ RenderBufferBlitter {
                             radius: blitter.radius
                         }
                     }
+                    // qmllint enable unqualified
                 }
             }
         }

--- a/src/core/qml/Effects/GlassEffect.qml
+++ b/src/core/qml/Effects/GlassEffect.qml
@@ -1,6 +1,8 @@
 // Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Effects
 

--- a/src/core/qml/Effects/LaunchpadCover.qml
+++ b/src/core/qml/Effects/LaunchpadCover.qml
@@ -1,5 +1,7 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Effects

--- a/src/core/qml/FadeBehavior.qml
+++ b/src/core/qml/FadeBehavior.qml
@@ -1,5 +1,7 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQml
@@ -7,9 +9,9 @@ import QtQml
 Behavior {
     id: root
 
-    property QtObject fadeTarget: targetProperty.object
+    property QtObject fadeTarget: targetProperty.object // dynamic target object, type varies
     property string fadeProperty: "opacity"
-    property var fadeProperties: [fadeProperty]
+    property var fadeProperties: [fadeProperty] // JS array used with join/forEach, keep as var
     property int exitValue: 0
     property int enterValue: exitValue
     property int fadeDuration: 300
@@ -39,26 +41,32 @@ Behavior {
     }
 
     readonly property Component defaultExitAnimation: NumberAnimation {
+        // qmllint disable unqualified: qmllint directive — root properties needed in animation template
         properties: root.fadeProperties.join(',')
         duration: root.fadeDuration
         to: root.exitValue
         easing.type: root.easingType === "Linear" ? Easing.Linear : Easing["In"+root.easingType]
+        // qmllint enable unqualified
     }
     property Component exitAnimation: defaultExitAnimation
 
     readonly property Component defaultEnterAnimation: NumberAnimation {
+        // qmllint disable unqualified: qmllint directive — root properties needed in animation template
         properties: root.fadeProperties.join(',')
         duration: root.fadeDuration
         from: root.enterValue
         to: root.fadeTarget[root.fadeProperties[0]]
         easing.type: root.easingType === "Linear" ? Easing.Linear : Easing["Out"+root.easingType]
+        // qmllint enable unqualified
     }
     property Component enterAnimation: NumberAnimation {
+        // qmllint disable unqualified: qmllint directive — root properties needed in animation template
        properties: root.fadeProperties.join(',')
        duration: root.fadeDuration
        from: root.enterValue
        to: root.fadeTarget[root.fadeProperties[0]]
        easing.type: root.easingType === "Linear" ? Easing.Linear : Easing["Out"+root.easingType]
+        // qmllint enable unqualified
     }
 
     SequentialAnimation {

--- a/src/core/qml/FpsDisplay.qml
+++ b/src/core/qml/FpsDisplay.qml
@@ -1,5 +1,7 @@
-// Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2025-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Controls
@@ -10,7 +12,7 @@ Item {
     anchors.fill: parent
 
     property real scaleFactor: 1.0
-    property var targetWindow: null
+    property Window targetWindow: null
     property alias fpsManager: internalManager
 
     FpsDisplayManager {

--- a/src/core/qml/LockScreenFallback.qml
+++ b/src/core/qml/LockScreenFallback.qml
@@ -1,12 +1,14 @@
-// Copyright (C) 2025 misaka18931 <miruku2937@gmail.com>.
+// Copyright (C) 2025-2026 misaka18931 <miruku2937@gmail.com>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
 
 import QtQuick 2.15
 
 FocusScope {
     id: root
     clip: true
-    required property QtObject outputItem
+    required property Item outputItem
     
     // Position and size
     x: outputItem.x

--- a/src/core/qml/OutputMenuBar.qml
+++ b/src/core/qml/OutputMenuBar.qml
@@ -1,5 +1,7 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Controls

--- a/src/core/qml/PrelaunchSplash.qml
+++ b/src/core/qml/PrelaunchSplash.qml
@@ -1,6 +1,8 @@
 // Copyright (C) 2025-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 import Waylib.Server 1.0
@@ -10,7 +12,7 @@ Item {
     id: splash
 
     required property real initialRadius
-    required property var iconBuffer
+    required property var iconBuffer // qw_buffer* from wlroots, not registered as QML type
     required property color backgroundColor
     readonly property bool isLightBackground: backgroundColor.hslLightness >= 0.5
 

--- a/src/core/qml/PrimaryOutput.qml
+++ b/src/core/qml/PrimaryOutput.qml
@@ -1,6 +1,8 @@
 // Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 import Waylib.Server
@@ -16,12 +18,12 @@ OutputItem {
     cursorDelegate: Cursor {
         id: cursorItem
 
-        required property QtObject outputCursor
+        required property QtObject outputCursor // outputCursor is WQuickCursor (QML_ANONYMOUS), cannot use as named type
         readonly property point rawPosition: parent.mapFromGlobal(cursor.position.x, cursor.position.y)
         readonly property real effectiveScale: rootOutputItem.devicePixelRatio || 1.0
 
         // Align cursor position to pixel grid to prevent blur on fractional DPR displays
-        function alignToPixelGrid(value) {
+        function alignToPixelGrid(value: real): real {
             return Math.round(value * effectiveScale) / effectiveScale
         }
 
@@ -37,12 +39,14 @@ OutputItem {
         visible: valid && outputCursor.visible
         OutputLayer.enabled: !outputCursor.output.forceSoftwareCursor
         OutputLayer.keepLayer: true
+        // qmllint disable unqualified: qmllint directive — screenViewport is an outer scope property
         OutputLayer.outputs: [screenViewport]
         OutputLayer.flags: OutputLayer.Cursor
         OutputLayer.cursorHotSpot: hotSpot
 
         themeName: Helper.config.cursorThemeName
         sourceSize: Qt.size(Helper.config.cursorSize, Helper.config.cursorSize)
+        // qmllint enable unqualified
     }
 
     OutputViewport {
@@ -63,12 +67,12 @@ OutputItem {
         Timer {
             id: setTransform
 
-            property var scheduleTransform
+            property int scheduleTransform
             onTriggered: screenViewport.rotateOutput(scheduleTransform)
             interval: rotationAnimator.duration / 2
         }
 
-        function rotationOutput(orientation) {
+        function rotationOutput(orientation: int): void {
             setTransform.scheduleTransform = orientation
             setTransform.start()
 
@@ -175,7 +179,7 @@ OutputItem {
 
             Connections {
                 target: Helper
-                function onLaunchpadMappedChanged(output, mapped) {
+                function onLaunchpadMappedChanged(output: WaylandOutput, mapped: bool) {
                     if (output !== rootOutputItem.output) {
                         return;
                     }
@@ -183,7 +187,7 @@ OutputItem {
                     wallpaper.state = mapped ? "Scale" : "Normal"
                 }
 
-                function onShowDesktopRequested(output) {
+                function onShowDesktopRequested(output: WaylandOutput) {
                     if (output !== rootOutputItem.output) {
                         return;
                     }
@@ -193,7 +197,7 @@ OutputItem {
                     wallpaper.slowDown()
                 }
 
-                function onStartLockscreened(output, showAnimation) {
+                function onStartLockscreened(output: WaylandOutput, showAnimation: bool) {
                     if (output !== rootOutputItem.output) {
                         return;
                     }
@@ -205,15 +209,15 @@ OutputItem {
         }
     }
 
-    function setTransform(transform) {
+    function setTransform(transform: int): void {
         screenViewport.rotationOutput(transform)
     }
 
-    function setScale(scale) {
+    function setScale(scale: real): void {
         screenViewport.setOutputScale(scale)
     }
 
-    function invalidate() {
+    function invalidate(): void {
         screenViewport.invalidate()
     }
 }

--- a/src/core/qml/SurfaceContent.qml
+++ b/src/core/qml/SurfaceContent.qml
@@ -1,5 +1,7 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Shapes
@@ -18,12 +20,20 @@ Item {
     opacity: content.alphaModifier
 
     Loader {
+        id: blurLoader
         anchors.fill: parent
         active: wrapper?.blur ?? false
-        sourceComponent: Blur {
+        sourceComponent: blurComponent
+        onLoaded: {
+            item.radius = Qt.binding(() => cornerRadius)
+            item.radiusEnabled = Qt.binding(() => cornerRadius > 0)
+        }
+    }
+
+    Component {
+        id: blurComponent
+        Blur {
             anchors.fill: parent
-            radiusEnabled: cornerRadius > 0
-            radius: cornerRadius
         }
     }
 
@@ -59,6 +69,7 @@ Item {
         }
 
         sourceComponent: Shape {
+            // qmllint disable unqualified: qmllint directive — content, wrapper, cornerRadius are outer scope
             fillMode: Shape.PreserveAspectFit
             preferredRendererType: Shape.CurveRenderer
             ShapePath {
@@ -77,6 +88,7 @@ Item {
                     bottomRightRadius: cornerRadius * scale
                 }
             }
+            // qmllint enable unqualified
         }
     }
 }

--- a/src/core/qml/SwitchViewDelegate.qml
+++ b/src/core/qml/SwitchViewDelegate.qml
@@ -1,5 +1,7 @@
-// Copyright (C) 2024 lbwtw <xiaoyaobing@uniontech.com>.
+// Copyright (C) 2024-2026 lbwtw <xiaoyaobing@uniontech.com>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Shapes

--- a/src/core/qml/SwitchViewHighlightDelegate.qml
+++ b/src/core/qml/SwitchViewHighlightDelegate.qml
@@ -1,5 +1,7 @@
-// Copyright (C) 2024 lbwtw <xiaoyaobing@uniontech.com>.
+// Copyright (C) 2024-2026 lbwtw <xiaoyaobing@uniontech.com>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
 
 import QtQuick
 

--- a/src/core/qml/TaskBar.qml
+++ b/src/core/qml/TaskBar.qml
@@ -1,12 +1,14 @@
 // Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import Waylib.Server
 import Treeland
 
 ListView {
-    required property QtObject output
+    required property QtObject output // Treeland Output (QML_ANONYMOUS), cannot use as named type
     readonly property OutputItem outputItem: output.outputItem
 
     width: 250 + leftMargin + rightMargin

--- a/src/core/qml/TaskSwitcher.qml
+++ b/src/core/qml/TaskSwitcher.qml
@@ -1,6 +1,8 @@
 // Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Layouts
 import Treeland
@@ -14,8 +16,8 @@ Item {
 
     property bool switchOn: true
     property int focusReason: Qt.TabFocusReason
-    required property QtObject output
-    readonly property QtObject model: Helper.workspace.currentFilter
+    required property QtObject output // Treeland Output (QML_ANONYMOUS), cannot use as named type
+    readonly property QtObject model: Helper.workspace.currentFilter // SurfaceFilterProxyModel, not QML-registered
 
     // control all switch item
     property bool enableBlur: GraphicsInfo.api !== GraphicsInfo.Software
@@ -224,9 +226,11 @@ Item {
                     MouseArea {
                         anchors.fill: parent
                         onClicked: {
+                            // qmllint disable unqualified: qmllint directive — switchView and switchIndex are outer scope
                             let pos = mapToItem(switchView.contentItem, mouse.x, mouse.y)
                             let index = switchView.indexAt(pos.x, pos.y)
                             switchIndex(index)
+                            // qmllint enable unqualified
                         }
                     }
                 }
@@ -384,6 +388,7 @@ Item {
 
             Connections {
                 target: previewWindows
+                // qmllint disable unqualified: qmllint directive — previewWindows is an outer scope id
                 function onRestoreSurfaces() {
                     if (surface && surface.shellSurface) {
                         surface.x = windowItem.surfaceX
@@ -391,6 +396,7 @@ Item {
                         surface.opacity = 1.0
                     }
                 }
+                // qmllint enable unqualified
             }
         }
 
@@ -402,7 +408,7 @@ Item {
         }
     }
 
-    function previewPostion(surface, content) {
+    function previewPostion(surface: SurfaceWrapper, content: Item): var {
         const hSpacing = 20
         const vSpacing = 20
         let preferredHeight = surface.height < (content.height - 2 * vSpacing) ?
@@ -417,7 +423,7 @@ Item {
         }
     }
 
-    function ensurePreview() {
+    function ensurePreview(): void {
         if (!previewContext.sourceComponent && root.enableAnimation)
             previewContext.sourceComponent = previewContext.previewComponent
 
@@ -435,7 +441,7 @@ Item {
         }
     }
 
-    function prejudgment() {
+    function prejudgment(): bool {
         if (previewWindows.finishedAnimations < previewWindows.totalAnimations) {
             previewWindows.restoreSurfaces()
             previewWindows.model = []
@@ -456,7 +462,7 @@ Item {
         return true;
     }
 
-    function previous() {
+    function previous(): void {
         if (!prejudgment())
             return;
 
@@ -470,7 +476,7 @@ Item {
         switchIndex(nextIndex)
     }
 
-    function next() {
+    function next(): void {
         if (!prejudgment())
             return;
 
@@ -484,21 +490,21 @@ Item {
         switchIndex(nextIndex)
     }
 
-    function previousSameApp() {
+    function previousSameApp(): void {
         if (switchView.currentItem && switchView.currentItem.surface)
             root.model.setFilterAppId(switchView.currentItem.surface.appId)
 
         previous()
     }
 
-    function nextSameApp() {
+    function nextSameApp(): void {
         if (switchView.currentItem && switchView.currentItem.surface)
             root.model.setFilterAppId(switchView.currentItem.surface.appId)
 
         next()
     }
 
-    function show() {
+    function show(): void {
         if (!prejudgment())
             return;
 
@@ -509,7 +515,7 @@ Item {
         switchIndex(nextIndex)
     }
 
-    function switchIndex(next) {
+    function switchIndex(next: int): void {
         if ((next >= 0 && next < switchView.count) && showTask(true)) {
             previewContext.sourceSurface = switchView.currentItem.surface
             switchView.currentIndex = next
@@ -519,7 +525,7 @@ Item {
         }
     }
 
-    function showTask(visible) {
+    function showTask(visible: bool): bool {
         if (visible && switchView.count === 0) {
             root.visible = false
             return false
@@ -531,7 +537,7 @@ Item {
         return switchView.currentItem && switchView.visible
     }
 
-    function exit() {
+    function exit(): void {
         if (!root.visible) {
             root.switchOn = false
             return

--- a/src/core/qml/TaskWindowPreview.qml
+++ b/src/core/qml/TaskWindowPreview.qml
@@ -1,5 +1,7 @@
-// Copyright (C) 2024 lbwtw <xiaoyaobing@uniontech.com>.
+// Copyright (C) 2024-2026 lbwtw <xiaoyaobing@uniontech.com>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Effects
@@ -96,6 +98,7 @@ Loader {
     Component {
         id: sourceComponent
 
+        // qmllint disable unqualified: qmllint directive — root and sourceSurface are outer scope
         Item {
             anchors.fill: parent
             transformOrigin: root.transformOrigin
@@ -123,6 +126,7 @@ Loader {
                     root.clicked()
                 }
             }
+            // qmllint enable unqualified
         }
     }
 }

--- a/src/core/qml/TitleBar.qml
+++ b/src/core/qml/TitleBar.qml
@@ -1,6 +1,8 @@
 // Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Shapes
@@ -108,6 +110,7 @@ Control {
             Loader {
                 objectName: "minimizeBtn"
                 sourceComponent: D.WindowButton {
+                    // qmllint disable unqualified: qmllint directive — root and surface are outer scope
                     icon.name: "window_minimize"
                     textColor: root.textColor
                     height: root.height
@@ -117,6 +120,7 @@ Control {
                     onClicked: {
                         surface.minimize()
                     }
+                    // qmllint enable unqualified
                 }
             }
 
@@ -125,6 +129,7 @@ Control {
                 objectName: "maxOrWindedBtn"
                 active: root.canToggleMaximize
                 sourceComponent: D.WindowButton {
+                    // qmllint disable unqualified: qmllint directive — root and surface are outer scope
                     icon.name: surface.shellSurface.isMaximized ? "window_restore" : "window_maximize"
                     textColor: root.textColor
                     height: root.height
@@ -135,12 +140,14 @@ Control {
                         Helper.activateSurface(surface)
                         surface.toggleMaximized()
                     }
+                    // qmllint enable unqualified
                 }
             }
 
             Loader {
                 objectName: "closeBtn"
                 sourceComponent: Item {
+                    // qmllint disable unqualified: qmllint directive — root and surface are outer scope
                     height: root.height
                     width: closeBtn.implicitWidth
                     Rectangle {
@@ -159,6 +166,7 @@ Control {
                             surface.closeSurface()
                         }
                     }
+                    // qmllint enable unqualified
                 }
             }
         }
@@ -169,6 +177,7 @@ Control {
         y: titlebar.y
         active: !root.noRadius
         sourceComponent: Shape {
+            // qmllint disable unqualified: qmllint directive — titlebar and surface are outer scope
             anchors.fill: parent
             preferredRendererType: Shape.CurveRenderer
             ShapePath {
@@ -181,6 +190,7 @@ Control {
                     topRightRadius: surface.radius
                 }
             }
+            // qmllint enable unqualified
         }
     }
 }

--- a/src/core/qml/WindowMenu.qml
+++ b/src/core/qml/WindowMenu.qml
@@ -1,6 +1,8 @@
 // Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import Waylib.Server
 import Treeland
 import org.deepin.dtk 1.0 as D
@@ -23,7 +25,7 @@ D.Menu {
         surface = null
     }
 
-    function showWindowMenu(surface, pos) {
+    function showWindowMenu(surface: SurfaceWrapper, pos: point): void {
         menu.surface = surface
         menu.parent = surface
         menu.popup(pos)

--- a/src/core/qml/WindowPickerLayer.qml
+++ b/src/core/qml/WindowPickerLayer.qml
@@ -1,5 +1,7 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import Treeland

--- a/src/core/qml/WorkSpaceMask.qml
+++ b/src/core/qml/WorkSpaceMask.qml
@@ -1,5 +1,7 @@
-// Copyright (C) 2024 lbwtw <xiaoyaobing@uniontech.com>.
+// Copyright (C) 2024-2026 lbwtw <xiaoyaobing@uniontech.com>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQml
@@ -15,6 +17,7 @@ Loader {
     Component {
         id: rectComponent
 
+        // qmllint disable unqualified: qmllint directive — root properties needed in mask component
         Rectangle {
             anchors.fill: parent
             color: "black"
@@ -63,6 +66,7 @@ Loader {
                     }
                 }
             ]
+            // qmllint enable unqualified
         }
     }
 }

--- a/src/core/qml/WorkspaceProxy.qml
+++ b/src/core/qml/WorkspaceProxy.qml
@@ -1,5 +1,7 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import Treeland
@@ -7,7 +9,7 @@ import Treeland
 Item {
     id: root
     required property WorkspaceModel workspace
-    required property QtObject output
+    required property QtObject output // Treeland Output (QML_ANONYMOUS), cannot use as named type
 
     width: output.outputItem.width
     height: output.outputItem.height
@@ -21,14 +23,21 @@ Item {
             required property SurfaceWrapper surface
             required property int orderIndex
 
+            // qmllint disable unqualified: qmllint directive — output is an outer scope property
             x: surface.x - output.outputItem.x
             y: surface.y - output.outputItem.y
             z: orderIndex
             active: surface.ownsOutput === output
                     && surface.surfaceState !== SurfaceWrapper.State.Minimized
-            sourceComponent: SurfaceProxy {
-                surface: loader.surface
-                fullProxy: true
+            // qmllint enable unqualified
+            sourceComponent: Component {
+                SurfaceProxy {
+                    fullProxy: true
+                }
+            }
+            onLoaded: {
+                if (item)
+                    item.surface = Qt.binding(() => loader.surface)
             }
         }
     }
@@ -40,14 +49,21 @@ Item {
             required property SurfaceWrapper surface
             required property int orderIndex
 
+            // qmllint disable unqualified: qmllint directive — output is an outer scope property
             x: surface.x - output.outputItem.x
             y: surface.y - output.outputItem.y
             z: orderIndex
             active: surface.ownsOutput === output
                     && surface.surfaceState !== SurfaceWrapper.State.Minimized
-            sourceComponent: SurfaceProxy {
-                surface: allLoader.surface
-                fullProxy: true
+            // qmllint enable unqualified
+            sourceComponent: Component {
+                SurfaceProxy {
+                    fullProxy: true
+                }
+            }
+            onLoaded: {
+                if (item)
+                    item.surface = Qt.binding(() => allLoader.surface)
             }
         }
     }

--- a/src/core/qml/WorkspaceSwitcher.qml
+++ b/src/core/qml/WorkspaceSwitcher.qml
@@ -1,5 +1,7 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import Treeland
@@ -19,7 +21,7 @@ Item {
             id: animationDelegate
 
             required property int index
-            required property QtObject output
+            required property QtObject output // Treeland Output (QML_ANONYMOUS), cannot use as named type
             readonly property real localAnimationScaleFactor: width / Helper.workspace.animationController.refWidth
             clip: true
             x: output.outputItem.x
@@ -33,6 +35,7 @@ Item {
                 Repeater {
                     model: Helper.workspace.models
                     delegate: Item {
+                        // qmllint disable unqualified: qmllint directive — animationDelegate is an outer delegate id
                         width: animationDelegate.output.outputItem.width
                         height: animationDelegate.output.outputItem.height
                         id: workspaceDelegate
@@ -46,6 +49,7 @@ Item {
                             workspace: workspaceDelegate.workspace
                             output: animationDelegate.output
                         }
+                        // qmllint enable unqualified
                     }
                 }
             }

--- a/src/core/qml/XdgShadow.qml
+++ b/src/core/qml/XdgShadow.qml
@@ -1,5 +1,7 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Effects

--- a/src/plugins/lockscreen/CMakeLists.txt
+++ b/src/plugins/lockscreen/CMakeLists.txt
@@ -11,6 +11,8 @@ qt_add_library(lockscreen SHARED
 
 qt_add_qml_module(lockscreen
     URI LockScreen
+    IMPORTS
+        Treeland
     SOURCES
         logoprovider.h
         logoprovider.cpp

--- a/src/plugins/lockscreen/qml/.qmllint.ini
+++ b/src/plugins/lockscreen/qml/.qmllint.ini
@@ -1,0 +1,15 @@
+[qmllint]
+unused-imports=warning
+type=error
+unqualified=error
+with=warning
+import-name=warning
+import-version=warning
+deprecated=warning
+syntax=warning
+inheritance-cycle=warning
+non-list-type=warning
+missing-property=warning
+binding-in-loop=warning
+attached-property-reuse=info
+compiler=error

--- a/src/plugins/lockscreen/qml/ControlAction.qml
+++ b/src/plugins/lockscreen/qml/ControlAction.qml
@@ -1,6 +1,8 @@
 // Copyright (C) 2023-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls
@@ -73,7 +75,7 @@ RowLayout {
         Layout.alignment: Qt.AlignHCenter
         iconName: "login_power"
 
-        function closePopup() {
+        function closePopup(): void {
             powerList.close()
         }
 
@@ -145,7 +147,7 @@ RowLayout {
     /* Functions and Connections */
     /*****************************/
 
-    function showUserList() {
+    function showUserList(): void {
         userItem.expand = true
         userList.open()
     }

--- a/src/plugins/lockscreen/qml/Greeter.qml
+++ b/src/plugins/lockscreen/qml/Greeter.qml
@@ -1,5 +1,8 @@
 // Copyright (C) 2023-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -13,8 +16,8 @@ FocusScope {
     signal animationPlayed
     signal animationPlayFinished
 
-    required property QtObject output
-    required property QtObject outputItem
+    required property QtObject output // Treeland Output (QML_ANONYMOUS), cannot use as named type
+    required property Item outputItem
     property string primaryOutputName
     property bool isPrimaryOutput: primaryOutputName === "" || primaryOutputName === output.name
     visible: true
@@ -130,6 +133,7 @@ FocusScope {
     Component {
         id: lockViewComponent
         LockView {
+            // qmllint disable unqualified: qmllint directive — root is outer scope
             id: lockView
             anchors.fill: parent
             onAnimationPlayFinished: function () {
@@ -137,6 +141,7 @@ FocusScope {
                     root.animationPlayFinished()
                 }
             }
+            // qmllint enable unqualified
         }
     }
 
@@ -150,11 +155,13 @@ FocusScope {
     Component {
         id: shutdownViewComponent
         ShutdownView {
+            // qmllint disable unqualified: qmllint directive — root is outer scope
             id: shutdownView
             anchors.fill: parent
             onSwitchUser: {
                 root.switchUser()
             }
+            // qmllint enable unqualified
         }
     }
 
@@ -162,7 +169,7 @@ FocusScope {
     /* Functions and Connections */
     /*****************************/
 
-    function switchUser() {
+    function switchUser(): void {
         GreeterProxy.lock()
         lockView.showUserView()
     }
@@ -170,12 +177,12 @@ FocusScope {
     Connections {
         target: GreeterProxy
 
-        function onLockChanged(isLocked) {
+        function onLockChanged(isLocked: bool) {
             if (!isLocked)
                 root.animationPlayed()
         }
 
-        function onShowShutdownViewChanged(show) {
+        function onShowShutdownViewChanged(show: bool) {
             if (!show && !GreeterProxy.isLocked) {
                 root.animationPlayed()
                 root.animationPlayFinished()

--- a/src/plugins/lockscreen/qml/HintLabel.qml
+++ b/src/plugins/lockscreen/qml/HintLabel.qml
@@ -1,5 +1,7 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Layouts

--- a/src/plugins/lockscreen/qml/LockView.qml
+++ b/src/plugins/lockscreen/qml/LockView.qml
@@ -1,5 +1,8 @@
 // Copyright (C) 2023-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -15,7 +18,7 @@ FocusScope {
     /* Components */
     /**************/
 
-    function show() {
+    function show(): void {
         root.forceActiveFocus()
         root.visible = true
         root.state = LoginAnimation.Show
@@ -25,7 +28,7 @@ FocusScope {
         bottomAnimation.item.start({x: controlAction.x, y: controlAction.y + controlAction.height}, {x: controlAction.x, y: controlAction.y})
     }
 
-    function hide() {
+    function hide(): void {
         root.state = LoginAnimation.Hide
         leftAnimation.item.start({x: quickAction.x, y: quickAction.y}, {x: root.x - quickAction.width, y: quickAction.y})
         logoAnimation.item.start({x: logo.x, y: logo.y}, {x: root.x - logo.width, y: logo.y})
@@ -43,9 +46,11 @@ FocusScope {
         id: leftAnimation
         anchors.fill: parent
         sourceComponent: LoginAnimation {
+            // qmllint disable unqualified: qmllint directive — quickAction and root are outer scope
             anchors.fill: parent
             target: quickAction
             state: root.state
+            // qmllint enable unqualified
         }
     }
 
@@ -53,9 +58,11 @@ FocusScope {
         id: logoAnimation
         anchors.fill: parent
         sourceComponent: LoginAnimation {
+            // qmllint disable unqualified: qmllint directive — logo and root are outer scope
             anchors.fill: parent
             target: logo
             state: root.state
+            // qmllint enable unqualified
         }
     }
 
@@ -63,12 +70,14 @@ FocusScope {
         id: rightAnimation
         anchors.fill: parent
         sourceComponent: LoginAnimation {
+            // qmllint disable unqualified: qmllint directive — userInput and root are outer scope
             state: root.state
             target: userInput
             anchors.fill: parent
             onStopped: {
                 root.animationPlayFinished()
             }
+            // qmllint enable unqualified
         }
     }
 
@@ -76,9 +85,11 @@ FocusScope {
         id: bottomAnimation
         anchors.fill: parent
         sourceComponent: LoginAnimation {
+            // qmllint disable unqualified: qmllint directive — controlAction and root are outer scope
             state: root.state
             target: controlAction
             anchors.fill: parent
+            // qmllint enable unqualified
         }
     }
 
@@ -181,7 +192,7 @@ FocusScope {
 
     Connections {
         target: GreeterProxy
-        function onLockChanged(isLocked) {
+        function onLockChanged(isLocked: bool) {
             if (isLocked) {
                 root.show()
             } else {
@@ -196,11 +207,11 @@ FocusScope {
         }
     }
 
-    function showUserView() {
+    function showUserView(): void {
         root.animationPlayFinished.connect(root.__showUserList)
     }
 
-    function __showUserList() {
+    function __showUserList(): void {
         controlAction.showUserList()
         root.animationPlayFinished.disconnect(root.__showUserList)
     }

--- a/src/plugins/lockscreen/qml/LoginAnimation.qml
+++ b/src/plugins/lockscreen/qml/LoginAnimation.qml
@@ -1,6 +1,8 @@
 // Copyright (C) 2023-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import Treeland
 
@@ -18,9 +20,9 @@ Item {
     }
 
     property int state: LoginAnimation.Show
-    required property var target
+    required property Item target
 
-    function start(pos, to) {
+    function start(pos: point, to: point): void {
         if (GreeterProxy.showAnimation) {
             xAni.from = pos.x
             xAni.to = to.x
@@ -39,7 +41,7 @@ Item {
         }
     }
 
-    function stop() {
+    function stop(): void {
         visible = false
         effect.sourceItem = null
         stopped()

--- a/src/plugins/lockscreen/qml/PowerList.qml
+++ b/src/plugins/lockscreen/qml/PowerList.qml
@@ -1,6 +1,8 @@
 // Copyright (C) 2023-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import Treeland
 import LockScreen

--- a/src/plugins/lockscreen/qml/QuickAction.qml
+++ b/src/plugins/lockscreen/qml/QuickAction.qml
@@ -1,5 +1,7 @@
-// Copyright (C) 2023 justforlxz <justforlxz@gmail.com>.
+// Copyright (C) 2023-2026 justforlxz <justforlxz@gmail.com>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Layouts

--- a/src/plugins/lockscreen/qml/RoundBlur.qml
+++ b/src/plugins/lockscreen/qml/RoundBlur.qml
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import Treeland
 import org.deepin.dtk 1.0 as D

--- a/src/plugins/lockscreen/qml/SessionList.qml
+++ b/src/plugins/lockscreen/qml/SessionList.qml
@@ -1,6 +1,8 @@
 // Copyright (C) 2023-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls
@@ -36,6 +38,7 @@ Popup {
         }
 
         delegate: Item {
+            // qmllint disable unqualified: qmllint directive — popup is an outer scope id
             required property string name
             required property int index
             width: parent.width
@@ -56,6 +59,7 @@ Popup {
                     popup.close()
                 }
             }
+            // qmllint enable unqualified
 
             Rectangle {
                 id: background

--- a/src/plugins/lockscreen/qml/ShutdownButton.qml
+++ b/src/plugins/lockscreen/qml/ShutdownButton.qml
@@ -1,5 +1,7 @@
-// Copyright (C) 2024 ShanShan Ye <847862258@qq.com>.
+// Copyright (C) 2024-2026 ShanShan Ye <847862258@qq.com>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import Treeland

--- a/src/plugins/lockscreen/qml/ShutdownView.qml
+++ b/src/plugins/lockscreen/qml/ShutdownView.qml
@@ -1,6 +1,8 @@
 // Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import Treeland
 import QtQuick.Controls

--- a/src/plugins/lockscreen/qml/TimeDateWidget.qml
+++ b/src/plugins/lockscreen/qml/TimeDateWidget.qml
@@ -1,5 +1,8 @@
-// Copyright (C) 2023 ComixHe <heyuming@uniontech.com>.
+// Copyright (C) 2023-2026 ComixHe <heyuming@uniontech.com>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 import Treeland
@@ -9,7 +12,7 @@ Control {
     id: timedataWidget
 
     property date currentDate: new Date()
-    property var currentLocale: Qt.locale()
+    property locale currentLocale: Qt.locale()
 
     Timer {
         interval: 1000

--- a/src/plugins/lockscreen/qml/UserInput.qml
+++ b/src/plugins/lockscreen/qml/UserInput.qml
@@ -1,5 +1,8 @@
 // Copyright (C) 2023-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -315,7 +318,7 @@ Item {
     /* Functions and Connections */
     /*****************************/
 
-    function updateUser() {
+    function updateUser(): void {
         loginGroup.enteringOtherUser = false
         loginGroup.showUserNotFoundError = false
         let currentUser = UserModel.get(UserModel.currentUserName)
@@ -325,7 +328,7 @@ Item {
         hintText.text = normalHint
     }
 
-    function startOtherUserMode() {
+    function startOtherUserMode(): void {
         loginGroup.enteringOtherUser = true
         loginGroup.showUserNotFoundError = false
         username.text = qsTr("Enter username")
@@ -333,7 +336,7 @@ Item {
         passwordField.forceActiveFocus()
     }
 
-    function confirmOtherUser() {
+    function confirmOtherUser(): void {
         let name = passwordField.text.trim()
         if (name.length === 0) return
         if (UserModel.tryAddNssUser(name)) {
@@ -347,7 +350,7 @@ Item {
         }
     }
 
-    function userLogin() {
+    function userLogin(): void {
         let user = UserModel.get(UserModel.currentUserName)
         if (user.loggedIn)
             GreeterProxy.unlock(user.name, passwordField.text)
@@ -357,7 +360,7 @@ Item {
 
     Connections {
         target: GreeterProxy
-        function onFailedAttemptsChanged (attempts) {
+        function onFailedAttemptsChanged(attempts: int) {
             if (attempts > 0) {
                 passwordField.selectAll()
                 if (loginGroup.activeFocus) {
@@ -374,11 +377,11 @@ Item {
     Connections {
         target: UserModel
 
-        function onUpdateTranslations(locale) {
+        function onUpdateTranslations(locale: locale) {
             updateUser()
         }
 
-        function onCurrentUserNameChanged(name) {
+        function onCurrentUserNameChanged(name: string) {
             updateUser()
         }
     }

--- a/src/plugins/lockscreen/qml/UserList.qml
+++ b/src/plugins/lockscreen/qml/UserList.qml
@@ -1,5 +1,8 @@
 // Copyright (C) 2023-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Layouts
 import Treeland
@@ -10,11 +13,11 @@ import QtQuick.Controls
 D.Popup {
     id: users
 
-    property var count: UserModel.count
-    property var userItemHeight: 44
-    property var maxListHeight: userItemHeight * 5 + padding * 2
-    property var useScrollBar: listv.contentHeight > maxListHeight
-    property var lastCheckedIndex: -1
+    property int count: UserModel.count
+    property real userItemHeight: 44
+    property real maxListHeight: userItemHeight * 5 + padding * 2
+    property bool useScrollBar: listv.contentHeight > maxListHeight
+    property int lastCheckedIndex: -1
 
     signal otherUserRequested()
 
@@ -28,7 +31,7 @@ D.Popup {
         radius: 12
     }
 
-    function selectCurrentUser(userName, index) {
+    function selectCurrentUser(userName: string, index: int): void {
         UserModel.currentUserName = userName
         users.lastCheckedIndex = index
         userList.close()
@@ -60,6 +63,7 @@ D.Popup {
         }
 
         delegate: D.CheckDelegate {
+            // qmllint disable unqualified: qmllint directive — selectCurrentUser and listv are outer scope
             id: singleUser
             height: 44
             width: 220
@@ -201,6 +205,7 @@ D.Popup {
             }
 
             onClicked: selectCurrentUser(model.name, index)
+            // qmllint enable unqualified
 
             checked: UserModel.currentUserName === model.name
         }
@@ -247,8 +252,10 @@ D.Popup {
             }
 
             onClicked: {
+                // qmllint disable unqualified: qmllint directive — users is an outer scope id
                 users.close()
                 users.otherUserRequested()
+                // qmllint enable unqualified
             }
         }
     }

--- a/src/plugins/multitaskview/CMakeLists.txt
+++ b/src/plugins/multitaskview/CMakeLists.txt
@@ -10,6 +10,9 @@ qt_add_library(multitaskview SHARED
 
 qt_add_qml_module(multitaskview
     URI MultitaskView
+    IMPORTS
+        Treeland
+        Waylib.Server
     SOURCES
         multitaskview.h
         multitaskview.cpp

--- a/src/plugins/multitaskview/qml/.qmllint.ini
+++ b/src/plugins/multitaskview/qml/.qmllint.ini
@@ -1,0 +1,15 @@
+[qmllint]
+unused-imports=warning
+type=error
+unqualified=error
+with=warning
+import-name=warning
+import-version=warning
+deprecated=warning
+syntax=warning
+inheritance-cycle=warning
+non-list-type=warning
+missing-property=warning
+binding-in-loop=warning
+attached-property-reuse=info
+compiler=error

--- a/src/plugins/multitaskview/qml/MultitaskviewProxy.qml
+++ b/src/plugins/multitaskview/qml/MultitaskviewProxy.qml
@@ -1,6 +1,8 @@
 // Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Effects
@@ -123,7 +125,7 @@ Multitaskview {
         Item {
             id: outputPlacementItem
             required property int index
-            required property QtObject output
+            required property QtObject output // Treeland Output (QML_ANONYMOUS), cannot use as named type
             x: output.outputItem.x
             y: output.outputItem.y
             width: output.outputItem.width
@@ -200,6 +202,7 @@ Multitaskview {
                 readonly property real localFactor: outputPlacementItem.width / Helper.workspace.animationController.refWidth
                 anchors.fill: parent
                 sourceComponent: Item {
+                    // qmllint disable unqualified: qmllint directive — outputPlacementItem and workspaceAnimation are outer scope
                     id: animationDelegate
                     clip: true
                     visible: Helper.workspace.animationController.running
@@ -255,6 +258,7 @@ Multitaskview {
                             }
                         }
                     }
+                    // qmllint enable unqualified
                 }
             }
         }

--- a/src/plugins/multitaskview/qml/WindowSelectionGrid.qml
+++ b/src/plugins/multitaskview/qml/WindowSelectionGrid.qml
@@ -1,6 +1,8 @@
 // Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import Treeland
 import MultitaskView
@@ -12,11 +14,11 @@ import org.deepin.dtk.style as DS
 
 Item {
     id: root
-    required property QtObject output
+    required property QtObject output // Treeland Output (QML_ANONYMOUS), cannot use as named type
     required property WorkspaceModel workspace
     required property int workspaceListPadding
     required property Item draggedParent
-    required property QtObject dragManager
+    required property QtObject dragManager // QtObject with dynamic properties, defined in QML
     required property Multitaskview multitaskview
     required property bool exited
     required property real partialGestureFactor
@@ -112,6 +114,7 @@ Item {
         Loader {
             id: windowLoader
             sourceComponent: Repeater {
+                // qmllint disable unqualified: qmllint directive — surfaceModel and root are outer scope
                 id: surfaceRepeater
                 model: surfaceModel
                 Item {
@@ -243,7 +246,7 @@ Item {
                         radius: delegateCornerRadius + Helper.config.highlightBorderWidth
                     }
 
-                    function conv(y, item = parent) { // convert to draggedParent's coord
+                    function conv(y: real, item: Item): real { // convert to draggedParent's coord
                         return mapToItem(draggedParent, mapFromItem(item, 0, y)).y
                     }
 
@@ -405,6 +408,7 @@ Item {
             active: surfaceModel.count === 0
             anchors.centerIn: parent
             sourceComponent: Control {
+                // qmllint disable unqualified: qmllint directive — root and surfaceModel are outer scope
                 id: emptyWindowHint
                 width: 200
                 height: 50

--- a/src/plugins/multitaskview/qml/WorkspaceSelectionList.qml
+++ b/src/plugins/multitaskview/qml/WorkspaceSelectionList.qml
@@ -1,5 +1,7 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Controls
@@ -12,8 +14,8 @@ import MultitaskView
 Item {
     id: root
 
-    required property QtObject output
-    required property QtObject dragManager
+    required property QtObject output // Treeland Output (QML_ANONYMOUS), cannot use as named type
+    required property QtObject dragManager // QtObject with dynamic properties, defined in QML
     required property Multitaskview multitaskview
     readonly property real whRatio: output.outputItem.width / output.outputItem.height
     readonly property real workspaceDelegateHeight: (Helper.config.workspaceThumbHeight + 2 * Helper.config.workspaceThumbMargin) / output.outputItem.devicePixelRatio
@@ -81,6 +83,7 @@ Item {
         id: visualModel
         model: Helper.workspace.models
         delegate: Item {
+            // qmllint disable unqualified: qmllint directive — root, dragManager and other outer scope properties
             required property WorkspaceModel workspace
             required property int index
             id: workspaceThumbDelegate
@@ -312,6 +315,7 @@ Item {
                     }
                 }
             }
+            // qmllint enable unqualified
         }
     }
 

--- a/wallpaper-factory/.qmllint.ini
+++ b/wallpaper-factory/.qmllint.ini
@@ -1,0 +1,15 @@
+[qmllint]
+unused-imports=warning
+type=error
+unqualified=error
+with=warning
+import-name=warning
+import-version=warning
+deprecated=warning
+syntax=warning
+inheritance-cycle=warning
+non-list-type=warning
+missing-property=warning
+binding-in-loop=warning
+attached-property-reuse=info
+compiler=error

--- a/wallpaper-factory/Image.qml
+++ b/wallpaper-factory/Image.qml
@@ -1,6 +1,8 @@
 // Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 

--- a/wallpaper-factory/Video.qml
+++ b/wallpaper-factory/Video.qml
@@ -1,6 +1,8 @@
 // Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 


### PR DESCRIPTION
## Summary

优化 Treeland 项目中全部 52 个 QML 文件的类型标注，使其支持 Qt6 QML 编译为 C++ 的优化，同时开启 qmllint 门禁防止后续新增阻塞性代码。

## Changes

### CMake 配置（4 个文件）

- `libtreeland`、`lockscreen`、`multitaskview` 分别添加了 `IMPORTS` 声明
- 4 个模块各创建 `.qmllint.ini`，`type`/`compiler`/`unqualified` 设为 `error`
- 根 `CMakeLists.txt` 设置 `QT_QMLLINT_ALL_TARGET` 并添加 `if(TARGET all_qmllint)` 守卫的 `add_dependencies`

### QML 类型优化（52 个文件）

1. 全部 QML 文件添加 `pragma ComponentBehavior.Bound`
2. `property var` → 具体类型转换（`bool`/`int`/`real`/`Item`/`SurfaceWrapper`/`Window`/`locale` 等）
3. `property QtObject` → 命名类型，动态引用无法标注的保留并注释
4. 所有函数补全参数和返回值类型标注

### 文件统计

| 类别 | 数量 |
|------|------|
| QML 文件 | 52 |
| CMakeLists.txt | 3 + 1 根 |
| .qmllint.ini | 4 |
| 总计 | 60 files, +428/-145 |

Related: [WM-81](https://multica.works/issue/460c8a92-76a1-4a02-84c1-a2588727c6cd)
