### PR TITLE
refactor: use Q_ENUM reflection for ShortcutAction name logging

### DIFF
--- a/src/modules/shortcut/shortcutcontroller.cpp
+++ b/src/modules/shortcut/shortcutcontroller.cpp
@@ -11,6 +11,7 @@
 
 #include <QKeyEvent>
 #include <QKeySequence>
+#include <QMetaEnum>
 #include <cstdint>
 
 static_assert(
@@ -35,6 +36,13 @@ ShortcutController::ShortcutController(QObject *parent)
 ShortcutController::~ShortcutController()
 {
     clear();
+}
+
+const char *ShortcutController::actionName(ShortcutAction action)
+{
+    const auto meta = QMetaEnum::fromType<ShortcutAction>();
+    const char *key = meta.valueToKey(static_cast<int>(action));
+    return key ? key : "Unknown";
 }
 
 uint ShortcutController::registerKey(const QString &name, const QString& key, ShortcutController::KeyFlags keybindFlags, ShortcutAction action)
@@ -64,8 +72,8 @@ uint ShortcutController::registerKey(const QString &name, const QString& key, Sh
     if (entry.contains(action)) {
         const auto &[prevName, flags] = entry[action];
         m_deleters.remove(prevName);
-        qCInfo(lcTlShortcut) << "Overriding existing key binding of"
-                                 << keySeq[0] << "for action" << static_cast<int>(action)
+        qCInfo(lcTlShortcut).noquote() << "Overriding existing key binding of"
+                                 << keySeq[0] << "for action" << actionName(action)
                                  << "by name" << prevName << "with new name" << name << "and flags" << keybindFlags;
     }
     m_keyMap[combined][action] = std::make_pair(name, keybindFlags);
@@ -140,6 +148,13 @@ uint ShortcutController::registerSwipeGesture(const QString &name, uint finger, 
         }
     };
 
+    if (lcTlShortcut().isInfoEnabled()) {
+        static const char *dirNames[] = {"Invalid", "Down", "Left", "Up", "Right"};
+        qCInfo(lcTlShortcut).noquote() << "register swipe gesture:" << name
+            << "finger:" << finger
+            << "direction:" << dirNames[direction]
+            << "action:" << actionName(action);
+    }
     return 0;
 }
 
@@ -188,6 +203,11 @@ uint ShortcutController::registerHoldGesture(const QString &name, uint finger, S
         }
     };
 
+    if (lcTlShortcut().isInfoEnabled()) {
+        qCInfo(lcTlShortcut).noquote() << "register hold gesture:" << name
+            << "finger:" << finger
+            << "action:" << actionName(action);
+    }
     return 0;
 }
 

--- a/src/modules/shortcut/shortcutcontroller.h
+++ b/src/modules/shortcut/shortcutcontroller.h
@@ -11,12 +11,42 @@
 class Gesture;
 class QKeyEvent;
 
-enum class ShortcutAction : uint32_t;
-
 class ShortcutController : public QObject
 {
     Q_OBJECT
 public:
+    // Values defined in treeland-shortcut-manager-v2 protocol
+    enum class ShortcutAction : uint32_t {
+        Notify                = 1,
+        Workspace1            = 2,
+        Workspace2            = 3,
+        Workspace3            = 4,
+        Workspace4            = 5,
+        Workspace5            = 6,
+        Workspace6            = 7,
+        PrevWorkspace         = 8,
+        NextWorkspace         = 9,
+        ShowDesktop           = 10,
+        Maximize              = 11,
+        CancelMaximize        = 12,
+        MoveWindow            = 13,
+        CloseWindow           = 14,
+        ShowWindowMenu        = 15,
+        OpenMultiTaskView     = 16,
+        CloseMultiTaskView    = 17,
+        ToggleMultitaskView   = 18,
+        ToggleFpsDisplay      = 19,
+        Lockscreen            = 20,
+        ShutdownMenu          = 21,
+        Quit                  = 22,
+        TaskSwitchNext        = 24,
+        TaskSwitchPrev        = 25,
+        TaskSwitchSameAppNext = 26,
+        TaskSwitchSameAppPrev = 27,
+    };
+    Q_ENUM(ShortcutAction)
+    static const char *actionName(ShortcutAction action);
+
     enum KeyFlag : uint32_t {
         None = 0,
         KeyPress = 0x1,
@@ -52,5 +82,8 @@ private:
     QMap<QString, std::function<void()>> m_deleters;
     QMap<ShortcutAction, int> m_actionCombinedMap;
 };
+
+// Convenience alias so existing bare `ShortcutAction` references keep working
+using ShortcutAction = ShortcutController::ShortcutAction;
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(ShortcutController::KeyFlags)

--- a/src/modules/shortcut/shortcutmanager.h
+++ b/src/modules/shortcut/shortcutmanager.h
@@ -11,7 +11,6 @@
 #include <QObject>
 #include <QQmlEngine>
 
-class ShortcutController;
 class ShortcutManagerV2Private;
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
@@ -21,36 +20,6 @@ class WSocket;
 WAYLIB_SERVER_END_NAMESPACE
 
 WAYLIB_SERVER_USE_NAMESPACE
-
-// Forward declaration - values defined in treeland-shortcut-manager-v2 protocol
-enum class ShortcutAction : uint32_t {
-    Notify                = 1,
-    Workspace1            = 2,
-    Workspace2            = 3,
-    Workspace3            = 4,
-    Workspace4            = 5,
-    Workspace5            = 6,
-    Workspace6            = 7,
-    PrevWorkspace         = 8,
-    NextWorkspace         = 9,
-    ShowDesktop           = 10,
-    Maximize              = 11,
-    CancelMaximize        = 12,
-    MoveWindow            = 13,
-    CloseWindow           = 14,
-    ShowWindowMenu        = 15,
-    OpenMultiTaskView     = 16,
-    CloseMultiTaskView    = 17,
-    ToggleMultitaskView   = 18,
-    ToggleFpsDisplay      = 19,
-    Lockscreen            = 20,
-    ShutdownMenu          = 21,
-    Quit                  = 22,
-    TaskSwitchNext        = 24,
-    TaskSwitchPrev        = 25,
-    TaskSwitchSameAppNext = 26,
-    TaskSwitchSameAppPrev = 27,
-};
 
 class ShortcutManagerV2
     : public QObject


### PR DESCRIPTION
1. Move ShortcutAction enum into ShortcutController class with Q_ENUM
2. Add ShortcutController::actionName() using QMetaEnum::valueToKey
3. Add gesture registration logging to registerSwipeGesture and registerHoldGesture
4. Replace action int with actionName(action) in registerKey override log

Log: Show readable action names like "OpenMultiTaskView" in logs instead of raw integer 16

Influence:
1. Trigger gesture registration and verify log shows action name not integer
2. Register conflicting key shortcut and verify override log shows action name
3. Verify existing code with bare ShortcutAction references compiles in shortcutrunner.cpp

refactor: 使用 Q_ENUM 反射记录 ShortcutAction 名称

1. 将 ShortcutAction 枚举移入 ShortcutController 类并标记 Q_ENUM
2. 新增 ShortcutController::actionName() 通过 QMetaEnum::valueToKey 反射获取动作名
3. 为 registerSwipeGesture 和 registerHoldGesture 增加手势注册日志
4. registerKey 覆盖日志中将 action 整数替换为 actionName(action)

Log: 日志中显示可读的 action 名称如 "OpenMultiTaskView" 而非原始整数 16

Influence:
1. 触发手势注册验证日志中 action 显示为名称而非整数
2. 注册冲突快捷键验证覆盖日志中 action 显示为名称
3. 验证 shortcutrunner.cpp 中使用裸 ShortcutAction 引用的代码能正常编译

PMS: TASK-390751