### PR TITLE
fix(service): add missing SEATD_SOCK for user session

### DIFF
--- a/misc/systemd/dde-session-pre.target.wants/treeland.service.in
+++ b/misc/systemd/dde-session-pre.target.wants/treeland.service.in
@@ -19,6 +19,7 @@ PartOf=dde-session-pre.target
 Before=dde-session-pre.target
 
 [Service]
+Environment=SEATD_SOCK=/run/dde-seatd.sock
 ExecCondition=/bin/sh -c 'test "$TREELAND_RUN_MODE" = "user" || exit 2'
 Type=dbus
 BusName=org.deepin.Compositor1


### PR DESCRIPTION
Add SEATD_SOCK to user session treeland.service.in so that it can connect to dde-seatd correctly.

## Summary by Sourcery

Bug Fixes:
- Ensure the treeland user session service correctly connects to dde-seatd by setting the SEATD_SOCK environment.