### PR TITLE
fix(lockscreen): accept numpad Enter key for password submission

### DIFF
--- a/src/plugins/lockscreen/qml/UserInput.qml
+++ b/src/plugins/lockscreen/qml/UserInput.qml
@@ -152,7 +152,7 @@ Item {
                 if (event.key === Qt.Key_CapsLock) {
                     capsIndicatorVisible = !capsIndicatorVisible
                     event.accepted = true
-                } else if (event.key === Qt.Key_Return) {
+                } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
                     if (loginGroup.enteringOtherUser)
                         confirmOtherUser()
                     else


### PR DESCRIPTION
Handle both Key_Return (main Enter) and Key_Enter (numpad Enter) in password input field for password submission.

修复锁屏密码输入框不支持小键盘Enter键的问题，增加对小键盘Enter键的响应。

Log: 修复锁屏小键盘Enter键无法提交密码
PMS: BUG-369463
Influence: 锁屏界面密码输入现在同时支持主键盘Enter和小键盘Enter提交。