### PR TITLE
fix(input): show negotiated cursor during drag

### DIFF
--- a/waylib/src/server/kernel/wseat.cpp
+++ b/waylib/src/server/kernel/wseat.cpp
@@ -355,6 +355,7 @@ public:
     void updateCapabilities();
     void attachInputDevice(WInputDevice *device);
     void detachInputDevice(WInputDevice *device);
+    bool canSetCursor(wlr_seat_client *client) const;
     // handle spontaneous & synthetic key event for focusWindow
     void handleKeyEvent(QKeyEvent &e);
 
@@ -452,12 +453,25 @@ void WSeatPrivate::on_destroy()
     q_func()->m_handle = nullptr;
 }
 
+bool WSeatPrivate::canSetCursor(wlr_seat_client *client) const
+{
+    const auto *seat = nativeHandle();
+    if (seat->pointer_state.focused_client == client)
+        return true;
+
+    const auto *drag = seat->drag;
+    return drag
+            && drag->grab_type == WLR_DRAG_GRAB_KEYBOARD_POINTER
+            && drag->seat_client == client;
+}
+
 void WSeatPrivate::on_request_set_cursor(wlr_seat_pointer_request_set_cursor_event *event)
 {
-    auto focused_client = nativeHandle()->pointer_state.focused_client;
-    /* This can be sent by any client, so we check to make sure this one is
-     * actually has pointer focus first. */
-    if (focused_client == event->seat_client) {
+    const bool accepted = canSetCursor(event->seat_client);
+
+    /* This can be sent by any client, so only accept it from the pointer-focused
+     * client or the source client of the active pointer drag. */
+    if (accepted) {
         /* Once we've vetted the client, we can tell the cursor to use the
          * provided surface as the cursor image. It will set the hardware cursor
          * on the output that it's currently on and continue to do so as the
@@ -804,7 +818,7 @@ WGlobal::CursorShape WSeat::requestedCursorShape() const
 {
     W_DC(WSeat);
 
-    if (d->cursorClient != d->nativeHandle()->pointer_state.focused_client) {
+    if (!d->canSetCursor(d->cursorClient)) {
         qCWarning(lcWlSeat, "Focused client never set cursor shape nor surface, will fallback to `Default`");
         return WGlobal::CursorShape::Default;
     }
@@ -816,7 +830,7 @@ WSurface *WSeat::requestedCursorSurface() const
 {
     W_DC(WSeat);
 
-    if (d->cursorClient == d->nativeHandle()->pointer_state.focused_client)
+    if (d->canSetCursor(d->cursorClient))
         return d->cursorSurface;
     return nullptr;
 }
@@ -1479,7 +1493,8 @@ void WSeat::notifyTouchFrame([[maybe_unused]] WCursor *cursor)
 void WSeat::setCursorShape(wlr_seat_client *client, WGlobal::CursorShape shape)
 {
     W_D(WSeat);
-    if (client != d->nativeHandle()->pointer_state.focused_client)
+    const bool accepted = d->canSetCursor(client);
+    if (!accepted)
         return;
     d->cursorShape = shape;
     d->cursorClient = client;

--- a/waylib/src/server/kernel/wseat.cpp
+++ b/waylib/src/server/kernel/wseat.cpp
@@ -516,17 +516,19 @@ void WSeatPrivate::on_request_start_drag(wlr_seat_request_start_drag_event *even
 void WSeatPrivate::on_start_drag(wlr_drag *drag)
 {
     doClearPointerFocus();
+    W_Q(WSeat);
+    if (dragSurface)
+        dragSurface->safeDeleteLater();
+    dragSurface = nullptr;
+
     if (drag->icon) {
-        W_Q(WSeat);
         auto *surface = qw_surface::from(drag->icon->surface);
         auto *wsurface = new WSurface(surface, q);
         QObject::connect(surface, &qw_surface::before_destroy,
                          wsurface, &WSurface::safeDeleteLater);
-        if (dragSurface)
-            dragSurface->safeDeleteLater();
         dragSurface = wsurface;
-        Q_EMIT q->requestDrag(dragSurface.get());
     }
+    Q_EMIT q->requestDrag(dragSurface.get());
 }
 void WSeatPrivate::handleKeyEvent(QKeyEvent &e)
 {


### PR DESCRIPTION
拖放过程中，合成器光标没有及时反映目标端协商出的动作，拖拽生命周期还错误依赖可选的 drag icon。

- 在 wlroots 数据源中增加统一的 DnD 状态事件，并通过 qwlroots 暴露给 waylib。
- 根据目标接受状态和协商动作显示禁止、复制、移动或询问光标。
- 拖拽结束时清理图标 surface、恢复拖拽前光标，并避免结束通知进入启动处理。
- 增加独立的 dragStarted 信号，无 drag icon 时也会更新 hover target 并发送 DDE 通知。

确保异步协商结果能够立即反馈到光标，同时解除拖拽业务生命周期对可选图标 surface 的依赖。

Log: show negotiated cursor during drag
PMS: BUG-339263
影响: drag时的光标形态变化