### PR TITLE
fix(lockscreen): use fixed leftPadding to fix implicitWidth binding loop

### DIFF
--- a/src/plugins/lockscreen/qml/UserInput.qml
+++ b/src/plugins/lockscreen/qml/UserInput.qml
@@ -144,17 +144,23 @@ Item {
             echoMode: loginGroup.enteringOtherUser ? TextInput.Normal
                       : (showPasswordBtn.hiddenPWD ? TextInput.Password : TextInput.Normal)
             rightPadding: 22
-            leftPadding: {
-                var remaining = width - contentWidth - rightPadding
-                if (capsIndicator.visible)
-                    return rightPadding
-                return Math.max(8, remaining > rightPadding ? rightPadding : remaining)
-            }
+            leftPadding: 22
             maximumLength: 510
             placeholderText: loginGroup.enteringOtherUser ? qsTr("Username") : qsTr("Password")
             placeholderTextColor: Qt.rgba(1.0, 1.0, 1.0, 0.6)
             color: palette.windowText
             font: D.DTK.fontManager.t8
+            onContentWidthChanged: updateLeftPadding()
+            onWidthChanged: updateLeftPadding()
+            Component.onCompleted: updateLeftPadding()
+
+            function updateLeftPadding() {
+                var remaining = width - contentWidth - rightPadding
+                if (capsIndicator.visible)
+                    leftPadding = rightPadding
+                else
+                    leftPadding = Math.max(8, remaining > rightPadding ? rightPadding : remaining)
+            }
             Keys.onPressed: function (event) {
                 if (event.key === Qt.Key_CapsLock) {
                     capsIndicatorVisible = !capsIndicatorVisible
@@ -177,6 +183,7 @@ Item {
                     verticalCenter: parent.verticalCenter
                 }
                 visible: passwordField.capsIndicatorVisible && !loginGroup.enteringOtherUser
+                onVisibleChanged: passwordField.updateLeftPadding()
                 palette.windowText: undefined
                 icon {
                     name: "login_capslock"


### PR DESCRIPTION
## Background

QML runtime reported a binding loop error:

```
qrc:/qt/qml/LockScreen/qml/UserInput.qml:104:9: QML TextField: Binding loop detected for property "implicitWidth":
qrc:/qt-project.org/imports/QtQuick/Controls/Fusion/TextField.qml:14:5
```

## Root cause

`passwordField`'s `leftPadding` was a dynamic binding depending on `width`/`contentWidth`. Combined with the Fusion style `implicitWidth` binding that sums `leftPadding`, this formed a binding loop: `implicitWidth → leftPadding → {width, contentWidth}`.

## Change

Replace the dynamic `leftPadding` binding with an imperative approach that keeps the original dynamic padding behavior while cutting the binding loop.

- File: `src/plugins/lockscreen/qml/UserInput.qml`
- `leftPadding` dynamic binding → initial constant `22` (symmetric with `rightPadding`)
- Add `updateLeftPadding()` that recomputes `leftPadding` from `width`/`contentWidth`/`capsIndicator.visible`, invoked via `onContentWidthChanged`, `onWidthChanged`, `Component.onCompleted`, and `capsIndicator.onVisibleChanged`
- `leftPadding` is no longer a binding, so `implicitWidth` reads it as a plain value — the binding loop is broken, `userCol` width and `loginBtn` position are unchanged
- Centering preserved via `horizontalAlignment: TextInput.AlignHCenter`

Influence:
1. Verify password input field displays and centers correctly on lockscreen
2. Check caps lock indicator does not overlap with password text
3. Test long password input does not break the layout

Multica issue: [WM-89](https://multica.uniontech.com/workspace/e1c725b6-7c31-4790-a381-3262f282537c/issue/8bb95da5-722d-4345-ac84-098632279453)
