### PR TITLE
fix(task-switcher): preserve surface positions during exit

### DIFF
--- a/src/core/qml/TaskSwitcher.qml
+++ b/src/core/qml/TaskSwitcher.qml
@@ -13,6 +13,7 @@ Item {
     visible: false
 
     property bool switchOn: true
+    property double lastSwitchTimestamp: 0
     property int focusReason: Qt.TabFocusReason
     required property QtObject output
     readonly property QtObject model: Helper.workspace.currentFilter
@@ -26,6 +27,7 @@ Item {
 
     readonly property int leftpreferredMargin: 20
     readonly property int rightpreferredMargin: 20
+    readonly property int mouseExitInterval: 400
     readonly property real radius: enableRadius ? 18 : 0
 
     x: output.outputItem.x + output.validRect.x
@@ -80,7 +82,7 @@ Item {
         anchors.fill: parent
 
         onClicked: {
-            root.exit()
+            root.exitByMouse()
         }
     }
 
@@ -116,7 +118,7 @@ Item {
                 sourceComponent: undefined
 
                 onClicked: {
-                    root.exit()
+                    root.exitByMouse()
                 }
             }
         }
@@ -291,7 +293,8 @@ Item {
 
         delegate: Item {
             id: windowItem
-            required property SurfaceWrapper surface
+            required property SurfaceWrapper modelData
+            readonly property SurfaceWrapper surface: modelData
             property real surfaceX: 0
             property real surfaceY: 0
 
@@ -435,7 +438,10 @@ Item {
         }
     }
 
-    function prejudgment() {
+    function prejudgment(updateTimestamp) {
+        if (updateTimestamp)
+            root.lastSwitchTimestamp = Date.now()
+
         if (previewWindows.finishedAnimations < previewWindows.totalAnimations) {
             previewWindows.restoreSurfaces()
             previewWindows.model = []
@@ -457,7 +463,7 @@ Item {
     }
 
     function previous() {
-        if (!prejudgment())
+        if (!prejudgment(true))
             return;
 
         var nextIndex = (switchView.currentIndex - 1 + switchView.count) % switchView.count
@@ -471,7 +477,7 @@ Item {
     }
 
     function next() {
-        if (!prejudgment())
+        if (!prejudgment(true))
             return;
 
         var nextIndex = (switchView.currentIndex + 1) % switchView.count
@@ -499,7 +505,7 @@ Item {
     }
 
     function show() {
-        if (!prejudgment())
+        if (!prejudgment(true))
             return;
 
         var nextIndex = switchView.currentIndex;
@@ -531,6 +537,11 @@ Item {
         return switchView.currentItem && switchView.visible
     }
 
+    function exitByMouse() {
+        if (Date.now() - root.lastSwitchTimestamp >= root.mouseExitInterval)
+            exit()
+    }
+
     function exit() {
         if (!root.visible) {
             root.switchOn = false
@@ -538,7 +549,7 @@ Item {
         }
 
         if (previewWindows.finishedAnimations !== previewWindows.totalAnimations) {
-            prejudgment()
+            prejudgment(false)
             return
         }
 
@@ -555,12 +566,16 @@ Item {
             switchItemAnimation.start()
         }
 
+        const playSurfaceAnimation = root.enableAnimation
+                && switchView.count > 0 && switchView.count <= 18
+        const surfaceSnapshot = playSurfaceAnimation ? root.model.surfaceSnapshot() : []
+
         if (switchView.currentItem)
             Helper.forceActivateSurface(switchView.currentItem.surface, focusReason)
 
-        if (root.enableAnimation && switchView.count > 0 && switchView.count <= 18) {
+        if (playSurfaceAnimation) {
             previewWindows.reverse = false
-            previewWindows.model = root.model
+            previewWindows.model = surfaceSnapshot
         } else {
             previewWindows.reverse = false
             previewWindows.finishedAnimations = 0

--- a/src/surface/surfacefilterproxymodel.cpp
+++ b/src/surface/surfacefilterproxymodel.cpp
@@ -12,6 +12,9 @@ SurfaceFilterProxyModel::SurfaceFilterProxyModel(QObject *parent)
 
 void SurfaceFilterProxyModel::setFilterAppId(const QString &appid)
 {
+    if (m_filterAppId == appid)
+        return;
+
 #if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
     beginFilterChange();
     m_filterAppId = appid;
@@ -20,6 +23,18 @@ void SurfaceFilterProxyModel::setFilterAppId(const QString &appid)
     m_filterAppId = appid;
     invalidateFilter();
 #endif
+}
+
+QVariantList SurfaceFilterProxyModel::surfaceSnapshot() const
+{
+    QVariantList surfaces;
+    surfaces.reserve(rowCount());
+
+    for (int row = 0; row < rowCount(); ++row) {
+        surfaces.append(data(index(row, 0), Qt::DisplayRole));
+    }
+
+    return surfaces;
 }
 
 int SurfaceFilterProxyModel::activeIndex()

--- a/src/surface/surfacefilterproxymodel.h
+++ b/src/surface/surfacefilterproxymodel.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #pragma once
@@ -14,6 +14,7 @@ public:
     explicit SurfaceFilterProxyModel(QObject *parent = nullptr);
 
     Q_INVOKABLE void setFilterAppId(const QString &appid);
+    Q_INVOKABLE QVariantList surfaceSnapshot() const;
 
     int activeIndex();
     void setActiveIndex(int index);


### PR DESCRIPTION
鼠标退出任务切换器时，窗口可能停留在集中布局位置。

- 退出动画使用静态窗口快照，避免动态模型重建 delegate。
- 跳过相同 AppId 的过滤刷新，并保留鼠标退出间隔保护。

模型刷新会覆盖 delegate 保存的桌面原始坐标，静态快照可稳定恢复依据。

Log: preserve surface positions during exit
PMS: BUG-367423

## Summary by Sourcery

Improve task switcher exit behavior to preserve window surface positions and avoid unnecessary model refresh when filtering by AppId.

Bug Fixes:
- Ensure windows return to their original desktop positions when exiting the task switcher by using static surface snapshots for exit animations and activation.
- Prevent redundant filter changes when setting the same AppId, avoiding model rebuilds that could disrupt stored surface coordinates.

Enhancements:
- Add timestamp-based protection for mouse-initiated exit from the task switcher to avoid accidental exits during rapid switching.
- Expose a snapshot API on the surface filter proxy model for stable reuse of surface data during animations and exit handling.