### PR TITLE
fix(workspace): reload workspace config after DConfig initialized

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1502,6 +1502,9 @@ void Helper::init(Treeland::Treeland *treeland)
             syncPaletteTypeWithWindowThemeType(m_config->windowThemeType());
             m_wallpaperManager->updateWallpaperConfig();
             tryInitRemoteSource();
+            //TODO: Isolate workspaces for different users to prevent them from sharing the same one.
+            if (m_userModel->currentUserName() != "dde")
+                m_shellHandler->workspace()->reloadFromConfig();
         };
         // TODO(YaoBing Xiao): pre-initialize dconfig, remove isInitializeSucceeded
 #if TREELANDCONFIG_DCONFIG_FILE_VERSION_MINOR > 0

--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -324,6 +324,28 @@ void Workspace::createSwitcher()
         });
     }
 }
+void Workspace::reloadFromConfig()
+{
+    auto *config = Helper::instance()->config();
+    auto targetCount = static_cast<int>(config->numWorkspace());
+    if (targetCount < 1){
+        targetCount = 1;
+        config->setNumWorkspace(1);
+    }
+    auto targetIndex = static_cast<int>(config->currentWorkspace());
+    
+    for (int need = targetCount - count(); need > 0; --need)
+        doCreateModel(QStringLiteral("workspace-%1").arg(count()), false);
+
+    for (int extra = count() - targetCount; extra > 0; --extra)
+        doRemoveModel(count() - 1);
+
+    if (targetIndex >= count())
+        targetIndex = count() - 1;
+    if (targetIndex < 0)
+        targetIndex = 0;
+    setCurrentIndex(targetIndex);
+}
 
 int Workspace::count() const
 {

--- a/src/workspace/workspace.h
+++ b/src/workspace/workspace.h
@@ -59,6 +59,8 @@ public:
     Q_INVOKABLE WorkspaceModel *modelAt(int index) const;
     Q_INVOKABLE WorkspaceModel *modelFromId(int id) const;
 
+    void reloadFromConfig();
+
     int count() const;
     int currentIndex() const;
     WorkspaceModel *showOnAllWorkspaceModel() const;


### PR DESCRIPTION
Re-read numWorkspace and currentWorkspace from the initialized DConfig object and adjust workspace count and active index accordingly.

DConfig异步初始化完成后，重新读取工作区数量和默认工作区配置，
据此调整工作区数量和活跃索引。

Log: 修复关机重启后工作区数量和默认工作区与关机前不一致
PMS: BUG-335653
Influence: 关机重启后多任务视图中工作区数量和默认工作区恢复为关机前状态。

## Summary by Sourcery

Bug Fixes:
- Ensure workspace count and default active workspace are restored correctly after shutdown and reboot by syncing with the initialized DConfig.