### PR TITLE
Fix dnd cursor

### DIFF
--- a/3rdparty/wlroots/include/wlr/types/wlr_data_device.h
+++ b/3rdparty/wlroots/include/wlr/types/wlr_data_device.h
@@ -80,6 +80,7 @@ struct wlr_data_source {
 
 	struct {
 		struct wl_signal destroy;
+		struct wl_signal dnd_action; // struct wlr_data_source
 	} events;
 };
 

--- a/3rdparty/wlroots/types/data_device/wlr_data_source.c
+++ b/3rdparty/wlroots/types/data_device/wlr_data_source.c
@@ -19,6 +19,7 @@ void wlr_data_source_init(struct wlr_data_source *source,
 	};
 	wl_array_init(&source->mime_types);
 	wl_signal_init(&source->events.destroy);
+	wl_signal_init(&source->events.dnd_action);
 }
 
 void wlr_data_source_send(struct wlr_data_source *source, const char *mime_type,
@@ -74,6 +75,7 @@ void wlr_data_source_dnd_action(struct wlr_data_source *source,
 	if (source->impl->dnd_action) {
 		source->impl->dnd_action(source, action);
 	}
+	wl_signal_emit_mutable(&source->events.dnd_action, source);
 }
 
 

--- a/qwlroots/src/types/qwdatadevice.h
+++ b/qwlroots/src/types/qwdatadevice.h
@@ -18,6 +18,8 @@ class QW_CLASS_OBJECT(data_source)
     QW_OBJECT
     Q_OBJECT
 
+    QW_SIGNAL(dnd_action)
+
 public:
     QW_FUNC_MEMBER(data_source, init, void, const wlr_data_source_impl *impl)
     QW_FUNC_MEMBER(data_source, accept, void, uint32_t serial, const char *mime_type)

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -3704,15 +3704,44 @@ void Helper::handleRequestDragForSeat(WSeat *seat, WSurface *)
     struct wlr_drag *drag = seat->nativeHandle()->drag;
     Q_ASSERT(drag);
 
-    QObject::connect(qw_drag::from(drag), &qw_drag::notify_drop, this, [this, seat] {
+    auto *qwDrag = qw_drag::from(drag);
+    QObject::connect(qwDrag, &qw_drag::notify_drop, this, [this, seat] {
         if (m_ddeShellV1)
             DDEActiveInterface::sendDrop(seat);
     });
 
-    QObject::connect(qw_drag::from(drag), &qw_drag::before_destroy, this, [seat, drag] {
+    QPointer<WCursor> dragCursor = seat->cursor();
+    QObject::connect(qwDrag, &qw_drag::before_destroy, this, [seat, drag, dragCursor] {
+        if (dragCursor)
+            dragCursor->setOverrideCursor(WCursor::toQCursor(WGlobal::CursorShape::Invalid));
         drag->data = NULL;
         seat->setAlwaysUpdateHoverTarget(false);
     });
+
+    // TODO: https://gitlab.freedesktop.org/wayland/wayland/-/work_items/444
+    const auto updateCursor = [drag, dragCursor] {
+        if (!dragCursor || drag->grab_type != WLR_DRAG_GRAB_KEYBOARD_POINTER)
+            return;
+
+        const auto action = drag->source
+                ? drag->source->current_dnd_action
+                : WL_DATA_DEVICE_MANAGER_DND_ACTION_NONE;
+        auto shape = WGlobal::CursorShape::NoDrop;
+        if (action == WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY)
+            shape = WGlobal::CursorShape::Copy;
+        else if (action == WL_DATA_DEVICE_MANAGER_DND_ACTION_MOVE)
+            shape = WGlobal::CursorShape::Move;
+        else if (action == WL_DATA_DEVICE_MANAGER_DND_ACTION_ASK)
+            shape = WGlobal::CursorShape::DndAsk;
+        dragCursor->setOverrideCursor(WCursor::toQCursor(shape));
+    };
+
+    if (drag->source) {
+        auto *qwSource = qw_data_source::from(drag->source);
+        QObject::connect(qwSource, &qw_data_source::notify_dnd_action,
+                         qwDrag, updateCursor);
+    }
+    updateCursor();
 
     if (m_ddeShellV1)
         DDEActiveInterface::sendStartDrag(seat);

--- a/waylib/src/server/kernel/private/wcursor_p.h
+++ b/waylib/src/server/kernel/private/wcursor_p.h
@@ -77,6 +77,7 @@ public:
 
     QW_NAMESPACE::qw_xcursor_manager *xcursor_manager = nullptr;
     QCursor cursor;
+    QCursor overrideCursor;
 
     WSeat *seat = nullptr;
     QPointer<QWindow> eventWindow;

--- a/waylib/src/server/kernel/wcursor.cpp
+++ b/waylib/src/server/kernel/wcursor.cpp
@@ -37,6 +37,7 @@ WAYLIB_SERVER_BEGIN_NAMESPACE
 
 WCursorPrivate::WCursorPrivate(WCursor *qq)
     : WWrapObjectPrivate(qq)
+    , overrideCursor(WCursor::toQCursor(WGlobal::CursorShape::Invalid))
 {
     initHandle(qw_cursor::create());
     handle()->set_data(this, qq);
@@ -556,7 +557,9 @@ Qt::CursorShape WCursor::defaultCursor()
 QCursor WCursor::cursor() const
 {
     W_DC(WCursor);
-    return d->cursor;
+    return WGlobal::isInvalidCursor(d->overrideCursor)
+            ? d->cursor
+            : d->overrideCursor;
 }
 
 void WCursor::setCursor(const QCursor &cursor)
@@ -565,7 +568,26 @@ void WCursor::setCursor(const QCursor &cursor)
 
     if (d->cursor == cursor)
         return;
+
     d->cursor = cursor;
+    if (WGlobal::isInvalidCursor(d->overrideCursor))
+        Q_EMIT cursorChanged();
+}
+
+QCursor WCursor::overrideCursor() const
+{
+    W_DC(WCursor);
+    return d->overrideCursor;
+}
+
+void WCursor::setOverrideCursor(const QCursor &cursor)
+{
+    W_D(WCursor);
+
+    if (d->overrideCursor == cursor)
+        return;
+
+    d->overrideCursor = cursor;
     Q_EMIT cursorChanged();
 }
 

--- a/waylib/src/server/kernel/wcursor.h
+++ b/waylib/src/server/kernel/wcursor.h
@@ -64,6 +64,9 @@ public:
     QCursor cursor() const;
     void setCursor(const QCursor &cursor);
 
+    QCursor overrideCursor() const;
+    void setOverrideCursor(const QCursor &cursor);
+
     // from client
     CursorShape requestedCursorShape() const;
     std::pair<WSurface*, QPoint> requestedCursorSurface() const;

--- a/waylib/src/server/kernel/wseat.cpp
+++ b/waylib/src/server/kernel/wseat.cpp
@@ -355,7 +355,6 @@ public:
     void updateCapabilities();
     void attachInputDevice(WInputDevice *device);
     void detachInputDevice(WInputDevice *device);
-    bool canSetCursor(wlr_seat_client *client) const;
     // handle spontaneous & synthetic key event for focusWindow
     void handleKeyEvent(QKeyEvent &e);
 
@@ -453,25 +452,12 @@ void WSeatPrivate::on_destroy()
     q_func()->m_handle = nullptr;
 }
 
-bool WSeatPrivate::canSetCursor(wlr_seat_client *client) const
-{
-    const auto *seat = nativeHandle();
-    if (seat->pointer_state.focused_client == client)
-        return true;
-
-    const auto *drag = seat->drag;
-    return drag
-            && drag->grab_type == WLR_DRAG_GRAB_KEYBOARD_POINTER
-            && drag->seat_client == client;
-}
-
 void WSeatPrivate::on_request_set_cursor(wlr_seat_pointer_request_set_cursor_event *event)
 {
-    const bool accepted = canSetCursor(event->seat_client);
-
-    /* This can be sent by any client, so only accept it from the pointer-focused
-     * client or the source client of the active pointer drag. */
-    if (accepted) {
+    auto focused_client = nativeHandle()->pointer_state.focused_client;
+    /* This can be sent by any client, so we check to make sure this one is
+     * actually has pointer focus first. */
+    if (focused_client == event->seat_client) {
         /* Once we've vetted the client, we can tell the cursor to use the
          * provided surface as the cursor image. It will set the hardware cursor
          * on the output that it's currently on and continue to do so as the
@@ -818,7 +804,7 @@ WGlobal::CursorShape WSeat::requestedCursorShape() const
 {
     W_DC(WSeat);
 
-    if (!d->canSetCursor(d->cursorClient)) {
+    if (d->cursorClient != d->nativeHandle()->pointer_state.focused_client) {
         qCWarning(lcWlSeat, "Focused client never set cursor shape nor surface, will fallback to `Default`");
         return WGlobal::CursorShape::Default;
     }
@@ -830,7 +816,7 @@ WSurface *WSeat::requestedCursorSurface() const
 {
     W_DC(WSeat);
 
-    if (d->canSetCursor(d->cursorClient))
+    if (d->cursorClient == d->nativeHandle()->pointer_state.focused_client)
         return d->cursorSurface;
     return nullptr;
 }
@@ -1493,8 +1479,7 @@ void WSeat::notifyTouchFrame([[maybe_unused]] WCursor *cursor)
 void WSeat::setCursorShape(wlr_seat_client *client, WGlobal::CursorShape shape)
 {
     W_D(WSeat);
-    const bool accepted = d->canSetCursor(client);
-    if (!accepted)
+    if (client != d->nativeHandle()->pointer_state.focused_client)
         return;
     d->cursorShape = shape;
     d->cursorClient = client;

--- a/waylib/src/server/kernel/wseat.cpp
+++ b/waylib/src/server/kernel/wseat.cpp
@@ -208,8 +208,8 @@ public:
         pointerFocusEventObject.clear();
         handle()->pointer_notify_clear_focus();
         Q_ASSERT(!handle()->handle()->pointer_state.focused_surface);
-        if (cursor) // reset cursur from QCursor resource, the last cursor is from wlr_surface
-            cursor->setCursor(cursor->cursor());
+        if (cursor) // reset cursor from QCursor resource, the last cursor is from wlr_surface
+            Q_EMIT cursor->cursorChanged();
     }
     inline void doSetKeyboardFocus(qw_surface *surface) {
         if (surface) {


### PR DESCRIPTION
https://gitlab.freedesktop.org/wayland/wayland/-/work_items/444 
根据上游讨论 和kwin，mutter保持一直 由合成器更新dnd 的action 光标

拖拽期间 源客户端已经发送leave事件 根据上游讨论源客户端之后不应该更新光标