### PR TITLE
搜狗输入法相关 fix窗口切换器出现悬浮窗

### DIFF
--- a/src/plugins/multitaskview/multitaskview.cpp
+++ b/src/plugins/multitaskview/multitaskview.cpp
@@ -118,6 +118,8 @@ void MultitaskviewSurfaceModel::initializeModel()
     for (const auto &surface : std::as_const(surfaces)) {
         if (!Helper::instance()->surfaceBelongsToCurrentSession(surface))
             continue;
+        if (surface->skipMutiTaskView())
+            continue;
         if (surface->ownsOutput() == output()) {
             if (surfaceReady(surface)) {
                 m_data.push_back(std::make_shared<SurfaceModelData>(

--- a/src/surface/surfacefilterproxymodel.cpp
+++ b/src/surface/surfacefilterproxymodel.cpp
@@ -56,16 +56,17 @@ bool SurfaceFilterProxyModel::filterAcceptsRow(int source_row,
     QModelIndex index = sourceModel()->index(source_row, 0, source_parent);
     SurfaceWrapper *surface = sourceModel()->data(index).value<SurfaceWrapper *>();
 
+    if (!surface || surface->skipSwitcher()) {
+        return false;
+    }
+
     if (m_filterAppId.isEmpty()) {
         return true;
     }
 
-    if (surface) {
-        return surface->appId() == m_filterAppId;
-    }
-
-    return false;
+    return surface->appId() == m_filterAppId;
 }
+
 
 bool SurfaceFilterProxyModel::lessThan(const QModelIndex &source_left,
                                        const QModelIndex &source_right) const

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -430,7 +430,7 @@ void SurfaceWrapper::setup()
             moveNormalGeometryInOutput(xwaylandSurfaceItem->implicitPosition());
         }
 
-        auto updateX11shouldSkipDock = [this]() {
+        auto updateX11SkipFlags = [this]() {
             // TODO: support missing type in waylib
             // https://github.com/linuxdeepin/dde-shell/blob/b94a3cec4e01cba64f56e040e74419248985d03d/panels/dock/taskmanager/x11window.cpp#L81-L107
             auto xwaylandSurface = qobject_cast<WXWaylandSurface *>(this->shellSurface());
@@ -456,13 +456,21 @@ void SurfaceWrapper::setup()
             // skipDock |= atoms.testFlag(WXWaylandSurface::WindowType::NET_WM_WINDOW_TYPE_TOOLBAR);
             skipDock |= atoms.testFlag(WXWaylandSurface::WindowType::NET_WM_WINDOW_TYPE_TOOLTIP);
             setSkipDockPreView(skipDock);
+
+            bool notSkipSwitcher = false;
+            notSkipSwitcher |=
+                atoms.testFlag(WXWaylandSurface::WindowType::NET_WM_WINDOW_TYPE_NORMAL);
+            notSkipSwitcher |=
+                atoms.testFlag(WXWaylandSurface::WindowType::NET_WM_WINDOW_TYPE_DIALOG);
+            setSkipSwitcher(!notSkipSwitcher);
+            setSkipMutiTaskView(!notSkipSwitcher);
         };
 
         connect(xwaylandSurface,
                 &WXWaylandSurface::bypassManagerChanged,
                 this,
-                [this, updateX11shouldSkipDock]() {
-                    updateX11shouldSkipDock();
+                [this, updateX11SkipFlags]() {
+                    updateX11SkipFlags();
                     updateSizeCapabilities();
                     updateActivateCapability();
                     updateFocusCapability();
@@ -470,11 +478,11 @@ void SurfaceWrapper::setup()
         connect(xwaylandSurface,
                 &WXWaylandSurface::windowTypesChanged,
                 this,
-                [this, updateX11shouldSkipDock]() {
-                    updateX11shouldSkipDock();
+                [this, updateX11SkipFlags]() {
+                    updateX11SkipFlags();
                     updateSizeCapabilities();
                 });
-        updateX11shouldSkipDock();
+        updateX11SkipFlags();
     }
     // Connect DConfig windowRadius change so QML bindings re-evaluate radius()
     if (m_type == Type::XdgToplevel || m_type == Type::XWayland) {

--- a/waylib/src/server/protocols/wxwayland.h
+++ b/waylib/src/server/protocols/wxwayland.h
@@ -46,6 +46,7 @@ public:
         _NET_WM_WINDOW_TYPE_MENU,
         _NET_WM_WINDOW_TYPE_NOTIFICATION,
         _NET_WM_WINDOW_TYPE_SPLASH,
+        _NET_WM_WINDOW_TYPE_DIALOG,
         _NET_SUPPORTED,
         AtomCount
     };

--- a/waylib/src/server/protocols/wxwaylandsurface.cpp
+++ b/waylib/src/server/protocols/wxwaylandsurface.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 JiDe Zhang <zhangjide@deepin.org>.
+// Copyright (C) 2023-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wxwaylandsurface.h"
@@ -292,6 +292,9 @@ void WXWaylandSurfacePrivate::updateWindowTypes()
             break;
         case WXWayland::_NET_WM_WINDOW_TYPE_SPLASH:
             types |= WXWaylandSurface::NET_WM_WINDOW_TYPE_SPLASH;
+            break;
+        case WXWayland::_NET_WM_WINDOW_TYPE_DIALOG:
+            types |= WXWaylandSurface::NET_WM_WINDOW_TYPE_DIALOG;
             break;
         default:
             break;

--- a/waylib/src/server/protocols/wxwaylandsurface.h
+++ b/waylib/src/server/protocols/wxwaylandsurface.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 JiDe Zhang <zhangjide@deepin.org>.
+// Copyright (C) 2023-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #pragma once
@@ -63,7 +63,8 @@ public:
         NET_WM_WINDOW_TYPE_COMBO = 64,
         NET_WM_WINDOW_TYPE_MENU = 128,
         NET_WM_WINDOW_TYPE_NOTIFICATION = 256,
-        NET_WM_WINDOW_TYPE_SPLASH = 512
+        NET_WM_WINDOW_TYPE_SPLASH = 512,
+        NET_WM_WINDOW_TYPE_DIALOG = 1024,
     };
     Q_ENUM(WindowType)
     Q_DECLARE_FLAGS(WindowTypes, WindowType)


### PR DESCRIPTION
修复 `skipSwitcher` 和 `skipMultiTaskView` 属性未生效的问题。在 `filterAcceptsRow` 和多任务视图中增加过滤检查；waylib 补齐 `_NET_WM_WINDOW_TYPE_DIALOG` 支持；XWayland 窗口按类型自动设置跳过标志，仅放行 Normal 和 Dialog。

参考 KWin `wantsTabFocus()` 白名单策略。未对齐项：dock 过滤 Treeland 用 compositor 侧黑名单（原有逻辑）而 KWin 读 `_NET_WM_STATE_SKIP_TASKBAR` 
