### PR TITLE
fix(workspace): prevent window titlebar from being obscured by dock

### DIFF
--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -599,20 +599,40 @@ void Output::arrangeLayerSurface(SurfaceWrapper *surface)
     }
 
     if (layer->exclusiveZone() > 0) {
-        // TODO: support set_exclusive_edge in layer-shell v5/wlroots 0.19
+        int effectiveZone = layer->exclusiveZone();
         switch (layer->getExclusiveZoneEdge()) {
             using enum WLayerSurface::AnchorType;
         case Top:
-            setExclusiveZone(Qt::TopEdge, layer, layer->exclusiveZone());
+            effectiveZone = qMax(effectiveZone, static_cast<int>(surfaceGeo.height()) + layer->topMargin());
             break;
         case Bottom:
-            setExclusiveZone(Qt::BottomEdge, layer, layer->exclusiveZone());
+            effectiveZone = qMax(effectiveZone, static_cast<int>(surfaceGeo.height()) + layer->bottomMargin());
             break;
         case Left:
-            setExclusiveZone(Qt::LeftEdge, layer, layer->exclusiveZone());
+            effectiveZone = qMax(effectiveZone, static_cast<int>(surfaceGeo.width()) + layer->leftMargin());
             break;
         case Right:
-            setExclusiveZone(Qt::RightEdge, layer, layer->exclusiveZone());
+            effectiveZone = qMax(effectiveZone, static_cast<int>(surfaceGeo.width()) + layer->rightMargin());
+            break;
+        default:
+            break;
+        }
+        // When desiredSize is 0 in the relevant dimension, surfaceGeo will be 0
+        // there, so qMax falls back to the original exclusiveZone value.
+        // exclusiveZone == -1 (overlay mode) is excluded by the > 0 check above.
+        switch (layer->getExclusiveZoneEdge()) {
+            using enum WLayerSurface::AnchorType;
+        case Top:
+            setExclusiveZone(Qt::TopEdge, layer, effectiveZone);
+            break;
+        case Bottom:
+            setExclusiveZone(Qt::BottomEdge, layer, effectiveZone);
+            break;
+        case Left:
+            setExclusiveZone(Qt::LeftEdge, layer, effectiveZone);
+            break;
+        case Right:
+            setExclusiveZone(Qt::RightEdge, layer, effectiveZone);
             break;
         default:
             qCWarning(lcTlOutput) << layer->appId()
@@ -628,10 +648,12 @@ void Output::arrangeLayerSurface(SurfaceWrapper *surface)
 void Output::arrangeLayerSurfaces()
 {
     auto oldExclusiveZone = m_exclusiveZone;
+    QHash<SurfaceWrapper *, QSizeF> oldSizes;
 
     for (auto *s : std::as_const(surfaces())) {
         if (s->type() != SurfaceWrapper::Type::Layer)
             continue;
+        oldSizes.insert(s, s->size());
         removeExclusiveZone(s->shellSurface());
     }
 
@@ -655,9 +677,21 @@ void Output::arrangeLayerSurfaces()
             arrangeLayerSurface(s);
     }
 
-    if (oldExclusiveZone != m_exclusiveZone) {
+    bool layerSizeChanged = false;
+    for (auto it = oldSizes.constBegin(); it != oldSizes.constEnd(); ++it) {
+        auto newSize = it.key()->size();
+        auto oldSize = it.value();
+        if (qAbs(newSize.width() - oldSize.width()) > 0.5
+            || qAbs(newSize.height() - oldSize.height()) > 0.5) {
+            layerSizeChanged = true;
+            break;
+        }
+    }
+
+    if (oldExclusiveZone != m_exclusiveZone || layerSizeChanged) {
         arrangeNonLayerSurfaces(ArrangeReason::ExclusiveZoneChanged);
-        Q_EMIT exclusiveZoneChanged();
+        if (oldExclusiveZone != m_exclusiveZone)
+            Q_EMIT exclusiveZoneChanged();
     }
 }
 


### PR DESCRIPTION
## Summary

When the dock/panel height increases, the exclusive zone may not cover the actual surface dimensions including margins, causing the dock to overlap with window titlebars. Additionally, when layer surface dimensions change without the exclusive zone value changing, non-layer surfaces are not re-arranged.

## Changes

1. **effectiveZone computation**: In `arrangeLayerSurface()`, compute effectiveZone as `max(exclusiveZone, surfaceDimension + margin)` to ensure the exclusive zone covers the actual layer surface size including margins.

2. **layerSizeChanged detection**: In `arrangeLayerSurfaces()`, save old sizes of layer surfaces before re-arrangement and compare with new sizes after. Use pixel-level comparison (`qAbs > 0.5`) to detect meaningful size changes and trigger `arrangeNonLayerSurfaces()` even when the exclusive zone value hasn't changed.

3. **Signal decoupling**: Emit `exclusiveZoneChanged()` signal only when the exclusive zone actually changes, not when only layer sizes change.

## Rebase Note

Rebased onto latest `master` and resolved conflict in `src/output/output.cpp` — adapted `arrangeNonLayerSurfaces()` call to pass `ArrangeReason::ExclusiveZoneChanged` as required by the current master API signature.

Multica issue: [WM-45](https://multica.uniontech.com/workspaces/e1c725b6-7c31-4790-a381-3262f282537c/issues/WM-45)

Fixes #BUG-344911
