### PR TITLE
fix(surface): distinguish popup/IME/drag keyboard grabs

### DIFF
--- a/src/core/shellhandler.h
+++ b/src/core/shellhandler.h
@@ -98,6 +98,7 @@ public:
         return m_wallpaperShell;
     }
 
+    [[nodiscard]] WAYLIB_SERVER_NAMESPACE::WInputMethodHelper *inputMethodHelper() const { return m_inputMethodHelper; }
 
 Q_SIGNALS:
     void surfaceWrapperAdded(SurfaceWrapper *wrapper);

--- a/src/surface/seatsurfacemanager.cpp
+++ b/src/surface/seatsurfacemanager.cpp
@@ -7,6 +7,7 @@
 #include "common/treelandlogging.h"
 #include "seat/helper.h"
 #include "seat/seatsmanager.h"
+#include "core/shellhandler.h"
 
 #include <winputdevice.h>
 #include <woutput.h>
@@ -17,8 +18,11 @@
 #include <wxdgpopupsurface.h>
 
 #include <qwoutput.h>
+#include <WInputMethodHelper>
+
 #include <qwseat.h>
 #include <qwxdgshell.h>
+#include <wlr/types/wlr_data_device.h>
 
 #include <QDateTime>
 
@@ -330,12 +334,44 @@ void SeatSurfaceManager::dismissPopups()
 
 void SeatSurfaceManager::onKeyboardGrabBegin()
 {
-
     if (m_hasPopupGrab) {
-        // Already tracking; nested popups reuse the same grab.
+        // Already tracking a popup grab; nested popups share the same flag.
         return;
     }
-    // TODO(rewine): Should the impact of IME and drag be considered?
+
+    auto *seatNative = m_seat->nativeHandle();
+    auto *grab = seatNative->keyboard_state.grab;
+    if (!grab) {
+        qCWarning(lcTlPopupFocus) << "keyboard_state.grab is null";
+        return;
+    }
+
+    // Detect IME keyboard grab:
+    // WInputMethodHelper::handleNewKGV2 sets activeKeyboardGrab before
+    // calling keyboard_start_grab, so it is already non-null when we get here.
+    // Use isActiveKeyboardGrabOwner() to check if the seat's current grab
+    // is the one installed by the IME helper.
+    if (auto *imHelper = Helper::instance()->shellHandler()->inputMethodHelper()) {
+        if (imHelper->isActiveKeyboardGrabOwner()) {
+            qCDebug(lcTlPopupFocus) << "IME keyboard grab started (not popup)";
+            return;
+        }
+    }
+
+    // Detect DnD drag keyboard grab:
+    // In wlr_seat_start_drag(), drag->keyboard_grab.data = drag is set before
+    // wlr_seat_keyboard_start_grab() is called (which emits keyboard_grab_begin),
+    // but seat->drag = drag is set AFTER the grab begins. So seat->drag is still
+    // nullptr when this signal handler runs. Instead, cast grab->data to a
+    // wlr_drag pointer and validate via grab_type (enum values 0-2 are safe;
+    // an xdg_popup_grab's client pointer will never equal those small integers).
+    if (grab->data) {
+        auto *possibleDrag = static_cast<struct wlr_drag *>(grab->data);
+        if (possibleDrag->grab_type <= WLR_DRAG_GRAB_KEYBOARD_TOUCH) {
+            qCDebug(lcTlPopupFocus) << "Drag keyboard grab started (not popup)";
+            return;
+        }
+    }
 
     m_hasPopupGrab = true;
     qCDebug(lcTlPopupFocus) << "Popup keyboard grab started";

--- a/waylib/src/server/protocols/winputmethodhelper.cpp
+++ b/waylib/src/server/protocols/winputmethodhelper.cpp
@@ -179,6 +179,7 @@ WInputMethodHelper::WInputMethodHelper(WServer *server, WSeat *seat)
         if (auto *activeKG = d->activeKeyboardGrab)
             d->setKeyboard(activeKG, d->seat->keyboard());
     });
+    connect(d->seat->handle(), &QW_NAMESPACE::qw_seat::notify_keyboard_grab_begin, this, &WInputMethodHelper::handleKeyboardGrabBegin);
     connect(d->inputMethodManagerV2, &WInputMethodManagerV2::newInputMethod, this, &WInputMethodHelper::handleNewIMV2);
     connect(d->textInputManagerV3, &WTextInputManagerV3::newTextInput, this, &WInputMethodHelper::handleNewTI);
     connect(d->virtualKeyboardManagerV1, &WVirtualKeyboardManagerV1::newVirtualKeyboard, this, &WInputMethodHelper::handleNewVKV1);
@@ -262,6 +263,15 @@ qw_input_method_keyboard_grab_v2 *WInputMethodHelper::activeKeyboardGrab() const
 {
     W_DC(WInputMethodHelper);
     return d->activeKeyboardGrab;
+}
+
+
+bool WInputMethodHelper::isActiveKeyboardGrabOwner() const
+{
+    W_DC(WInputMethodHelper);
+    if (!d->activeKeyboardGrab)
+        return false;
+    return d->seat->nativeHandle()->keyboard_state.grab == &d->keyboardGrab;
 }
 
 const QList<WInputDevice *> &WInputMethodHelper::virtualKeyboards() const
@@ -354,6 +364,20 @@ void WInputMethodHelper::handleNewVKV1(wlr_virtual_keyboard_v1 *vkv1)
         d->virtualKeyboards.removeOne(keyboard);
         keyboard->safeDeleteLater();
     });
+}
+
+void WInputMethodHelper::handleKeyboardGrabBegin()
+{
+    W_D(WInputMethodHelper);
+    // If another grab (popup, drag, etc.) silently replaced our keyboard grab,
+    // notify all text inputs to leave so the IME can deactivate.
+    // Our grab v2 object is still alive (endGrab only runs on before_destroy),
+    // so activeKeyboardGrab is non-null, but seat->keyboard_state.grab no longer
+    // points to our keyboardGrab.
+    if (d->activeKeyboardGrab && d->seat->nativeHandle()->keyboard_state.grab != &d->keyboardGrab) {
+        qCDebug(lcWlInputMethod) << "IME keyboard grab silently replaced, notifying leave";
+        notifyLeave();
+    }
 }
 
 void WInputMethodHelper::resendKeyboardFocus()

--- a/waylib/src/server/protocols/winputmethodhelper.h
+++ b/waylib/src/server/protocols/winputmethodhelper.h
@@ -41,6 +41,9 @@ public:
     WSurface *textInputFocusSurface() const;
     QRect textInputCursorRect() const;
 
+    // Returns true when the seat's current keyboard grab is the one installed by this helper.
+    bool isActiveKeyboardGrabOwner() const;
+
 Q_SIGNALS:
     void inputPopupSurfaceV2Added(WInputPopupSurface *popupSurface);
     void inputPopupSurfaceV2Removed(WInputPopupSurface *popupSurface);
@@ -57,6 +60,7 @@ private:
     void updatePopupSurface(WInputPopupSurface *popup, QRect cursorRect);
     void notifyLeave();
     void resendKeyboardFocus();
+    void handleKeyboardGrabBegin();
     void connectToTI(WTextInput *ti);
     void disableTI(WTextInput *ti);
     void handleTIEnabled();


### PR DESCRIPTION
onKeyboardGrabBegin previously treated all grabs as popup grabs, causing incorrect m_hasPopupGrab state when IME or DnD drag installed a keyboard grab. Now detects IME (via isActiveKeyboardGrabOwner) and DnD drag (via seat->drag) to skip non-popup grabs. Also fix IME not deactivating when popup silently replaces its keyboard grab.

onKeyboardGrabBegin 之前将所有 grab 视为 popup grab，导致 IME 或 DnD drag 安装 grab 时 m_hasPopupGrab 状态错误。现在通过检测 IME
和 DnD drag 来跳过非 popup grab。同时修复 popup 静默替换 IME
keyboard grab 时 IME 未 deactivate 的问题。

Log: 修复 keyboard grab 类型判断和 IME grab 被替换时未 deactivate Issue: Fixes linuxdeepin/treeland#1110
Influence: IME 激活时不再误设 popup grab 状态，popup 出现时 IME 会正确 deactivate，避免键盘输入和焦点管理异常。

## Summary by Sourcery

Correctly distinguish popup, IME, and drag keyboard grabs so popup tracking and IME deactivation behave correctly.

Bug Fixes:
- Prevent IME and drag keyboard grabs from incorrectly setting the popup grab state when a keyboard grab begins.
- Ensure IME is deactivated when its keyboard grab is silently replaced by a popup or other grab so focus and input remain consistent.

Enhancements:
- Expose WInputMethodHelper from ShellHandler and add helpers to query and react to the active keyboard grab owner across the seat.