### PR TITLE
fix(surface): fix null container dereference when proxy surface syncs…

### DIFF
--- a/src/surface/surfaceproxy.cpp
+++ b/src/surface/surfaceproxy.cpp
@@ -118,6 +118,16 @@ void SurfaceProxy::setSurface(SurfaceWrapper *newSurface)
                                        &SurfaceWrapper::noCornerRadiusChanged,
                                        this,
                                        &SurfaceProxy::updateNoCornerRadius);
+        m_sourceConnections
+            << connect(m_sourceSurface, &SurfaceWrapper::surfaceStateChanged, this, [this]() {
+                   if (m_proxySurface && m_sourceSurface) {
+                       auto newState = m_sourceSurface->surfaceState();
+                       if (m_proxySurface->m_surfaceState != newState) {
+                           m_proxySurface->m_surfaceState.setValueBypassingBindings(newState);
+                           m_proxySurface->m_surfaceState.notify();
+                       }
+                   }
+               });
 
         m_sourceConnections << connect(m_proxySurface,
                                        &SurfaceWrapper::widthChanged,


### PR DESCRIPTION
… state

When a SurfaceProxy forwards surfaceStateChanged to its proxy SurfaceWrapper via setSurfaceState(), the proxy crashes because it has no SurfaceContainer (container() returns nullptr).

The proxy SurfaceWrapper only needs its m_surfaceState property synchronized for QML binding purposes -- it should not go through the full state change logic (container filter, animations, shell surface calls).

Fix by directly updating the proxy's bindable property with setValueBypassingBindings() + notify() instead of calling setSurfaceState().

Close https://github.com/linuxdeepin/treeland/issues/1197