### PR TITLE
fix(taskswitch): reset currentMode when dismissed by mouse click

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1389,6 +1389,9 @@ void Helper::deleteTaskSwitch()
         m_taskSwitch->deleteLater();
         m_taskSwitch = nullptr;
     }
+    if (m_currentMode == CurrentMode::WindowSwitch) {
+        setCurrentMode(CurrentMode::Normal);
+    }
 }
 
 void Helper::init(Treeland::Treeland *treeland)


### PR DESCRIPTION
This change ensures that when the task switcher is dismissed by a mouse click, the helpers currentMode is correctly reset from WindowSwitch back to Normal, resolving shortcut lock from being silently blocked afterward.

修复鼠标点击关闭任务切换器后 currentMode 仍停留在 WindowSwitch 的
问题，避免后续快捷键被静默拦截。

PMS: BUG-370217
Log: 修复任务切换器鼠标退出后模式未重置导致快捷键失效的问题
Influence: 鼠标点击退出任务切换器后，快捷键恢复正常响应。

## Summary by Sourcery

Bug Fixes:
- Ensure currentMode is reset from WindowSwitch to Normal when the task switcher is dismissed so that keyboard shortcuts function correctly afterward.

## Summary by Sourcery

Bug Fixes:
- Ensure the task switcher correctly resets currentMode from WindowSwitch to Normal when closed so that keyboard shortcuts are no longer blocked.