### PR TITLE
fix(activation): pass seat through activation pipeline for multi-seat

### DIFF
--- a/src/modules/activation/activationmanagerinterfacev1.cpp
+++ b/src/modules/activation/activationmanagerinterfacev1.cpp
@@ -120,6 +120,7 @@ struct TokenInfo
     std::optional<uint32_t> serial;
     bool fromTrustedSurface = false; // set_surface called and surface was active at commit time
     QDeadlineTimer expiry;           // invalidated 60 s after registration
+    QPointer<WSeat> seat;            // seat associated with the token via set_serial
 };
 
 class ActivationManagerInterfaceV1Private
@@ -146,11 +147,12 @@ public:
     QString registerToken(const QString &appId,
                           wl_client *client,
                           std::optional<uint32_t> serial,
-                          bool fromTrustedSurface)
+                          bool fromTrustedSurface,
+                          WSeat *seat)
     {
         const QString token = QUuid::createUuid().toString(QUuid::WithoutBraces);
         m_tokens.append(TokenInfo{ token, appId, client, serial, fromTrustedSurface,
-                                   QDeadlineTimer(TokenLifetimeMs) });
+                                   QDeadlineTimer(TokenLifetimeMs), seat });
         qCDebug(lcTlActivation) << "Registered activation token" << token.left(8) + u"..."_s
                                << "for app" << appId
                                << (fromTrustedSurface ? "" : "(inactive-surface-token-request)");
@@ -208,16 +210,18 @@ protected:
         }
 
         auto disposition = dispositionForToken(token);
-        qCInfo(lcTlActivation) << "activate: emitting activateRequested for token" << token.left(8) + u"..."_s
-                             << "with disposition" << disposition;
-        // Keep token one-shot semantics; Helper performs the policy check.
+        // Retrieve the seat associated with the token before consuming it.
+        WSeat *tokenSeat = nullptr;
         auto it = std::find_if(m_tokens.begin(), m_tokens.end(),
                                [&token](const TokenInfo &t) { return t.token == token; });
         if (it != m_tokens.end()) {
+            tokenSeat = it->seat.data();
             m_tokens.erase(it);
         }
-        
-        Q_EMIT q->activateRequested(disposition, wsurface);
+
+        qCInfo(lcTlActivation) << "activate: emitting activateRequested for token" << token.left(8) + u"..."_s
+                             << "with disposition" << disposition;
+        Q_EMIT q->activateRequested(disposition, wsurface, tokenSeat);
     }
 
 private:
@@ -284,7 +288,7 @@ void TokenContext::commit(Resource *resource)
 
     // fromTrustedSurface: set_surface was called, surface still alive, and currently active
     const bool fromTrustedSurface = m_surface && m_manager->isTrustedSurface(m_surface, m_seat);
-    const QString token = m_manager->registerToken(m_appId, resource->client(), m_serial, fromTrustedSurface);
+    const QString token = m_manager->registerToken(m_appId, resource->client(), m_serial, fromTrustedSurface, m_seat);
     send_done(token);
 }
 

--- a/src/modules/activation/activationmanagerinterfacev1.h
+++ b/src/modules/activation/activationmanagerinterfacev1.h
@@ -41,7 +41,8 @@ public:
 Q_SIGNALS:
     // The server emits one signal with precomputed disposition for policy handling.
     void activateRequested(TokenDisposition disposition,
-                           WAYLIB_SERVER_NAMESPACE::WSurface *surface);
+                           WAYLIB_SERVER_NAMESPACE::WSurface *surface,
+                           WAYLIB_SERVER_NAMESPACE::WSeat *seat);
 
 protected:
     void create(WAYLIB_SERVER_NAMESPACE::WServer *server) override;

--- a/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
+++ b/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
@@ -456,8 +456,7 @@ void ForeignToplevelManagerInterfaceV1::initializeToplevelHandle(SurfaceWrapper 
     });
 
     connect(handle, &ForeignToplevelHandleV1::requestActivate, wrapper, [wrapper](WSeat *seat) {
-        Q_UNUSED(seat);
-        Helper::instance()->forceActivateSurface(wrapper);
+        Helper::instance()->forceActivateSurface(wrapper, Qt::OtherFocusReason, seat);
     });
 
     connect(handle,

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1742,7 +1742,7 @@ void Helper::init(Treeland::Treeland *treeland)
     connect(m_activationManagerV1,
             &ActivationManagerInterfaceV1::activateRequested,
             this,
-            [this](ActivationManagerInterfaceV1::TokenDisposition disposition, WSurface *wsurface) {
+            [this](ActivationManagerInterfaceV1::TokenDisposition disposition, WSurface *wsurface, WSeat *seat) {
                 auto wrapper = m_rootSurfaceContainer->getSurface(wsurface);
                 if (!wrapper) {
                     qCWarning(lcTlCore) << "Activation request for unknown surface!";
@@ -1761,8 +1761,7 @@ void Helper::init(Treeland::Treeland *treeland)
                 }
                 switch (disposition) {
                 case ActivationManagerInterfaceV1::TokenDisposition::Active:
-                    // TODO: activate the surface on the seat associated with the token
-                    forceActivateSurface(wrapper, Qt::OtherFocusReason);
+                    forceActivateSurface(wrapper, Qt::OtherFocusReason, seat);
                     break;
                 case ActivationManagerInterfaceV1::TokenDisposition::Attention:
                     wrapper->setAttention(true);


### PR DESCRIPTION
Propagate the seat associated with xdg_activation_token (set via set_serial) through the activateRequested signal so that consumers can activate surfaces on the correct seat. Also forward the seat from ForeignToplevelHandleV1::requestActivate.

将 xdg_activation_token 关联的 seat 通过 activateRequested 信号 传递，使消费者能在正确的 seat 上激活 surface。同时转发
ForeignToplevelHandleV1::requestActivate 中的 seat。

Log: 支持多seat场景下的 surface 激活，传递 token 关联的 seat
Issue: Fixes #1110
Influence: 多 seat 环境下，xdg_activation 和 foreign-toplevel 激活请求现在会在正确的 seat 上生效。