### PR TITLE
fix: fix XWayland cursor truncation on fractional-scaled multi-monitor

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1649,9 +1649,9 @@ void Helper::init(Treeland::Treeland *treeland)
     qw_viewporter::create(*m_server->handle());
     m_renderWindow->init(m_renderer, m_allocator);
 
-    auto *xwaylandOutputManager =
+    m_xwaylandOutputManager =
         m_server->attach<WXdgOutputManager>(m_rootSurfaceContainer->outputLayout());
-    xwaylandOutputManager->setScaleOverride(1.0);
+    m_xwaylandOutputManager->setScaleOverride(1.0);
 
     static const auto isXWaylandClient =
         [sessionManager = QPointer(m_sessionManager)](WClient *client) {
@@ -1664,7 +1664,22 @@ void Helper::init(Treeland::Treeland *treeland)
         return false;
        };
     xdgOutputManager->setFilter([](WClient *client) { return !isXWaylandClient(client); });
-    xwaylandOutputManager->setFilter([](WClient *client) { return isXWaylandClient(client); });
+    m_xwaylandOutputManager->setFilter([](WClient *client) {
+        return isXWaylandClient(client);
+    });
+
+    // XWayland perceives screen geometry in physical-pixel space scaled by
+    // maxDPR (the highest output scale), so that root window / xrandr geometry
+    // matches the coordinates XWayland clients actually receive.
+    auto updateXWaylandOutputScale = [this]() {
+        if (m_xwaylandOutputManager)
+            m_xwaylandOutputManager->setScaleOverride(m_renderWindow->effectiveDevicePixelRatio());
+    };
+    connect(m_renderWindow,
+            &WOutputRenderWindow::effectiveDevicePixelRatioChanged,
+            this,
+            updateXWaylandOutputScale);
+    updateXWaylandOutputScale();
     // User dde does not has a real Logind session, so just pass 0 as id
     m_sessionManager->updateActiveUserSession(QStringLiteral("dde"), 0);
     connect(m_userModel, &UserModel::userLoggedIn, m_sessionManager, &SessionManager::updateActiveUserSession);

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -72,6 +72,7 @@ class WSurface;
 class WSurfaceItem;
 class WToplevelSurface;
 class WXdgDecorationManager;
+class WXdgOutputManager;
 class WXWayland;
 
 class WForeignToplevel;
@@ -425,6 +426,7 @@ private:
     PersonalizationManagerInterfaceV1 *m_personalizationInterfaceV1 = nullptr;
     WallpaperColorInterfaceV1 *m_wallpaperColorV1 = nullptr;
     WOutputManagerV1 *m_outputManager = nullptr;
+    WXdgOutputManager *m_xwaylandOutputManager = nullptr;
     WindowManagementInterfaceV1 *m_windowManagementInterfaceV1 = nullptr;
     WindowManagementInterfaceV1::DesktopState m_showDesktop = WindowManagementInterfaceV1::DesktopState::Normal;
     DDEShellManagerInterfaceV1 *m_ddeShellV1 = nullptr;

--- a/waylib/src/server/protocols/wxdgoutput.cpp
+++ b/waylib/src/server/protocols/wxdgoutput.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Lu YaNing <luyaning@uniontech.org>.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wxdgoutput.h"
@@ -10,6 +10,7 @@
 #include "xdg-output-unstable-v1-protocol.h"
 
 #include <assert.h>
+#include <cmath>
 #include <stdlib.h>
 #include <stdio.h>
 
@@ -87,20 +88,26 @@ static void output_update(struct way_xdg_output_v1 *xdg_output) {
     struct wlr_output_layout_output *layout_output = xdg_output->layout_output;
     bool updated = false;
 
-    if (layout_output->x != xdg_output->x || layout_output->y != xdg_output->y) {
-        xdg_output->x = layout_output->x;
-        xdg_output->y = layout_output->y;
+    int32_t x, y;
+    if (xdg_output->manager->scale_override > 0.0) {
+        x = static_cast<int32_t>(std::floor(layout_output->x * xdg_output->manager->scale_override));
+        y = static_cast<int32_t>(std::floor(layout_output->y * xdg_output->manager->scale_override));
+    } else {
+        x = layout_output->x;
+        y = layout_output->y;
+    }
+
+    if (x != xdg_output->x || y != xdg_output->y) {
+        xdg_output->x = x;
+        xdg_output->y = y;
         updated = true;
     }
 
     int width, height;
+    wlr_output_effective_resolution(layout_output->output, &width, &height);
     if (xdg_output->manager->scale_override > 0.0) {
-        wlr_output_transformed_resolution(layout_output->output, &width, &height);
-
-        width /= xdg_output->manager->scale_override;
-        height /= xdg_output->manager->scale_override;
-    } else {
-        wlr_output_effective_resolution(layout_output->output, &width, &height);
+        width = static_cast<int>(std::ceil(width * xdg_output->manager->scale_override));
+        height = static_cast<int>(std::ceil(height * xdg_output->manager->scale_override));
     }
 
     if (xdg_output->width != width || xdg_output->height != height) {
@@ -437,8 +444,8 @@ void WXdgOutputManager::create([[maybe_unused]] WServer *wserver)
     W_D(WXdgOutputManager);
     if (d->layout) {
         d->manager = way_xdg_output_manager_v1_create(*server()->handle(),
-                                                    *d->layout->handle(),
-                                                    d->scaleOverride);
+                                                      *d->layout->handle(),
+                                                      d->scaleOverride);
         m_handle = d->manager;
     } else {
         qCWarning(lcWlXdgOutput) << "Output layout not set, xdg output manager will never be created!";


### PR DESCRIPTION
Scale XWayland-only xdg_output position and size by maxDPR so that the root window bounding box matches the physical-pixel coordinate space that XWayland clients actually receive.

将 XWayland 专用的 xdg_output 的 position 和 size 均按 maxDPR 缩放， 使 root window bounding box 与 XWayland 客户端实际收到的物理像素 坐标空间一致，修复分数缩放多显示器下光标坐标被截断的问题。

Log: 修复分数缩放多屏XWayland光标截断
PMS: BUG-370341
Influence: XWayland xdg_output按maxDPR缩放对齐物理坐标空间

## Summary by Sourcery

Align XWayland xdg_output geometry with the physical-pixel coordinate space used by XWayland clients to fix cursor truncation on fractional-scaled multi-monitor setups.

Bug Fixes:
- Correct XWayland root window and xdg_output bounds so cursor coordinates are no longer truncated with fractional scaling across multiple displays.

Enhancements:
- Introduce an explicit output scale for XWayland xdg_output, driven by the render window’s effective device pixel ratio, and rename the previous scale override API accordingly.