### PR TITLE
fix(seat): clear keyboard focus for all seats on internal QML focus

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2383,7 +2383,17 @@ void Helper::setActivatedSurface(SurfaceWrapper *newActivateSurface, WSeat *seat
 
 void Helper::onRenderWindowActiveFocusItemChanged()
 {
-    // TODO(muit-seat): Need to check whether the following logic is required.
+    if (!keyboardFocusSurface()) {
+        // Keyboard focus moved to a non-client window (e.g. internal QML component).
+        // Notify all seats to clear the keyboard focus surface.
+        const auto seats = m_seatManager->seats();
+        for (auto *seat : seats) {
+            if (auto *seatContainer = m_rootSurfaceContainer->getSeatContainer(seat)) {
+                if (seatContainer->keyboardFocusSurface())
+                    seatContainer->setKeyboardFocusSurface(nullptr);
+            }
+        }
+    }
 }
 
 void Helper::requestKeyboardFocus(SurfaceWrapper *wrapper, Qt::FocusReason reason, WSeat *seat)


### PR DESCRIPTION
When Qt focus moves to a non-client window (e.g. internal QML component), notify all seats to clear their keyboard focus surface.

当焦点切换到非客户端窗口时，通知所有seat清除键盘焦点。

Log: 焦点切换到内部QML组件时清除seat键盘焦点
Issue: Fixes #1110
Influence: 修复焦点切到treeland内部QML组件时客户端未收到键盘离开事件的问题。

## Summary by Sourcery

Bug Fixes:
- Ensure clients receive keyboard leave events when focus moves to internal QML components by clearing keyboard focus surfaces on all seats.