### PR TITLE
fix(lockscreen): add missing password error translation

### DIFF
--- a/src/plugins/lockscreen/translations/lockscreen.ca.ts
+++ b/src/plugins/lockscreen/translations/lockscreen.ca.ts
@@ -1,48 +1,12 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
-<context>
-    <name>Center</name>
-    <message>
-        <source>Return to default mode</source>
-        <translation type="vanished">Torna al mode predeterminat</translation>
-    </message>
-    <message>
-        <source>Do you want to back to default?</source>
-        <translation type="vanished">Voleu tornar als valors per defecte?</translation>
-    </message>
-    <message>
-        <source>This action will reboot machine, please confirm.</source>
-        <translation type="vanished">Aquesta acció reiniciarà la màquina; si us plau, confirmeu-ho.</translation>
-    </message>
-    <message>
-        <source>Back To Default Mode</source>
-        <translation type="vanished">Torna al mode predeterminat</translation>
-    </message>
-    <message>
-        <source>Other Users</source>
-        <translation type="vanished">Altres usuaris</translation>
-    </message>
-    <message>
-        <source>Power</source>
-        <translation type="vanished">Energia</translation>
-    </message>
-</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>ControlAction</name>
     <message>
-        <source>Other Users</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/ControlAction.qml" line="55"/>
+        <location filename="../qml/ControlAction.qml" line="83"/>
         <source>Power</source>
         <translation>Energia</translation>
-    </message>
-</context>
-<context>
-    <name>Greeter</name>
-    <message>
-        <source>Password is incorrect.</source>
-        <translation type="vanished">La contrasenya és incorrecta.</translation>
     </message>
 </context>
 <context>
@@ -54,47 +18,32 @@
     </message>
 </context>
 <context>
-    <name>LockView</name>
-    <message>
-        <location filename="../qml/LockView.qml" line="176"/>
-        <source>Password is incorrect.</source>
-        <translation>La contrasenya és incorrecta.</translation>
-    </message>
-</context>
-<context>
     <name>PowerList</name>
     <message>
-        <location filename="../qml/PowerList.qml" line="60"/>
+        <location filename="../qml/PowerList.qml" line="58"/>
         <source>Hibernate</source>
         <translation>Hiberna</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="50"/>
+        <location filename="../qml/PowerList.qml" line="49"/>
         <source>Suspend</source>
         <translation>Suspèn</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="43"/>
+        <location filename="../qml/PowerList.qml" line="42"/>
         <source>Reboot</source>
         <translation>Reinicia</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="36"/>
+        <location filename="../qml/PowerList.qml" line="35"/>
         <source>Shut Down</source>
         <translation>Atura</translation>
     </message>
 </context>
 <context>
-    <name>SessionModel</name>
-    <message>
-        <source>%1 (Wayland)</source>
-        <translation type="vanished">%1 (Wayland)</translation>
-    </message>
-</context>
-<context>
     <name>ShutdownView</name>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="32"/>
+        <location filename="../qml/ShutdownView.qml" line="31"/>
         <source>lock</source>
         <translation>bloca</translation>
     </message>
@@ -104,20 +53,9 @@
         <translation>canvia d&apos;usuari</translation>
     </message>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="43"/>
+        <location filename="../qml/ShutdownView.qml" line="44"/>
         <source>Logout</source>
         <translation>Surt</translation>
-    </message>
-</context>
-<context>
-    <name>User</name>
-    <message>
-        <source>Administrator</source>
-        <translation type="vanished">Administrador</translation>
-    </message>
-    <message>
-        <source>Standard User</source>
-        <translation type="vanished">Usuari estàndard</translation>
     </message>
 </context>
 <context>
@@ -128,9 +66,37 @@
         <translation>Introduïu la contrasenya</translation>
     </message>
     <message>
-        <location filename="../qml/UserInput.qml" line="141"/>
+        <location filename="../qml/UserInput.qml" line="154"/>
         <source>Password</source>
         <translation>Contrasenya</translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="154"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="341"/>
+        <source>Enter username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="354"/>
+        <source>User not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="376"/>
+        <source>Password is incorrect.</source>
+        <translation type="unfinished">La contrasenya és incorrecta.</translation>
+    </message>
+</context>
+<context>
+    <name>UserList</name>
+    <message>
+        <location filename="../qml/UserList.qml" line="236"/>
+        <source>Other…</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugins/lockscreen/translations/lockscreen.en_US.ts
+++ b/src/plugins/lockscreen/translations/lockscreen.en_US.ts
@@ -2,49 +2,11 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="en_US">
 <context>
-    <name>Center</name>
-    <message>
-        <source>Return to default mode</source>
-        <translation type="vanished">Return to default mode</translation>
-    </message>
-    <message>
-        <source>Do you want to back to default?</source>
-        <translation type="vanished">Do you want to back to default?</translation>
-    </message>
-    <message>
-        <source>This action will reboot machine, please confirm.</source>
-        <translation type="vanished">This action will reboot machine, please confirm.</translation>
-    </message>
-    <message>
-        <source>Back To Default Mode</source>
-        <translation type="vanished">Back To Default Mode</translation>
-    </message>
-    <message>
-        <source>Other Users</source>
-        <translation type="vanished">Other Users</translation>
-    </message>
-    <message>
-        <source>Power</source>
-        <translation type="vanished">Power</translation>
-    </message>
-</context>
-<context>
     <name>ControlAction</name>
     <message>
-        <source>Other Users</source>
-        <translation type="obsolete">Other Users</translation>
-    </message>
-    <message>
-        <location filename="../qml/ControlAction.qml" line="55"/>
+        <location filename="../qml/ControlAction.qml" line="83"/>
         <source>Power</source>
         <translation type="unfinished">Power</translation>
-    </message>
-</context>
-<context>
-    <name>Greeter</name>
-    <message>
-        <source>Password is incorrect.</source>
-        <translation type="vanished">Password is incorrect.</translation>
     </message>
 </context>
 <context>
@@ -56,47 +18,32 @@
     </message>
 </context>
 <context>
-    <name>LockView</name>
-    <message>
-        <location filename="../qml/LockView.qml" line="176"/>
-        <source>Password is incorrect.</source>
-        <translation type="unfinished">Password is incorrect.</translation>
-    </message>
-</context>
-<context>
     <name>PowerList</name>
     <message>
-        <location filename="../qml/PowerList.qml" line="60"/>
+        <location filename="../qml/PowerList.qml" line="58"/>
         <source>Hibernate</source>
         <translation>Hibernate</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="50"/>
+        <location filename="../qml/PowerList.qml" line="49"/>
         <source>Suspend</source>
         <translation>Suspend</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="43"/>
+        <location filename="../qml/PowerList.qml" line="42"/>
         <source>Reboot</source>
         <translation>Reboot</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="36"/>
+        <location filename="../qml/PowerList.qml" line="35"/>
         <source>Shut Down</source>
         <translation>Shut Down</translation>
     </message>
 </context>
 <context>
-    <name>SessionModel</name>
-    <message>
-        <source>%1 (Wayland)</source>
-        <translation type="vanished">%1 (Wayland)</translation>
-    </message>
-</context>
-<context>
     <name>ShutdownView</name>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="32"/>
+        <location filename="../qml/ShutdownView.qml" line="31"/>
         <source>lock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -106,20 +53,9 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="43"/>
+        <location filename="../qml/ShutdownView.qml" line="44"/>
         <source>Logout</source>
         <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>User</name>
-    <message>
-        <source>Administrator</source>
-        <translation type="vanished">Administrator</translation>
-    </message>
-    <message>
-        <source>Standard User</source>
-        <translation type="vanished">Standard User</translation>
     </message>
 </context>
 <context>
@@ -130,8 +66,36 @@
         <translation>Please enter password</translation>
     </message>
     <message>
-        <location filename="../qml/UserInput.qml" line="141"/>
+        <location filename="../qml/UserInput.qml" line="154"/>
         <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="154"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="341"/>
+        <source>Enter username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="354"/>
+        <source>User not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="376"/>
+        <source>Password is incorrect.</source>
+        <translation type="unfinished">Password is incorrect.</translation>
+    </message>
+</context>
+<context>
+    <name>UserList</name>
+    <message>
+        <location filename="../qml/UserList.qml" line="236"/>
+        <source>Other…</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugins/lockscreen/translations/lockscreen.es.ts
+++ b/src/plugins/lockscreen/translations/lockscreen.es.ts
@@ -1,48 +1,12 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
-<context>
-    <name>Center</name>
-    <message>
-        <source>Return to default mode</source>
-        <translation type="vanished">Regresar al modo por defecto</translation>
-    </message>
-    <message>
-        <source>Do you want to back to default?</source>
-        <translation type="vanished">¿Quiere volver a la configuración predeterminada?</translation>
-    </message>
-    <message>
-        <source>This action will reboot machine, please confirm.</source>
-        <translation type="vanished">Esta acción reiniciara la maquina, confirme</translation>
-    </message>
-    <message>
-        <source>Back To Default Mode</source>
-        <translation type="vanished">De regreso al modo por defecto</translation>
-    </message>
-    <message>
-        <source>Other Users</source>
-        <translation type="vanished">Otros usuarios</translation>
-    </message>
-    <message>
-        <source>Power</source>
-        <translation type="vanished">Encender</translation>
-    </message>
-</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>ControlAction</name>
     <message>
-        <source>Other Users</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/ControlAction.qml" line="55"/>
+        <location filename="../qml/ControlAction.qml" line="83"/>
         <source>Power</source>
         <translation>Encender</translation>
-    </message>
-</context>
-<context>
-    <name>Greeter</name>
-    <message>
-        <source>Password is incorrect.</source>
-        <translation type="vanished">La contraseña es incorrecta.</translation>
     </message>
 </context>
 <context>
@@ -54,47 +18,32 @@
     </message>
 </context>
 <context>
-    <name>LockView</name>
-    <message>
-        <location filename="../qml/LockView.qml" line="176"/>
-        <source>Password is incorrect.</source>
-        <translation>La contraseña es incorrecta.</translation>
-    </message>
-</context>
-<context>
     <name>PowerList</name>
     <message>
-        <location filename="../qml/PowerList.qml" line="60"/>
+        <location filename="../qml/PowerList.qml" line="58"/>
         <source>Hibernate</source>
         <translation>Hibernar</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="50"/>
+        <location filename="../qml/PowerList.qml" line="49"/>
         <source>Suspend</source>
         <translation>Suspender</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="43"/>
+        <location filename="../qml/PowerList.qml" line="42"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="36"/>
+        <location filename="../qml/PowerList.qml" line="35"/>
         <source>Shut Down</source>
         <translation>Apagar</translation>
     </message>
 </context>
 <context>
-    <name>SessionModel</name>
-    <message>
-        <source>%1 (Wayland)</source>
-        <translation type="vanished">%1 (Wayland)</translation>
-    </message>
-</context>
-<context>
     <name>ShutdownView</name>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="32"/>
+        <location filename="../qml/ShutdownView.qml" line="31"/>
         <source>lock</source>
         <translation>Bloquear</translation>
     </message>
@@ -104,20 +53,9 @@
         <translation>Cambiar usuario</translation>
     </message>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="43"/>
+        <location filename="../qml/ShutdownView.qml" line="44"/>
         <source>Logout</source>
         <translation>Cerrar sesión </translation>
-    </message>
-</context>
-<context>
-    <name>User</name>
-    <message>
-        <source>Administrator</source>
-        <translation type="vanished">Administrador</translation>
-    </message>
-    <message>
-        <source>Standard User</source>
-        <translation type="vanished">Usuario regular </translation>
     </message>
 </context>
 <context>
@@ -128,9 +66,37 @@
         <translation>Ingrese la contraseña</translation>
     </message>
     <message>
-        <location filename="../qml/UserInput.qml" line="141"/>
+        <location filename="../qml/UserInput.qml" line="154"/>
         <source>Password</source>
         <translation>Contraseña</translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="154"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="341"/>
+        <source>Enter username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="354"/>
+        <source>User not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="376"/>
+        <source>Password is incorrect.</source>
+        <translation type="unfinished">La contraseña es incorrecta.</translation>
+    </message>
+</context>
+<context>
+    <name>UserList</name>
+    <message>
+        <location filename="../qml/UserList.qml" line="236"/>
+        <source>Other…</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugins/lockscreen/translations/lockscreen.fi.ts
+++ b/src/plugins/lockscreen/translations/lockscreen.fi.ts
@@ -1,48 +1,12 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
-<context>
-    <name>Center</name>
-    <message>
-        <source>Return to default mode</source>
-        <translation type="vanished">Takaisin oletustilaan</translation>
-    </message>
-    <message>
-        <source>Do you want to back to default?</source>
-        <translation type="vanished">Haluatko palata oletukseen?</translation>
-    </message>
-    <message>
-        <source>This action will reboot machine, please confirm.</source>
-        <translation type="vanished">Tämä käynnistää tietokoneen uudelleen, vahvista.</translation>
-    </message>
-    <message>
-        <source>Back To Default Mode</source>
-        <translation type="vanished">Takaisin oletustilaan</translation>
-    </message>
-    <message>
-        <source>Other Users</source>
-        <translation type="vanished">Muut käyttäjät</translation>
-    </message>
-    <message>
-        <source>Power</source>
-        <translation type="vanished">Virta</translation>
-    </message>
-</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>ControlAction</name>
     <message>
-        <source>Other Users</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/ControlAction.qml" line="55"/>
+        <location filename="../qml/ControlAction.qml" line="83"/>
         <source>Power</source>
         <translation>Virta</translation>
-    </message>
-</context>
-<context>
-    <name>Greeter</name>
-    <message>
-        <source>Password is incorrect.</source>
-        <translation type="vanished">Salasana on väärä.</translation>
     </message>
 </context>
 <context>
@@ -54,47 +18,32 @@
     </message>
 </context>
 <context>
-    <name>LockView</name>
-    <message>
-        <location filename="../qml/LockView.qml" line="176"/>
-        <source>Password is incorrect.</source>
-        <translation>Salasana on väärä.</translation>
-    </message>
-</context>
-<context>
     <name>PowerList</name>
     <message>
-        <location filename="../qml/PowerList.qml" line="60"/>
+        <location filename="../qml/PowerList.qml" line="58"/>
         <source>Hibernate</source>
         <translation>Horrostila</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="50"/>
+        <location filename="../qml/PowerList.qml" line="49"/>
         <source>Suspend</source>
         <translation>Lepotila</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="43"/>
+        <location filename="../qml/PowerList.qml" line="42"/>
         <source>Reboot</source>
         <translation>Käynnistä</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="36"/>
+        <location filename="../qml/PowerList.qml" line="35"/>
         <source>Shut Down</source>
         <translation>Sammuta</translation>
     </message>
 </context>
 <context>
-    <name>SessionModel</name>
-    <message>
-        <source>%1 (Wayland)</source>
-        <translation type="vanished">%1 (Wayland)</translation>
-    </message>
-</context>
-<context>
     <name>ShutdownView</name>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="32"/>
+        <location filename="../qml/ShutdownView.qml" line="31"/>
         <source>lock</source>
         <translation>Lukitse</translation>
     </message>
@@ -104,20 +53,9 @@
         <translation>Vaihda käyttäjää</translation>
     </message>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="43"/>
+        <location filename="../qml/ShutdownView.qml" line="44"/>
         <source>Logout</source>
         <translation>Kirjaudu ulos</translation>
-    </message>
-</context>
-<context>
-    <name>User</name>
-    <message>
-        <source>Administrator</source>
-        <translation type="vanished">Järjestelmänvalvoja</translation>
-    </message>
-    <message>
-        <source>Standard User</source>
-        <translation type="vanished">Normaali käyttäjä</translation>
     </message>
 </context>
 <context>
@@ -128,9 +66,37 @@
         <translation>Anna salasana</translation>
     </message>
     <message>
-        <location filename="../qml/UserInput.qml" line="141"/>
+        <location filename="../qml/UserInput.qml" line="154"/>
         <source>Password</source>
         <translation>Salasana</translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="154"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="341"/>
+        <source>Enter username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="354"/>
+        <source>User not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="376"/>
+        <source>Password is incorrect.</source>
+        <translation type="unfinished">Salasana on väärä.</translation>
+    </message>
+</context>
+<context>
+    <name>UserList</name>
+    <message>
+        <location filename="../qml/UserList.qml" line="236"/>
+        <source>Other…</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugins/lockscreen/translations/lockscreen.fr.ts
+++ b/src/plugins/lockscreen/translations/lockscreen.fr.ts
@@ -1,48 +1,12 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
-<context>
-    <name>Center</name>
-    <message>
-        <source>Return to default mode</source>
-        <translation type="vanished">Revenir au mode par défaut</translation>
-    </message>
-    <message>
-        <source>Do you want to back to default?</source>
-        <translation type="vanished">Souhaitez-vous revenir aux paramètres par défaut ?</translation>
-    </message>
-    <message>
-        <source>This action will reboot machine, please confirm.</source>
-        <translation type="vanished">Cette action redémarrera la machine, veuillez confirmer.</translation>
-    </message>
-    <message>
-        <source>Back To Default Mode</source>
-        <translation type="vanished">Retour au mode par défaut</translation>
-    </message>
-    <message>
-        <source>Other Users</source>
-        <translation type="vanished">Autres utilisateurs</translation>
-    </message>
-    <message>
-        <source>Power</source>
-        <translation type="vanished">Énergie</translation>
-    </message>
-</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>ControlAction</name>
     <message>
-        <source>Other Users</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/ControlAction.qml" line="55"/>
+        <location filename="../qml/ControlAction.qml" line="83"/>
         <source>Power</source>
         <translation>Énergie</translation>
-    </message>
-</context>
-<context>
-    <name>Greeter</name>
-    <message>
-        <source>Password is incorrect.</source>
-        <translation type="vanished">Mot de passe incorrect.</translation>
     </message>
 </context>
 <context>
@@ -54,47 +18,32 @@
     </message>
 </context>
 <context>
-    <name>LockView</name>
-    <message>
-        <location filename="../qml/LockView.qml" line="176"/>
-        <source>Password is incorrect.</source>
-        <translation>Mot de passe incorrect.</translation>
-    </message>
-</context>
-<context>
     <name>PowerList</name>
     <message>
-        <location filename="../qml/PowerList.qml" line="60"/>
+        <location filename="../qml/PowerList.qml" line="58"/>
         <source>Hibernate</source>
         <translation>Hibernation</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="50"/>
+        <location filename="../qml/PowerList.qml" line="49"/>
         <source>Suspend</source>
         <translation>Suspendre</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="43"/>
+        <location filename="../qml/PowerList.qml" line="42"/>
         <source>Reboot</source>
         <translation>Redémarrer</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="36"/>
+        <location filename="../qml/PowerList.qml" line="35"/>
         <source>Shut Down</source>
         <translation>Éteindre</translation>
     </message>
 </context>
 <context>
-    <name>SessionModel</name>
-    <message>
-        <source>%1 (Wayland)</source>
-        <translation type="vanished">%1 (Wayland)</translation>
-    </message>
-</context>
-<context>
     <name>ShutdownView</name>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="32"/>
+        <location filename="../qml/ShutdownView.qml" line="31"/>
         <source>lock</source>
         <translation>verrouiller</translation>
     </message>
@@ -104,20 +53,9 @@
         <translation>changer d&apos;utilisateur</translation>
     </message>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="43"/>
+        <location filename="../qml/ShutdownView.qml" line="44"/>
         <source>Logout</source>
         <translation>Déconnexion</translation>
-    </message>
-</context>
-<context>
-    <name>User</name>
-    <message>
-        <source>Administrator</source>
-        <translation type="vanished">Administrateur</translation>
-    </message>
-    <message>
-        <source>Standard User</source>
-        <translation type="vanished">Utilisateur standard</translation>
     </message>
 </context>
 <context>
@@ -128,9 +66,37 @@
         <translation>Veuillez saisir votre mot de passe</translation>
     </message>
     <message>
-        <location filename="../qml/UserInput.qml" line="141"/>
+        <location filename="../qml/UserInput.qml" line="154"/>
         <source>Password</source>
         <translation>Mot de passe</translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="154"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="341"/>
+        <source>Enter username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="354"/>
+        <source>User not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="376"/>
+        <source>Password is incorrect.</source>
+        <translation type="unfinished">Mot de passe incorrect.</translation>
+    </message>
+</context>
+<context>
+    <name>UserList</name>
+    <message>
+        <location filename="../qml/UserList.qml" line="236"/>
+        <source>Other…</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugins/lockscreen/translations/lockscreen.gl_ES.ts
+++ b/src/plugins/lockscreen/translations/lockscreen.gl_ES.ts
@@ -1,48 +1,12 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="gl_ES">
-<context>
-    <name>Center</name>
-    <message>
-        <source>Return to default mode</source>
-        <translation type="vanished">Volver ao modo predeterminado</translation>
-    </message>
-    <message>
-        <source>Do you want to back to default?</source>
-        <translation type="vanished">Queres volver á configuración predeterminada?</translation>
-    </message>
-    <message>
-        <source>This action will reboot machine, please confirm.</source>
-        <translation type="vanished">Esta acción reiniciará a máquina, confirme.</translation>
-    </message>
-    <message>
-        <source>Back To Default Mode</source>
-        <translation type="vanished">Volver ao modo predeterminado</translation>
-    </message>
-    <message>
-        <source>Other Users</source>
-        <translation type="vanished">Outros usuarios</translation>
-    </message>
-    <message>
-        <source>Power</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="gl_ES">
 <context>
     <name>ControlAction</name>
     <message>
-        <source>Other Users</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/ControlAction.qml" line="55"/>
+        <location filename="../qml/ControlAction.qml" line="83"/>
         <source>Power</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>Greeter</name>
-    <message>
-        <source>Password is incorrect.</source>
-        <translation type="vanished">O contrasinal non é válido</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -54,47 +18,32 @@
     </message>
 </context>
 <context>
-    <name>LockView</name>
-    <message>
-        <location filename="../qml/LockView.qml" line="176"/>
-        <source>Password is incorrect.</source>
-        <translation>O contrasinal non é válido</translation>
-    </message>
-</context>
-<context>
     <name>PowerList</name>
     <message>
-        <location filename="../qml/PowerList.qml" line="60"/>
+        <location filename="../qml/PowerList.qml" line="58"/>
         <source>Hibernate</source>
         <translation>Hibernar</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="50"/>
+        <location filename="../qml/PowerList.qml" line="49"/>
         <source>Suspend</source>
         <translation>Suspender</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="43"/>
+        <location filename="../qml/PowerList.qml" line="42"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="36"/>
+        <location filename="../qml/PowerList.qml" line="35"/>
         <source>Shut Down</source>
         <translation>Apagar</translation>
     </message>
 </context>
 <context>
-    <name>SessionModel</name>
-    <message>
-        <source>%1 (Wayland)</source>
-        <translation type="vanished">%1 (Wayland)</translation>
-    </message>
-</context>
-<context>
     <name>ShutdownView</name>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="32"/>
+        <location filename="../qml/ShutdownView.qml" line="31"/>
         <source>lock</source>
         <translation>bloquear</translation>
     </message>
@@ -104,20 +53,9 @@
         <translation>cambiar usuario</translation>
     </message>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="43"/>
+        <location filename="../qml/ShutdownView.qml" line="44"/>
         <source>Logout</source>
         <translation>Pechar sesión</translation>
-    </message>
-</context>
-<context>
-    <name>User</name>
-    <message>
-        <source>Administrator</source>
-        <translation type="vanished">Administrador</translation>
-    </message>
-    <message>
-        <source>Standard User</source>
-        <translation type="vanished">Usuario estándar</translation>
     </message>
 </context>
 <context>
@@ -128,9 +66,37 @@
         <translation>Introduza o contrasinal</translation>
     </message>
     <message>
-        <location filename="../qml/UserInput.qml" line="141"/>
+        <location filename="../qml/UserInput.qml" line="154"/>
         <source>Password</source>
         <translation>Contrasinal</translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="154"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="341"/>
+        <source>Enter username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="354"/>
+        <source>User not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="376"/>
+        <source>Password is incorrect.</source>
+        <translation type="unfinished">O contrasinal non é válido</translation>
+    </message>
+</context>
+<context>
+    <name>UserList</name>
+    <message>
+        <location filename="../qml/UserList.qml" line="236"/>
+        <source>Other…</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugins/lockscreen/translations/lockscreen.ja.ts
+++ b/src/plugins/lockscreen/translations/lockscreen.ja.ts
@@ -1,48 +1,12 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
-<context>
-    <name>Center</name>
-    <message>
-        <source>Return to default mode</source>
-        <translation type="vanished">デフォルトモードに戻る</translation>
-    </message>
-    <message>
-        <source>Do you want to back to default?</source>
-        <translation type="vanished">デフォルトに戻してもよろしいですか？</translation>
-    </message>
-    <message>
-        <source>This action will reboot machine, please confirm.</source>
-        <translation type="vanished">この操作を行うには再起動をする必要があります。</translation>
-    </message>
-    <message>
-        <source>Back To Default Mode</source>
-        <translation type="vanished">デフォルトモードに戻る</translation>
-    </message>
-    <message>
-        <source>Other Users</source>
-        <translation type="vanished">その他のユーザー</translation>
-    </message>
-    <message>
-        <source>Power</source>
-        <translation type="vanished">電源</translation>
-    </message>
-</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>ControlAction</name>
     <message>
-        <source>Other Users</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/ControlAction.qml" line="55"/>
+        <location filename="../qml/ControlAction.qml" line="83"/>
         <source>Power</source>
         <translation>電源</translation>
-    </message>
-</context>
-<context>
-    <name>Greeter</name>
-    <message>
-        <source>Password is incorrect.</source>
-        <translation type="vanished">パスワードが違います</translation>
     </message>
 </context>
 <context>
@@ -54,47 +18,32 @@
     </message>
 </context>
 <context>
-    <name>LockView</name>
-    <message>
-        <location filename="../qml/LockView.qml" line="176"/>
-        <source>Password is incorrect.</source>
-        <translation>パスワードが違います</translation>
-    </message>
-</context>
-<context>
     <name>PowerList</name>
     <message>
-        <location filename="../qml/PowerList.qml" line="60"/>
+        <location filename="../qml/PowerList.qml" line="58"/>
         <source>Hibernate</source>
         <translation>ハイバネート</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="50"/>
+        <location filename="../qml/PowerList.qml" line="49"/>
         <source>Suspend</source>
         <translation>サスペンド</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="43"/>
+        <location filename="../qml/PowerList.qml" line="42"/>
         <source>Reboot</source>
         <translation>再起動</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="36"/>
+        <location filename="../qml/PowerList.qml" line="35"/>
         <source>Shut Down</source>
         <translation>シャットダウン</translation>
     </message>
 </context>
 <context>
-    <name>SessionModel</name>
-    <message>
-        <source>%1 (Wayland)</source>
-        <translation type="vanished">%1 (Wayland)</translation>
-    </message>
-</context>
-<context>
     <name>ShutdownView</name>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="32"/>
+        <location filename="../qml/ShutdownView.qml" line="31"/>
         <source>lock</source>
         <translation>ロック</translation>
     </message>
@@ -104,20 +53,9 @@
         <translation>ユーザーの切替</translation>
     </message>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="43"/>
+        <location filename="../qml/ShutdownView.qml" line="44"/>
         <source>Logout</source>
         <translation>ログアウト</translation>
-    </message>
-</context>
-<context>
-    <name>User</name>
-    <message>
-        <source>Administrator</source>
-        <translation type="vanished">管理者</translation>
-    </message>
-    <message>
-        <source>Standard User</source>
-        <translation type="vanished">標準ユーザー</translation>
     </message>
 </context>
 <context>
@@ -128,9 +66,37 @@
         <translation>パスワードを入力してください</translation>
     </message>
     <message>
-        <location filename="../qml/UserInput.qml" line="141"/>
+        <location filename="../qml/UserInput.qml" line="154"/>
         <source>Password</source>
         <translation>パスワード</translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="154"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="341"/>
+        <source>Enter username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="354"/>
+        <source>User not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="376"/>
+        <source>Password is incorrect.</source>
+        <translation type="unfinished">パスワードが違います</translation>
+    </message>
+</context>
+<context>
+    <name>UserList</name>
+    <message>
+        <location filename="../qml/UserList.qml" line="236"/>
+        <source>Other…</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugins/lockscreen/translations/lockscreen.pl.ts
+++ b/src/plugins/lockscreen/translations/lockscreen.pl.ts
@@ -1,48 +1,12 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
-<context>
-    <name>Center</name>
-    <message>
-        <source>Return to default mode</source>
-        <translation type="vanished">Przywróć do trybu domyślnego</translation>
-    </message>
-    <message>
-        <source>Do you want to back to default?</source>
-        <translation type="vanished">Czy przywrócić do trybu domyślnego?</translation>
-    </message>
-    <message>
-        <source>This action will reboot machine, please confirm.</source>
-        <translation type="vanished">Urządzenie zostanie uruchomione ponownie, prosimy o potwierdzenie.</translation>
-    </message>
-    <message>
-        <source>Back To Default Mode</source>
-        <translation type="vanished">Przywróć do trybu domyślnego</translation>
-    </message>
-    <message>
-        <source>Other Users</source>
-        <translation type="vanished">Pozostali użytkownicy</translation>
-    </message>
-    <message>
-        <source>Power</source>
-        <translation type="vanished">Zasilanie</translation>
-    </message>
-</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>ControlAction</name>
     <message>
-        <source>Other Users</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/ControlAction.qml" line="55"/>
+        <location filename="../qml/ControlAction.qml" line="83"/>
         <source>Power</source>
         <translation>Zasilanie</translation>
-    </message>
-</context>
-<context>
-    <name>Greeter</name>
-    <message>
-        <source>Password is incorrect.</source>
-        <translation type="vanished">Błędne hasło.</translation>
     </message>
 </context>
 <context>
@@ -54,47 +18,32 @@
     </message>
 </context>
 <context>
-    <name>LockView</name>
-    <message>
-        <location filename="../qml/LockView.qml" line="176"/>
-        <source>Password is incorrect.</source>
-        <translation>Błędne hasło.</translation>
-    </message>
-</context>
-<context>
     <name>PowerList</name>
     <message>
-        <location filename="../qml/PowerList.qml" line="60"/>
+        <location filename="../qml/PowerList.qml" line="58"/>
         <source>Hibernate</source>
         <translation>Hibernacja</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="50"/>
+        <location filename="../qml/PowerList.qml" line="49"/>
         <source>Suspend</source>
         <translation>Wstrzymaj</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="43"/>
+        <location filename="../qml/PowerList.qml" line="42"/>
         <source>Reboot</source>
         <translation>Uruchom ponownie</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="36"/>
+        <location filename="../qml/PowerList.qml" line="35"/>
         <source>Shut Down</source>
         <translation>Zamknij</translation>
     </message>
 </context>
 <context>
-    <name>SessionModel</name>
-    <message>
-        <source>%1 (Wayland)</source>
-        <translation type="vanished">%1 (Wayland)</translation>
-    </message>
-</context>
-<context>
     <name>ShutdownView</name>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="32"/>
+        <location filename="../qml/ShutdownView.qml" line="31"/>
         <source>lock</source>
         <translation>Zablokuj</translation>
     </message>
@@ -104,20 +53,9 @@
         <translation>Zmień użytkownika</translation>
     </message>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="43"/>
+        <location filename="../qml/ShutdownView.qml" line="44"/>
         <source>Logout</source>
         <translation>Wyloguj</translation>
-    </message>
-</context>
-<context>
-    <name>User</name>
-    <message>
-        <source>Administrator</source>
-        <translation type="vanished">Administrator</translation>
-    </message>
-    <message>
-        <source>Standard User</source>
-        <translation type="vanished">Użytkownik standardowy</translation>
     </message>
 </context>
 <context>
@@ -128,9 +66,37 @@
         <translation>Wprowadź hasło</translation>
     </message>
     <message>
-        <location filename="../qml/UserInput.qml" line="141"/>
+        <location filename="../qml/UserInput.qml" line="154"/>
         <source>Password</source>
         <translation>Hasło</translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="154"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="341"/>
+        <source>Enter username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="354"/>
+        <source>User not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="376"/>
+        <source>Password is incorrect.</source>
+        <translation type="unfinished">Błędne hasło.</translation>
+    </message>
+</context>
+<context>
+    <name>UserList</name>
+    <message>
+        <location filename="../qml/UserList.qml" line="236"/>
+        <source>Other…</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugins/lockscreen/translations/lockscreen.pt_BR.ts
+++ b/src/plugins/lockscreen/translations/lockscreen.pt_BR.ts
@@ -1,48 +1,12 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
-<context>
-    <name>Center</name>
-    <message>
-        <source>Return to default mode</source>
-        <translation type="vanished">Retornar ao modo padrão</translation>
-    </message>
-    <message>
-        <source>Do you want to back to default?</source>
-        <translation type="vanished">Você quer voltar ao padrão?</translation>
-    </message>
-    <message>
-        <source>This action will reboot machine, please confirm.</source>
-        <translation type="vanished">Esta ação reinicializará o computador, por favor confirme.</translation>
-    </message>
-    <message>
-        <source>Back To Default Mode</source>
-        <translation type="vanished">Voltar ao modo padrão</translation>
-    </message>
-    <message>
-        <source>Other Users</source>
-        <translation type="vanished">Outros usuários</translation>
-    </message>
-    <message>
-        <source>Power</source>
-        <translation type="vanished">Energia</translation>
-    </message>
-</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>ControlAction</name>
     <message>
-        <source>Other Users</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/ControlAction.qml" line="55"/>
+        <location filename="../qml/ControlAction.qml" line="83"/>
         <source>Power</source>
         <translation>Energia</translation>
-    </message>
-</context>
-<context>
-    <name>Greeter</name>
-    <message>
-        <source>Password is incorrect.</source>
-        <translation type="vanished">A senha está incorreta.</translation>
     </message>
 </context>
 <context>
@@ -54,47 +18,32 @@
     </message>
 </context>
 <context>
-    <name>LockView</name>
-    <message>
-        <location filename="../qml/LockView.qml" line="176"/>
-        <source>Password is incorrect.</source>
-        <translation>A senha está incorreta.</translation>
-    </message>
-</context>
-<context>
     <name>PowerList</name>
     <message>
-        <location filename="../qml/PowerList.qml" line="60"/>
+        <location filename="../qml/PowerList.qml" line="58"/>
         <source>Hibernate</source>
         <translation>Hibernar</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="50"/>
+        <location filename="../qml/PowerList.qml" line="49"/>
         <source>Suspend</source>
         <translation>Suspender</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="43"/>
+        <location filename="../qml/PowerList.qml" line="42"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="36"/>
+        <location filename="../qml/PowerList.qml" line="35"/>
         <source>Shut Down</source>
         <translation>Desligar</translation>
     </message>
 </context>
 <context>
-    <name>SessionModel</name>
-    <message>
-        <source>%1 (Wayland)</source>
-        <translation type="vanished">%1 (Wayland)</translation>
-    </message>
-</context>
-<context>
     <name>ShutdownView</name>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="32"/>
+        <location filename="../qml/ShutdownView.qml" line="31"/>
         <source>lock</source>
         <translation>Bloquear</translation>
     </message>
@@ -104,20 +53,9 @@
         <translation>Trocar de usuário</translation>
     </message>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="43"/>
+        <location filename="../qml/ShutdownView.qml" line="44"/>
         <source>Logout</source>
         <translation>Sair</translation>
-    </message>
-</context>
-<context>
-    <name>User</name>
-    <message>
-        <source>Administrator</source>
-        <translation type="vanished">Administrador</translation>
-    </message>
-    <message>
-        <source>Standard User</source>
-        <translation type="vanished">Usuário padrão</translation>
     </message>
 </context>
 <context>
@@ -128,9 +66,37 @@
         <translation>Por favor, digite a senha</translation>
     </message>
     <message>
-        <location filename="../qml/UserInput.qml" line="141"/>
+        <location filename="../qml/UserInput.qml" line="154"/>
         <source>Password</source>
         <translation>Senha</translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="154"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="341"/>
+        <source>Enter username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="354"/>
+        <source>User not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="376"/>
+        <source>Password is incorrect.</source>
+        <translation type="unfinished">A senha está incorreta.</translation>
+    </message>
+</context>
+<context>
+    <name>UserList</name>
+    <message>
+        <location filename="../qml/UserList.qml" line="236"/>
+        <source>Other…</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugins/lockscreen/translations/lockscreen.ru.ts
+++ b/src/plugins/lockscreen/translations/lockscreen.ru.ts
@@ -1,48 +1,12 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ru">
-<context>
-    <name>Center</name>
-    <message>
-        <source>Return to default mode</source>
-        <translation type="vanished">Вернуться к начальным настройкам</translation>
-    </message>
-    <message>
-        <source>Do you want to back to default?</source>
-        <translation type="vanished">Вы уверены, что хотите вернуться к начальным настройкам?</translation>
-    </message>
-    <message>
-        <source>This action will reboot machine, please confirm.</source>
-        <translation type="vanished">Это действие перезагрузить устройство, пожалуйста, подтвердите.</translation>
-    </message>
-    <message>
-        <source>Back To Default Mode</source>
-        <translation type="vanished">Вернуться к начальным настройкам</translation>
-    </message>
-    <message>
-        <source>Other Users</source>
-        <translation type="vanished">Другие пользователи</translation>
-    </message>
-    <message>
-        <source>Power</source>
-        <translation type="vanished">Питание</translation>
-    </message>
-</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
 <context>
     <name>ControlAction</name>
     <message>
-        <source>Other Users</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/ControlAction.qml" line="55"/>
+        <location filename="../qml/ControlAction.qml" line="83"/>
         <source>Power</source>
         <translation>Питание</translation>
-    </message>
-</context>
-<context>
-    <name>Greeter</name>
-    <message>
-        <source>Password is incorrect.</source>
-        <translation type="vanished">Неверный пароль.</translation>
     </message>
 </context>
 <context>
@@ -50,51 +14,36 @@
     <message>
         <location filename="../qml/HintLabel.qml" line="26"/>
         <source>Password Hint</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>LockView</name>
-    <message>
-        <location filename="../qml/LockView.qml" line="176"/>
-        <source>Password is incorrect.</source>
-        <translation>Неверный пароль.</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerList</name>
     <message>
-        <location filename="../qml/PowerList.qml" line="60"/>
+        <location filename="../qml/PowerList.qml" line="58"/>
         <source>Hibernate</source>
         <translation>Спящий режим</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="50"/>
+        <location filename="../qml/PowerList.qml" line="49"/>
         <source>Suspend</source>
         <translation>Приостановить</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="43"/>
+        <location filename="../qml/PowerList.qml" line="42"/>
         <source>Reboot</source>
         <translation>Перезагрузить</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="36"/>
+        <location filename="../qml/PowerList.qml" line="35"/>
         <source>Shut Down</source>
         <translation>Выключить</translation>
     </message>
 </context>
 <context>
-    <name>SessionModel</name>
-    <message>
-        <source>%1 (Wayland)</source>
-        <translation type="vanished">%1 (Wayland)</translation>
-    </message>
-</context>
-<context>
     <name>ShutdownView</name>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="32"/>
+        <location filename="../qml/ShutdownView.qml" line="31"/>
         <source>lock</source>
         <translation>заблокировать</translation>
     </message>
@@ -104,20 +53,9 @@
         <translation>сменить пользователя</translation>
     </message>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="43"/>
+        <location filename="../qml/ShutdownView.qml" line="44"/>
         <source>Logout</source>
         <translation>Выйти</translation>
-    </message>
-</context>
-<context>
-    <name>User</name>
-    <message>
-        <source>Administrator</source>
-        <translation type="vanished">Администратор</translation>
-    </message>
-    <message>
-        <source>Standard User</source>
-        <translation type="vanished">Обычный пользователь</translation>
     </message>
 </context>
 <context>
@@ -128,9 +66,37 @@
         <translation>Пожалуйста, введите пароль</translation>
     </message>
     <message>
-        <location filename="../qml/UserInput.qml" line="141"/>
+        <location filename="../qml/UserInput.qml" line="154"/>
         <source>Password</source>
         <translation>Пароль</translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="154"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="341"/>
+        <source>Enter username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="354"/>
+        <source>User not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="376"/>
+        <source>Password is incorrect.</source>
+        <translation type="unfinished">Неверный пароль.</translation>
+    </message>
+</context>
+<context>
+    <name>UserList</name>
+    <message>
+        <location filename="../qml/UserList.qml" line="236"/>
+        <source>Other…</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugins/lockscreen/translations/lockscreen.sq.ts
+++ b/src/plugins/lockscreen/translations/lockscreen.sq.ts
@@ -1,48 +1,12 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sq">
-<context>
-    <name>Center</name>
-    <message>
-        <source>Return to default mode</source>
-        <translation type="vanished">Rikthehu te mënyra parazgjedhje</translation>
-    </message>
-    <message>
-        <source>Do you want to back to default?</source>
-        <translation type="vanished">Doni të shkohet mbrapsht te parazgjedhja?</translation>
-    </message>
-    <message>
-        <source>This action will reboot machine, please confirm.</source>
-        <translation type="vanished">Ky veprim do të rinisë makinën, ju lutemi, ripohojeni</translation>
-    </message>
-    <message>
-        <source>Back To Default Mode</source>
-        <translation type="vanished">Mbrapsht Te Mënyra Parazgjedhje</translation>
-    </message>
-    <message>
-        <source>Other Users</source>
-        <translation type="vanished">Përdorues të Tjerë</translation>
-    </message>
-    <message>
-        <source>Power</source>
-        <translation type="vanished">Energji</translation>
-    </message>
-</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
 <context>
     <name>ControlAction</name>
     <message>
-        <source>Other Users</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/ControlAction.qml" line="55"/>
+        <location filename="../qml/ControlAction.qml" line="83"/>
         <source>Power</source>
         <translation>Energji</translation>
-    </message>
-</context>
-<context>
-    <name>Greeter</name>
-    <message>
-        <source>Password is incorrect.</source>
-        <translation type="vanished">Fjalëkalimi është i pasaktë</translation>
     </message>
 </context>
 <context>
@@ -54,47 +18,32 @@
     </message>
 </context>
 <context>
-    <name>LockView</name>
-    <message>
-        <location filename="../qml/LockView.qml" line="176"/>
-        <source>Password is incorrect.</source>
-        <translation>Fjalëkalimi është i pasaktë</translation>
-    </message>
-</context>
-<context>
     <name>PowerList</name>
     <message>
-        <location filename="../qml/PowerList.qml" line="60"/>
+        <location filename="../qml/PowerList.qml" line="58"/>
         <source>Hibernate</source>
         <translation>Dimëroje</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="50"/>
+        <location filename="../qml/PowerList.qml" line="49"/>
         <source>Suspend</source>
         <translation>Pezulloje</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="43"/>
+        <location filename="../qml/PowerList.qml" line="42"/>
         <source>Reboot</source>
         <translation>Rinise</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="36"/>
+        <location filename="../qml/PowerList.qml" line="35"/>
         <source>Shut Down</source>
         <translation>Fike</translation>
     </message>
 </context>
 <context>
-    <name>SessionModel</name>
-    <message>
-        <source>%1 (Wayland)</source>
-        <translation type="vanished">%1 (Wayland)</translation>
-    </message>
-</context>
-<context>
     <name>ShutdownView</name>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="32"/>
+        <location filename="../qml/ShutdownView.qml" line="31"/>
         <source>lock</source>
         <translation>kyçe</translation>
     </message>
@@ -104,20 +53,9 @@
         <translation>ndërroni përdorues</translation>
     </message>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="43"/>
+        <location filename="../qml/ShutdownView.qml" line="44"/>
         <source>Logout</source>
         <translation>Dalje</translation>
-    </message>
-</context>
-<context>
-    <name>User</name>
-    <message>
-        <source>Administrator</source>
-        <translation type="vanished">Përgjegjës</translation>
-    </message>
-    <message>
-        <source>Standard User</source>
-        <translation type="vanished">Përdorues Standard</translation>
     </message>
 </context>
 <context>
@@ -128,9 +66,37 @@
         <translation>Ju lutemi, jepni fjalëkalim</translation>
     </message>
     <message>
-        <location filename="../qml/UserInput.qml" line="141"/>
+        <location filename="../qml/UserInput.qml" line="154"/>
         <source>Password</source>
         <translation>Fjalëkalim</translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="154"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="341"/>
+        <source>Enter username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="354"/>
+        <source>User not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="376"/>
+        <source>Password is incorrect.</source>
+        <translation type="unfinished">Fjalëkalimi është i pasaktë</translation>
+    </message>
+</context>
+<context>
+    <name>UserList</name>
+    <message>
+        <location filename="../qml/UserList.qml" line="236"/>
+        <source>Other…</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugins/lockscreen/translations/lockscreen.tr.ts
+++ b/src/plugins/lockscreen/translations/lockscreen.tr.ts
@@ -1,48 +1,12 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="tr">
-<context>
-    <name>Center</name>
-    <message>
-        <source>Return to default mode</source>
-        <translation type="vanished">Varsayılan moda dön</translation>
-    </message>
-    <message>
-        <source>Do you want to back to default?</source>
-        <translation type="vanished">Varsayılana geri dönmek ister misiniz?</translation>
-    </message>
-    <message>
-        <source>This action will reboot machine, please confirm.</source>
-        <translation type="vanished">Bu işlem makineyi yeniden başlatacaktır, lütfen onaylayın.</translation>
-    </message>
-    <message>
-        <source>Back To Default Mode</source>
-        <translation type="vanished">Varsayılan Moda Geri Dön</translation>
-    </message>
-    <message>
-        <source>Other Users</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Power</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="tr">
 <context>
     <name>ControlAction</name>
     <message>
-        <source>Other Users</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/ControlAction.qml" line="55"/>
+        <location filename="../qml/ControlAction.qml" line="83"/>
         <source>Power</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>Greeter</name>
-    <message>
-        <source>Password is incorrect.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -50,74 +14,48 @@
     <message>
         <location filename="../qml/HintLabel.qml" line="26"/>
         <source>Password Hint</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>LockView</name>
-    <message>
-        <location filename="../qml/LockView.qml" line="176"/>
-        <source>Password is incorrect.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerList</name>
     <message>
-        <location filename="../qml/PowerList.qml" line="60"/>
+        <location filename="../qml/PowerList.qml" line="58"/>
         <source>Hibernate</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="50"/>
+        <location filename="../qml/PowerList.qml" line="49"/>
         <source>Suspend</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="43"/>
+        <location filename="../qml/PowerList.qml" line="42"/>
         <source>Reboot</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="36"/>
+        <location filename="../qml/PowerList.qml" line="35"/>
         <source>Shut Down</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>SessionModel</name>
-    <message>
-        <source>%1 (Wayland)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShutdownView</name>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="32"/>
+        <location filename="../qml/ShutdownView.qml" line="31"/>
         <source>lock</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/ShutdownView.qml" line="37"/>
         <source>switch user</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="43"/>
+        <location filename="../qml/ShutdownView.qml" line="44"/>
         <source>Logout</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>User</name>
-    <message>
-        <source>Administrator</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Standard User</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -125,12 +63,40 @@
     <message>
         <location filename="../qml/UserInput.qml" line="15"/>
         <source>Please enter password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/UserInput.qml" line="141"/>
+        <location filename="../qml/UserInput.qml" line="154"/>
         <source>Password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="154"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="341"/>
+        <source>Enter username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="354"/>
+        <source>User not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="376"/>
+        <source>Password is incorrect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UserList</name>
+    <message>
+        <location filename="../qml/UserList.qml" line="236"/>
+        <source>Other…</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugins/lockscreen/translations/lockscreen.uk.ts
+++ b/src/plugins/lockscreen/translations/lockscreen.uk.ts
@@ -1,48 +1,12 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
-<context>
-    <name>Center</name>
-    <message>
-        <source>Return to default mode</source>
-        <translation type="vanished">Повернутися до типового режиму</translation>
-    </message>
-    <message>
-        <source>Do you want to back to default?</source>
-        <translation type="vanished">Хочете повернутися до типових параметрів?</translation>
-    </message>
-    <message>
-        <source>This action will reboot machine, please confirm.</source>
-        <translation type="vanished">У результаті виконання цієї дії комп&apos;ютер буде перезавантажено. Будь ласка, підтвердьте це.</translation>
-    </message>
-    <message>
-        <source>Back To Default Mode</source>
-        <translation type="vanished">Повернутися до типового режиму</translation>
-    </message>
-    <message>
-        <source>Other Users</source>
-        <translation type="vanished">Інші користувачі</translation>
-    </message>
-    <message>
-        <source>Power</source>
-        <translation type="vanished">Живлення</translation>
-    </message>
-</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>ControlAction</name>
     <message>
-        <source>Other Users</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/ControlAction.qml" line="55"/>
+        <location filename="../qml/ControlAction.qml" line="83"/>
         <source>Power</source>
         <translation>Живлення</translation>
-    </message>
-</context>
-<context>
-    <name>Greeter</name>
-    <message>
-        <source>Password is incorrect.</source>
-        <translation type="vanished">Неправильний пароль.</translation>
     </message>
 </context>
 <context>
@@ -54,47 +18,32 @@
     </message>
 </context>
 <context>
-    <name>LockView</name>
-    <message>
-        <location filename="../qml/LockView.qml" line="176"/>
-        <source>Password is incorrect.</source>
-        <translation>Неправильний пароль.</translation>
-    </message>
-</context>
-<context>
     <name>PowerList</name>
     <message>
-        <location filename="../qml/PowerList.qml" line="60"/>
+        <location filename="../qml/PowerList.qml" line="58"/>
         <source>Hibernate</source>
         <translation>Приспати</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="50"/>
+        <location filename="../qml/PowerList.qml" line="49"/>
         <source>Suspend</source>
         <translation>Призупинити</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="43"/>
+        <location filename="../qml/PowerList.qml" line="42"/>
         <source>Reboot</source>
         <translation>Перезавантажити</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="36"/>
+        <location filename="../qml/PowerList.qml" line="35"/>
         <source>Shut Down</source>
         <translation>Вимкнути</translation>
     </message>
 </context>
 <context>
-    <name>SessionModel</name>
-    <message>
-        <source>%1 (Wayland)</source>
-        <translation type="vanished">%1 (Wayland)</translation>
-    </message>
-</context>
-<context>
     <name>ShutdownView</name>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="32"/>
+        <location filename="../qml/ShutdownView.qml" line="31"/>
         <source>lock</source>
         <translation>Заблокувати</translation>
     </message>
@@ -104,20 +53,9 @@
         <translation>Перемкнути користувача</translation>
     </message>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="43"/>
+        <location filename="../qml/ShutdownView.qml" line="44"/>
         <source>Logout</source>
         <translation>Вийти</translation>
-    </message>
-</context>
-<context>
-    <name>User</name>
-    <message>
-        <source>Administrator</source>
-        <translation type="vanished">Адміністратор</translation>
-    </message>
-    <message>
-        <source>Standard User</source>
-        <translation type="vanished">Стандартний користувач</translation>
     </message>
 </context>
 <context>
@@ -128,9 +66,37 @@
         <translation>Будь ласка, введіть пароль</translation>
     </message>
     <message>
-        <location filename="../qml/UserInput.qml" line="141"/>
+        <location filename="../qml/UserInput.qml" line="154"/>
         <source>Password</source>
         <translation>Пароль</translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="154"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="341"/>
+        <source>Enter username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="354"/>
+        <source>User not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="376"/>
+        <source>Password is incorrect.</source>
+        <translation type="unfinished">Неправильний пароль.</translation>
+    </message>
+</context>
+<context>
+    <name>UserList</name>
+    <message>
+        <location filename="../qml/UserList.qml" line="236"/>
+        <source>Other…</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugins/lockscreen/translations/lockscreen.zh_CN.ts
+++ b/src/plugins/lockscreen/translations/lockscreen.zh_CN.ts
@@ -1,48 +1,12 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
-<context>
-    <name>Center</name>
-    <message>
-        <source>Return to default mode</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Do you want to back to default?</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>This action will reboot machine, please confirm.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Back To Default Mode</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Other Users</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Power</source>
-        <translation type="vanished">电源</translation>
-    </message>
-</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>ControlAction</name>
     <message>
-        <source>Other Users</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/ControlAction.qml" line="55"/>
+        <location filename="../qml/ControlAction.qml" line="83"/>
         <source>Power</source>
         <translation>电源</translation>
-    </message>
-</context>
-<context>
-    <name>Greeter</name>
-    <message>
-        <source>Password is incorrect.</source>
-        <translation type="vanished">密码错误</translation>
     </message>
 </context>
 <context>
@@ -54,47 +18,32 @@
     </message>
 </context>
 <context>
-    <name>LockView</name>
-    <message>
-        <location filename="../qml/LockView.qml" line="176"/>
-        <source>Password is incorrect.</source>
-        <translation>密码错误</translation>
-    </message>
-</context>
-<context>
     <name>PowerList</name>
     <message>
-        <location filename="../qml/PowerList.qml" line="60"/>
+        <location filename="../qml/PowerList.qml" line="58"/>
         <source>Hibernate</source>
         <translation>休眠</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="50"/>
+        <location filename="../qml/PowerList.qml" line="49"/>
         <source>Suspend</source>
         <translation>待机</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="43"/>
+        <location filename="../qml/PowerList.qml" line="42"/>
         <source>Reboot</source>
         <translation>重启</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="36"/>
+        <location filename="../qml/PowerList.qml" line="35"/>
         <source>Shut Down</source>
         <translation>关机</translation>
     </message>
 </context>
 <context>
-    <name>SessionModel</name>
-    <message>
-        <source>%1 (Wayland)</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
     <name>ShutdownView</name>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="32"/>
+        <location filename="../qml/ShutdownView.qml" line="31"/>
         <source>lock</source>
         <translation>锁定</translation>
     </message>
@@ -104,20 +53,9 @@
         <translation>切换帐户</translation>
     </message>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="43"/>
+        <location filename="../qml/ShutdownView.qml" line="44"/>
         <source>Logout</source>
         <translation>注销</translation>
-    </message>
-</context>
-<context>
-    <name>User</name>
-    <message>
-        <source>Administrator</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Standard User</source>
-        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -128,9 +66,37 @@
         <translation>请输入密码</translation>
     </message>
     <message>
-        <location filename="../qml/UserInput.qml" line="141"/>
+        <location filename="../qml/UserInput.qml" line="154"/>
         <source>Password</source>
         <translation>密码</translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="154"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="341"/>
+        <source>Enter username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="354"/>
+        <source>User not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="376"/>
+        <source>Password is incorrect.</source>
+        <translation type="unfinished">密码错误</translation>
+    </message>
+</context>
+<context>
+    <name>UserList</name>
+    <message>
+        <location filename="../qml/UserList.qml" line="236"/>
+        <source>Other…</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugins/lockscreen/translations/lockscreen.zh_HK.ts
+++ b/src/plugins/lockscreen/translations/lockscreen.zh_HK.ts
@@ -1,48 +1,12 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
-<context>
-    <name>Center</name>
-    <message>
-        <source>Return to default mode</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Do you want to back to default?</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>This action will reboot machine, please confirm.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Back To Default Mode</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Other Users</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Power</source>
-        <translation type="vanished">電源</translation>
-    </message>
-</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>ControlAction</name>
     <message>
-        <source>Other Users</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/ControlAction.qml" line="55"/>
+        <location filename="../qml/ControlAction.qml" line="83"/>
         <source>Power</source>
         <translation>電源</translation>
-    </message>
-</context>
-<context>
-    <name>Greeter</name>
-    <message>
-        <source>Password is incorrect.</source>
-        <translation type="vanished">密碼錯誤</translation>
     </message>
 </context>
 <context>
@@ -54,47 +18,32 @@
     </message>
 </context>
 <context>
-    <name>LockView</name>
-    <message>
-        <location filename="../qml/LockView.qml" line="176"/>
-        <source>Password is incorrect.</source>
-        <translation>密碼錯誤</translation>
-    </message>
-</context>
-<context>
     <name>PowerList</name>
     <message>
-        <location filename="../qml/PowerList.qml" line="60"/>
+        <location filename="../qml/PowerList.qml" line="58"/>
         <source>Hibernate</source>
         <translation>休眠</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="50"/>
+        <location filename="../qml/PowerList.qml" line="49"/>
         <source>Suspend</source>
         <translation>待機</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="43"/>
+        <location filename="../qml/PowerList.qml" line="42"/>
         <source>Reboot</source>
         <translation>重啓</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="36"/>
+        <location filename="../qml/PowerList.qml" line="35"/>
         <source>Shut Down</source>
         <translation>關機</translation>
     </message>
 </context>
 <context>
-    <name>SessionModel</name>
-    <message>
-        <source>%1 (Wayland)</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
     <name>ShutdownView</name>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="32"/>
+        <location filename="../qml/ShutdownView.qml" line="31"/>
         <source>lock</source>
         <translation>鎖定</translation>
     </message>
@@ -104,20 +53,9 @@
         <translation>切換帳户</translation>
     </message>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="43"/>
+        <location filename="../qml/ShutdownView.qml" line="44"/>
         <source>Logout</source>
         <translation>註銷</translation>
-    </message>
-</context>
-<context>
-    <name>User</name>
-    <message>
-        <source>Administrator</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Standard User</source>
-        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -128,9 +66,37 @@
         <translation>請輸入密碼</translation>
     </message>
     <message>
-        <location filename="../qml/UserInput.qml" line="141"/>
+        <location filename="../qml/UserInput.qml" line="154"/>
         <source>Password</source>
         <translation>密碼</translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="154"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="341"/>
+        <source>Enter username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="354"/>
+        <source>User not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="376"/>
+        <source>Password is incorrect.</source>
+        <translation type="unfinished">密碼錯誤</translation>
+    </message>
+</context>
+<context>
+    <name>UserList</name>
+    <message>
+        <location filename="../qml/UserList.qml" line="236"/>
+        <source>Other…</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugins/lockscreen/translations/lockscreen.zh_TW.ts
+++ b/src/plugins/lockscreen/translations/lockscreen.zh_TW.ts
@@ -1,48 +1,12 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
-<context>
-    <name>Center</name>
-    <message>
-        <source>Return to default mode</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Do you want to back to default?</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>This action will reboot machine, please confirm.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Back To Default Mode</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Other Users</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Power</source>
-        <translation type="vanished">電源</translation>
-    </message>
-</context>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>ControlAction</name>
     <message>
-        <source>Other Users</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/ControlAction.qml" line="55"/>
+        <location filename="../qml/ControlAction.qml" line="83"/>
         <source>Power</source>
         <translation>電源</translation>
-    </message>
-</context>
-<context>
-    <name>Greeter</name>
-    <message>
-        <source>Password is incorrect.</source>
-        <translation type="vanished">密碼錯誤</translation>
     </message>
 </context>
 <context>
@@ -54,47 +18,32 @@
     </message>
 </context>
 <context>
-    <name>LockView</name>
-    <message>
-        <location filename="../qml/LockView.qml" line="176"/>
-        <source>Password is incorrect.</source>
-        <translation>密碼錯誤</translation>
-    </message>
-</context>
-<context>
     <name>PowerList</name>
     <message>
-        <location filename="../qml/PowerList.qml" line="60"/>
+        <location filename="../qml/PowerList.qml" line="58"/>
         <source>Hibernate</source>
         <translation>休眠</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="50"/>
+        <location filename="../qml/PowerList.qml" line="49"/>
         <source>Suspend</source>
         <translation>待機</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="43"/>
+        <location filename="../qml/PowerList.qml" line="42"/>
         <source>Reboot</source>
         <translation>重啟</translation>
     </message>
     <message>
-        <location filename="../qml/PowerList.qml" line="36"/>
+        <location filename="../qml/PowerList.qml" line="35"/>
         <source>Shut Down</source>
         <translation>關機</translation>
     </message>
 </context>
 <context>
-    <name>SessionModel</name>
-    <message>
-        <source>%1 (Wayland)</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
     <name>ShutdownView</name>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="32"/>
+        <location filename="../qml/ShutdownView.qml" line="31"/>
         <source>lock</source>
         <translation>鎖定</translation>
     </message>
@@ -104,20 +53,9 @@
         <translation>切換帳戶</translation>
     </message>
     <message>
-        <location filename="../qml/ShutdownView.qml" line="43"/>
+        <location filename="../qml/ShutdownView.qml" line="44"/>
         <source>Logout</source>
         <translation>登出</translation>
-    </message>
-</context>
-<context>
-    <name>User</name>
-    <message>
-        <source>Administrator</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Standard User</source>
-        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -128,9 +66,37 @@
         <translation>請輸入密碼</translation>
     </message>
     <message>
-        <location filename="../qml/UserInput.qml" line="141"/>
+        <location filename="../qml/UserInput.qml" line="154"/>
         <source>Password</source>
         <translation>密碼</translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="154"/>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="341"/>
+        <source>Enter username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="354"/>
+        <source>User not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/UserInput.qml" line="376"/>
+        <source>Password is incorrect.</source>
+        <translation type="unfinished">密碼錯誤</translation>
+    </message>
+</context>
+<context>
+    <name>UserList</name>
+    <message>
+        <location filename="../qml/UserList.qml" line="236"/>
+        <source>Other…</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
Add "Password is incorrect." to the UserInput translation context and remove obsolete/vanished entries across all lock screen translation files.

修复锁屏密码错误提示翻译缺失问题，为UserInput翻译上下文补充
"Password is incorrect."词条，并清理各语言翻译文件中的失效条目。

Log: 修复锁屏密码错误提示不显示中文的问题
PMS: BUG-366615
Influence: 锁屏界面密码错误提示将正确显示本地化翻译，不再回退为英文。

## Summary by Sourcery

Update lock screen translations to handle user/password input errors in the UserInput context and clean up obsolete entries across all locales.

Bug Fixes:
- Ensure the lock screen password error message is translated via the UserInput context instead of falling back to English.

Enhancements:
- Synchronize lock screen translation files across locales with new UserInput and UserList strings (username prompts, user-not-found, and Other user entry) and remove obsolete or vanished messages.