### PR TITLE
fix filter hold gestures by finger count at start and trigger gesture immediately

### DIFF
--- a/misc/dconfig/org.deepin.dde.treeland.user.seat.json
+++ b/misc/dconfig/org.deepin.dde.treeland.user.seat.json
@@ -144,6 +144,17 @@
             "description[zh_CN]": "按住按键后开始重复输入前的等待时间（以毫秒为单位）。值越低等待时间越短。有效范围通常为 0 到 1000 毫秒。",
             "permissions": "readwrite",
             "visibility": "public"
+        },
+        "touchpadHoldTimeoutMs": {
+            "value": 0,
+            "serial": 0,
+            "flags": [],
+            "name": "Touchpad Hold Gesture Timeout",
+            "name[zh_CN]": "触控板长按手势超时",
+            "description": "Duration in milliseconds to wait after a libinput HOLD BEGIN event before triggering the hold gesture action.",
+            "description[zh_CN]": "收到 libinput HOLD BEGIN 事件后等待多少毫秒再触发 hold 手势动作。",
+            "permissions": "readwrite",
+            "visibility": "public"
         }
     }
 }

--- a/src/input/gestures.cpp
+++ b/src/input/gestures.cpp
@@ -357,7 +357,6 @@ HoldGesture::HoldGesture(QObject *parent)
     , m_holdTimer(new QTimer(this))
 {
     m_holdTimer->setSingleShot(true);
-    m_holdTimer->setInterval(1000);
     connect(m_holdTimer, &QTimer::timeout, this, &HoldGesture::longPressed);
 }
 
@@ -433,7 +432,16 @@ void GestureRecognizer::registerHoldGesture(HoldGesture *gesture)
         m_holdGestures.removeOne(gesture);
         m_activeHoldGestures.removeOne(gesture);
     });
+    gesture->setInterval(m_holdTimeout);
     m_holdGestures << gesture;
+}
+
+void GestureRecognizer::setHoldTimeout(int msec)
+{
+    m_holdTimeout = msec;
+    for (auto &&gesture : std::as_const(m_holdGestures)) {
+        gesture->setInterval(msec);
+    }
 }
 
 void GestureRecognizer::unregisterHoldGesture(HoldGesture *gesture)

--- a/src/input/gestures.cpp
+++ b/src/input/gestures.cpp
@@ -361,6 +361,44 @@ HoldGesture::HoldGesture(QObject *parent)
     connect(m_holdTimer, &QTimer::timeout, this, &HoldGesture::longPressed);
 }
 
+bool HoldGesture::minimumFingerCountIsRelevant() const
+{
+    return m_minimumFingerCountRelevant;
+}
+
+void HoldGesture::setMinimumFingerCount(uint count)
+{
+    if (count == m_minimumFingerCount) {
+        return;
+    }
+    m_minimumFingerCount = count;
+    m_minimumFingerCountRelevant = true;
+}
+
+uint HoldGesture::minimumFingerCount() const
+{
+    return m_minimumFingerCount;
+}
+
+bool HoldGesture::maximumFingerCountIsRelevant() const
+{
+    return m_maximumFingerCountRelevant;
+}
+
+void HoldGesture::setMaximumFingerCount(uint count)
+{
+    if (count == m_maximumFingerCount) {
+        return;
+    }
+    m_maximumFingerCount = count;
+    m_maximumFingerCountRelevant = true;
+}
+
+uint HoldGesture::maximumFingerCount() const
+{
+    return m_maximumFingerCount;
+}
+
 HoldGesture::~HoldGesture()
 {
     if (m_holdTimer != nullptr) {
@@ -411,10 +449,16 @@ void GestureRecognizer::startHoldGesture(uint fingerCount)
 {
     m_currentFingerCount = fingerCount;
     for (auto &&gesture : std::as_const(m_holdGestures)) {
-        if (!gesture->isActive()) {
-            gesture->startTimer();
-            m_activeHoldGestures << gesture;
-        }
+        if (gesture->isActive())
+            continue;
+
+        if ((gesture->minimumFingerCountIsRelevant() && gesture->minimumFingerCount() > fingerCount)
+            || (gesture->maximumFingerCountIsRelevant()
+                && gesture->maximumFingerCount() < fingerCount))
+            continue;
+
+        gesture->startTimer();
+        m_activeHoldGestures << gesture;
     }
 }
 

--- a/src/input/gestures.h
+++ b/src/input/gestures.h
@@ -106,8 +106,20 @@ public:
     void stopTimer();
     bool isActive() const;
 
+    bool minimumFingerCountIsRelevant() const;
+    void setMinimumFingerCount(uint count);
+    uint minimumFingerCount() const;
+
+    bool maximumFingerCountIsRelevant() const;
+    void setMaximumFingerCount(uint count);
+    uint maximumFingerCount() const;
+
 private:
     QTimer *m_holdTimer;
+    bool m_minimumFingerCountRelevant = false;
+    uint m_minimumFingerCount = 0;
+    bool m_maximumFingerCountRelevant = false;
+    uint m_maximumFingerCount = 0;
 };
 
 class GestureRecognizer : public QObject

--- a/src/input/gestures.h
+++ b/src/input/gestures.h
@@ -159,6 +159,7 @@ public:
 
     void startHoldGesture(uint fingerCount);
     void endHoldGesture();
+    void setHoldTimeout(int msec);
 
 private:
     void cancelSwipeActiveGestures();
@@ -173,5 +174,6 @@ private:
 
     QPointF m_currentDelta = QPointF(0, 0);
     uint m_currentFingerCount = 0;
+    int m_holdTimeout = 0;
     GestureRecognizer::Axis m_currentSwipeAxis = GestureRecognizer::None;
 };

--- a/src/input/inputdevice.cpp
+++ b/src/input/inputdevice.cpp
@@ -472,3 +472,8 @@ void InputDevice::processHoldEnd()
         m_touchpadRecognizer->endHoldGesture();
     }
 }
+
+void InputDevice::setHoldTimeout(int msec)
+{
+    m_touchpadRecognizer->setHoldTimeout(msec);
+}

--- a/src/input/inputdevice.cpp
+++ b/src/input/inputdevice.cpp
@@ -404,6 +404,8 @@ InputDevice *InputDevice::instance()
 [[maybe_unused]] HoldGesture* InputDevice::registerTouchpadHold(const HoldFeedBack &feed)
 {
     auto hold_gesture = new HoldGesture();
+    hold_gesture->setMinimumFingerCount(feed.fingerCount);
+    hold_gesture->setMaximumFingerCount(feed.fingerCount);
 
     if (feed.actionCallback) {
         QObject::connect(hold_gesture, &HoldGesture::cancelled, feed.actionCallback);

--- a/src/input/inputdevice.h
+++ b/src/input/inputdevice.h
@@ -53,6 +53,7 @@ public:
 
     void processHoldStart(uint finger);
     void processHoldEnd();
+    void setHoldTimeout(int msec);
 
 private:
     InputDevice(QObject *parent = nullptr);

--- a/src/input/inputmanager.cpp
+++ b/src/input/inputmanager.cpp
@@ -96,6 +96,8 @@ void InputManager::onConfigInitializeSucceed()
         }
     }
 
+    InputDevice::instance()->setHoldTimeout(m_seatDConfig->touchpadHoldTimeoutMs());
+
     auto backend = Helper::instance()->backend();
     connect(backend,
             &WBackend::inputAdded,


### PR DESCRIPTION
## Summary by Sourcery

Filter and trigger touchpad hold gestures based on the finger count present at gesture start, and make hold gestures fire immediately instead of after a delay.

New Features:
- Allow configuring minimum and maximum finger counts on hold gestures to constrain which gestures activate for a given touch event.

Bug Fixes:
- Prevent hold gestures from activating when the current finger count does not match the configured finger count range.