### PR TITLE
fix(lockscreen): reposition caps indicator and center password input

### DIFF
--- a/src/plugins/lockscreen/qml/UserInput.qml
+++ b/src/plugins/lockscreen/qml/UserInput.qml
@@ -140,9 +140,21 @@ Item {
             width: loginGroup.width
             height: 30
             anchors.horizontalCenter: parent.horizontalCenter
+            horizontalAlignment: TextInput.AlignHCenter
             echoMode: loginGroup.enteringOtherUser ? TextInput.Normal
                       : (showPasswordBtn.hiddenPWD ? TextInput.Password : TextInput.Normal)
-            rightPadding: capsIndicator.visible ? 24 + capsIndicator.width : 24
+            rightPadding: 22
+            leftPadding:{
+                var remaining = width - contentWidth - rightPadding
+                if(capsIndicator.visible)
+                {
+                    return rightPadding
+                }
+                else
+                {
+                    return Math.max(8, remaining > rightPadding ? rightPadding : remaining)
+                }
+            }
             maximumLength: 510
             placeholderText: loginGroup.enteringOtherUser ? qsTr("Username") : qsTr("Password")
             placeholderTextColor: Qt.rgba(1.0, 1.0, 1.0, 0.6)
@@ -161,52 +173,56 @@ Item {
                 }
             }
 
-            RowLayout {
+            D.ActionButton {
+                id: capsIndicator
                 height: parent.height
+                anchors {
+                    left: parent.left
+                    leftMargin: 3
+                    verticalCenter:parent.verticalCenter
+                }
+                visible: passwordField.capsIndicatorVisible && !loginGroup.enteringOtherUser
+                palette.windowText: undefined
+                icon {
+                    name: "login_capslock"
+                    height: 10
+                    width: 10
+                }
+                Layout.alignment: Qt.AlignHCenter
+                implicitWidth: 16
+                implicitHeight: 16
+            }
+
+            D.ActionButton {
+                id: showPasswordBtn
                 anchors {
                     right: parent.right
                     rightMargin: 3
+                    verticalCenter:parent.verticalCenter
+                }
+                property bool hiddenPWD: true
+                visible: !loginGroup.enteringOtherUser
+                icon {
+                    name: hiddenPWD ? "login_display_password" : "login_hidden_password"
+                    height: 10
+                    width: 10
+                }
+                Layout.alignment: Qt.AlignHCenter
+                implicitWidth: 16
+                implicitHeight: 16
+                hoverEnabled: true
+
+                background: Rectangle {
+                    anchors.fill: parent
+                    radius: 4
+                    color: showPasswordBtn.hovered ? Qt.rgba(
+                                                        0, 0, 0,
+                                                        0.1) : "transparent"
                 }
 
-                D.ActionButton {
-                    id: capsIndicator
-                    visible: passwordField.capsIndicatorVisible && !loginGroup.enteringOtherUser
-                    palette.windowText: undefined
-                    icon {
-                        name: "login_capslock"
-                        height: 10
-                        width: 10
-                    }
-                    Layout.alignment: Qt.AlignHCenter
-                    implicitWidth: 16
-                    implicitHeight: 16
-                }
-
-                D.ActionButton {
-                    id: showPasswordBtn
-                    property bool hiddenPWD: true
-                    visible: !loginGroup.enteringOtherUser
-                    icon {
-                        name: hiddenPWD ? "login_display_password" : "login_hidden_password"
-                        height: 10
-                        width: 10
-                    }
-                    Layout.alignment: Qt.AlignHCenter
-                    implicitWidth: 16
-                    implicitHeight: 16
-                    hoverEnabled: true
-
-                    background: Rectangle {
-                        anchors.fill: parent
-                        radius: 4
-                        color: showPasswordBtn.hovered ? Qt.rgba(
-                                                            0, 0, 0,
-                                                            0.1) : "transparent"
-                    }
-
-                    onClicked: hiddenPWD = !hiddenPWD
-                }
+                onClicked: hiddenPWD = !hiddenPWD
             }
+        
 
             background: RoundBlur {
                 color: Qt.rgba(1, 1, 1, 0.4)

--- a/src/plugins/lockscreen/qml/UserInput.qml
+++ b/src/plugins/lockscreen/qml/UserInput.qml
@@ -152,7 +152,7 @@ Item {
                 if (event.key === Qt.Key_CapsLock) {
                     capsIndicatorVisible = !capsIndicatorVisible
                     event.accepted = true
-                } else if (event.key === Qt.Key_Return) {
+                } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
                     if (loginGroup.enteringOtherUser)
                         confirmOtherUser()
                     else


### PR DESCRIPTION
Move caps lock indicator from RowLayout to left-anchor, place passwordvisibility button on right with independent anchors. Add text horizontal
center alignment and dynamic leftPadding calculation.
    
将大写锁定指示器从RowLayout中移出，改为左侧锚定定位；密码可见性按钮
独立锚定在右侧。添加文本水平居中对齐和动态左边距计算。
    
Log: 调整锁屏密码输入框布局，大写指示器移至左侧并居中显示文本
PMS: BUG-286119
Influence: 锁屏密码输入框文本居中显示，大写锁定指示器位置调整至左侧，密码显示按钮保持右侧，提升视觉体验。