### PR TITLE
fix 切工作区时概率崩溃 

### DIFF
--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -1236,6 +1236,8 @@ void SurfaceWrapper::updateBoundingRect()
 
 void SurfaceWrapper::updateVisible()
 {
+    if (m_wrapperAboutToRemove)
+        return;
     bool isVisible = !m_hideByWorkspace && !isMinimized()
         && ((surface() && surface()->mapped())
             || (m_prelaunchSplash && m_prelaunchSplash->isVisible()))


### PR DESCRIPTION
fix(surface): add m_wrapperAboutToRemove guard to updateBoundingRect
Add early return guard to updateBoundingRect() to prevent accessing
destroyed members during SurfaceWrapper teardown, consistent with
other state update functions guarded by m_wrapperAboutToRemove.

为updateBoundingRect()添加m_wrapperAboutToRemove提前返回守卫，
防止wrapper销毁期间（如destroy->invalidate->removeSurface链路）
访问已销毁的成员对象。

Log: 为updateBoundingRect添加wrapper销毁守卫
PMS: BUG-371455
Influence: 修复 wrapper 销毁期间访问触发崩溃。

```
#0  Waylib::Server::WSurface::mapped (this=0x5cde89036080) at /data/dev/treeland/waylib/src/server/kernel/wsurface.cpp:254
#1  0x000073631d20d08a in SurfaceWrapper::updateVisible (this=0x5cde89a68a40) at /data/dev/treeland/src/surface/surfacewrapper.cpp:1243
#2  0x000073631d2101b5 in SurfaceWrapper::setHideByWorkspace (this=0x5cde89a68a40, hide=false) at /data/dev/treeland/src/surface/surfacewrapper.cpp:2073
#3  0x000073631d24545a in WorkspaceModel::removeSurface (this=0x5cde85a2c910, surface=0x5cde89a68a40) at /data/dev/treeland/src/workspace/workspacemodel.cpp:87
#4  0x000073631d23e014 in Workspace::removeSurface (this=0x5cde858267c0, surface=0x5cde89a68a40) at /data/dev/treeland/src/workspace/workspace.cpp:144
#5  0x000073631d2077fa in SurfaceWrapper::invalidate (this=0x5cde89a68a40) at /data/dev/treeland/src/surface/surfacewrapper.cpp:205
#6  0x000073631d20c39e in SurfaceWrapper::destroy (this=0x5cde89a68a40) at /data/dev/treeland/src/surface/surfacewrapper.cpp:1086
#7  0x000073631d08542d in RootSurfaceContainer::destroyForSurface (this=0x5cde858d1d20, wrapper=0x5cde89a68a40) at /data/dev/treeland/src/core/rootsurfacecontainer.cpp:151
……
```

## Summary by Sourcery

Bug Fixes:
- Guard visibility updates when a surface wrapper is marked for removal to avoid workspace-switch crashes caused by accessing invalid surfaces.