### PR TITLE
fix: resolve sfinae and qml type registration warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,6 +115,7 @@ set_target_properties(libtreeland PROPERTIES
 qt_add_qml_module(libtreeland
     URI Treeland
     VERSION "2.0"
+    IMPORTS Waylib.Server 1.0
 
     SOURCES
         ${DDM_DBUS_SOURCES}

--- a/src/core/shellhandler.h
+++ b/src/core/shellhandler.h
@@ -20,6 +20,8 @@
 
 Q_MOC_INCLUDE("workspace/workspace.h")
 Q_MOC_INCLUDE(<wlayersurface.h>)
+Q_MOC_INCLUDE(<wxdgtoplevelsurface.h>)
+Q_MOC_INCLUDE(<wxwaylandsurface.h>)
 
 QW_BEGIN_NAMESPACE
 class qw_buffer;

--- a/src/modules/capture/CMakeLists.txt
+++ b/src/modules/capture/CMakeLists.txt
@@ -25,6 +25,7 @@ set_target_properties(${MODULE_NAME} PROPERTIES
 qt_add_qml_module(${MODULE_NAME}
     URI Treeland.Capture
     VERSION 1.0
+    IMPORTS Treeland 2.0
     NO_PLUGIN
     SOURCES
         ${CMAKE_SOURCE_DIR}/src/modules/capture/capture.h

--- a/src/modules/foreign-toplevel/foreigntoplevelhandlev1.h
+++ b/src/modules/foreign-toplevel/foreigntoplevelhandlev1.h
@@ -12,6 +12,8 @@
 
 #include <sys/types.h>
 
+Q_MOC_INCLUDE(<woutput.h>)
+
 class SurfaceEntry;
 class ForeignToplevelManagerInterfaceV1;
 class ForeignToplevelHandleV1Private;

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -35,6 +35,7 @@ class QJsonObject;
 Q_MOC_INCLUDE(<QDBusObjectPath>)
 Q_MOC_INCLUDE(<qwgammacontorlv1.h>)
 Q_MOC_INCLUDE(<qwoutputmanagementv1.h>)
+Q_MOC_INCLUDE(<woutput.h>)
 Q_MOC_INCLUDE(<wlayersurface.h>)
 Q_MOC_INCLUDE(<wtoplevelsurface.h>)
 Q_MOC_INCLUDE(<wxdgsurface.h>)

--- a/waylib/examples/tinywl/CMakeLists.txt
+++ b/waylib/examples/tinywl/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(${TARGET}
 qt_add_qml_module(${TARGET}
     URI Tinywl
     VERSION "2.0"
+    IMPORTS Waylib.Server 1.0
 
     SOURCES helper.h helper.cpp
     SOURCES surfacewrapper.h surfacewrapper.cpp

--- a/waylib/src/server/kernel/wbackend.h
+++ b/waylib/src/server/kernel/wbackend.h
@@ -9,6 +9,9 @@
 
 #include <QObject>
 
+Q_MOC_INCLUDE("woutput.h")
+Q_MOC_INCLUDE("winputdevice.h")
+
 QW_BEGIN_NAMESPACE
 class qw_session;
 QW_END_NAMESPACE

--- a/waylib/src/server/kernel/woutputlayout.h
+++ b/waylib/src/server/kernel/woutputlayout.h
@@ -7,6 +7,8 @@
 #include <WServer>
 #include <limits.h>
 
+Q_MOC_INCLUDE("woutput.h")
+
 QW_BEGIN_NAMESPACE
 class qw_output_layout;
 QW_END_NAMESPACE

--- a/waylib/src/server/kernel/wseat.h
+++ b/waylib/src/server/kernel/wseat.h
@@ -39,6 +39,7 @@ class WAYLIB_SERVER_EXPORT WSeatEventFilter : public QObject
     friend class WSeat;
     friend class WSeatPrivate;
     Q_OBJECT
+    QML_ANONYMOUS
 public:
     explicit WSeatEventFilter(QObject *parent = nullptr);
 

--- a/waylib/src/server/kernel/wsurface.h
+++ b/waylib/src/server/kernel/wsurface.h
@@ -11,6 +11,8 @@
 #include <QRect>
 #include <QQmlEngine>
 
+Q_MOC_INCLUDE("woutput.h")
+
 struct wlr_surface;
 
 QW_BEGIN_NAMESPACE

--- a/waylib/src/server/protocols/wlayershell.h
+++ b/waylib/src/server/protocols/wlayershell.h
@@ -9,6 +9,8 @@
 
 #include <QQmlEngine>
 
+Q_MOC_INCLUDE("wlayersurface.h")
+
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
 class WXdgShell;

--- a/waylib/src/server/protocols/wxdgdialogmanagerv1.h
+++ b/waylib/src/server/protocols/wxdgdialogmanagerv1.h
@@ -7,6 +7,8 @@
 
 #include <QObject>
 
+Q_MOC_INCLUDE("wxdgtoplevelsurface.h")
+
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
 class WXdgToplevelSurface;

--- a/waylib/src/server/protocols/wxdgshell.h
+++ b/waylib/src/server/protocols/wxdgshell.h
@@ -7,6 +7,8 @@
 
 class wlr_xdg_popup;
 
+Q_MOC_INCLUDE("wxdgtoplevelsurface.h")
+
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
 class WXdgToplevelSurface;

--- a/waylib/src/server/protocols/wxwayland.h
+++ b/waylib/src/server/protocols/wxwayland.h
@@ -13,6 +13,8 @@
 
 #include <functional>
 
+Q_MOC_INCLUDE("wxwaylandsurface.h")
+
 QW_BEGIN_NAMESPACE
 class qw_xwayland;
 class qw_compositor;


### PR DESCRIPTION
## Summary

Fix `-Wsfinae-incomplete` warnings and QML type-registration `base-type-not-found` warnings in waylib/treeland (14 files, 24 insertions).

### SFINAE incomplete-type warnings (`Q_MOC_INCLUDE`)

Add `Q_MOC_INCLUDE` directives so moc completes types before SFINAE probing for signal/slot parameters:

- waylib (quote style): `woutputlayout.h`, `wbackend.h`, `wsurface.h`, `wlayershell.h`, `wxdgshell.h`, `wxwayland.h`, `wxdgdialogmanagerv1.h`
- treeland (angle-bracket style): `helper.h`, `shellhandler.h`, `foreigntoplevelhandlev1.h`

### QML cross-module base-type warnings

- Add `QML_ANONYMOUS` to `WSeatEventFilter` so qmltyperegistrar can resolve it as a base type of `Helper`
- Add CMake `IMPORTS` to QML modules so cross-module base types resolve:
  - `src/CMakeLists.txt` (Treeland 2.0) → `IMPORTS Waylib.Server 1.0`
  - `src/modules/capture/CMakeLists.txt` (Treeland.Capture) → `IMPORTS Treeland 2.0`
  - `waylib/examples/tinywl/CMakeLists.txt` (Tinywl) → `IMPORTS Waylib.Server 1.0`

### Notes

- `Q_MOC_INCLUDE` placement follows the pattern of commit `8a3e65490` (after includes, before class/namespace declaration)
- `ObjectListModel<T>` template base-type warnings are benign (Qt qmltyperegistrar cannot resolve template instantiations) and intentionally not addressed
- Supersedes #1189 (fork-based PR whose commitlint/SPDX checks failed because the fork was behind upstream master)

Multica issue: [WM-86](https://agentapi-dev.uniontech.com/issue/868b2b3e-edc7-4e10-afbc-41c56d5855f7)
