### PR TITLE
fix(output): detach proxy hardware layers before output teardown

### DIFF
--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -159,6 +159,16 @@ Output::Output(WOutputItem *output, QObject *parent)
 
 Output::~Output()
 {
+    // Copy outputs reuse the primary output's hardware layers. Detach them
+    // explicitly before destroying the viewport so that the output gets a new
+    // frame and stale hardware-plane contents (notably the cursor) are cleared.
+    if (m_type == Type::Proxy && m_outputViewport) {
+        for (auto *layer : std::as_const(m_hardwareLayersOfPrimaryOutput)) {
+            Helper::instance()->window()->detach(layer, m_outputViewport);
+        }
+        m_hardwareLayersOfPrimaryOutput.clear();
+    }
+
     if (m_taskBar) {
         delete m_taskBar;
         m_taskBar = nullptr;


### PR DESCRIPTION
Detach copy-output hardware layers from the proxy output viewport before destroying it so the primary output is scheduled for a fresh frame and stale hardware-plane contents, including the cursor, are cleared.

Log: clear stale cursor content after copy output teardown
PMS: BUG-370673
Influence: Copy output teardown and reconnect display refresh

## Summary by Sourcery

Bug Fixes:
- Clear stale cursor and hardware-plane content by detaching proxy output hardware layers before destroying the output viewport.