### PR TITLE
fix(lockscreen): use fixed leftPadding to fix implicitWidth binding loop

### DIFF
--- a/src/plugins/lockscreen/qml/UserInput.qml
+++ b/src/plugins/lockscreen/qml/UserInput.qml
@@ -144,12 +144,7 @@ Item {
             echoMode: loginGroup.enteringOtherUser ? TextInput.Normal
                       : (showPasswordBtn.hiddenPWD ? TextInput.Password : TextInput.Normal)
             rightPadding: 22
-            leftPadding: {
-                var remaining = width - contentWidth - rightPadding
-                if (capsIndicator.visible)
-                    return rightPadding
-                return Math.max(8, remaining > rightPadding ? rightPadding : remaining)
-            }
+            leftPadding: 22
             maximumLength: 510
             placeholderText: loginGroup.enteringOtherUser ? qsTr("Username") : qsTr("Password")
             placeholderTextColor: Qt.rgba(1.0, 1.0, 1.0, 0.6)


### PR DESCRIPTION
## Summary

Fix the QML `implicitWidth` binding loop reported at runtime for the lockscreen password `TextField`.

```
qrc:/qt/qml/LockScreen/qml/UserInput.qml:104:9: QML TextField: Binding loop detected for property "implicitWidth"
```

### Root cause

`passwordField.leftPadding` was a dynamic binding that read `width` and `contentWidth`. The QtQuick Controls Fusion style computes `implicitWidth = max(contentWidth, placeholder.implicitWidth) + leftPadding + rightPadding`, which reads `leftPadding`. This formed a binding loop:

`implicitWidth → leftPadding → {width, contentWidth}`

### Fix (architect-approved plan A)

Replace the dynamic `leftPadding` binding with a fixed value `22`, symmetric with `rightPadding: 22`. The constant `leftPadding` no longer depends on `width`/`contentWidth`, so the binding cycle is broken.

```diff
             rightPadding: 22
-            leftPadding: {
-                var remaining = width - contentWidth - rightPadding
-                if (capsIndicator.visible)
-                    return rightPadding
-                return Math.max(8, remaining > rightPadding ? rightPadding : remaining)
-            }
+            leftPadding: 22
```

### Safety

- `passwordField.implicitWidth = max(contentWidth, placeholder.implicitWidth) + 22 + 22`, unchanged for the common short/empty text case, so `userCol` width and `loginBtn` (anchored to `userCol.right`) position do not move.
- `horizontalAlignment: TextInput.AlignHCenter` is preserved; centering is kept by symmetric padding + `AlignHCenter`.
- The only behavioral difference: for extremely long passwords (`contentWidth ≥ 176px`), `leftPadding` no longer shrinks from 22 to 8; `AlignHCenter` already centers/clips overflowing text, so this is acceptable.
- Binding loop is a runtime warning; CI compile does not catch it — please verify by launching the lock screen / greeter and confirming the warning is gone.

## Multica Issue

[WM-89](https://agentapi-dev.uniontech.com/workspace/e1c725b6-7c31-4790-a381-3262f282537c/issues/8bb95da5-722d-4345-ac84-098632279453)

## Test Plan

1. Launch the lock screen / greeter and confirm no binding loop warning is emitted.
2. Verify the password field stays centered with short and empty input.
3. Verify the caps-lock indicator and show-password button positions are unchanged.
4. Verify the login button position is unchanged.

## Summary by Sourcery

Bug Fixes:
- Resolve the QML implicitWidth binding loop for the lockscreen password TextField by removing the dynamic left padding binding.