### PR TITLE
fix(workspace): activate focus on touchpad gesture workspace switch

### DIFF
--- a/src/modules/shortcut/shortcutrunner.cpp
+++ b/src/modules/shortcut/shortcutrunner.cpp
@@ -294,7 +294,7 @@ void ShortcutRunner::finishWorkspaceSwipe()
     if (!m_slideBounce && (m_desktopOffset > 0.98 || m_desktopOffset < -0.98)) {
         // m_desktopOffset is very close to 1 or -1, just set to the toId directly
         // Not need to play the slide animation
-        workspace->setCurrentIndex(m_toId);
+        workspace->switchTo(m_toId, false);
         auto *controller = workspace->animationController();
         controller->setRunning(false);
         return;
@@ -319,7 +319,7 @@ void ShortcutRunner::finishWorkspaceSwipe()
     if (m_toId >= 0 && m_toId < workspace->count()) {
         controller->slideRunning(m_toId);
         controller->startSlideAnimation();
-        workspace->setCurrentIndex(m_toId);
+        workspace->switchTo(m_toId, false);
     }
 }
 

--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -239,7 +239,7 @@ void Workspace::switchToPrev()
     }
 }
 
-void Workspace::switchTo(int index)
+void Workspace::switchTo(int index, bool animated)
 {
     if (index < 0 || index >= m_models->rowCount() || index == currentIndex())
         return;
@@ -250,8 +250,18 @@ void Workspace::switchTo(int index)
     auto oldCurrentIndex = currentIndex();
     setCurrentIndex(index);
     Helper::instance()->activateSurface(current()->latestActiveSurface());
-    createSwitcher();
-    m_animationController->slide(oldCurrentIndex, currentIndex());
+
+    if (animated) {
+        createSwitcher();
+        m_animationController->slide(oldCurrentIndex, currentIndex());
+    } else if (m_switcher && m_switcher->isVisible()) {
+        // activateSurface restacks the target surface via stackToLast(), placing it above
+        // the already-visible workspace switcher. Raise the switcher back on top so the
+        // slide animation is not visually broken by the real window peeking through.
+        auto *switcherParent = m_switcher->parentItem();
+        Q_ASSERT(switcherParent && !switcherParent->childItems().isEmpty());
+        m_switcher->stackAfter(switcherParent->childItems().last());
+    }
 }
 
 WorkspaceModel *Workspace::current() const

--- a/src/workspace/workspace.h
+++ b/src/workspace/workspace.h
@@ -67,7 +67,7 @@ public:
     void setCurrentIndex(int newCurrentIndex);
     Q_INVOKABLE void switchToNext();
     Q_INVOKABLE void switchToPrev();
-    Q_INVOKABLE void switchTo(int index);
+    Q_INVOKABLE void switchTo(int index, bool animated = true);
 
     WorkspaceModel *current() const;
     void setCurrent(WorkspaceModel *container);


### PR DESCRIPTION
Touchpad gesture path called setCurrentIndex directly, bypassing switchTo, so dismissAllPopups and activateSurface were skipped. Add animated param to switchTo: gesture path reuses switchTo(state mgmt) while skipping built-in slide() that conflicts with its own animation.

触控板手势切换工作区路径直接调用setCurrentIndex，绕过switchTo，
导致dismissAllPopups和activateSurface被跳过。为switchTo增加animated 参数：手势路径复用switchTo的状态管理逻辑，同时跳过与其外部动画冲突
的内置slide()动画。

Log: 修复触控板手势切换工作区不激活窗口焦点
Influence: switchTo新增animated参数(默认true,向后兼容)；手势路径
finishWorkspaceSwipe改调switchTo(m_toId,false)，补齐dismissAllPopups 与activateSurface；非动画分支额外restack已存在的switcher以防止
activateSurface的stackToLast将窗口盖到动画层之上。

## Summary by Sourcery

Ensure workspace switching via touchpad gestures uses the same focus and popup management as other workspace transitions while allowing non-animated paths.

Bug Fixes:
- Fix workspace switching via touchpad gestures not activating the target workspace window or dismissing popups.

Enhancements:
- Add an optional animation flag to workspace switching to support gesture-driven transitions without triggering the built-in slide animation.