### PR TITLE
fix(greeter): reconnect to DDM on service changes

### DIFF
--- a/src/greeter/greeterproxy.cpp
+++ b/src/greeter/greeterproxy.cpp
@@ -23,6 +23,7 @@
 #include <QDBusInterface>
 #include <QDBusPendingCall>
 #include <QDBusReply>
+#include <QDBusServiceWatcher>
 #include <QGuiApplication>
 #include <QLocalSocket>
 #include <QScopeGuard>
@@ -91,6 +92,27 @@ GreeterProxy::GreeterProxy(QObject *parent)
     : QObject(parent)
 {
     m_socket = new QLocalSocket(this);
+    auto conn = QDBusConnection::systemBus();
+    auto *displayManagerWatcher =
+        new QDBusServiceWatcher(QStringLiteral("org.deepin.DisplayManager"),
+                                conn,
+                                QDBusServiceWatcher::WatchForRegistration
+                                    | QDBusServiceWatcher::WatchForUnregistration,
+                                this);
+    connect(displayManagerWatcher,
+            &QDBusServiceWatcher::serviceRegistered,
+            this,
+            [this](const QString &) {
+                qCInfo(lcTlGreeter) << "Display manager service registered";
+                updateAuthSocket();
+            });
+    connect(displayManagerWatcher,
+            &QDBusServiceWatcher::serviceUnregistered,
+            this,
+            [this](const QString &) {
+                qCWarning(lcTlGreeter) << "Display manager service unregistered";
+                m_socket->abort();
+            });
 
     // connect signals
     connect(m_socket, &QLocalSocket::connected, this, &GreeterProxy::connected);
@@ -98,7 +120,6 @@ GreeterProxy::GreeterProxy(QObject *parent)
     connect(m_socket, &QLocalSocket::readyRead, this, &GreeterProxy::readyRead);
     connect(m_socket, &QLocalSocket::errorOccurred, this, &GreeterProxy::error);
 
-    auto conn = QDBusConnection::systemBus();
     conn.connect(Logind::serviceName(),
                  Logind::managerPath(),
                  Logind::managerIfaceName(),


### PR DESCRIPTION
Watch the display manager D-Bus lifecycle. Close the stale authentication socket when the service disappears and refresh AuthInfo using the existing connection path when it returns.

Log: DDM 成功重启后，旧认证 socket 会失效。Treeland 监听
org.deepin.DisplayManager 的注销和注册，在服务注销时关闭旧 socket， 并在服务重新注册后重新获取 AuthInfo()、连接新的认证 socket。
该机制只处理 DDM 成功恢复后的认证链路，不处理 start-limit-hit。

PMS:
Influence: Affects greeter-to-DDM authentication socket recovery after a successful DDM restart.

需要合入ddm相关的修改 https://github.com/linuxdeepin/ddm/pull/104