### PR TITLE
feat: set fcitx input method environment in session service

### DIFF
--- a/misc/systemd/dde-session-pre.target.wants/treeland-sd.service.in
+++ b/misc/systemd/dde-session-pre.target.wants/treeland-sd.service.in
@@ -22,6 +22,14 @@ UnsetEnvironment=DISPLAY
 UnsetEnvironment=WAYLAND_DISPLAY
 ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/treeland-sd --type wayland
 ExecStartPost=-/usr/bin/systemctl --user set-environment WAYLAND_DISPLAY=treeland.socket
+ExecStartPost=-/usr/bin/systemctl --user set-environment QT_IM_MODULE=fcitx
+ExecStartPost=-/usr/bin/systemctl --user set-environment QT_IM_MODULES=wayland;fcitx
+ExecStartPost=-/usr/bin/systemctl --user set-environment SDL_IM_MODULE=fcitx
+ExecStartPost=-/usr/bin/systemctl --user set-environment XMODIFIERS=@im=fcitx
+ExecStop=-/usr/bin/systemctl --user unset-environment XMODIFIERS
+ExecStop=-/usr/bin/systemctl --user unset-environment SDL_IM_MODULE
+ExecStop=-/usr/bin/systemctl --user unset-environment QT_IM_MODULES
+ExecStop=-/usr/bin/systemctl --user unset-environment QT_IM_MODULE
 ExecStop=-/usr/bin/systemctl --user unset-environment WAYLAND_DISPLAY
 Slice=session.slice
 RestartSec=1s


### PR DESCRIPTION
1. Add ExecStartPost to set QT_IM_MODULE and QT_IM_MODULES for fcitx
2. Add ExecStop to unset QT_IM_MODULE and QT_IM_MODULES on service stop
3. Ensure input method environment is properly configured for treeland session

Log: Set fcitx environment variables in treeland session systemd service for proper input method initialization.

Influence:
1. Verify fcitx input method works in Qt applications under treeland
2. Verify QT_IM_MODULE and QT_IM_MODULES are set after session starts
3. Verify environment variables are cleaned up when session stops
4. Verify no regression for other input methods

feat: 在会话服务中设置 fcitx 输入法环境变量

1. 添加 ExecStartPost 设置 fcitx 的 QT_IM_MODULE 和 QT_IM_MODULES
2. 添加 ExecStop 在服务停止时取消设置 QT_IM_MODULE 和 QT_IM_MODULES
3. 确保 treeland 会话中输入法环境正确配置

Log: 在 treeland 会话 systemd 服务中设置 fcitx 环境变量以确保输入法正常初始化。

Influence:
1. 验证 treeland 下 Qt 应用中 fcitx 输入法正常工作
2. 验证会话启动后 QT_IM_MODULE 和 QT_IM_MODULES 已设置
3. 验证会话停止后环境变量被清理
4. 验证其他输入法无回归问题

PMS: TASK-390751

## Summary by Sourcery

Configure fcitx input method environment variables in the treeland session systemd service to ensure proper initialization and cleanup across session lifecycle.

New Features:
- Set QT_IM_MODULE and QT_IM_MODULES for fcitx when the treeland session service starts to enable fcitx in Qt applications.

Enhancements:
- Unset fcitx-related QT_IM_MODULE and QT_IM_MODULES environment variables when the treeland session service stops to avoid leaking session-specific configuration.