### PR TITLE
restore configured topology after output reconnect 

### DIFF
--- a/src/core/lockscreen.cpp
+++ b/src/core/lockscreen.cpp
@@ -124,6 +124,10 @@ void LockScreen::removeOutput(Output *output)
     SurfaceContainer::removeOutput(output);
 #if EXT_SESSION_LOCK_V1
     auto outputItem = output->outputItem();
+    disconnect(outputItem,
+               &WOutputItem::geometryChanged,
+               this,
+               &LockScreen::onOutputGeometryChanged);
     m_lockSurfaces.erase(outputItem);
     m_fallbackItems.erase(outputItem);
 
@@ -249,9 +253,12 @@ void LockScreen::onLockSurfaceRemoved(WSessionLockSurface *surface)
 void LockScreen::onOutputGeometryChanged()
 {
     WOutputItem *outputItem = qobject_cast<WOutputItem *>(QObject::sender());
-    Q_ASSERT(m_lockSurfaces.find(outputItem) != m_lockSurfaces.end());
+    const auto it = m_lockSurfaces.find(outputItem);
+    if (it == m_lockSurfaces.end()) {
+        return;
+    }
 
-    auto *lockSurface = m_lockSurfaces[outputItem].get();
+    auto *lockSurface = it->second.get();
     if (lockSurface) {
         // Resize the lock surface to match the new output size
         lockSurface->configureSize(outputItem->size().toSize());

--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -430,8 +430,29 @@ void RootSurfaceContainer::ensureCursorVisible()
 
 void RootSurfaceContainer::updateSurfaceOutputs(SurfaceWrapper *surface)
 {
-    const QRectF geometry = surface->geometry();
-    auto outputs = m_outputLayout->getIntersectedOutputs(geometry.toRect());
+    QList<WOutput *> outputs;
+
+    if (surface->type() != SurfaceWrapper::Type::Layer) {
+        for (auto *output : m_outputModel->objects()) {
+            if (!output->output()->isEnabled())
+                continue;
+
+            outputs.append(output->output());
+            if (outputs.size() > 1)
+                break;
+        }
+
+        if (outputs.size() != 1) {
+            const QRectF geometry = surface->geometry();
+            outputs = m_outputLayout->getIntersectedOutputs(geometry.toRect());
+            outputs.removeIf([](WOutput *output) {
+                return !output->isEnabled();
+            });
+        }
+    } else {
+        const QRectF geometry = surface->geometry();
+        outputs = m_outputLayout->getIntersectedOutputs(geometry.toRect());
+    }
     surface->setOutputs(outputs);
 
     if (auto *ws = Helper::instance()->workspace())

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -147,6 +147,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <limits>
 #include <pwd.h>
 #include <unistd.h>
 #include <utility>
@@ -237,6 +238,39 @@ static bool hasSavedOutputState(OutputConfig *config)
                       || !config->scaleIsDefaultValue()
                       || !config->transformIsDefaultValue()
                       || !config->adaptiveSyncEnabledIsDefaultValue());
+}
+
+static wlr_output_mode *closestOutputMode(WOutput *output,
+                                          int width,
+                                          int height,
+                                          int refresh)
+{
+    if (!output || !output->nativeHandle()) {
+        return nullptr;
+    }
+
+    wlr_output_mode *mode = nullptr;
+    wlr_output_mode *closestMode = nullptr;
+    qint64 closestResolutionDistance = std::numeric_limits<qint64>::max();
+    qint64 closestRefreshDistance = std::numeric_limits<qint64>::max();
+    wl_list_for_each(mode, &output->nativeHandle()->modes, link) {
+        const qint64 resolutionDistance = std::abs(static_cast<qint64>(mode->width) - width)
+            + std::abs(static_cast<qint64>(mode->height) - height);
+        const qint64 refreshDistance = std::abs(static_cast<qint64>(mode->refresh) - refresh);
+        if (resolutionDistance < closestResolutionDistance
+            || (resolutionDistance == closestResolutionDistance
+                && refreshDistance < closestRefreshDistance)) {
+            closestMode = mode;
+            closestResolutionDistance = resolutionDistance;
+            closestRefreshDistance = refreshDistance;
+        }
+
+        if (resolutionDistance == 0 && refreshDistance == 0) {
+            break;
+        }
+    }
+
+    return closestMode;
 }
 
 static bool outputMatchesId(Output *output, const QString &outputId)
@@ -502,8 +536,13 @@ void Helper::onOutputAdded(WOutput *output)
         o = createCopyOutput(output, m_rootSurfaceContainer->primaryOutput());
     }
     m_outputList.append(o);
-    if (!ensureOutputInRootContainer(o)) {
+    const bool outputRegistered = ensureOutputInRootContainer(o);
+    if (!outputRegistered) {
         qCWarning(lcTlCore) << "Failed to register output in root container" << output->name();
+    }
+    if (scanned && m_mode == OutputMode::Copy
+        && outputRegistered && !output->isEnabled()) {
+        o->enable();
     }
     if (m_outputManagerHelper) {
         m_outputManagerHelper->setMode(m_mode == OutputMode::Extension
@@ -587,6 +626,13 @@ void Helper::onOutputAdded(WOutput *output)
         // A hot-plugged output keeps outputLayout's auto-added position, which
         // extends the current topology to the right.
         if (!isInitialOutput) {
+            const bool restoreAsExtensionOutput =
+                m_mode == OutputMode::Extension
+                && m_globalConfig->singleOutputId().isEmpty()
+                && !m_globalConfig->createCopyOutput();
+            if (restoreAsExtensionOutput && !output->isEnabled()) {
+                outputObject->enable();
+            }
             return;
         }
 
@@ -654,19 +700,11 @@ void Helper::onOutputAdded(WOutput *output)
             layout->move(output, QPoint(static_cast<int>(config->x()), static_cast<int>(config->y())));
         }
 
-        wlr_output_mode *mode, *configMode = nullptr;
-        wl_list_for_each(mode, &output->nativeHandle()->modes, link) {
-            if (mode->width == width && mode->height == height && mode->refresh == refresh) {
-                configMode = mode;
-                break;
-            }
+        if (auto *mode = closestOutputMode(output, width, height, refresh)) {
+            newState.set_mode(mode);
+        } else {
+            newState.set_custom_mode(width, height, refresh);
         }
-        if (configMode)
-            newState.set_mode(configMode);
-        else
-            newState.set_custom_mode(width,
-                                     height,
-                                     refresh);
 
         newState.set_adaptive_sync_enabled(config->adaptiveSyncEnabled());
         newState.set_transform(static_cast<wl_output_transform>(transform));
@@ -918,7 +956,69 @@ void Helper::handleCopyModeOutputDisable(Output *affectedOutput)
 
 void Helper::onOutputTestOrApply(qw_output_configuration_v1 *config, bool onlyTest)
 {
-    QList<WOutputState> states = m_outputManager->stateListPending();
+    QList<WOutputState> states = m_outputManager->stateListPending(config);
+
+    const auto enabledOutputCount = std::count_if(
+        states.cbegin(),
+        states.cend(),
+        [](const WOutputState &state) {
+            return state.enabled;
+        });
+    const bool allEnabledOutputsOverlap = enabledOutputCount > 1
+        && std::all_of(states.cbegin(), states.cend(), [](const WOutputState &state) {
+               return !state.enabled || (state.x == 0 && state.y == 0);
+           });
+    const auto currentlyEnabledOutputCount = std::count_if(
+        states.cbegin(),
+        states.cend(),
+        [](const WOutputState &state) {
+            return state.output->isEnabled();
+        });
+    const bool expandingFromSingleOutput =
+        currentlyEnabledOutputCount == 1 && enabledOutputCount > 1;
+
+    if (m_mode == OutputMode::Extension
+        && (allEnabledOutputsOverlap || expandingFromSingleOutput)) {
+        QList<WOutputState> restoredStates = states;
+        bool configsValid = true;
+        bool hasNonZeroPosition = false;
+
+        for (auto &state : restoredStates) {
+            if (!state.enabled) {
+                continue;
+            }
+
+            Output *output = getOutput(state.output);
+            OutputConfig *outputConfig = output ? output->config() : nullptr;
+            if (!outputConfig || !outputConfig->isInitializeSucceeded()
+                || !hasSavedOutputState(outputConfig)) {
+                configsValid = false;
+                break;
+            }
+
+            const int width = static_cast<int>(outputConfig->width());
+            const int height = static_cast<int>(outputConfig->height());
+            const int refresh = static_cast<int>(outputConfig->refresh());
+            if (width <= 0 || height <= 0 || refresh <= 0) {
+                configsValid = false;
+                break;
+            }
+
+            state.x = static_cast<int32_t>(outputConfig->x());
+            state.y = static_cast<int32_t>(outputConfig->y());
+            hasNonZeroPosition |= state.x != 0 || state.y != 0;
+
+            state.mode = closestOutputMode(state.output, width, height, refresh);
+            if (!state.mode) {
+                configsValid = false;
+                break;
+            }
+        }
+
+        if (configsValid && hasNonZeroPosition) {
+            states = std::move(restoredStates);
+        }
+    }
 
     if (onlyTest) {
         bool ok = true;
@@ -1179,6 +1279,13 @@ void Helper::onOutputCommitFinished(qw_output_configuration_v1 *config, bool suc
             // extension/single-output topology, never a copy topology.
             m_outputManagerHelper->storeCopyOutputConfig(false);
 
+            const auto enabledOutputCount = std::count_if(
+                m_pendingOutputConfig.states.cbegin(),
+                m_pendingOutputConfig.states.cend(),
+                [](const WOutputState &state) {
+                    return state.enabled;
+                });
+
             for (const WOutputState &state : std::as_const(m_pendingOutputConfig.states)) {
                 auto *output = getOutput(state.output);
                 if (!output) {
@@ -1191,6 +1298,7 @@ void Helper::onOutputCommitFinished(qw_output_configuration_v1 *config, bool suc
 
                 auto *outputConfig = output->config();
                 const bool enabled = state.enabled;
+                const bool preservePosition = enabled && enabledOutputCount == 1;
                 const qlonglong x = state.x;
                 const qlonglong y = state.y;
                 const qlonglong width = state.mode ? state.mode->width : state.customModeSize.width();
@@ -1208,7 +1316,8 @@ void Helper::onOutputCommitFinished(qw_output_configuration_v1 *config, bool suc
                                                                       refresh,
                                                                       transform,
                                                                       scale,
-                                                                      adaptiveSyncEnabled] {
+                                                                      adaptiveSyncEnabled,
+                                                                      preservePosition] {
 
                     if (!enabled) {
                         return;
@@ -1218,6 +1327,9 @@ void Helper::onOutputCommitFinished(qw_output_configuration_v1 *config, bool suc
                         return;
                     }
 
+                    if (preservePosition) {
+                        return;
+                    }
                     outputConfig->setX(x);
                     outputConfig->setY(y);
                     outputConfig->setWidth(width);
@@ -3516,6 +3628,10 @@ void Helper::restoreExtensionModeFromConfig(bool preserveSingleOutputConfig)
                 return;
             }
 
+            if (!m_outputList.contains(outputObject)) {
+                return;
+            }
+
             auto *output = outputObject->output();
             auto *config = outputObject->config();
             if (!hasSavedOutputState(config)) {
@@ -3542,16 +3658,8 @@ void Helper::restoreExtensionModeFromConfig(bool preserveSingleOutputConfig)
 
             qw_output_state state;
             state.set_enabled(true);
-            wlr_output_mode *mode = nullptr;
-            wlr_output_mode *savedMode = nullptr;
-            wl_list_for_each(mode, &output->nativeHandle()->modes, link) {
-                if (mode->width == width && mode->height == height && mode->refresh == refresh) {
-                    savedMode = mode;
-                    break;
-                }
-            }
-            if (savedMode) {
-                state.set_mode(savedMode);
+            if (auto *mode = closestOutputMode(output, width, height, refresh)) {
+                state.set_mode(mode);
             } else {
                 state.set_custom_mode(width, height, refresh);
             }

--- a/waylib/src/server/protocols/woutputmanagerv1.cpp
+++ b/waylib/src/server/protocols/woutputmanagerv1.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 rewine <luhongxu@deepin.org>.
+// Copyright (C) 2023-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "woutputmanagerv1.h"
@@ -8,6 +8,8 @@
 #include <qwoutput.h>
 #include <qwoutputmanagementv1.h>
 #include <qwdisplay.h>
+
+#include <QHash>
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
@@ -39,7 +41,8 @@ public:
     qw_output_manager_v1 *manager { nullptr };
     QPointer<WBackend> backend;
     QList<WOutputState> stateList;
-    QList<WOutputState> stateListPending;
+    QHash<qw_output_configuration_v1 *, QList<WOutputState>> pendingStateLists;
+    qw_output_configuration_v1 *currentPendingConfig { nullptr };
 };
 
 WOutputManagerV1::WOutputManagerV1()
@@ -53,7 +56,7 @@ void WOutputManagerV1Private::outputMgrApplyOrTest(qw_output_configuration_v1 *c
     W_Q(WOutputManagerV1);
     wlr_output_configuration_head_v1 *config_head;
 
-    stateListPending.clear();
+    QList<WOutputState> pendingStates;
 
     wl_list_for_each(config_head, &config->handle()->heads, link) {
         auto *output = QW_NAMESPACE::qw_output::from(config_head->state.output);
@@ -61,7 +64,7 @@ void WOutputManagerV1Private::outputMgrApplyOrTest(qw_output_configuration_v1 *c
 
         const auto &state = config_head->state;
 
-        stateListPending.append(WOutputState {
+        pendingStates.append(WOutputState {
             .output = woutput,
             .enabled = state.enabled,
             .mode = state.mode,
@@ -75,13 +78,15 @@ void WOutputManagerV1Private::outputMgrApplyOrTest(qw_output_configuration_v1 *c
         });
     }
 
+    currentPendingConfig = config;
+    pendingStateLists.insert(config, std::move(pendingStates));
     Q_EMIT q->requestTestOrApply(config, onlyTest);
 }
 
-const QList<WOutputState> &WOutputManagerV1::stateListPending()
+QList<WOutputState> WOutputManagerV1::stateListPending(qw_output_configuration_v1 *config) const
 {
-    W_D(WOutputManagerV1);
-    return d->stateListPending;
+    W_D(const WOutputManagerV1);
+    return d->pendingStateLists.value(config ? config : d->currentPendingConfig);
 }
 
 void WOutputManagerV1::updateConfig()
@@ -119,15 +124,18 @@ void WOutputManagerV1::sendResult(qw_output_configuration_v1 *config, bool ok)
 {
     W_D(WOutputManagerV1);
 
+    const QList<WOutputState> pendingStates = d->pendingStateLists.take(config);
+    if (d->currentPendingConfig == config)
+        d->currentPendingConfig = nullptr;
+
     if (ok) {
         config->send_succeeded();
-        d->stateList = d->stateListPending;
+        d->stateList = pendingStates;
     } else {
         config->send_failed();
     }
 
     delete config;
-    d->stateListPending.clear();
 
     // Schedule updateConfig through the event loop to avoid recursion
     QMetaObject::invokeMethod(this, &WOutputManagerV1::updateConfig, Qt::QueuedConnection);

--- a/waylib/src/server/protocols/woutputmanagerv1.h
+++ b/waylib/src/server/protocols/woutputmanagerv1.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 rewine <luhongxu@deepin.org>.
+// Copyright (C) 2023-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #pragma once
@@ -50,7 +50,8 @@ class WAYLIB_SERVER_EXPORT WOutputManagerV1: public QObject, public WObject,  pu
 public:
     explicit WOutputManagerV1();
 
-    const QList<WOutputState> &stateListPending();
+    QList<WOutputState> stateListPending(
+        QW_NAMESPACE::qw_output_configuration_v1 *config = nullptr) const;
 
     void sendResult(QW_NAMESPACE::qw_output_configuration_v1 *config, bool ok);
     void newOutput(WOutput *output);


### PR DESCRIPTION
## Summary by Sourcery

Improve restoration and preservation of multi-output topology and modes when outputs are (re)connected or configurations are applied.

New Features:
- Restore previously configured extension-mode output layout when re-enabling or reconnecting outputs, instead of defaulting to overlapping outputs.
- Select the closest available output mode to a saved configuration when exact width/height/refresh matches are not present, falling back to custom modes only if no suitable mode exists.

Bug Fixes:
- Ensure copy and extension outputs are enabled when appropriate after hot-plugging, avoiding disabled outputs that should participate in the configured topology.
- Preserve single-output position when committing new configurations so its stored coordinates are not unintentionally reset.
- Avoid assigning surface outputs that are disabled, and handle lockscreen output geometry changes safely when outputs are removed to prevent invalid access.
- Fix pending output state tracking in the output manager by associating state lists with specific configurations and cleaning them up correctly.

Enhancements:
- Refine logic for mapping surfaces to outputs, preferring a single active output when applicable before falling back to intersection-based selection.