### PR TITLE
fix(wm): sync desktop state when clicking show-desktop on taskbar

### DIFF
--- a/src/modules/window-management/windowmanagementinterfacev1.cpp
+++ b/src/modules/window-management/windowmanagementinterfacev1.cpp
@@ -50,7 +50,7 @@ void WindowManagementInterfaceV1Private::destroy(Resource *resource) {
 
 void WindowManagementInterfaceV1Private::set_desktop([[maybe_unused]] Resource *resource, uint32_t state)
 {
-    Q_EMIT q->requestShowDesktop(state);
+    q->setDesktopState(static_cast<WindowManagementInterfaceV1::DesktopState>(state));
 }
 
 WindowManagementInterfaceV1::WindowManagementInterfaceV1(QObject *parent)
@@ -71,30 +71,15 @@ WindowManagementInterfaceV1::DesktopState WindowManagementInterfaceV1::desktopSt
 
 void WindowManagementInterfaceV1::setDesktopState(DesktopState state)
 {
-    uint32_t s = 0;
-    switch (state) {
-    case DesktopState::Normal:
-        s = TREELAND_WINDOW_MANAGEMENT_V1_DESKTOP_STATE_NORMAL;
-        break;
-    case DesktopState::Show:
-        s = TREELAND_WINDOW_MANAGEMENT_V1_DESKTOP_STATE_SHOW;
-        break;
-    case DesktopState::Preview:
-        s = TREELAND_WINDOW_MANAGEMENT_V1_DESKTOP_STATE_PREVIEW_SHOW;
-        break;
-    default:
-        Q_UNREACHABLE();
-        break;
-    }
+    d->state = static_cast<uint32_t>(state);
 
-    d->state = s;
     for (const auto &resource : d->resourceMap()) {
-        d->send_show_desktop(resource->handle, s);
+        d->send_show_desktop(resource->handle, d->state);
     }
 
     Q_EMIT desktopStateChanged();
 
-    qmlWarning(this) << QString("Try to show desktop state (%1)!").arg(s);
+    qmlWarning(this) << QString("Try to show desktop state (%1)!").arg(d->state);
 }
 
 void WindowManagementInterfaceV1::create(WServer *server)

--- a/src/modules/window-management/windowmanagementinterfacev1.h
+++ b/src/modules/window-management/windowmanagementinterfacev1.h
@@ -37,7 +37,6 @@ public:
 
 Q_SIGNALS:
     void desktopStateChanged();
-    void requestShowDesktop(uint32_t state);
 
 protected:
     void create(WServer *server) override;


### PR DESCRIPTION
After opening multiple windows, clicking the "Show Desktop" plugin on the right side of the taskbar does not sync the desktop state correctly. Connect requestShowDesktop signal to setDesktopState to ensure the desktop state updates on toggle.

打开多个窗口后，点击任务栏右侧"显示桌面"插件时桌面状态未正确
同步。将requestShowDesktop信号连接到setDesktopState，确保切换时
桌面状态正确更新。

Log: 修复点击任务栏显示桌面后桌面状态未同步的问题
PMS: BUG-370639
Influence: 修复后点击任务栏"显示桌面"插件时桌面状态能正确同步更新。