### PR TITLE
chore: bump version to 0.8.17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.25.0)
 
 project(Treeland
-    VERSION 0.8.16
+    VERSION 0.8.17
     LANGUAGES CXX C)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,27 @@
+treeland (0.8.17) unstable; urgency=medium
+
+  * fix(seat): restore group keyboard when virtual keyboard is destroyed
+  * fix(gesture): fix workspace gesture issues and add lock screen
+    guards
+  * fix(input): update cursor from DnD action
+  * fix(output): avoid enabling output before restoring topology
+  * fix(glass): pull refraction to lip and retune glass defaults
+  * fix(animation): smooth minimize transitions
+  * feat(glass): implement Liquid Glass effect with smooth corner
+    deformation
+  * fix(multitaskview): resolve transition, gesture and workspace
+    switching issues
+  * fix(output): prevent repeated repositioning of child windows across
+    outputs
+  * fix(surface): child may remain below parent after XdgToplevel
+    set_parent
+  * fix(task-switcher): restore surface state after interrupted exit
+  * fix(surface): fix skipSwitcher/skipMultitaskView for X11 surfaces
+  * feat(waylib): add _NET_WM_WINDOW_TYPE_DIALOG support for XWayland
+  * fix(surface): add m_wrapperAboutToRemove guard to updateBoundingRect
+
+ -- rewine <luhongxu@deepin.org>  Fri, 31 Jul 2026 10:50:39 +0800
+
 treeland (0.8.16) unstable; urgency=medium
 
   * fix(waylib/xwayland): deny Activate for surfaces without Focus


### PR DESCRIPTION
Log: bump

## Summary by Sourcery

Bump the project version from 0.8.16 to 0.8.17 in build configuration and packaging metadata.

Build:
- Update CMake project version to 0.8.17.

Deployment:
- Adjust Debian packaging changelog to reflect version 0.8.17.