### PR TITLE
fix(glass): pull refraction to lip and retune glass defaults

### DIFF
--- a/examples/test_glass/Main.qml
+++ b/examples/test_glass/Main.qml
@@ -18,8 +18,8 @@ Item {
     property real effectWidth: 300
     property real effectHeight: 200
     property real effectRadius: 12
-    property real glassThickness: 40
-    property real glassBezelWidth: 36
+    property real glassThickness: 30
+    property real glassBezelWidth: 30
     property real glassIor: 1.33
     property bool glassBlurEnabled: true
     property int glassBlurMax: 64
@@ -27,7 +27,7 @@ Item {
     property real glassBlurMultiplier: 0.0
     property real glassSpecular: 0.0
     property real glassTint: 0.0
-    property real glassRefractionMaxTan: 2.0
+    property real glassRefractionMaxTan: 3.3
     property real glassContentEdgePull: 0.0
     property real glassContentRampEnd: 0.0
     property real glassProfilePower: 2.0

--- a/examples/test_glass/helper.h
+++ b/examples/test_glass/helper.h
@@ -103,14 +103,14 @@ private:
     int m_blurStrength = 60;
     qreal m_blurAmount = 0.6;
     qreal m_blurMultiplier = 0.0;
-    qreal m_glassBezel = 36;
-    qreal m_glassThickness = 40;
+    qreal m_glassBezel = 30;
+    qreal m_glassThickness = 30;
     qreal m_glassIor = 1.33;
     qreal m_glassSpecular = 0.0;
     qreal m_glassTint = 0.0;
     qreal m_glassContentEdgePull = 0.0;
     qreal m_glassContentRampEnd = 0.0;
-    qreal m_glassRefractionMaxTan = 2.0;
+    qreal m_glassRefractionMaxTan = 3.3;
     qreal m_glassProfilePower = 2.0;
     qreal m_glassInnerShadow = 0.0;
     qreal m_glassBrightness = 0.0;

--- a/misc/dconfig/org.deepin.dde.treeland.user.json
+++ b/misc/dconfig/org.deepin.dde.treeland.user.json
@@ -476,7 +476,7 @@
             "visibility": "public"
         },
         "glassBezel": {
-            "value": 36,
+            "value": 30,
             "serial": 0,
             "flags": [],
             "name": "Glass Bezel Width",
@@ -487,7 +487,7 @@
             "visibility": "public"
         },
         "glassThickness": {
-            "value": 40,
+            "value": 30,
             "serial": 0,
             "flags": [],
             "name": "Glass Base Thickness",

--- a/misc/shaders/liquidglass.frag
+++ b/misc/shaders/liquidglass.frag
@@ -345,6 +345,21 @@ vec3 sampleBg(vec2 uv)
     return texture(source, clamp(uv, vec2(0.002), vec2(0.998))).rgb;
 }
 
+// Stretch-aware 5-tap filter. radiusPx≈0 collapses to a single sample.
+vec3 sampleBgSoft(vec2 uv, vec2 resolution, float radiusPx)
+{
+    if (radiusPx < 0.01)
+        return sampleBg(uv);
+
+    vec2 px = vec2(radiusPx) / max(resolution, vec2(1.0));
+    vec3 color = sampleBg(uv) * 0.36;
+    color += sampleBg(uv + vec2(px.x, 0.0)) * 0.16;
+    color += sampleBg(uv - vec2(px.x, 0.0)) * 0.16;
+    color += sampleBg(uv + vec2(0.0, px.y)) * 0.16;
+    color += sampleBg(uv - vec2(0.0, px.y)) * 0.16;
+    return color;
+}
+
 vec4 finishColor(vec3 color, float shapeAlpha)
 {
     if (ubuf.tint > 1e-4)
@@ -416,16 +431,14 @@ void main()
     float maxTan = max(ubuf.refractionMaxTan, 0.1);
 
     vec2 profile = surfaceProfile(t);
-    float h = profile.x;
-
+    // Path length stays slab-like (not h*thickness). Profile height collapsed
+    // to ~0 at the lip and left an unrefracted ring inside the outline.
     float thick = max(ubuf.thickness, 0.0);
     float edgePull = clamp(ubuf.contentEdgePull, 0.0, 1.0);
-    float outerSoft = smoothstep(0.0, max(2.5 * edgeAA, 2.5), opticalDistFromEdge);
-    float slopeSoft = mix(outerSoft, 1.0, edgePull);
-    float rawTan = profile.y * (thick / bezel);
-    float slopeMag = min(rawTan, maxTan) * slopeSoft;
+    float rawTan = profile.y * (thick / max(bezel, 1.0));
+    float slopeMag = min(rawTan, maxTan);
 
-    float H = h * thick;
+    float H = thick;
 
     float rampEnd = clamp(ubuf.contentRampEnd, 0.001, 1.0);
     // edgePull=0 → contentRamp = smoothstep(0, rampEnd, t); keep exact mix for pull>0.
@@ -441,14 +454,21 @@ void main()
     float sinI = slopeMag * incidentInvLen;
     float sinT = clamp(sinI / iorG, 0.0, 0.999);
     float tanT = sinT * inversesqrt(max(1.0 - sinT * sinT, 1e-4));
-    float magG = H * contentRamp * max(slopeMag - tanT, 0.0);
-    magG = min(magG, maxDisp);
+    // Cap the geometric Snell term first, then apply contentRamp so edgePull
+    // still controls the lip when thickness would otherwise slam into maxDisp.
+    float magG = min(H * max(slopeMag - tanT, 0.0), maxDisp) * contentRamp;
     vec2 inward = -n2;
     vec2 offG = inward * magG;
 
-    vec2 baseUv = shadePoint / size + 0.5;
-    // sampleBg clamps; avoid a second clamp here.
-    vec3 color = sampleBg(baseUv + offG / size);
+    vec2 sampleUv = shadePoint / size + 0.5 + offG / size;
+    // Soften only where UV stretch exceeds ~1px (curved warp jaggies).
+    float filterPx = 0.0;
+    if (magG > 0.5) {
+        float stretchX = length(vec2(dFdx(sampleUv.x), dFdy(sampleUv.x))) * size.x;
+        float stretchY = length(vec2(dFdx(sampleUv.y), dFdy(sampleUv.y))) * size.y;
+        filterPx = clamp(max(max(stretchX, stretchY) - 1.0, 0.0) * 0.85, 0.0, 2.5);
+    }
+    vec3 color = sampleBgSoft(sampleUv, size, filterPx);
 
     if (ubuf.specular > 1e-4) {
         vec3 N = normalize(vec3(n2 * slopeMag, 1.0));

--- a/src/core/qml/Effects/Blur.qml
+++ b/src/core/qml/Effects/Blur.qml
@@ -55,7 +55,7 @@ RenderBufferBlitter {
             saturation: blitter.saturation
             contentEdgePull: 0.0
             contentRampEnd: 0.0
-            refractionMaxTan: 2.0
+            refractionMaxTan: 3.3
             profilePower: Helper.config.glassProfilePower
             innerShadow: 0.0
         }

--- a/src/core/qml/Effects/GlassEffect.qml
+++ b/src/core/qml/Effects/GlassEffect.qml
@@ -12,13 +12,13 @@ Item {
     // Liquid Glass material controls.
     // Blur and shadow stay delegated to Qt Quick MultiEffect / callers.
     property real radius: 12
-    property real thickness: 40
-    property real bezelWidth: 36
+    property real thickness: 30
+    property real bezelWidth: 30
     property real ior: 1.33
     property real specular: 0.0
     property real tint: 0.0
     // Limit the geometric surface slope near the silhouette.
-    property real refractionMaxTan: 2.0
+    property real refractionMaxTan: 3.3
     property real contentEdgePull: 0.0
     property real contentRampEnd: 0.0
     property real profilePower: 2.0

--- a/tests/test_effect_glass/main.cpp
+++ b/tests/test_effect_glass/main.cpp
@@ -143,6 +143,9 @@ private:
         m_glass->setProperty("thickness", 120.0);
         m_glass->setProperty("profilePower", 4.0);
         m_glass->setProperty("ior", 1.45);
+        // Extreme corner stress fixture: keep slope cap fixed so product
+        // refractionMaxTan defaults do not retune this geometry check.
+        m_glass->setProperty("refractionMaxTan", 2.0);
         QTest::qWait(50);
     }
 
@@ -228,13 +231,14 @@ private Q_SLOTS:
     void liquidGlassDefaultsMatch()
     {
         QCOMPARE(m_glass->property("radius").toReal(), 12.0);
-        QCOMPARE(m_glass->property("thickness").toReal(), 40.0);
-        QCOMPARE(m_glass->property("bezelWidth").toReal(), 36.0);
+        QCOMPARE(m_glass->property("thickness").toReal(), 30.0);
+        QCOMPARE(m_glass->property("bezelWidth").toReal(), 30.0);
         QCOMPARE(m_glass->property("ior").toReal(), 1.33);
         QCOMPARE(m_glass->property("specular").toReal(), 0.0);
         QCOMPARE(m_glass->property("tint").toReal(), 0.0);
         QCOMPARE(m_glass->property("saturation").toReal(), 0.0);
         QCOMPARE(m_glass->property("blurAmount").toReal(), 0.6);
+        QCOMPARE(m_glass->property("refractionMaxTan").toReal(), 3.3);
 
     }
     void dconfigDefaultsMatch()
@@ -245,8 +249,8 @@ private Q_SLOTS:
 
         const QJsonObject contents =
             QJsonDocument::fromJson(descriptor.readAll()).object().value("contents").toObject();
-        QCOMPARE(contents.value("glassBezel").toObject().value("value").toDouble(), 36.0);
-        QCOMPARE(contents.value("glassThickness").toObject().value("value").toDouble(), 40.0);
+        QCOMPARE(contents.value("glassBezel").toObject().value("value").toDouble(), 30.0);
+        QCOMPARE(contents.value("glassThickness").toObject().value("value").toDouble(), 30.0);
         QCOMPARE(contents.value("glassProfilePower").toObject().value("value").toDouble(), 2.0);
         QCOMPARE(contents.value("glassSaturation").toObject().value("value").toDouble(), 0.0);
         QCOMPARE(contents.value("glassSpecular").toObject().value("value").toDouble(), 0.0);


### PR DESCRIPTION
## Summary
- Keep optical path length slab-like (`H = thickness`) so warped content reaches the glass outline instead of leaving an unrefracted rim.
- Drop multi-pixel `outerSoft` slope fade; soften only UV-stretch samples via stretch-aware `sampleBgSoft`.
- Cap Snell displacement before `contentRamp` so `contentEdgePull` still works when thickness hits `maxDisp`.
- Default `thickness`/`bezel` to 30 and `refractionMaxTan` to 3.3; pin corner-seam stress tests to `maxTan=2`.

## Test plan
- [x] `test_effect_glass` — 28 passed, 1 skipped
- [x] Visual check with `examples/test_glass` — refraction reaches corners/edges; curved stretch jaggies reduced
- [ ] Spot-check window blur / multitaskview / lockscreen glass regions with new defaults

## Summary by Sourcery

Retune the liquid glass refraction to keep optical path length slab-like, pull refraction fully to the glass lip, and update default geometry and slope limits for smoother edges and corners.

Enhancements:
- Introduce a stretch-aware background sampling filter to selectively soften highly stretched refraction regions and reduce jaggies.
- Adjust refraction geometry so optical path length is thickness-based and Snell displacement capping preserves content edge pull behavior.
- Clamp bezel usage and remove the outer soft slope fade to avoid unrefracted rims near the glass outline.

Tests:
- Update glass effect tests and example configurations to validate the new default thickness, bezel width, and refraction slope cap, and to pin extreme corner stress cases to a fixed slope limit.