### PR TITLE
fix(waylib): use notify_* API for keyboard focus operations

### DIFF
--- a/waylib/src/server/kernel/wseat.cpp
+++ b/waylib/src/server/kernel/wseat.cpp
@@ -229,9 +229,9 @@ public:
             // Send keyboard enter with current modifiers.
             // This ensures the newly focused client receives the current modifier state
             // (Num Lock, Caps Lock, etc.) as required by Wayland protocol.
-            handle()->keyboard_enter(*surface, keycodes, numKeycodes, modifiers);
+            handle()->keyboard_notify_enter(*surface, keycodes, numKeycodes, modifiers);
         } else {
-            handle()->keyboard_clear_focus();
+            handle()->keyboard_notify_clear_focus();
         }
     }
     inline void doTouchNotifyDown(WSurface *surface, uint32_t time_msec, int32_t touch_id, const QPointF &pos) {


### PR DESCRIPTION
Use keyboard_notify_enter and keyboard_notify_clear_focus instead of keyboard_enter and keyboard_clear_focus, ensuring keyboard focus events go through the grab system so popup grabs work correctly.

使用 notify_* 系列函数进行键盘焦点操作，确保事件经过
grab 系统，使 popup grab 等机制正常工作。

Log: 修复键盘焦点切换未经过grab系统的问题
Issue: Fixes linuxdeepin/treeland#1110
Influence: 键盘焦点切换现在正确经过grab系统，popup grab等机制可正常拦截和处理焦点变化。

## Summary by Sourcery

Bug Fixes:
- Ensure keyboard focus enter/clear operations go through the grab system to fix incorrect handling of popup grabs and focus changes.