### PR TITLE
fix(gesture): fix workspace gesture issues and add lock screen guards

### DIFF
--- a/src/input/gestures.cpp
+++ b/src/input/gestures.cpp
@@ -317,6 +317,13 @@ int GestureRecognizer::startSwipeGesture(uint fingerCount,
                 continue;
             }
         }
+        // Axis not yet locked — skip all gestures. The first updateSwipeGesture
+        // will lock the axis, then the two-pass loop rebuilds the active list
+        // with only matching-direction gestures.
+        if (m_currentSwipeAxis == Axis::None) {
+            continue;
+        }
+
         switch (gesture->direction()) {
         case SwipeGesture::Up:
             [[fallthrough]];

--- a/src/modules/shortcut/shortcutrunner.cpp
+++ b/src/modules/shortcut/shortcutrunner.cpp
@@ -186,7 +186,7 @@ void ShortcutRunner::onActionProgress(ShortcutAction action, qreal progress, con
     case ShortcutAction::OpenMultiTaskView:
     {
         auto helper = Helper::instance();
-        if (!helper->m_multitaskView)
+        if (!helper->m_multitaskView || !helper->isNormalOrMultitaskview())
             break;
         if (helper->currentMode() == Helper::CurrentMode::Normal
             && qFuzzyIsNull(helper->m_multitaskView->partialFactor())) {
@@ -201,7 +201,7 @@ void ShortcutRunner::onActionProgress(ShortcutAction action, qreal progress, con
     case ShortcutAction::CloseMultiTaskView:
     {
         auto helper = Helper::instance();
-        if (!helper->m_multitaskView)
+        if (!helper->m_multitaskView || !helper->isNormalOrMultitaskview())
             break;
         if (helper->currentMode() != Helper::CurrentMode::Multitaskview) {
             break;
@@ -225,7 +225,7 @@ void ShortcutRunner::onActionFinish(ShortcutAction action, const QString &name, 
     case ShortcutAction::OpenMultiTaskView:
     {
         auto helper = Helper::instance();
-        if (!helper->m_multitaskView)
+        if (!helper->m_multitaskView || !helper->isNormalOrMultitaskview())
             break;
         const bool triggered = helper->m_multitaskView->partialFactor() > 0.5;
         helper->m_multitaskView->setStatus(triggered ? IMultitaskView::Active
@@ -237,7 +237,7 @@ void ShortcutRunner::onActionFinish(ShortcutAction action, const QString &name, 
     case ShortcutAction::CloseMultiTaskView:
     {
         auto helper = Helper::instance();
-        if (!helper->m_multitaskView)
+        if (!helper->m_multitaskView || !helper->isNormalOrMultitaskview())
             break;
         const bool triggered = (1.0 - helper->m_multitaskView->partialFactor()) > 0.5;
         if (qFuzzyCompare(helper->m_multitaskView->partialFactor(), 0.0)
@@ -269,83 +269,47 @@ void ShortcutRunner::updateWorkspaceSwipe(qreal cb)
     Q_ASSERT(controller);
 
     m_desktopOffset = cb;
+
     if (!m_slideEnable) {
         m_slideEnable = true;
-        m_slideBounce = false;
-
         m_fromId = workspace->currentIndex();
-        if (cb > 0) {
-            m_toId = m_fromId + 1;
-            if (m_toId > workspace->count())
-                return;
-
-            if (m_toId == workspace->count())
-                m_slideBounce = true;
-        } else if (cb < 0) {
-            m_toId = m_fromId - 1;
-            if (m_toId < -1)
-                return;
-
-            if (m_toId == -1)
-                m_slideBounce = true;
-        }
-
-        controller->slideNormal(m_fromId, m_toId);
+        controller->slideNormal(m_fromId);
         workspace->createSwitcher();
         controller->setRunning(true);
     }
 
-    if (m_slideEnable) {
-        controller->startGestureSlide(m_desktopOffset, m_slideBounce);
-    }
+    controller->startGestureSlide(
+        cb,
+        isWorkspaceBounce(cb, workspace->currentIndex(), workspace->count()));
 }
 
 void ShortcutRunner::finishWorkspaceSwipe()
 {
     if (!m_slideEnable)
         return;
-
     m_slideEnable = false;
-
-    // precision control. if it is infinitely close to 0, resetting the current index will cause
-    // flickering
-    qreal epison = std::floor(std::abs(m_desktopOffset) * 100) / 100;
-    if (epison < 0.01)
-        return;
-
     Workspace *workspace = Helper::instance()->workspace();
-    if (!m_slideBounce && (m_desktopOffset > 0.98 || m_desktopOffset < -0.98)) {
-        // m_desktopOffset is very close to 1 or -1, just set to the toId directly
-        // Not need to play the slide animation
-        workspace->switchTo(m_toId, false);
-        auto *controller = workspace->animationController();
-        controller->setRunning(false);
-        return;
-    }
+    int currentIdx = workspace->currentIndex();
+    int wsCount = workspace->count();
 
-    m_fromId = workspace->currentIndex();
-    m_toId = 0;
-
+    // determine target based on offset threshold, but never cross boundary
+    m_toId = currentIdx;
     if (m_desktopOffset > 0.3) {
-        m_toId = m_slideBounce ? m_fromId : m_fromId + 1;
-        if (m_toId >= workspace->count())
-            return;
+        if (!isWorkspaceBounce(m_desktopOffset, currentIdx, wsCount))
+            m_toId = currentIdx + 1;
     } else if (m_desktopOffset <= -0.3) {
-        m_toId = m_slideBounce ? m_fromId : m_fromId - 1;
-        if (m_toId < 0)
-            return;
-    } else {
-        m_toId = m_fromId;
+        if (!isWorkspaceBounce(m_desktopOffset, currentIdx, wsCount))
+            m_toId = currentIdx - 1;
     }
+
+    // final safety bounds check
+    m_toId = qBound(0, m_toId, wsCount - 1);
 
     auto controller = workspace->animationController();
-    if (m_toId >= 0 && m_toId < workspace->count()) {
-        controller->slideRunning(m_toId);
-        controller->startSlideAnimation();
-        workspace->switchTo(m_toId, false);
-    }
+    controller->slideRunning(m_toId);
+    controller->startSlideAnimation();
+    workspace->switchTo(m_toId, false);
 }
-
 void ShortcutRunner::taskswitchAction(bool isRepeat, bool isSameApp, bool isPrev)
 {
     auto *helper = Helper::instance();

--- a/src/modules/shortcut/shortcutrunner.h
+++ b/src/modules/shortcut/shortcutrunner.h
@@ -28,11 +28,16 @@ private:
     void finishWorkspaceSwipe();
     void taskswitchAction(bool isRepeat, bool isSameApp, bool isPrev);
 
+    // dynamic bounce check: true when cb pushes beyond workspace boundary
+    inline bool isWorkspaceBounce(qreal cb, int currentIndex, int wsCount) const
+    {
+        return (cb > 0 && currentIndex >= wsCount - 1) || (cb < 0 && currentIndex <= 0);
+    }
+
     qreal m_desktopOffset = 0;
     int m_fromId = 0;
     int m_toId = 0;
     bool m_slideEnable = false;
-    bool m_slideBounce = false;
 
     QTimer *m_quickSwitchTimer = nullptr;
     ShortcutAction m_currentAction;

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2342,7 +2342,8 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *targetWindow, QInputEvent 
         seat->cursor()->setVisible(false);
     }
 
-    doGesture(event);
+    if (m_currentMode != CurrentMode::LockScreen)
+        doGesture(event);
 
     // Per-seat move/resize handling
     const auto *seatContainer = m_rootSurfaceContainer->getSeatContainer(seat);

--- a/src/workspace/workspaceanimationcontroller.cpp
+++ b/src/workspace/workspaceanimationcontroller.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 #include "workspaceanimationcontroller.h"
 
@@ -131,13 +131,14 @@ void WorkspaceAnimationController::slideRunning(uint toWorkspaceIndex)
     m_currentDirection = m_animationDestination > m_animationInitial ? Right : Left;
 }
 
-void WorkspaceAnimationController::slideNormal(uint fromWorkspaceIndex, uint toWorkspaceIndex)
+void WorkspaceAnimationController::slideNormal(uint fromWorkspaceIndex)
 {
+    m_slideAnimation->stop();
+    m_bounceAnimation->stop();
     m_initialIndex = fromWorkspaceIndex;
-    m_destinationIndex = toWorkspaceIndex;
+    m_destinationIndex = fromWorkspaceIndex;
     m_animationInitial = refWrap() * fromWorkspaceIndex;
-    m_animationDestination = refWrap() * toWorkspaceIndex;
-    m_currentDirection = (fromWorkspaceIndex < toWorkspaceIndex) ? Right : Left;
+    m_animationDestination = m_animationInitial;
     setViewportPos(m_animationInitial);
 }
 
@@ -145,7 +146,10 @@ void WorkspaceAnimationController::slide(uint fromWorkspaceIndex, uint toWorkspa
 {
     m_needBounce = false;
     slideRunning(toWorkspaceIndex);
-    slideNormal(fromWorkspaceIndex, toWorkspaceIndex);
+    slideNormal(fromWorkspaceIndex);
+    m_destinationIndex = toWorkspaceIndex;
+    m_animationDestination = refWrap() * toWorkspaceIndex;
+    m_currentDirection = (fromWorkspaceIndex < toWorkspaceIndex) ? Right : Left;
     startSlideAnimation();
 }
 

--- a/src/workspace/workspaceanimationcontroller.h
+++ b/src/workspace/workspaceanimationcontroller.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 #pragma once
 
@@ -55,7 +55,7 @@ Q_SIGNALS:
 
 public Q_SLOTS:
     void slideRunning(uint toWorkspaceIndex);
-    void slideNormal(uint fromWorkspaceIndex, uint toWorkspaceIndex);
+    void slideNormal(uint fromWorkspaceIndex);
     void slide(uint fromWorkspaceIndex, uint toWorkspaceIndex);
     void bounce(uint currentWorkspaceIndex, Direction direction);
     void setRunning(bool running);


### PR DESCRIPTION
1. Fix intermittent unresponsive workspace switching in multitask view
2. Fix workspace icon disappearing during desktop gesture switching
3. Block gesture and multitask view trigger under lock screen
4. Change workspace bounce to dynamic calculation

1. 修复多任务视图工作区切换偶现不跟手
2. 修复桌面使用手势切换工作区时图标消失的问题
3. 锁屏状态下禁止手势和任务视图触发
4. 修改工作区边界反弹为动态计算

Log: 修复工作区手势相关问题及锁屏守卫
PMS: BUG-370247
Influence:
1. 修复多任务视图工作区切换偶现不跟手
2. 修复桌面手势切换工作区图标消失
3. 锁屏下禁止手势操作

## Summary by Sourcery

Improve workspace gesture reliability and add lock-screen protection for gesture handling.

Bug Fixes:
- Resolve cases where multitask view workspace switching becomes unresponsive or out of sync with gestures.
- Prevent workspace icons from disappearing when switching desktops via gestures.
- Block multitask view and gesture handling when the system is in lock-screen mode to avoid unintended actions.

Enhancements:
- Adjust workspace swipe handling and animation controller to use dynamic boundary bounce calculation for smoother edge behavior.
- Refine swipe gesture recognition to lock the gesture axis before activating direction-specific gestures.