### PR TITLE
fix(animation): smooth minimize transitions

### DIFF
--- a/src/core/qml/Animations/MinimizeAnimation.qml
+++ b/src/core/qml/Animations/MinimizeAnimation.qml
@@ -21,20 +21,101 @@ Item {
     required property rect position
     required property var direction
     property int duration: 400 * Helper.animationSpeed
+    property int animationDuration: duration
+    readonly property real minimizedRotation: -30
+    readonly property bool showShadow: !target.noDecoration
+            && (direction === MinimizeAnimation.Direction.Hide
+                ? target.previousSurfaceState === SurfaceWrapper.State.Normal
+                : target.surfaceState === SurfaceWrapper.State.Normal)
 
     function start() {
+        configureAnimation(direction === MinimizeAnimation.Direction.Hide
+                           ? Qt.rect(target.x, target.y, target.width, target.height)
+                           : position,
+                           direction === MinimizeAnimation.Direction.Hide
+                           ? position
+                           : Qt.rect(target.x, target.y, target.width, target.height),
+                           direction === MinimizeAnimation.Direction.Hide ? 1 : 0,
+                           direction === MinimizeAnimation.Direction.Hide ? 0 : 1,
+                           direction === MinimizeAnimation.Direction.Hide ? 0 : minimizedRotation,
+                           direction === MinimizeAnimation.Direction.Hide ? minimizedRotation : 0,
+                           duration);
         mainAnimation.start();
     }
 
-    ShaderEffectSource {
+    function redirect() {
+        const currentGeometry = Qt.rect(effect.x, effect.y, effect.width, effect.height);
+        const currentOpacity = effect.opacity;
+        const currentRotation = effect.rotation;
+        mainAnimation.stop();
+
+        const targetGeometry = direction === MinimizeAnimation.Direction.Hide
+                ? position
+                : Qt.rect(target.x, target.y, target.width, target.height);
+        const targetOpacity = direction === MinimizeAnimation.Direction.Hide ? 0 : 1;
+        const targetRotation = direction === MinimizeAnimation.Direction.Hide
+                ? minimizedRotation
+                : 0;
+        const fullGeometry = Qt.rect(target.x, target.y, target.width, target.height);
+        const remaining = Math.max(
+            normalizedDistance(currentGeometry.x, targetGeometry.x,
+                               fullGeometry.x, position.x),
+            normalizedDistance(currentGeometry.y, targetGeometry.y,
+                               fullGeometry.y, position.y),
+            normalizedDistance(currentGeometry.width, targetGeometry.width,
+                               fullGeometry.width, position.width),
+            normalizedDistance(currentGeometry.height, targetGeometry.height,
+                               fullGeometry.height, position.height),
+            Math.abs(currentOpacity - targetOpacity),
+            Math.abs(currentRotation - targetRotation) / Math.abs(minimizedRotation));
+
+        const redirectedDuration = duration > 0
+                ? Math.max(1, duration * Math.min(1, remaining))
+                : 0;
+        configureAnimation(currentGeometry, targetGeometry,
+                           currentOpacity, targetOpacity,
+                           currentRotation, targetRotation,
+                           redirectedDuration);
+        mainAnimation.start();
+    }
+
+    function normalizedDistance(value, targetValue, firstEndpoint, secondEndpoint) {
+        const distance = Math.abs(firstEndpoint - secondEndpoint);
+        return distance > 0 ? Math.abs(value - targetValue) / distance : 0;
+    }
+
+    function configureAnimation(fromGeometry, toGeometry, fromOpacity, toOpacity,
+                                fromRotation, toRotation, newDuration) {
+        animationDuration = newDuration;
+        xAnimation.from = fromGeometry.x;
+        xAnimation.to = toGeometry.x;
+        yAnimation.from = fromGeometry.y;
+        yAnimation.to = toGeometry.y;
+        widthAnimation.from = fromGeometry.width;
+        widthAnimation.to = toGeometry.width;
+        heightAnimation.from = fromGeometry.height;
+        heightAnimation.to = toGeometry.height;
+        opacityAnimation.from = fromOpacity;
+        opacityAnimation.to = toOpacity;
+        rotationAnimation.from = fromRotation;
+        rotationAnimation.to = toRotation;
+    }
+
+    Item {
         id: effect
-        live: false
-        hideSource: true
-        sourceItem: root.target
-        x: root.target.x
-        y: root.target.y
-        width: root.target.width
-        height: root.target.height
+
+        XdgShadow {
+            anchors.fill: parent
+            visible: root.showShadow
+            cornerRadius: root.target.radius
+        }
+
+        ShaderEffectSource {
+            anchors.fill: parent
+            live: false
+            hideSource: true
+            sourceItem: root.target
+        }
     }
 
     ParallelAnimation {
@@ -45,50 +126,47 @@ Item {
                 root.finished();
             })
         }
-        XAnimator {
+        NumberAnimation {
+            id: xAnimation
             target: effect
-            from: root.direction === MinimizeAnimation.Direction.Hide ? root.target.x : position.x
-            to: root.direction === MinimizeAnimation.Direction.Hide ? position.x : root.target.x
+            property: "x"
             easing.type: Easing.OutExpo
-            duration: root.duration
-        }
-        YAnimator {
-            target: effect
-            from: root.direction === MinimizeAnimation.Direction.Hide ? root.target.y : position.y
-            to: root.direction === MinimizeAnimation.Direction.Hide ? position.y : root.target.y
-            easing.type: Easing.OutExpo
-            duration: root.duration
+            duration: root.animationDuration
         }
         NumberAnimation {
+            id: yAnimation
+            target: effect
+            property: "y"
+            easing.type: Easing.OutExpo
+            duration: root.animationDuration
+        }
+        NumberAnimation {
+            id: widthAnimation
             target: effect
             property: "width"
-            from: root.direction === MinimizeAnimation.Direction.Hide ? root.target.width : position.width
-            to: root.direction === MinimizeAnimation.Direction.Hide ? position.width : root.target.width
             easing.type: Easing.OutExpo
-            duration: root.duration
+            duration: root.animationDuration
         }
         NumberAnimation {
+            id: heightAnimation
             target: effect
             property: "height"
-            from: root.direction === MinimizeAnimation.Direction.Hide ? root.target.height : position.height
-            to: root.direction === MinimizeAnimation.Direction.Hide ? position.height : root.target.height
             easing.type: Easing.OutExpo
-            duration: root.duration
+            duration: root.animationDuration
         }
-        OpacityAnimator {
+        NumberAnimation {
+            id: opacityAnimation
             target: effect
-            from: root.direction === MinimizeAnimation.Direction.Hide ? 1 : 0
-            to: root.direction === MinimizeAnimation.Direction.Hide ? 0 : 1
+            property: "opacity"
             easing.type: Easing.OutExpo
-            duration: root.duration
+            duration: root.animationDuration
         }
-        RotationAnimator {
-            target: effect;
-            from: root.direction === MinimizeAnimation.Direction.Hide ? 0 : -30;
-            to: root.direction === MinimizeAnimation.Direction.Hide ? -30 : 0;
-            direction: root.direction === MinimizeAnimation.Direction.Hide ? RotationAnimator.Counterclockwise : RotationAnimator.Clockwise
+        NumberAnimation {
+            id: rotationAnimation
+            target: effect
+            property: "rotation"
             easing.type: Easing.OutExpo
-            duration: root.duration
+            duration: root.animationDuration
         }
     }
 

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -1641,8 +1641,13 @@ void SurfaceWrapper::onMinimizeAnimationFinished()
 
 void SurfaceWrapper::startMinimizeAnimation(const QRectF &iconGeometry, uint direction)
 {
-    if (m_minimizeAnimation)
+    if (m_minimizeAnimation) {
+        m_minimizeAnimation->setProperty("direction", direction);
+        m_minimizeAnimation->setProperty("position", QVariant::fromValue(iconGeometry));
+        const bool ok = QMetaObject::invokeMethod(m_minimizeAnimation, "redirect");
+        Q_ASSERT(ok);
         return;
+    }
     if (!Helper::instance()->surfaceBelongsToCurrentSession(this))
         return;
 


### PR DESCRIPTION
1. Redirect running minimize and restore animations from their current visual state.
2. Render window shadows with animation snapshots to prevent late shadow flashes.
3. Scale redirected duration by remaining distance and refresh the dock target position.

Log: Make minimize and restore animations interruptible with continuous shadows.
Influence: Minimize and restore transitions stay continuous.

fix(animation): 优化窗口最小化过渡

1. 从当前画面状态重定向正在运行的最小化和恢复动画。
2. 为动画快照同步绘制窗口阴影，避免阴影延迟闪现。
3. 根据剩余距离调整反向时长，并更新 Dock 目标位置。

Log: 实现可打断且阴影连续的最小化和恢复动画。
Influence: 最小化和恢复过渡更加连贯。

## Summary by Sourcery

Make window minimize and restore transitions smoother and interruptible while keeping visual continuity, including shadows.

Bug Fixes:
- Prevent window shadows from flashing or desynchronizing during minimize and restore animations.
- Ensure repeated minimize or restore requests do not restart animations abruptly from the initial state.

Enhancements:
- Redirect in-progress minimize and restore animations from the current visual state and scale remaining duration based on animation progress.
- Render window shadows alongside the animated snapshot for consistent visuals during transitions.