### PR TITLE
fix(waylib/xwayland): deny Activate for surfaces without Focus capabi…

### DIFF
--- a/waylib/src/server/protocols/wxwaylandsurface.cpp
+++ b/waylib/src/server/protocols/wxwaylandsurface.cpp
@@ -422,10 +422,13 @@ bool WXWaylandSurface::hasCapability(Capability cap) const
                     | NET_WM_WINDOW_TYPE_DROPDOWN_MENU | NET_WM_WINDOW_TYPE_POPUP_MENU
                     | NET_WM_WINDOW_TYPE_COMBO | NET_WM_WINDOW_TYPE_MENU
                     | NET_WM_WINDOW_TYPE_NOTIFICATION | NET_WM_WINDOW_TYPE_SPLASH));
+    // TODO(xwayland): To implement ICCCM focus model, refer to
+    // https://github.com/labwc/labwc/blob/9ba3303246b1b1bf4dbf13793faa62ec74872e3b/src/xwayland.c#L108
+    case Activate: [[fallthrough]];
     case Focus:
-        return wlr_xwayland_surface_override_redirect_wants_focus(d->nativeHandle())
+        return !isBypassManager()
+            && wlr_xwayland_surface_override_redirect_wants_focus(d->nativeHandle())
             && wlr_xwayland_surface_icccm_input_model(d->nativeHandle()) != WLR_ICCCM_INPUT_MODEL_NONE;
-    case Activate:
     case FullScreen:
         return !isBypassManager();
     default:


### PR DESCRIPTION
…lity

WXWaylandSurface::hasCapability(Activate) fell through to the Focus case but was listed after it, making the intent unclear. Rearrange so Activate leads into Focus: surfaces that cannot receive focus (override-redirect or NONE input model) are also denied activation.

This prevents activating OR surfaces and is consistent with the Q_ASSERT in Helper::setActivatedSurface.

PMS: bug-view-371095.html
Log: 修复XWayland无Focus能力的窗口仍可被Activate的问题
Influence: 没有Focus能力的XWayland窗口不再被激活

## Summary by Sourcery

Restrict XWayland surface activation to windows that can receive focus, aligning Activate handling with the Focus capability.

Bug Fixes:
- Prevent activation of XWayland windows that lack focus capability, such as override-redirect or NONE input model surfaces.

Enhancements:
- Clarify capability handling in WXWaylandSurface by making Activate explicitly fall through to Focus and documenting future ICCCM focus model work.