### PR TITLE
fix: remove version pinning from QML module IMPORTS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,7 +115,7 @@ set_target_properties(libtreeland PROPERTIES
 qt_add_qml_module(libtreeland
     URI Treeland
     VERSION "2.0"
-    IMPORTS Waylib.Server 1.0
+    IMPORTS Waylib.Server
 
     SOURCES
         ${DDM_DBUS_SOURCES}

--- a/src/modules/capture/CMakeLists.txt
+++ b/src/modules/capture/CMakeLists.txt
@@ -25,7 +25,6 @@ set_target_properties(${MODULE_NAME} PROPERTIES
 qt_add_qml_module(${MODULE_NAME}
     URI Treeland.Capture
     VERSION 1.0
-    IMPORTS Treeland 2.0
     NO_PLUGIN
     SOURCES
         ${CMAKE_SOURCE_DIR}/src/modules/capture/capture.h

--- a/waylib/examples/tinywl/CMakeLists.txt
+++ b/waylib/examples/tinywl/CMakeLists.txt
@@ -29,7 +29,7 @@ add_executable(${TARGET}
 qt_add_qml_module(${TARGET}
     URI Tinywl
     VERSION "2.0"
-    IMPORTS Waylib.Server 1.0
+    IMPORTS Waylib.Server
 
     SOURCES helper.h helper.cpp
     SOURCES surfacewrapper.h surfacewrapper.cpp


### PR DESCRIPTION
Remove strict version constraints from IMPORTS directives to avoid runtime QML module resolution failures when the installed module version differs.

移除 IMPORTS 指令中的版本号，避免运行时因版本不匹配
导致 QML 模块加载失败。

Log: 移除QML模块IMPORTS版本号限制
Influence: 修复目标环境因QML模块版本不匹配导致treeland启动崩溃的问题。