### PR TITLE
Feat: 二分屏

### DIFF
--- a/misc/dconfig/org.deepin.dde.treeland.user.json
+++ b/misc/dconfig/org.deepin.dde.treeland.user.json
@@ -551,6 +551,39 @@
             "description[zh_CN]": "控制超椭圆形状的表面轮廓指数。2 产生更圆的轮廓；值越高边缘过渡越尖锐。范围：1.0-10.0。",
             "permissions": "readwrite",
             "visibility": "public"
+        },
+        "edgeSideTriggerDistance": {
+            "value": 20,
+            "serial": 0,
+            "flags": [],
+            "name": "Edge Side Trigger Distance",
+            "name[zh_CN]": "左右边缘触发距离",
+            "description": "Distance in pixels from the left/right screen edge at which half-screen tiling triggers",
+            "description[zh_CN]": "距离屏幕左/右边缘多少像素时触发半屏平铺",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "edgeTopTriggerDistance": {
+            "value": 5,
+            "serial": 0,
+            "flags": [],
+            "name": "Edge Top Trigger Distance",
+            "name[zh_CN]": "顶部边缘触发距离",
+            "description": "Distance in pixels from the top screen edge at which maximize triggers",
+            "description[zh_CN]": "距离屏幕顶部边缘多少像素时触发最大化",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "edgeInnerDelayMs": {
+            "value": 250,
+            "serial": 0,
+            "flags": [],
+            "name": "Edge Inner Delay",
+            "name[zh_CN]": "内边延迟",
+            "description": "Delay in milliseconds before activating edge tiling on an inner edge between screens",
+            "description[zh_CN]": "多屏内边延迟激活边缘平铺的毫秒数",
+            "permissions": "readwrite",
+            "visibility": "public"
         }
     }
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -263,6 +263,7 @@ qt_add_qml_module(libtreeland
         core/qml/FadeBehavior.qml
         core/qml/CaptureSelectorLayer.qml
         core/qml/WindowPickerLayer.qml
+        core/qml/EdgeTilePreview.qml
         core/qml/LockScreenFallback.qml
         core/qml/PrelaunchSplash.qml
     RESOURCE_PREFIX

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -195,6 +195,8 @@ qt_add_qml_module(libtreeland
         surface/surfaceproxy.h
         surface/surfacewrapper.cpp
         surface/surfacewrapper.h
+        surface/quicktile.cpp
+        surface/quicktile.h
         utils/cmdline.cpp
         utils/cmdline.h
         utils/propertymonitor.cpp

--- a/src/core/qml/EdgeTilePreview.qml
+++ b/src/core/qml/EdgeTilePreview.qml
@@ -1,0 +1,9 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+import QtQuick
+
+Rectangle {
+    visible: false
+    color: Qt.alpha(Helper.config.activeColor, 0.25)
+}

--- a/src/core/qmlengine.cpp
+++ b/src/core/qmlengine.cpp
@@ -36,6 +36,7 @@ QmlEngine::QmlEngine(QObject *parent)
     , showDesktopAnimatioComponentn(this, "Treeland", "ShowDesktopAnimation")
     , captureSelectorComponent(this, "Treeland", "CaptureSelectorLayer")
     , windowPickerComponent(this, "Treeland", "WindowPickerLayer")
+    , edgeTilePreviewComponent(this, "Treeland", "EdgeTilePreview")
     , launchpadAnimationComponent(this, "Treeland", "LaunchpadAnimation")
     , launchpadCoverComponent(this, "Treeland", "LaunchpadCover")
     , layershellAnimationComponent(this, "Treeland", "LayerShellAnimation")
@@ -243,6 +244,11 @@ QQuickItem *QmlEngine::createCaptureSelector(QQuickItem *parent, CaptureManagerV
 QQuickItem *QmlEngine::createWindowPicker(QQuickItem *parent)
 {
     return createComponent(windowPickerComponent, parent);
+}
+
+QQuickItem *QmlEngine::createEdgeTilePreview(QQuickItem *parent)
+{
+    return createComponent(edgeTilePreviewComponent, parent);
 }
 
 QQuickItem *QmlEngine::createLockScreenFallback(QQuickItem *parent, const QVariantMap &properties)

--- a/src/core/qmlengine.h
+++ b/src/core/qmlengine.h
@@ -69,6 +69,7 @@ public:
     QQuickItem *createShowDesktopAnimation(SurfaceWrapper *surface, QQuickItem *parent, bool show);
     QQuickItem *createCaptureSelector(QQuickItem *parent, CaptureManagerV1 *captureManager);
     QQuickItem *createWindowPicker(QQuickItem *parent);
+    QQuickItem *createEdgeTilePreview(QQuickItem *parent);
     QQuickItem *createLockScreenFallback(QQuickItem *parent,
                                          const QVariantMap &properties = QVariantMap());
     QQuickItem *createFpsDisplay(QQuickItem *parent);
@@ -103,6 +104,7 @@ private:
     QQmlComponent showDesktopAnimatioComponentn;
     QQmlComponent captureSelectorComponent;
     QQmlComponent windowPickerComponent;
+    QQmlComponent edgeTilePreviewComponent;
     QQmlComponent launchpadAnimationComponent;
     QQmlComponent launchpadCoverComponent;
     QQmlComponent layershellAnimationComponent;

--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -808,12 +808,37 @@ void RootSurfaceContainer::beginMoveResizeForSeat(WSeat *seat, SurfaceWrapper *s
         container->endMoveResize();
     }
 
+    const auto state = surface->surfaceState();
+    const bool wasTiled = edges == Qt::Edges()
+        && (state == SurfaceWrapper::State::Tiling || state == SurfaceWrapper::State::Maximized);
+    const QRectF tiledGeo = wasTiled ? surface->geometry() : QRectF();
+
     container->beginMoveResize(surface, edges);
 
     WSeat *actualSeat = seat ? seat : getDefaultSeat();
-    if (actualSeat && actualSeat->cursor()) {
-        container->moveResizeState().initialPosition = actualSeat->cursor()->position();
+    const bool hasCursor = actualSeat && actualSeat->cursor();
+    const QPointF cursor = hasCursor ? actualSeat->cursor()->position() : QPointF();
+
+    // De-tile: restore saved size, reposition so the cursor stays at the same
+    // relative grab ratio within the window
+    if (wasTiled && !tiledGeo.isEmpty() && hasCursor
+        && container->moveResizeState().surface == surface) {
+        const QSizeF restoredSize = surface->normalGeometry().isValid()
+            ? surface->normalGeometry().size()
+            : tiledGeo.size();
+        const qreal fx =
+            tiledGeo.width() > 0 ? (cursor.x() - tiledGeo.left()) / tiledGeo.width() : 0;
+        const qreal fy =
+            tiledGeo.height() > 0 ? (cursor.y() - tiledGeo.top()) / tiledGeo.height() : 0;
+        QPointF newPos(cursor.x() - fx * restoredSize.width(),
+                       cursor.y() - fy * restoredSize.height());
+        newPos = surface->alignToPixelGrid(newPos);
+        surface->setPosition(newPos);
+        container->moveResizeState().startGeometry = QRectF(newPos, restoredSize);
     }
+
+    if (actualSeat && actualSeat->cursor())
+        container->moveResizeState().initialPosition = cursor;
 }
 
 void RootSurfaceContainer::doMoveResizeForSeat(WSeat *seat, const QPointF &delta)

--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -9,6 +9,7 @@
 #include "seat/seatsmanager.h"
 #include "surface/surfacewrapper.h"
 #include "treelandconfig.hpp"
+#include "treelanduserconfig.hpp"
 #include "wallpaper/wallpapermanager.h"
 #include "workspace/workspace.h"
 
@@ -388,7 +389,11 @@ WCursor *RootSurfaceContainer::cursor() const
 Output *RootSurfaceContainer::cursorOutput() const
 {
     Q_ASSERT(m_cursor->layout() == m_outputLayout);
-    const auto &pos = m_cursor->position();
+    return outputAt(m_cursor->position());
+}
+
+Output *RootSurfaceContainer::outputAt(const QPointF &pos) const
+{
     auto o = m_outputLayout->handle()->output_at(pos.x(), pos.y());
     if (!o)
         return nullptr;
@@ -819,12 +824,136 @@ void RootSurfaceContainer::doMoveResizeForSeat(WSeat *seat, const QPointF &delta
     }
 }
 
+QQuickItem *RootSurfaceContainer::ensureEdgeTilePreview()
+{
+    if (m_edgeTilePreview)
+        return m_edgeTilePreview;
+
+    auto *engine = Helper::instance()->qmlEngine();
+    if (!engine)
+        return nullptr;
+
+    m_edgeTilePreview = engine->createEdgeTilePreview(this);
+    if (m_edgeTilePreview)
+        m_edgeTilePreview->setZ(OverlayZOrder);
+    return m_edgeTilePreview;
+}
+
+void RootSurfaceContainer::updateEdgeTilePreview(QuickTile::Mode mode, Output *out)
+{
+    auto *preview = ensureEdgeTilePreview();
+    if (!preview)
+        return;
+
+    if (mode == QuickTile::Mode::None || !out) {
+        preview->setVisible(false);
+        return;
+    }
+
+    const QRectF geo = QuickTile::geometry(mode, out);
+    if (!geo.isValid()) {
+        preview->setVisible(false);
+        return;
+    }
+
+    preview->setX(geo.x());
+    preview->setY(geo.y());
+    preview->setWidth(geo.width());
+    preview->setHeight(geo.height());
+    preview->setVisible(true);
+}
+
+void RootSurfaceContainer::detectEdgeTilingForSeat(WSeat *seat)
+{
+    auto *container = getSeatContainerOrDefault(seat);
+    if (!container)
+        return;
+
+    auto *cfg = Helper::instance()->config();
+    const qreal sideTrigger = cfg ? qreal(cfg->edgeSideTriggerDistance()) : 20.0;
+    const qreal topTrigger = cfg ? qreal(cfg->edgeTopTriggerDistance()) : 5.0;
+    auto &mrState = container->moveResizeState();
+    QuickTile::Mode mode = QuickTile::Mode::None;
+    Output *out = nullptr;
+    bool innerBorder = false;
+
+    if (mrState.surface && mrState.edges == Qt::Edges()) {
+        WSeat *actualSeat = seat ? seat : getDefaultSeat();
+        WCursor *cursor = actualSeat ? actualSeat->cursor() : nullptr;
+        const QPointF pos = cursor ? cursor->position() : QPointF();
+        out = outputAt(pos);
+        if (out) {
+            const QRectF area = out->validGeometry();
+            if (pos.x() <= area.left() + sideTrigger) {
+                mode = QuickTile::Mode::Left;
+            } else if (pos.x() >= area.right() - sideTrigger) {
+                mode = QuickTile::Mode::Right;
+            } else if (pos.y() <= area.top() + topTrigger) {
+                mode = QuickTile::Mode::Maximize;
+            }
+
+            // Multi-screen inner-edge detection:
+            // Sample 1px outside the edge; if another output covers that
+            // point, this is an inner edge
+            if (mode != QuickTile::Mode::None) {
+                QPointF samplePt;
+                switch (mode) {
+                case QuickTile::Mode::Maximize:
+                    samplePt = QPointF(pos.x(), area.top() - 1.0);
+                    break;
+                case QuickTile::Mode::Left:
+                    samplePt = QPointF(area.left() - 1.0, pos.y());
+                    break;
+                case QuickTile::Mode::Right:
+                    samplePt = QPointF(area.right(), pos.y());
+                    break;
+                case QuickTile::Mode::None:
+                    break;
+                }
+                for (Output *o : outputs()) {
+                    if (o == out)
+                        continue;
+                    if (o->geometry().contains(samplePt)) {
+                        innerBorder = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    // Re-evaluate when the edge state changes, or when the cursor crosses to
+    // a different output while the preview is active
+    if (mrState.detectedTileMode != mode || mrState.edgeTileInnerBorder != innerBorder
+        || out != mrState.detectedTileOutput) {
+        mrState.detectedTileMode = mode;
+        mrState.edgeTileInnerBorder = innerBorder;
+        mrState.detectedTileOutput = out;
+
+        if (mode == QuickTile::Mode::None) {
+            container->stopEdgeTileDelay();
+            mrState.edgeTilePreviewActive = false;
+            updateEdgeTilePreview(QuickTile::Mode::None, nullptr);
+        } else if (innerBorder) {
+            container->stopEdgeTileDelay();
+            mrState.edgeTilePreviewActive = false;
+            updateEdgeTilePreview(QuickTile::Mode::None, nullptr);
+            container->startEdgeTileDelay();
+        } else {
+            container->stopEdgeTileDelay();
+            mrState.edgeTilePreviewActive = true;
+            updateEdgeTilePreview(mode, out);
+        }
+    }
+}
+
 void RootSurfaceContainer::endMoveResizeForSeat(WSeat *seat)
 {
     auto *container = getSeatContainerOrDefault(seat);
     if (container) {
         container->endMoveResize();
     }
+    updateEdgeTilePreview(QuickTile::Mode::None, nullptr);
 }
 
 void RootSurfaceContainer::cancelMoveResizeForSeat(WSeat *seat)
@@ -833,6 +962,7 @@ void RootSurfaceContainer::cancelMoveResizeForSeat(WSeat *seat)
     if (container) {
         container->cancelMoveResize();
     }
+    updateEdgeTilePreview(QuickTile::Mode::None, nullptr);
 }
 
 SurfaceWrapper *RootSurfaceContainer::getMoveResizeSurfaceForSeat(WSeat *seat) const

--- a/src/core/rootsurfacecontainer.h
+++ b/src/core/rootsurfacecontainer.h
@@ -21,6 +21,8 @@ WAYLIB_SERVER_END_NAMESPACE
 
 WAYLIB_SERVER_USE_NAMESPACE
 
+class Output;
+
 class OutputListModel : public ObjectListModel<Output>
 {
     Q_OBJECT
@@ -69,6 +71,7 @@ public:
 
     void beginMoveResizeForSeat(WSeat *seat, SurfaceWrapper *surface, Qt::Edges edges);
     void doMoveResizeForSeat(WSeat *seat, const QPointF &delta);
+    void detectEdgeTilingForSeat(WSeat *seat);
     void endMoveResizeForSeat(WSeat *seat);
     void cancelMoveResizeForSeat(WSeat *seat);
     SurfaceWrapper *getMoveResizeSurfaceForSeat(WSeat *seat) const;
@@ -83,6 +86,8 @@ public:
     WCursor *cursor() const;
 
     Output *cursorOutput() const;
+    Output *outputAt(const QPointF &pos) const;
+    void updateEdgeTilePreview(QuickTile::Mode mode, Output *out);
     Output *primaryOutput() const;
     void setPrimaryOutput(Output *newPrimaryOutput, bool updateDconfig = false);
     const QList<Output *> &outputs() const;
@@ -128,7 +133,7 @@ private:
 
     void ensureCursorVisible();
     void updateSurfaceOutputs(SurfaceWrapper *surface);
-
+    QQuickItem *ensureEdgeTilePreview();
     void onSeatAdded(WSeat *seat);
     void onSeatRemoved(WSeat *seat);
 
@@ -140,6 +145,7 @@ private:
     QPointer<Output> m_primaryOutput;
     WCursor *m_cursor = nullptr;
     WSurfaceItem *m_dragSurfaceItem = nullptr;
+    QPointer<QQuickItem> m_edgeTilePreview;
 
     // Per-seat state management
     QMap<WSeat*, SeatSurfaceManager*> m_seatContainers;

--- a/src/modules/shortcut/shortcutcontroller.h
+++ b/src/modules/shortcut/shortcutcontroller.h
@@ -43,6 +43,8 @@ public:
         TaskSwitchPrev        = 25,
         TaskSwitchSameAppNext = 26,
         TaskSwitchSameAppPrev = 27,
+        TileLeft              = 28,
+        TileRight             = 29,
     };
     Q_ENUM(ShortcutAction)
     static const char *actionName(ShortcutAction action);

--- a/src/modules/shortcut/shortcutrunner.cpp
+++ b/src/modules/shortcut/shortcutrunner.cpp
@@ -10,6 +10,7 @@
 #include "output/output.h"
 #include "seat/helper.h"
 #include "shortcutcontroller.h"
+#include "surface/quicktile.h"
 #include "surface/surfacewrapper.h"
 #include "treelandconfig.hpp"
 #include "utils/fpsdisplaymanager.h"
@@ -102,6 +103,19 @@ void ShortcutRunner::onActionTrigger(ShortcutAction action, const QString &name,
         if (surface) {
             Q_EMIT surface->moveRequested();
         }
+        break;
+    }
+    case ShortcutAction::TileLeft:
+    case ShortcutAction::TileRight: {
+        auto surface = helper->activatedSurface();
+        if (!surface)
+            break;
+        auto *out = surface->ownsOutput();
+        if (!out)
+            break;
+        const auto mode =
+            (action == ShortcutAction::TileLeft) ? QuickTile::Mode::Left : QuickTile::Mode::Right;
+        QuickTile::apply(surface, mode, out);
         break;
     }
     case ShortcutAction::CloseWindow: {

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2474,6 +2474,9 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *targetWindow, QInputEvent 
 
             auto increment_pos = ev->globalPosition() - moveResizeState.initialPosition;
             m_rootSurfaceContainer->doMoveResizeForSeat(seat, increment_pos);
+            // Edge-tiling detection during move (resize is not tiled).
+            if (moveResizeState.edges == Qt::Edges())
+                m_rootSurfaceContainer->detectEdgeTilingForSeat(seat);
 
             return true;
         } else if (event->type() == QEvent::KeyPress

--- a/src/surface/quicktile.cpp
+++ b/src/surface/quicktile.cpp
@@ -1,0 +1,68 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "surface/quicktile.h"
+
+#include "output/output.h"
+#include "surface/surfacewrapper.h"
+
+namespace QuickTile {
+
+QRectF geometry(Mode mode, Output *output)
+{
+    if (mode == Mode::None || !output)
+        return QRectF();
+
+    const QRectF area = output->validGeometry();
+    switch (mode) {
+    case Mode::Left:
+        return QRectF(area.topLeft(), QSizeF(area.width() / 2, area.height()));
+    case Mode::Right:
+        return QRectF(QPointF(area.left() + area.width() / 2, area.top()),
+                      QSizeF(area.width() / 2, area.height()));
+    case Mode::Maximize:
+        return area;
+    case Mode::None:
+        break;
+    }
+    return QRectF();
+}
+
+void apply(SurfaceWrapper *surface, Mode mode, Output *output)
+{
+    if (!surface)
+        return;
+
+    if (mode == Mode::None) {
+        cancel(surface);
+        return;
+    }
+
+    if (mode == Mode::Maximize) {
+        // Use the cursor's output geometry, not the surface's current output,
+        // so maximize lands on the screen the user dragged to (matches preview).
+        if (output)
+            surface->setMaximizedGeometry(output->validGeometry());
+        surface->maximize();
+        return;
+    }
+
+    const QRectF geo = geometry(mode, output);
+    if (!geo.isValid())
+        return;
+
+    // Order matters: setTilingGeometry first so that a subsequent
+    // setSurfaceState(Tiling) reads the new m_tilingGeometry as its target.
+    surface->setTilingGeometry(geo);
+    surface->setSurfaceState(SurfaceWrapper::State::Tiling);
+}
+
+void cancel(SurfaceWrapper *surface)
+{
+    if (!surface)
+        return;
+
+    surface->setSurfaceStateDirectly(SurfaceWrapper::State::Normal);
+}
+
+} // namespace QuickTile

--- a/src/surface/quicktile.h
+++ b/src/surface/quicktile.h
@@ -1,0 +1,27 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+#pragma once
+
+#include <QRectF>
+#include <QSizeF>
+#include <qglobal.h>
+
+class Output;
+class SurfaceWrapper;
+
+namespace QuickTile {
+enum class Mode
+{
+    None,
+    Left,
+    Right,
+    Maximize,
+};
+
+QRectF geometry(Mode mode, Output *output);
+
+void apply(SurfaceWrapper *surface, Mode mode, Output *output);
+
+// Instantly restore `surface` to Normal
+void cancel(SurfaceWrapper *surface);
+} // namespace QuickTile

--- a/src/surface/seatsurfacemanager.cpp
+++ b/src/surface/seatsurfacemanager.cpp
@@ -8,6 +8,7 @@
 #include "seat/helper.h"
 #include "seat/seatsmanager.h"
 #include "core/shellhandler.h"
+#include "output/output.h"
 
 #include <winputdevice.h>
 #include <woutput.h>
@@ -158,6 +159,14 @@ void SeatSurfaceManager::beginMoveResize(SurfaceWrapper *surface, Qt::Edges edge
 {
     if (m_moveResizeState.surface)
         endMoveResize();
+    // Move of a tiled/maximized window: instantly de-tile to Normal BEFORE
+    // recording startGeometry, so startGeometry captures normalGeometry and no
+    // state-change animation contends with doMoveResize's setPosition.
+    if (edges == Qt::Edges()) {
+        const auto st = surface->surfaceState();
+        if (st == SurfaceWrapper::State::Tiling || st == SurfaceWrapper::State::Maximized)
+            surface->setSurfaceStateDirectly(SurfaceWrapper::State::Normal);
+    }
 
     if (surface->surfaceState() != SurfaceWrapper::State::Normal ||
         surface->isAnimationRunning())
@@ -167,6 +176,7 @@ void SeatSurfaceManager::beginMoveResize(SurfaceWrapper *surface, Qt::Edges edge
     m_moveResizeState.edges = edges;
     m_moveResizeState.startGeometry = surface->geometry();
     m_moveResizeState.settingPositionFlag = false;
+    m_moveResizeState.detectedTileMode = QuickTile::Mode::None;
 
     surface->setXwaylandPositionFromSurface(false);
     surface->setPositionAutomatic(false);
@@ -206,24 +216,32 @@ void SeatSurfaceManager::endMoveResize()
         return;
 
     auto surface = m_moveResizeState.surface;
-    auto *sh = surface->shellSurface();
-    if (sh && sh->isInitialized()) {
-        // Mark resize operation as complete
-        surface->shellSurface()->setResizeing(false);
+    const auto detectedMode = m_moveResizeState.detectedTileMode;
 
-        // Ensure window is still visible on screen after move/resize
-        if (m_rootContainer) {
-            m_rootContainer->ensureSurfaceNormalPositionValid(surface);
-        }
-
-        surface->setXwaylandPositionFromSurface(true);
-    }
-
-    // Clear state and notify
+    // Clear state first so filterSurfaceStateChange won't intercept the
+    // subsequent setSurfaceState(Tiling) issued by QuickTile::apply.
     m_moveResizeState.surface = nullptr;
     m_moveResizeState.edges = Qt::Edges();
     m_moveResizeState.startGeometry = QRectF();
     m_moveResizeState.initialPosition = QPointF();
+    m_moveResizeState.settingPositionFlag = false;
+    m_moveResizeState.detectedTileMode = QuickTile::Mode::None;
+
+    auto *sh = surface->shellSurface();
+    if (sh && sh->isInitialized()) {
+        // Mark resize operation as complete
+        surface->shellSurface()->setResizeing(false);
+        surface->setXwaylandPositionFromSurface(true);
+    }
+
+    if (detectedMode == QuickTile::Mode::None) {
+        // Ensure window is still visible on screen after a plain move/resize.
+        if (m_rootContainer)
+            m_rootContainer->ensureSurfaceNormalPositionValid(surface);
+    } else {
+        Output *out = m_rootContainer ? m_rootContainer->cursorOutput() : nullptr;
+        QuickTile::apply(surface, detectedMode, out);
+    }
 
     Q_EMIT moveResizeChanged();
 }
@@ -240,6 +258,9 @@ void SeatSurfaceManager::cancelMoveResize()
 
     auto surface = m_moveResizeState.surface;
     auto startGeo = m_moveResizeState.startGeometry;
+    // Cancel discards any edge-tiling detected during the move: restore the
+    // original (normal) geometry captured at beginMoveResize.
+    m_moveResizeState.detectedTileMode = QuickTile::Mode::None;
 
     // Restore original geometry before ending
     if (m_moveResizeState.edges != Qt::Edges()) {

--- a/src/surface/seatsurfacemanager.cpp
+++ b/src/surface/seatsurfacemanager.cpp
@@ -4,6 +4,7 @@
 #include "seatsurfacemanager.h"
 
 #include "rootsurfacecontainer.h"
+#include "treelanduserconfig.hpp"
 #include "common/treelandlogging.h"
 #include "seat/helper.h"
 #include "seat/seatsmanager.h"
@@ -11,6 +12,7 @@
 #include "output/output.h"
 
 #include <winputdevice.h>
+#include <wcursor.h>
 #include <woutput.h>
 #include <woutputitem.h>
 #include <woutputlayout.h>
@@ -26,6 +28,7 @@
 #include <wlr/types/wlr_data_device.h>
 
 #include <QDateTime>
+#include <QTimer>
 
 WAYLIB_SERVER_USE_NAMESPACE
 
@@ -177,6 +180,9 @@ void SeatSurfaceManager::beginMoveResize(SurfaceWrapper *surface, Qt::Edges edge
     m_moveResizeState.startGeometry = surface->geometry();
     m_moveResizeState.settingPositionFlag = false;
     m_moveResizeState.detectedTileMode = QuickTile::Mode::None;
+    m_moveResizeState.edgeTilePreviewActive = false;
+    m_moveResizeState.edgeTileInnerBorder = false;
+    m_moveResizeState.detectedTileOutput = nullptr;
 
     surface->setXwaylandPositionFromSurface(false);
     surface->setPositionAutomatic(false);
@@ -212,11 +218,13 @@ void SeatSurfaceManager::doMoveResize(const QPointF &delta)
 
 void SeatSurfaceManager::endMoveResize()
 {
+    stopEdgeTileDelay();
     if (!m_moveResizeState.surface)
         return;
 
     auto surface = m_moveResizeState.surface;
     const auto detectedMode = m_moveResizeState.detectedTileMode;
+    const bool previewActive = m_moveResizeState.edgeTilePreviewActive;
 
     // Clear state first so filterSurfaceStateChange won't intercept the
     // subsequent setSurfaceState(Tiling) issued by QuickTile::apply.
@@ -226,6 +234,9 @@ void SeatSurfaceManager::endMoveResize()
     m_moveResizeState.initialPosition = QPointF();
     m_moveResizeState.settingPositionFlag = false;
     m_moveResizeState.detectedTileMode = QuickTile::Mode::None;
+    m_moveResizeState.edgeTilePreviewActive = false;
+    m_moveResizeState.edgeTileInnerBorder = false;
+    m_moveResizeState.detectedTileOutput = nullptr;
 
     auto *sh = surface->shellSurface();
     if (sh && sh->isInitialized()) {
@@ -233,13 +244,14 @@ void SeatSurfaceManager::endMoveResize()
         surface->shellSurface()->setResizeing(false);
         surface->setXwaylandPositionFromSurface(true);
     }
-
-    if (detectedMode == QuickTile::Mode::None) {
+    if (!previewActive || detectedMode == QuickTile::Mode::None) {
         // Ensure window is still visible on screen after a plain move/resize.
         if (m_rootContainer)
             m_rootContainer->ensureSurfaceNormalPositionValid(surface);
     } else {
-        Output *out = m_rootContainer ? m_rootContainer->cursorOutput() : nullptr;
+        Output *out = nullptr;
+        if (m_rootContainer && m_seat && m_seat->cursor())
+            out = m_rootContainer->outputAt(m_seat->cursor()->position());
         QuickTile::apply(surface, detectedMode, out);
     }
 
@@ -261,6 +273,9 @@ void SeatSurfaceManager::cancelMoveResize()
     // Cancel discards any edge-tiling detected during the move: restore the
     // original (normal) geometry captured at beginMoveResize.
     m_moveResizeState.detectedTileMode = QuickTile::Mode::None;
+    m_moveResizeState.detectedTileOutput = nullptr;
+    m_moveResizeState.edgeTilePreviewActive = false;
+    m_moveResizeState.edgeTileInnerBorder = false;
 
     // Restore original geometry before ending
     if (m_moveResizeState.edges != Qt::Edges()) {
@@ -278,6 +293,36 @@ void SeatSurfaceManager::cancelMoveResize(SurfaceWrapper *surface)
     if (m_moveResizeState.surface != surface)
         return;
     endMoveResize();
+}
+
+void SeatSurfaceManager::startEdgeTileDelay()
+{
+    if (!m_edgeTileDelayTimer) {
+        m_edgeTileDelayTimer = new QTimer(this);
+        m_edgeTileDelayTimer->setSingleShot(true);
+        connect(m_edgeTileDelayTimer, &QTimer::timeout, this, [this]() {
+            auto &mr = m_moveResizeState;
+            if (mr.surface && mr.edges == Qt::Edges()
+                && mr.detectedTileMode != QuickTile::Mode::None) {
+                mr.edgeTilePreviewActive = true;
+                Output *out = nullptr;
+                if (m_rootContainer && m_seat && m_seat->cursor())
+                    out = m_rootContainer->outputAt(m_seat->cursor()->position());
+                if (m_rootContainer)
+                    m_rootContainer->updateEdgeTilePreview(mr.detectedTileMode, out);
+            }
+        });
+    }
+    auto *helper = Helper::instance();
+    auto *cfg = helper ? helper->config() : nullptr;
+    m_edgeTileDelayTimer->setInterval(cfg ? cfg->edgeInnerDelayMs() : 250);
+    m_edgeTileDelayTimer->start();
+}
+
+void SeatSurfaceManager::stopEdgeTileDelay()
+{
+    if (m_edgeTileDelayTimer)
+        m_edgeTileDelayTimer->stop();
 }
 
 bool SeatSurfaceManager::shouldHandleShortcuts() const

--- a/src/surface/seatsurfacemanager.h
+++ b/src/surface/seatsurfacemanager.h
@@ -9,7 +9,10 @@
 #include <QQuickItem>
 #include <QMap>
 
+class QTimer;
+
 class RootSurfaceContainer;
+class Output;
 class Helper;
 
 class SeatSurfaceManager : public QObject
@@ -33,7 +36,11 @@ public:
         QRectF startGeometry;               ///< Geometry at start of move/resize
         QPointF initialPosition;            ///< Initial cursor position
         bool settingPositionFlag = false;   ///< Flag to prevent recursive updates
-        QuickTile::Mode detectedTileMode = QuickTile::Mode::None;  ///< Edge-tiling mode detected during move
+        QuickTile::Mode detectedTileMode =
+            QuickTile::Mode::None;          ///< Edge-tiling mode detected during move
+        bool edgeTilePreviewActive = false; ///< Whether the edge-tiling preview is activated
+        bool edgeTileInnerBorder = false;   ///< Whether the detected edge is shared with an adjacent output (inner edge)
+        Output *detectedTileOutput = nullptr;  ///< The output on which the edge was detected (for cross-screen preview updates)
     };
 
     MoveResizeState &moveResizeState() { return m_moveResizeState; }
@@ -44,6 +51,8 @@ public:
     SurfaceWrapper *moveResizeSurface() const;
     void cancelMoveResize(SurfaceWrapper *surface);
     void cancelMoveResize();
+    void startEdgeTileDelay();
+    void stopEdgeTileDelay();
     bool shouldHandleShortcuts() const;
     bool metaKeyPressed() const { return m_metaKeyPressed; }
     void setMetaKeyPressed(bool pressed);
@@ -73,4 +82,5 @@ private:
 
     // Popup grab state
     bool m_hasPopupGrab = false;
+    QTimer *m_edgeTileDelayTimer = nullptr;
 };

--- a/src/surface/seatsurfacemanager.h
+++ b/src/surface/seatsurfacemanager.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "surface/surfacewrapper.h"
+#include "surface/quicktile.h"
 #include <wseat.h>
 #include <QQuickItem>
 #include <QMap>
@@ -32,6 +33,7 @@ public:
         QRectF startGeometry;               ///< Geometry at start of move/resize
         QPointF initialPosition;            ///< Initial cursor position
         bool settingPositionFlag = false;   ///< Flag to prevent recursive updates
+        QuickTile::Mode detectedTileMode = QuickTile::Mode::None;  ///< Edge-tiling mode detected during move
     };
 
     MoveResizeState &moveResizeState() { return m_moveResizeState; }

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -1012,42 +1012,87 @@ SurfaceWrapper::State SurfaceWrapper::surfaceState() const
     return m_surfaceState;
 }
 
-void SurfaceWrapper::setSurfaceState(State newSurfaceState)
+bool SurfaceWrapper::checkSetSurfaceState(State newSurfaceState)
 {
     if (m_wrapperAboutToRemove)
-        return;
+        return false;
 
     if (m_geometryAnimation)
-        return;
+        return false;
 
     if (m_surfaceState == newSurfaceState)
-        return;
+        return false;
 
     if (container()->filterSurfaceStateChange(this, newSurfaceState, m_surfaceState))
+        return false;
+
+    return true;
+}
+
+void SurfaceWrapper::setSurfaceState(State newSurfaceState)
+{
+    if (!checkSetSurfaceState(newSurfaceState))
         return;
 
-    QRectF targetGeometry;
-
-    if (newSurfaceState == State::Maximized) {
-        targetGeometry = m_maximizedGeometry;
-    } else if (newSurfaceState == State::Fullscreen) {
-        targetGeometry = m_fullscreenGeometry;
-    } else if (newSurfaceState == State::Normal) {
-        targetGeometry = m_normalGeometry;
-    } else if (newSurfaceState == State::Tiling) {
-        targetGeometry = m_tilingGeometry;
-    }
+    const QRectF targetGeometry = targetGeometryForState(newSurfaceState);
 
     if (targetGeometry.isValid()) {
         startStateChangeAnimation(newSurfaceState, targetGeometry);
     } else {
-        if (m_geometryAnimation) {
-            m_geometryAnimation->disconnect(this);
-            m_geometryAnimation->deleteLater();
-            m_geometryAnimation = nullptr;
-        }
-
+        abortGeometryAnimation();
         doSetSurfaceState(newSurfaceState);
+    }
+}
+
+void SurfaceWrapper::setSurfaceStateDirectly(State newSurfaceState)
+{
+    if (!checkSetSurfaceState(newSurfaceState))
+        return;
+
+    const QRectF targetGeometry = targetGeometryForState(newSurfaceState);
+    abortGeometryAnimation();
+
+    if (targetGeometry.isValid()) {
+        if (!applySurfaceStateGeometry(newSurfaceState, targetGeometry))
+            return;
+    } else {
+        doSetSurfaceState(newSurfaceState);
+    }
+}
+
+QRectF SurfaceWrapper::targetGeometryForState(State state) const
+{
+    switch (state) {
+    case State::Maximized:
+        return m_maximizedGeometry;
+    case State::Fullscreen:
+        return m_fullscreenGeometry;
+    case State::Normal:
+        return m_normalGeometry;
+    case State::Tiling:
+        return m_tilingGeometry;
+    default:
+        return QRectF();
+    }
+}
+
+bool SurfaceWrapper::applySurfaceStateGeometry(State state, const QRectF &targetGeometry)
+{
+    if (!resize(targetGeometry.size(), true))
+        return false;
+
+    setPosition(alignToPixelGrid(targetGeometry.topLeft()));
+    doSetSurfaceState(state);
+    resize(targetGeometry.size());
+    return true;
+}
+
+void SurfaceWrapper::abortGeometryAnimation()
+{
+    if (m_geometryAnimation) {
+        m_geometryAnimation->disconnect(this);
+        m_geometryAnimation->deleteLater();
+        m_geometryAnimation = nullptr;
     }
 }
 
@@ -1508,27 +1553,18 @@ void SurfaceWrapper::onAnimationReady()
     Q_ASSERT(m_pendingState != m_surfaceState);
     Q_ASSERT(m_pendingGeometry.isValid());
 
-    if (!resize(m_pendingGeometry.size(), true)) {
+    if (!applySurfaceStateGeometry(m_pendingState, m_pendingGeometry)) {
         // abort change state if cannot resize
-        m_geometryAnimation->disconnect(this);
-        m_geometryAnimation->deleteLater();
-        m_geometryAnimation = nullptr;
+        abortGeometryAnimation();
         return;
     }
-
-    QPointF alignedPos = alignToPixelGrid(m_pendingGeometry.topLeft());
-    setPosition(alignedPos);
-    doSetSurfaceState(m_pendingState);
-    resize(m_pendingGeometry.size());
 }
 
 void SurfaceWrapper::onAnimationFinished()
 {
     setXwaylandPositionFromSurface(true);
     Q_ASSERT(m_geometryAnimation);
-    m_geometryAnimation->disconnect(this);
-    m_geometryAnimation->deleteLater();
-    m_geometryAnimation = nullptr;
+    abortGeometryAnimation();
 }
 
 bool SurfaceWrapper::startStateChangeAnimation(State targetState, const QRectF &targetGeometry)

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -203,6 +203,7 @@ public:
     State previousSurfaceState() const;
     State surfaceState() const;
     void setSurfaceState(State newSurfaceState);
+    void setSurfaceStateDirectly(State newSurfaceState);
     QBindable<State> bindableSurfaceState();
     bool isNormal() const;
     bool isMaximized() const;
@@ -410,6 +411,10 @@ private:
     void createNewOrClose(uint direction);
     void itemChange(ItemChange change, const ItemChangeData &data) override;
 
+    QRectF targetGeometryForState(State state) const;
+    bool applySurfaceStateGeometry(State state, const QRectF &targetGeometry);
+    bool checkSetSurfaceState(State);
+    void abortGeometryAnimation();
     void doSetSurfaceState(State newSurfaceState);
     Q_SLOT void onAnimationReady();
     Q_SLOT void onAnimationFinished();


### PR DESCRIPTION
### 实现

- 基础二分屏
   - 拖动至边缘分屏/最大化
   - 拖出还原
   - 屏幕交界延迟触发
   - 多 seat 下可用
   - 平铺区域预览
   - 快捷键接口（未测试）

### 未实现、不完善

- 动效
- 平铺后对侧窗口选择器
- 双侧平铺后调整尺寸
- 多 seat 下区域预览
- 拖出还原时视觉效果欠佳