### PR TITLE
fix(seat): restore group keyboard when seat keyboard is NULL

### DIFF
--- a/waylib/src/server/kernel/wseat.cpp
+++ b/waylib/src/server/kernel/wseat.cpp
@@ -1110,6 +1110,11 @@ void WSeat::setKeyboardFocusSurface(WSurface *surface)
     if (d->m_keyboardFocusSurface == surface)
         return;
 
+    if (!keyboard() && d->groupkeyboardDevice) {
+        qCWarning(lcWlSeat, "WSeat: seat keyboard is NULL in setKeyboardFocusSurface, restoring group keyboard");
+        setKeyboard(d->groupkeyboardDevice);
+    }
+
     d->m_keyboardFocusSurface = surface;
     if (isValid())
         d->doSetKeyboardFocus(surface ? surface->handle() : nullptr);

--- a/waylib/src/server/kernel/wseat.cpp
+++ b/waylib/src/server/kernel/wseat.cpp
@@ -315,13 +315,21 @@ public:
     }
     inline bool doNotifyModifiers(WInputDevice *device) {
         auto keyboard = qobject_cast<qw_keyboard*>(device->handle());
+
+        // wlr_seat_set_keyboard() already sends modifiers when the keyboard
+        // changes, so skip the explicit send to avoid a duplicate.
+        bool keyboardChanged = (q_func()->keyboard() != device);
         q_func()->setKeyboard(device);
 
         if (!keyboardFocusSurface())
             return false;
 
-        /* Send modifiers to the client. */
-        this->handle()->keyboard_notify_modifiers(&keyboard->handle()->modifiers);
+        // Only send modifiers explicitly when the keyboard did NOT change.
+        // If it changed, wlr_seat_set_keyboard() already sent them.
+        if (!keyboardChanged) {
+            /* Send modifiers to the client. */
+            this->handle()->keyboard_notify_modifiers(&keyboard->handle()->modifiers);
+        }
         return true;
     }
     inline void doMouseMove(WCursor *cursor, const QPointingDevice *device, uint32_t timestamp) {
@@ -669,17 +677,17 @@ void WSeatPrivate::attachInputDevice(WInputDevice *device)
     if (device->type() == WInputDevice::Type::Keyboard) {
         auto keyboard = qobject_cast<qw_keyboard*>(device->handle());
 
-        /* We need to prepare an XKB keymap and assign it to the keyboard. This
-         * assumes the defaults (e.g. layout = "us"). */
-        struct xkb_rule_names rules = {};
-        struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-        struct xkb_keymap *keymap = xkb_map_new_from_names(context, &rules,
-                                                           XKB_KEYMAP_COMPILE_NO_FLAGS);
-
-        keyboard->set_keymap(keymap);
-        xkb_keymap_unref(keymap);
-        xkb_context_unref(context);
         if (device == groupkeyboardDevice || device->isVirtual()) {
+            /* We need to prepare an XKB keymap and assign it to the keyboard.
+             * This assumes the defaults (e.g. layout = "us"). */
+            struct xkb_rule_names rules = {};
+            struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+            struct xkb_keymap *keymap = xkb_map_new_from_names(context, &rules,
+                                                               XKB_KEYMAP_COMPILE_NO_FLAGS);
+            keyboard->set_keymap(keymap);
+            xkb_keymap_unref(keymap);
+            xkb_context_unref(context);
+
             device->safeConnect(&qw_keyboard::notify_key, q, [this, device] (wlr_keyboard_key_event *event) {
                 on_keyboard_key(event, device);
             });
@@ -688,6 +696,22 @@ void WSeatPrivate::attachInputDevice(WInputDevice *device)
             });
             q->setKeyboard(device);
         } else {
+            // Reuse group keymap pointer so wlr_seat_set_keyboard() sees
+            // no keymap change and skips a spurious keymap event.
+            if (group && group->keyboard.keymap) {
+                keyboard->set_keymap(group->keyboard.keymap);
+            } else {
+                qCWarning(lcWlSeat,
+                          "WSeat: group keyboard has no keymap for physical keyboard '%s'",
+                          qPrintable(device->name()));
+                struct xkb_rule_names rules = {};
+                struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+                struct xkb_keymap *keymap = xkb_map_new_from_names(context, &rules,
+                                                                   XKB_KEYMAP_COMPILE_NO_FLAGS);
+                keyboard->set_keymap(keymap);
+                xkb_keymap_unref(keymap);
+                xkb_context_unref(context);
+            }
             wlr_keyboard_group_add_keyboard(group, keyboard->handle());
         }
     }
@@ -707,8 +731,11 @@ void WSeatPrivate::detachInputDevice(WInputDevice *device)
     }
 
     if (device->type() == WInputDevice::Type::Keyboard) {
-        auto keyboard = qobject_cast<qw_keyboard*>(device->handle());
-        wlr_keyboard_group_remove_keyboard(group, keyboard->handle());
+        // Only physical keyboards are group members.
+        if (device != groupkeyboardDevice && !device->isVirtual()) {
+            auto keyboard = qobject_cast<qw_keyboard*>(device->handle());
+            wlr_keyboard_group_remove_keyboard(group, keyboard->handle());
+        }
     }
     [[maybe_unused]] bool ok = QWlrootsIntegration::instance()->removeInputDevice(device);
     Q_ASSERT(ok);

--- a/waylib/src/server/protocols/winputmethodhelper.cpp
+++ b/waylib/src/server/protocols/winputmethodhelper.cpp
@@ -360,7 +360,15 @@ void WInputMethodHelper::handleNewVKV1(wlr_virtual_keyboard_v1 *vkv1)
     d->virtualKeyboards.append(keyboard);
     d->seat->attachInputDevice(keyboard);
     keyboard->safeConnect(&qw_input_device::before_destroy, this, [d, keyboard] () {
-        if (d->seat) d->seat->detachInputDevice(keyboard);
+        if (d->seat) {
+            // Switch seat keyboard to group before the virtual keyboard's
+            // wlr_keyboard is destroyed. This removes handle_keyboard_destroy
+            // listener from the virtual keyboard, preventing
+            // wlr_seat_set_keyboard(NULL).
+            if (d->seat->keyboard() == keyboard && d->seat->keyboardGroupKeyboard())
+                d->seat->setKeyboard(d->seat->keyboardGroupKeyboard());
+            d->seat->detachInputDevice(keyboard);
+        }
         d->virtualKeyboards.removeOne(keyboard);
         keyboard->safeDeleteLater();
     });


### PR DESCRIPTION
When a virtual keyboard (e.g. input method) that was set as the seat
keyboard is destroyed, wlroots handle_keyboard_destroy() calls
wlr_seat_set_keyboard(NULL). The keyboard capability remains advertised
since updateCapabilities() is not triggered. New clients (e.g. Chrome)
then create wl_keyboard resources without receiving keymap, causing
SIGSEGV in xkb_state_update_mask() when modifiers arrive.

Restore the group keyboard in setKeyboardFocusSurface() before setting
focus, ensuring keymap reaches clients before enter and modifiers.

## Summary by Sourcery

Handle seat keyboard restoration and keymap reuse to prevent crashes when virtual keyboards are destroyed and physical keyboards are grouped.

Bug Fixes:
- Avoid sending duplicate wl_keyboard.modifiers events when switching keyboards, preventing client crashes in xkb_state_update_mask().
- Restore the group keyboard when the seat keyboard becomes NULL so new clients receive a valid keymap before enter and modifier events.
- Ensure only physical, non-virtual keyboards are removed from the keyboard group when detaching devices.

Enhancements:
- Reuse the group keyboard's existing keymap for physical keyboards instead of allocating new keymaps, avoiding unnecessary keymap broadcasts and spurious client state rebuilds.
- Add diagnostic logging and safeguards when attaching keyboards if the group keyboard unexpectedly lacks a keymap.