### PR TITLE
WM-85: fix -Wsfinae-incomplete warnings with Q_MOC_INCLUDE

### DIFF
--- a/src/core/shellhandler.h
+++ b/src/core/shellhandler.h
@@ -19,6 +19,7 @@
 #include <QSet>
 
 Q_MOC_INCLUDE("workspace/workspace.h")
+Q_MOC_INCLUDE(<wlayersurface.h>)
 
 QW_BEGIN_NAMESPACE
 class qw_buffer;

--- a/src/modules/foreign-toplevel/dockpreviewcontextv1.h
+++ b/src/modules/foreign-toplevel/dockpreviewcontextv1.h
@@ -11,6 +11,8 @@
 #include <QString>
 #include <memory>
 
+Q_MOC_INCLUDE("modules/foreign-toplevel/foreigntoplevelhandlev1.h")
+
 class ForeignToplevelHandleV1;
 class ForeignToplevelManagerInterfaceV1;
 class DockPreviewContextV1Private;


### PR DESCRIPTION
Closes WM-85

Add `Q_MOC_INCLUDE` directives to two header files to resolve `-Wsfinae-incomplete` warnings during moc compilation:

- `src/modules/foreign-toplevel/dockpreviewcontextv1.h`: add `Q_MOC_INCLUDE("modules/foreign-toplevel/foreigntoplevelhandlev1.h")`
- `src/core/shellhandler.h`: add `Q_MOC_INCLUDE(<wlayersurface.h>)`

## Summary by Sourcery

Add Q_MOC_INCLUDE directives to resolve moc compilation warnings related to incomplete SFINAE with foreign-toplevel and shell handler types.

Bug Fixes:
- Resolve -Wsfinae-incomplete moc compilation warnings in dockpreviewcontextv1 by explicitly including ForeignToplevelHandleV1.
- Resolve -Wsfinae-incomplete moc compilation warnings in shellhandler by explicitly including wlayersurface.