### PR TITLE
fix(seat): add keyboardFocusPriority check in setKeyboardFocusSurface

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2410,17 +2410,11 @@ void Helper::requestKeyboardFocus(SurfaceWrapper *wrapper, Qt::FocusReason reaso
     if (!seat)
         seat = m_primarySeat;
 
-    if (wrapper) {
-        wrapper->setFocus(true, reason);
-    }
-    // Old surface focus clearing is delegated to SeatSurfaceManager::setKeyboardFocusSurface,
-    // which handles multi-seat arbitration.
-
-    // Delegate to SeatSurfaceManager which handles Wayland focus, multi-seat arbitration,
-    // and interaction metadata in one place.
+    // Delegate to SeatSurfaceManager which handles keyboardFocusPriority checks,
+    // Qt focus management, Wayland focus, multi-seat arbitration, and interaction metadata.
     auto *seatContainer = m_rootSurfaceContainer->getSeatContainer(seat);
     Q_ASSERT(seatContainer);
-    seatContainer->setKeyboardFocusSurface(wrapper);
+    seatContainer->setKeyboardFocusSurface(wrapper, reason);
 }
 
 void Helper::setCursorPosition(const QPointF &position)
@@ -2739,7 +2733,9 @@ void Helper::setLockScreenImpl(ILockScreen *impl)
         setNoAnimation(false);
 #endif
         if (auto *surface = activatedSurface()) {
-            surface->setFocus(true, Qt::NoFocusReason);
+            if (surface->hasFocusCapability()) {
+                requestKeyboardFocus(surface, Qt::NoFocusReason);
+            }
         }
     });
     if (!impl) {

--- a/src/surface/seatsurfacemanager.cpp
+++ b/src/surface/seatsurfacemanager.cpp
@@ -4,6 +4,7 @@
 #include "seatsurfacemanager.h"
 
 #include "rootsurfacecontainer.h"
+#include "common/treelandlogging.h"
 #include "seat/helper.h"
 #include "seat/seatsmanager.h"
 
@@ -75,13 +76,28 @@ void SeatSurfaceManager::onActivatedSurfaceFocusCapabilityChanged()
     }
 }
 
-void SeatSurfaceManager::setKeyboardFocusSurface(SurfaceWrapper *surface)
+void SeatSurfaceManager::setKeyboardFocusSurface(SurfaceWrapper *surface, Qt::FocusReason reason)
 {
     if (m_keyboardFocusSurface == surface)
         return;
     Q_ASSERT(m_seat && m_seat->nativeHandle());
 
     auto *oldSurface = m_keyboardFocusSurface;
+
+    // Only check priority when transferring focus between two surfaces.
+    // Clearing focus to nullptr (e.g. surfaceDestroyed) must always be allowed.
+    if (oldSurface && surface) {
+        int oldSurfacePriority = oldSurface->shellSurface() ? oldSurface->shellSurface()->keyboardFocusPriority() : 0;
+        int newSurfacePriority = surface->shellSurface() ? surface->shellSurface()->keyboardFocusPriority() : 0;
+        if (oldSurfacePriority > newSurfacePriority) {
+            qCDebug(lcTlShell) << "Keyboard focus rejected: current surface priority"
+                               << oldSurfacePriority
+                               << "> new surface priority"
+                               << newSurfacePriority;
+            return;
+        }
+    }
+
     // Clear focus from old surface if no other seat has it
     if (oldSurface) {
         bool otherSeatHasFocus = false;
@@ -115,11 +131,9 @@ void SeatSurfaceManager::setKeyboardFocusSurface(SurfaceWrapper *surface)
     m_seat->setKeyboardFocusSurface(surface ? surface->surface() : nullptr);
 
     if (surface) {
+        surface->setFocus(true, reason);
         surface->setProperty("lastInteractingSeat", QVariant::fromValue(m_seat));
         surface->setProperty("lastInteractionTime", QDateTime::currentMSecsSinceEpoch());
-
-        // Qt focus is managed by the caller (requestKeyboardFocus or Qt Scene Graph),
-        // only set Wayland keyboard focus here.
     }
 }
 

--- a/src/surface/seatsurfacemanager.h
+++ b/src/surface/seatsurfacemanager.h
@@ -24,7 +24,7 @@ public:
     SurfaceWrapper *activatedSurface() const { return m_activatedSurface; }
     void setActivatedSurface(SurfaceWrapper *surface, Qt::FocusReason reason);
     SurfaceWrapper *keyboardFocusSurface() const { return m_keyboardFocusSurface; }
-    void setKeyboardFocusSurface(SurfaceWrapper *surface);
+    void setKeyboardFocusSurface(SurfaceWrapper *surface, Qt::FocusReason reason = Qt::OtherFocusReason);
 
     struct MoveResizeState {
         SurfaceWrapper *surface = nullptr;  ///< The surface being moved/resized


### PR DESCRIPTION
Prevent low-priority surfaces from stealing keyboard focus from high-priority surfaces (e.g. lock screen, exclusive layer surfaces).

在 setKeyboardFocusSurface 中添加 keyboardFocusPriority 检查， 防止低优先级 surface 抢占高优先级 surface（如锁屏、独占 layer surface） 的键盘焦点。

Log: 修复键盘焦点抢占问题，添加 keyboardFocusPriority 检查
Issue: linuxdeepin/treeland#1110
Influence: 锁屏、exclusive layer surface 等高优先级 surface 的键盘焦点 不再被低优先级 surface 抢占，提升焦点管理安全性。