### PR TITLE
fix(surface): remove stale subsurface items after teardown

### DIFF
--- a/waylib/src/server/kernel/wsurface.cpp
+++ b/waylib/src/server/kernel/wsurface.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 JiDe Zhang <zhangjide@deepin.org>.
+// Copyright (C) 2023-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wsurface.h"
@@ -206,7 +206,7 @@ void WSurfacePrivate::setSubsurface(qw_subsurface *newSubsurface)
     if (subsurface == newSubsurface)
         return;
     subsurface = newSubsurface;
-    QObject::connect(subsurface, &qw_subsurface::destroyed, q, &WSurface::isSubsurfaceChanged);
+    QObject::connect(subsurface, &qw_subsurface::before_destroy, q, &WSurface::isSubsurfaceChanged);
 
     if (isSubsurface != !subsurface.isNull()){
         isSubsurface = !subsurface.isNull();

--- a/waylib/src/server/qtquick/private/wsurfaceitem_p.h
+++ b/waylib/src/server/qtquick/private/wsurfaceitem_p.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 JiDe Zhang <zhangjide@deepin.org>.
+// Copyright (C) 2023-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #pragma once
@@ -10,6 +10,7 @@
 #include <QSGImageNode>
 #include <QSGRenderNode>
 #include <private/qquickitem_p.h>
+#include <qwsubcompositor.h>
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
@@ -36,7 +37,7 @@ public:
     void updateSubsurfaceItem();
     void onPaddingsChanged();
     void updateContentPosition();
-    WSurfaceItem *ensureSubsurfaceItem(WSurface *subsurfaceSurface, QQuickItem *parent);
+    WSurfaceItem *ensureSubsurfaceItem(QW_NAMESPACE::qw_subsurface *subsurface, QQuickItem *parent);
     void updateSubsurfaceContainers();
     void connectSubsurfaceContainerSignals(SubsurfaceContainer *container);
 
@@ -87,4 +88,3 @@ public:
 };
 
 WAYLIB_SERVER_END_NAMESPACE
-

--- a/waylib/src/server/qtquick/wsurfaceitem.cpp
+++ b/waylib/src/server/qtquick/wsurfaceitem.cpp
@@ -1017,8 +1017,8 @@ void WSurfaceItem::releaseResources()
             d->subsurfaces.removeOne(item);
             item->releaseResources();
             auto surface = item->surface();
-            if (surface) {
-                bool ok = QObject::disconnect(surface, &WSurface::destroyed, this, nullptr);
+            if (auto sub = surface ? qw_subsurface::try_from_wlr_surface(surface->handle()->handle()) : nullptr) {
+                bool ok = QObject::disconnect(sub, &qw_subsurface::before_destroy, this, nullptr);
                 Q_ASSERT(ok);
             }
         }
@@ -1301,10 +1301,11 @@ void WSurfaceItemPrivate::updateSubsurfaceItem()
         wlr_subsurface *subsurface;
         QQuickItem *prev = nullptr;
         wl_list_for_each(subsurface, subsurfaceList, current.link) {
-            WSurface *surface = WSurface::fromHandle(subsurface->surface);
+            auto qwSubsurface = qw_subsurface::from(subsurface);
+            WSurface *surface = WSurface::fromHandle(qwSubsurface->handle()->surface);
             if (!surface)
                 continue;
-            WSurfaceItem *item = ensureSubsurfaceItem(surface, container);
+            WSurfaceItem *item = ensureSubsurfaceItem(qwSubsurface, container);
             item->setSurfaceSizeRatio(surfaceSizeRatio);
             Q_ASSERT(item->parentItem() == container);
             if (prev) {
@@ -1342,9 +1343,13 @@ void WSurfaceItemPrivate::updateContentPosition()
     updateBoundingRect();
 }
 
-WSurfaceItem *WSurfaceItemPrivate::ensureSubsurfaceItem(WSurface *subsurfaceSurface, QQuickItem *parent)
+WSurfaceItem *WSurfaceItemPrivate::ensureSubsurfaceItem(qw_subsurface *subsurface, QQuickItem *parent)
 {
     Q_Q(WSurfaceItem);
+
+    Q_ASSERT(subsurface);
+    WSurface *subsurfaceSurface = WSurface::fromHandle(subsurface->handle()->surface);
+    Q_ASSERT(subsurfaceSurface);
 
     for (int i = 0; i < subsurfaces.count(); ++i) {
         auto surfaceItem = subsurfaces.at(i);
@@ -1367,7 +1372,6 @@ WSurfaceItem *WSurfaceItemPrivate::ensureSubsurfaceItem(WSurface *subsurfaceSurf
         }
     }
 
-    Q_ASSERT(subsurfaceSurface);
     auto surfaceItem = new WSurfaceItem(parent);
     // Delay destroy WSurfaceItem, because if the cause of destroy is because the parent
     // surface destroy, and the parent WSurfaceItem::cacheLastBuffer maybe enabled,
@@ -1376,8 +1380,8 @@ WSurfaceItem *WSurfaceItemPrivate::ensureSubsurfaceItem(WSurface *subsurfaceSurf
     // contents.
     QPointer<WSurfaceItem> surfaceItemGuard(surfaceItem);
     QObject::connect(
-        subsurfaceSurface,
-        &WSurface::destroyed,
+        subsurface,
+        &qw_subsurface::before_destroy,
         q,
         [this, surfaceItemGuard] {
             auto surfaceItem = surfaceItemGuard.data();
@@ -1389,8 +1393,7 @@ WSurfaceItem *WSurfaceItemPrivate::ensureSubsurfaceItem(WSurface *subsurfaceSurf
             // already scheduled for deletion.
             if (subsurfaces.removeOne(surfaceItem))
                 surfaceItem->deleteLater();
-        },
-        Qt::QueuedConnection);
+        });
     surfaceItem->setDelegate(delegate);
     surfaceItem->setFlags(surfaceFlags);
     surfaceItem->setSurface(subsurfaceSurface);


### PR DESCRIPTION
Update subsurface items whenever the subsurface state changes, including when the last subsurface is removed. Detach and delete obsolete items before rebuilding the containers to prevent bounding rect calculation from accessing a destroyed subsurface item.

Log: Fix crash when calculating the bounding rect after subsurface teardown
PMS: BUG-367449
Influence: Subsurface teardown

## Summary by Sourcery

Bug Fixes:
- Remove and delete subsurface items that no longer correspond to existing subsurfaces before rebuilding containers to avoid crashes during bounding rect calculations.