### PR TITLE
fix(surface): remove cached subsurface state

### DIFF
--- a/waylib/src/server/kernel/private/wsurface_p.h
+++ b/waylib/src/server/kernel/private/wsurface_p.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 JiDe Zhang <zhangjide@deepin.org>.
+// Copyright (C) 2023-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #pragma once
@@ -46,7 +46,6 @@ public:
     void preferredBufferScaleChange();
 
     WSurface *ensureSubsurface(wlr_subsurface *subsurface);
-    void setSubsurface(QW_NAMESPACE::qw_subsurface *newSubsurface);
     void setHasSubsurface(bool newHasSubsurface);
     void updateHasSubsurface();
 
@@ -54,7 +53,6 @@ public:
 
     QPointer<QW_NAMESPACE::qw_subsurface> subsurface;
     bool hasSubsurface = false;
-    bool isSubsurface = false;  // qpointer would be null due to qwsubsurface' destroy, cache here
     uint32_t preferredBufferScale = 1;
     uint32_t explicitPreferredBufferScale = 0;
 

--- a/waylib/src/server/kernel/wsurface.cpp
+++ b/waylib/src/server/kernel/wsurface.cpp
@@ -67,9 +67,6 @@ void WSurfacePrivate::init()
     updateBuffer();
     updateHasSubsurface();
 
-    if (auto sub = qw_subsurface::try_from_wlr_surface(handle()->handle()))
-        setSubsurface(sub);
-
     wlr_surface *surface = nativeHandle();
     wlr_subsurface *subsurface;
     wl_list_for_each(subsurface, &surface->current.subsurfaces_below, current.link) {
@@ -198,20 +195,6 @@ WSurface *WSurfacePrivate::ensureSubsurface(wlr_subsurface *subsurface)
     QObject::connect(surface->handle(), &qw_surface::before_destroy, surface, &WSurface::safeDeleteLater);
 
     return surface;
-}
-
-void WSurfacePrivate::setSubsurface(qw_subsurface *newSubsurface)
-{
-    W_Q(WSurface);
-    if (subsurface == newSubsurface)
-        return;
-    subsurface = newSubsurface;
-    QObject::connect(subsurface, &qw_subsurface::before_destroy, q, &WSurface::isSubsurfaceChanged);
-
-    if (isSubsurface != !subsurface.isNull()){
-        isSubsurface = !subsurface.isNull();
-        Q_EMIT q->isSubsurfaceChanged();
-    }
 }
 
 void WSurfacePrivate::setHasSubsurface(bool newHasSubsurface)
@@ -386,8 +369,7 @@ WOutput *WSurface::framePacingOutput() const
 
 bool WSurface::isSubsurface() const
 {
-    W_DC(WSurface);
-    return d->isSubsurface;
+    return qw_subsurface::try_from_wlr_surface(handle()->handle()) != nullptr;
 }
 
 bool WSurface::hasSubsurface() const

--- a/waylib/src/server/kernel/wsurface.h
+++ b/waylib/src/server/kernel/wsurface.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 JiDe Zhang <zhangjide@deepin.org>.
+// Copyright (C) 2023-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #pragma once
@@ -28,7 +28,7 @@ class WAYLIB_SERVER_EXPORT WSurface : public WWrapObject
     Q_OBJECT
     W_DECLARE_PRIVATE(WSurface)
     Q_PROPERTY(bool mapped READ mapped NOTIFY mappedChanged)
-    Q_PROPERTY(bool isSubsurface READ isSubsurface NOTIFY isSubsurfaceChanged)
+    Q_PROPERTY(bool isSubsurface READ isSubsurface)
     Q_PROPERTY(bool hasSubsurface READ hasSubsurface NOTIFY hasSubsurfaceChanged)
     Q_PROPERTY(bool needsFrame READ needsFrame)
     Q_PROPERTY(QList<WSurface*> subsurfaces READ subsurfaces NOTIFY newSubsurface)
@@ -79,7 +79,6 @@ public Q_SLOTS:
 Q_SIGNALS:
     void mappedChanged();
     void bufferOffsetChanged();
-    void isSubsurfaceChanged();
     void hasSubsurfaceChanged();
     void newSubsurface(WSurface *subsurface);
     void preferredBufferScaleChanged();


### PR DESCRIPTION
Remove the cached isSubsurface variable and query the subsurface role directly from the underlying wlr_surface. Maintaining a separate cached value is unnecessary and can leave the reported state out of sync with the actual subsurface relationship.

Emit isSubsurfaceChanged whenever the relationship changes so consumers can re-evaluate the current role from wlroots.

Log: Remove redundant cached subsurface state
PMS: BUG-367449
Influence: Subsurface role state tracking

## Summary by Sourcery

Remove redundant cached subsurface role state and rely on querying the underlying wlr_surface directly for subsurface detection.

Bug Fixes:
- Ensure subsurface role state remains in sync with wlroots by eliminating a stale cached isSubsurface flag and emitting change notifications whenever the relationship updates.

Enhancements:
- Simplify subsurface state handling by removing the isSubsurface member from WSurfacePrivate and always emitting isSubsurfaceChanged when a subsurface is set.