### PR TITLE
fix(surface): child may remain below parent after XdgToplevel set_parent

### DIFF
--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -1263,6 +1263,35 @@ void SurfaceWrapper::updateSubSurfaceStacking()
     }
 }
 
+void SurfaceWrapper::ensureAboveParent()
+{
+    if (!m_parentSurface)
+        return;
+
+    if (!parentItem() || parentItem() != m_parentSurface->parentItem())
+        return;
+
+    const auto &children = parentItem()->childItems();
+    int childIndex = children.indexOf(this);
+    if (childIndex == -1)
+        return;
+
+    // Surface that should sit directly below this child: the previous sibling's
+    // top-most surface, or the parent itself if this is the first child.
+    const auto &siblings = m_parentSurface->m_subSurfaces;
+    int myPos = siblings.lastIndexOf(this);
+    SurfaceWrapper *below = (myPos > 0) ? siblings[myPos - 1]->stackLastSurface() : m_parentSurface;
+    int belowIndex = children.indexOf(below);
+    if (belowIndex == -1)
+        return;
+
+    if (childIndex > belowIndex)
+        return;
+
+    qCDebug(lcTlSurface) << "Reordering surface" << this << "above parent" << m_parentSurface;
+    m_parentSurface->updateSubSurfaceStacking();
+}
+
 void SurfaceWrapper::updateClipRect()
 {
     if (!clip() || !window())
@@ -1917,6 +1946,7 @@ void SurfaceWrapper::addSubSurface(SurfaceWrapper *surface)
     surface->m_parentSurface = this;
     surface->updateExplicitAlwaysOnTop();
     m_subSurfaces.append(surface);
+    surface->ensureAboveParent();
 }
 
 void SurfaceWrapper::removeSubSurface(SurfaceWrapper *surface)

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -404,6 +404,7 @@ private:
     void updateBoundingRect();
     void updateVisible();
     void updateSubSurfaceStacking();
+    void ensureAboveParent();
     void updateClipRect();
     void geometryChange(const QRectF &newGeo, const QRectF &oldGeometry) override;
     void createNewOrClose(uint direction);


### PR DESCRIPTION
addSubSurface only updates the parent-child data structures (m_parentSurface, m_subSurfaces) without checking or adjusting the Z-order. When a parent window is already stacked above its new child, the child stays behind, violating the expected parent-below-child stacking invariant.

Add ensureAboveParent() called at the end of addSubSurface: compares childItems indices between parent and child, and if the child is below, invokes updateSubSurfaceStacking() to reorder all children above the parent.

Cross-container set_parent is handled implicitly — the subsequent container migration appends the child at the end of the new container (visually on top).