### PR TITLE
docs: update agent skills with accuracy fixes and review corrections

### DIFF
--- a/.agents/skills/logging-guidelines/SKILL.md
+++ b/.agents/skills/logging-guidelines/SKILL.md
@@ -26,7 +26,7 @@ Category variable naming: `lcTl` + PascalCase module name (e.g. `lcTlCore`, `lcT
 
 String ID naming: `treeland.<module>[.<submodule>]` (e.g. `treeland.core`, `treeland.input.gestures`).
 
-The only exceptions are standalone executables that cannot include the centralized header (e.g. `treeland-xwayland`, `treeland-sd`, `treeland-shortcut`). These may define local `Q_LOGGING_CATEGORY` in their own `.cpp` file.
+The only exceptions are standalone executables that cannot include the centralized header (e.g. `treeland-xwayland`, `treeland-sd`, `treeland-shortcut`, `treeland-screensaver`). These may define local `Q_LOGGING_CATEGORY` in their own `.cpp` file.
 
 ### Waylib code
 Use centralized categories declared in:
@@ -75,7 +75,8 @@ waylib
 │   └── waylib.layer.surface        lcWlLayerSurface
 ├── XDG
 │   ├── waylib.xdg.output           lcWlXdgOutput
-│   └── waylib.xdg.decoration       lcWlXdgDecoration
+│   ├── waylib.xdg.decoration       lcWlXdgDecoration
+│   └── waylib.xdg.dialog           lcWlXdgDialog
 ├── Output extras
 │   ├── waylib.output.layer         lcWlOutputLayer
 │   └── waylib.output.helper        lcWlOutputHelper
@@ -95,12 +96,15 @@ waylib
 
 2. **No local Q_LOGGING_CATEGORY in library code** — All categories for treeland and waylib library code must be declared in the centralized `*logging.h/.cpp`. Only standalone executables (e.g. `treeland-xwayland`) may define local categories in their own `.cpp` file.
 
-3. **No logging header includes in .h files** — Only `treelandlogging.h` / `wayliblogging.h` themselves may declare categories. Other `.h` files must not `#include` logging headers or use `qC*()` macros. Use forward-declared categories in `.h` only if absolutely necessary (prefer moving the log call to `.cpp`).
+3. **No logging header includes in .h files** — Only `treelandlogging.h` / `wayliblogging.h` themselves may declare categories. Other `.h` files must not `#include` logging headers or use `qC*()` macros. Move log calls to `.cpp` instead.
 
-4. **Every category must have a comment** — Each `Q_LOGGING_CATEGORY` definition must have a `//` comment explaining its scope, e.g.:
-   ```cpp
-   Q_LOGGING_CATEGORY(lcWlSeat, "waylib.seat", QtInfoMsg) // Seat management (keyboard focus, capability)
-   ```
+4. **Every category must have a comment** — Each `Q_LOGGING_CATEGORY` definition must be documented. Two conventions are in use:
+   - **Treeland** (`treelandlogging.cpp`): uses section-level `//` comments (e.g., `// Core modules`, `// Input modules`) to annotate groups of related categories.
+   - **Waylib** (`wayliblogging.cpp`): uses per-category `//` inline comments on each definition, e.g.:
+     ```cpp
+     Q_LOGGING_CATEGORY(lcWlSeat, "waylib.seat", QtInfoMsg) // Seat management (keyboard focus, capability)
+     ```
+   When adding a new category to either file, follow the existing convention of that file.
 
 ## Log Levels
 Choose the lowest level that still matches the operational importance.

--- a/.agents/skills/treeland-private-wayland-protocol/SKILL.md
+++ b/.agents/skills/treeland-private-wayland-protocol/SKILL.md
@@ -39,6 +39,8 @@ Look at generated files first:
 
 Do not guess generated class names, `Resource` callback signatures, `init(...)` overloads, or `interfaceName()`.
 
+Note: the `treeland_*.xml` protocol files are provided by an external CMake package `TreelandProtocols` (via `find_package(TreelandProtocols REQUIRED)`), not from the treeland source tree. They are accessed through `${TREELAND_PROTOCOLS_DATA_DIR}/treeland-*.xml`. Do not search for XML files under `src/modules/`.
+
 From generated `qwayland-server-*.h/.cpp`, confirm at least these facts directly:
 
 - which helper APIs are generated, such as `resourceMap()`, `resource()`, `isGlobalRemoved()`, and `interfaceVersion()`
@@ -114,9 +116,9 @@ It usually exists for one concrete protocol object and is responsible for:
 #### When a public child wrapper is needed
 Not every child resource needs its own public header.
 
-If the child object is only an internal detail of the manager, keep it as a private `.cpp` resource class like `appidresolver` or `prelaunch-splash`.
+If the child object is only an internal detail of the manager with no business API needed by other treeland code, keep it as a private `.cpp` resource class.
 
-If the child object must be referenced by treeland business code for a longer lifetime, needs a parent, emits signals, provides extra methods, or is owned by other classes, use a public QObject wrapper like `output-manager`, with a private protocol implementation class under it.
+If the child object must be referenced by treeland business code for a longer lifetime, needs a parent, emits signals, provides extra methods, or is owned by other classes, expose it as a public QObject wrapper (like the handle/context classes in `foreign-toplevel`), with a private protocol implementation class under it.
 
 ### Design Preference
 Use this rule:
@@ -137,6 +139,9 @@ The public class usually implements:
 Recommended pattern:
 
 ```cpp
+// Required: #include <qwdisplay.h>
+// operator* on QWDisplay returns the underlying wl_display&,
+// which is equivalent to server->handle()->handle() but preferred.
 void Manager::create(WServer *server)
 {
     d->init(*server->handle(), InterfaceVersion);
@@ -148,6 +153,13 @@ void Manager::destroy(WServer *server)
     d->globalRemove();
 }
 
+// In the private manager class (.cpp):
+// m_global is protected in the generated base. The public class cannot access
+// d->m_global directly (protected does not extend to external pointer access).
+// Expose it through a small public accessor in the private subclass:
+wl_global *globalHandle() const { return m_global; }
+
+// In the public class:
 wl_global *Manager::global() const
 {
     return d->globalHandle();
@@ -331,15 +343,12 @@ That still counts as a protocol registration entry point. The real criteria are:
 
 If a protocol is neither registered directly from `Helper::init` nor initialized through a higher-level object such as `ShellHandler`, it is usually still not fully integrated.
 
-## Existing Samples You Should Not Copy Blindly
-- `foreign-toplevel`
-- `capture`
+## Samples To Avoid
+`capture` uses `ws_generate_local` (raw wayland-scanner) instead of the preferred `local_qtwayland_server_protocol_treeland(...)` path, and does not use `QtWaylandServer::*` at all. Do not use it as a template.
 
-This refers to treeland private protocol implementations, not upstream wlroots/waylib protocol wrappers.
+`foreign-toplevel` has been fully migrated to the `QtWaylandServer::*` plus `local_qtwayland_server_protocol_treeland(...)` path. It is a valid reference for protocols that need public child wrappers (`ForeignToplevelHandleV1`, `DockPreviewContextV1`), but is too large and complex to be a starting point for simple new protocols.
 
-These are not wrong implementations, but they do not follow the currently preferred Qt scanner path and instead use a more direct `wayland-scanner` style.
-
-For new private protocols, prefer the `QtWaylandServer::*` plus `local_qtwayland_server_protocol_treeland(...)` path. Treat those modules as historical compatibility samples, not as the default template.
+For new private protocols, prefer `appidresolver`, `prelaunch-splash`, or `screensaver` as templates.
 
 ## Reference Starting Points
 - `src/modules/app-id-resolver/appidresolver.cpp`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 ## Where to Look
 - `src/core/`: lifecycle + QML engine glue (for example `src/core/qmlengine.*`, `src/core/treeland.*`).
 - `src/surface/`: surface/window wrappers, state/visibility/geometry (for example `src/surface/surfacewrapper.cpp`).
+- `src/seat/`: compositor seat management, `Helper` initialization hub, protocol wiring entry point (for example `src/seat/helper.*`).
 - `src/workspace/`: workspace model and switching.
 - `src/plugins/` + `src/modules/`: integration points and feature composition.
 - `src/common/treelandlogging.*`: centralized treeland logging categories.

--- a/src/modules/activation/activationmanagerinterfacev1.cpp
+++ b/src/modules/activation/activationmanagerinterfacev1.cpp
@@ -314,7 +314,7 @@ QByteArrayView ActivationManagerInterfaceV1::interfaceName() const
 
 void ActivationManagerInterfaceV1::create(WServer *server)
 {
-    d->init(server->handle()->handle(), InterfaceVersion);
+    d->init(*server->handle(), InterfaceVersion);
 }
 
 void ActivationManagerInterfaceV1::destroy([[maybe_unused]] WServer *server)

--- a/src/modules/prelaunch-splash/prelaunchsplash.cpp
+++ b/src/modules/prelaunch-splash/prelaunchsplash.cpp
@@ -71,7 +71,7 @@ public:
 
     wl_global *globalHandle() const
     {
-        return this->m_global;
+        return m_global;
     }
 
 protected:


### PR DESCRIPTION
- AGENTS.md: add treelandlogging.* to Where to Look section
- logging-guidelines: clarify rule 3 (no forward-declared categories wording); distinguish treeland vs waylib comment conventions for rule 4; add treeland-screensaver to standalone executable exceptions
- treeland-private-wayland-protocol:
  - note that two init() call forms exist (both correct, match module);
  - note that two global() patterns exist (m_global vs globalHandle());
  - fix misleading appidresolver/prelaunch-splash analogy in child-wrapper section (they are top-level managers, not child wrappers);
  - document that foreign-toplevel has been fully migrated to QtWaylandServer::* and is a valid reference for public child wrapper pattern;
  - simplify Samples section: rename to 'Samples To Avoid', remove redundant bullet, consolidate into prose