### PR TITLE
fix(output): avoid enabling output before restoring topology

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -514,7 +514,6 @@ void Helper::onOutputAdded(WOutput *output)
         }
     }
 
-    o->enable();
     if (scanned && m_mode == OutputMode::Copy) {
         QStringList copyOutputs = m_outputManagerHelper->copyOutputIds();
         const QString addedOutputId = WallpaperManager::getOutputId(o);


### PR DESCRIPTION
Remove the eager output enable from Helper::onOutputAdded so output activation remains controlled by the configured topology. Enabling an output immediately after it is added can override the restored state before OutputManager reapplies single-output or copy-mode configuration, especially after reconnect and hotplug.

Log: restore display mode after output reconnect
Influence: Output mode restoration after display reconnect, hotplug, and restart

## Summary by Sourcery

Bug Fixes:
- Prevent newly added outputs from being enabled before OutputManager reapplies single-output or copy-mode configuration, preserving restored display modes after reconnect or hotplug.