### PR TITLE
fix: allow treeland to start without any users

### DIFF
--- a/src/core/treeland.cpp
+++ b/src/core/treeland.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Dingyuan Zhang <lxz@mkacg.com>.
+// Copyright (C) 2023-2026 Dingyuan Zhang <lxz@mkacg.com>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "treeland.h"
@@ -314,7 +314,10 @@ Treeland::Treeland()
     d->init();
 
     auto globalSession = d->helper->sessionManager()->globalSession();
-    Q_ASSERT(globalSession);
+    if (!globalSession) {
+        qCCritical(lcTlCore) << "Global session is null, skipping initialization";
+        return;
+    }
 
     if (CmdLine::ref().run().has_value()) {
         auto exec = [runCmd = CmdLine::ref().run().value(), d, globalSession] {

--- a/src/greeter/usermodel.cpp
+++ b/src/greeter/usermodel.cpp
@@ -63,7 +63,8 @@ UserModel::UserModel(QObject *parent)
 
     auto userList = d->manager.userList();
     if (!userList) {
-        qFatal() << userList.error();
+        qCWarning(lcTlGreeter) << "Failed to get user list:" << userList.error();
+        return;
     }
 
     const auto uids = userList.value();
@@ -95,8 +96,12 @@ UserModel::UserModel(QObject *parent)
     }
 
     if (d->currentUserName.isEmpty()) {
-        qCWarning(lcTlGreeter) << "Couldn't find last user, using current running user as current user";
-        d->currentUserName = d->users.first()->userName();
+        if (d->users.isEmpty()) {
+            qCWarning(lcTlGreeter) << "No users found, currentUserName remains empty";
+        } else {
+            qCWarning(lcTlGreeter) << "Couldn't find last user, using current running user as current user";
+            d->currentUserName = d->users.first()->userName();
+        }
     }
 }
 

--- a/src/session/session.cpp
+++ b/src/session/session.cpp
@@ -18,6 +18,7 @@
 #include <wxwayland.h>
 
 #include <pwd.h>
+#include <unistd.h>
 #include <xcb/randr.h>
 
 #define _DEEPIN_NO_TITLEBAR "_DEEPIN_NO_TITLEBAR"
@@ -381,8 +382,13 @@ std::shared_ptr<Session> SessionManager::ensureSession(int id, QString username)
     // Session does not exist, create new session with deleter
     auto passwd = getpwnam(username.toLocal8Bit().data());
     if (!passwd) {
-        qCWarning(lcTlCore) << "Failed to get passwd entry for user:" << username;
-        return nullptr;
+        qCWarning(lcTlCore) << "Failed to get passwd entry for user:" << username
+                            << ", falling back to current user uid";
+        passwd = getpwuid(getuid());
+        if (!passwd) {
+            qCCritical(lcTlCore) << "Failed to get passwd entry for current user";
+            return nullptr;
+        }
     }
     auto session = std::make_shared<Session>();
     session->m_id = id;


### PR DESCRIPTION
## Summary

Fix treeland crash when no system users exist. The compositor previously assumed the "dde" user always exists and would crash via assertion, undefined behavior, or qFatal. This PR ensures treeland can start gracefully in the absence of users.

## Changes

1. **session.cpp**: fall back to `getpwuid(getuid())` when `getpwnam("dde")` fails in `ensureSession`, ensuring `globalSession()` is never null
2. **usermodel.cpp**: guard empty user list before calling `.first()` to avoid undefined behavior
3. **usermodel.cpp**: replace `qFatal` with `qCWarning` + early return for graceful D-Bus degradation (Accounts service unavailable)
4. **treeland.cpp**: replace `Q_ASSERT(globalSession)` with a runtime null check

Related: [WM-82](https://multica.cloud/issues/b14d92c7-590d-4044-8fa5-d152e6c7fcfb)

## Summary by Sourcery

Ensure Treeland starts and degrades gracefully when no system users or global session are available.

Bug Fixes:
- Avoid crashing when the Accounts service fails to provide a user list by logging a warning and aborting initialization of the user model.
- Prevent undefined behavior when no users are returned by guarding access to the first user entry.
- Allow session creation to succeed even when the requested username has no passwd entry by falling back to the current process user, while handling failure explicitly.
- Avoid Treeland startup crashes due to a null global session by converting the assert into a runtime check with critical logging and early return.