### PR TITLE
refactor: 窗口录屏

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -3460,30 +3460,14 @@ void Helper::handleNewForeignToplevelCaptureRequest(wlr_ext_foreign_toplevel_ima
         return;
     }
 
-    WSurfaceItem *surfaceItem = surfaceWrapper->surfaceItem();
-    if (!surfaceItem) {
-        qCWarning(lcTlCapture) << "Could not get WSurfaceItem from SurfaceWrapper";
-        return;
-    }
-
-    WSurfaceItemContent *surfaceContent = surfaceItem->findItemContent();
-    if (!surfaceContent) {
-        qCWarning(lcTlCapture) << "Could not find WSurfaceItemContent";
-        return;
-    }
-
-    qCDebug(lcTlCapture) << "Found WSurfaceItemContent for capture:"
-             << "size=" << surfaceContent->size()
-             << "implicitSize=" << QSizeF(surfaceContent->implicitWidth(), surfaceContent->implicitHeight())
-             << "isTextureProvider=" << surfaceContent->isTextureProvider();
-
     auto *output = surfaceWrapper->ownsOutput()->output();
     if (!output) {
         qCWarning(lcTlCapture) << "Could not get WOutput from SurfaceWrapper";
         return;
     }
 
-    auto *imageCaptureSource = new WExtImageCaptureSourceV1Impl(surfaceContent, output);
+    auto *imageCaptureSource =
+        new WExtImageCaptureSourceV1Impl(surfaceWrapper->surfaceItem(), output);
 
     bool success = wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request_accept(
         request, imageCaptureSource->handle());

--- a/waylib/src/server/qtquick/private/wbufferrenderer.cpp
+++ b/waylib/src/server/qtquick/private/wbufferrenderer.cpp
@@ -788,6 +788,103 @@ int WBufferRenderer::indexOfSource(QQuickItem *s)
     return -1;
 }
 
+void WBufferRenderer::renderTransientItem(QQuickItem *item)
+{
+    Q_ASSERT(state.buffer);
+
+    auto *wd = QQuickWindowPrivate::get(window());
+    auto *rc = state.context;
+
+    // Get the item's SG transform node (includes its entire subtree: content,
+    // subsurfaces, etc.).
+    auto *itemNode = QQuickItemPrivate::get(item)->itemNode();
+    if (!itemNode)
+        return;
+
+    // Save original parent and transform.
+    QSGNode *savedParent = itemNode->parent();
+    QMatrix4x4 savedMatrix = itemNode->matrix();
+
+    // Create a temporary root node and re-parent the item under it.
+    // This isolates the item's subtree from the rest of the scene graph.
+    auto *tempRoot = new QSGRootNode();
+    if (savedParent)
+        savedParent->removeChildNode(itemNode);
+    tempRoot->appendChildNode(itemNode);
+
+    // Reset transform so the item fills the FBO from the origin.
+    itemNode->setMatrix(QMatrix4x4());
+
+    // Create a dedicated renderer for the transient subtree.
+    auto *dr = qobject_cast<QSGDefaultRenderContext *>(rc);
+    const bool useDepth = dr ? dr->useDepthBufferFor2D() : false;
+    const auto renderMode = useDepth ? QSGRendererInterface::RenderMode2D
+                                     : QSGRendererInterface::RenderMode2DNoDepthBuffer;
+    auto *transientRenderer = rc->createRenderer(renderMode);
+    transientRenderer->setRootNode(tempRoot);
+    transientRenderer->setClearColor(m_clearColor);
+
+    // --- Mirror the GL/RHI setup from render() (lines 522-573) ---
+    transientRenderer->setDevicePixelRatio(window()->effectiveDevicePixelRatio());
+    transientRenderer->setDeviceRect(QRect(QPoint(0, 0), state.pixelSize));
+    transientRenderer->setRenderTarget(state.sgRenderTarget);
+
+    bool flipY = wd->rhi ? !wd->rhi->isYUpInNDC() : false;
+    if (state.renderTarget.rt().mirrorVertically())
+        flipY = !flipY;
+    transientRenderer->setViewportRect(QRect(QPoint(0, 0), state.pixelSize));
+
+    // Ortho projection: map item's logical coordinates to the viewport.
+    const qreal dpr = state.devicePixelRatio;
+    const QSizeF logicalSize = QSizeF(state.pixelSize) / dpr;
+    float left = 0, right = logicalSize.width();
+    float bottom = logicalSize.height(), top = 0;
+
+    if (flipY)
+        std::swap(top, bottom);
+
+    QMatrix4x4 matrix;
+    matrix.ortho(left, right, bottom, top, 1, -1);
+    QMatrix4x4 projectionMatrix = matrix; // worldTransform is identity
+
+    QMatrix4x4 projectionMatrixWithNativeNDC;
+    if (wd->rhi && !wd->rhi->isYUpInNDC()) {
+        std::swap(top, bottom);
+        matrix.setToIdentity();
+        matrix.ortho(left, right, bottom, top, 1, -1);
+    }
+    projectionMatrixWithNativeNDC = matrix;
+
+    transientRenderer->setProjectionMatrix(projectionMatrix);
+    transientRenderer->setProjectionMatrixWithNativeNDC(projectionMatrixWithNativeNDC);
+
+    auto *textureRT = static_cast<QRhiTextureRenderTarget *>(state.sgRenderTarget.rt);
+    textureRT->setFlags(textureRT->flags() & ~QRhiTextureRenderTarget::PreserveColorContents);
+
+    // Render the isolated subtree.
+    rc->renderNextFrame(transientRenderer);
+    wd->rhi->finish();
+
+    // Flush pending resource updates (same as render() post-render step).
+    if (auto *drc = qobject_cast<QSGDefaultRenderContext *>(state.context)) {
+        QRhiResourceUpdateBatch *batch = wd->rhi->nextResourceUpdateBatch();
+        drc->currentFrameCommandBuffer()->resourceUpdate(batch);
+    }
+
+    wlr_damage_ring_add_whole(m_damageRing.get());
+
+    // --- Restore original state ---
+    itemNode->setMatrix(savedMatrix);
+    tempRoot->removeChildNode(itemNode);
+    if (savedParent)
+        savedParent->appendChildNode(itemNode);
+
+    // Destroy renderer (setRootNode(nullptr) first to prevent dangling ref).
+    transientRenderer->setRootNode(nullptr);
+    delete transientRenderer;
+    delete tempRoot;
+}
+
 QSGRenderer *WBufferRenderer::ensureRenderer(int sourceIndex, QSGRenderContext *rc)
 {
     Data &d = m_sourceList[sourceIndex];

--- a/waylib/src/server/qtquick/private/wbufferrenderer_p.h
+++ b/waylib/src/server/qtquick/private/wbufferrenderer_p.h
@@ -97,6 +97,7 @@ protected:
     void render(int sourceIndex, const QMatrix4x4 &renderMatrix,
                 const QRectF &sourceRect = {}, const QRectF &targetRect = {});
     void endRender();
+    void renderTransientItem(QQuickItem *item);
     void componentComplete() override;
 
 private:

--- a/waylib/src/server/qtquick/woutputrenderwindow.cpp
+++ b/waylib/src/server/qtquick/woutputrenderwindow.cpp
@@ -1918,6 +1918,35 @@ bool WOutputRenderWindow::inRendering() const
     return d->inRendering;
 }
 
+wlr_buffer *WOutputRenderWindow::renderItemToBuffer(WBufferRenderer *renderer,
+                                                    QQuickItem *item,
+                                                    const QSize &pixelSize,
+                                                    qreal dpr,
+                                                    uint32_t format)
+{
+    Q_D(WOutputRenderWindow);
+    Q_ASSERT(renderer);
+
+    auto buffer = renderer->beginRender(
+        pixelSize,
+        dpr,
+        format,
+        WBufferRenderer::RenderFlags(
+            WBufferRenderer::DontConfigureSwapchain
+            | WBufferRenderer::RedirectOpenGLContextDefaultFrameBufferObject));
+    if (!buffer)
+        return nullptr;
+
+    d->pushRenderer(renderer);
+    renderer->renderTransientItem(item);
+    if (!d->rendererList.isEmpty())
+        d->rendererList.pop();
+
+    renderer->endRender();
+
+    return renderer->lastBuffer();
+}
+
 void WOutputRenderWindow::setRenderEnabled(bool enabled) {
     Q_D(WOutputRenderWindow);
     d->renderEnabled = enabled;

--- a/waylib/src/server/qtquick/woutputrenderwindow.h
+++ b/waylib/src/server/qtquick/woutputrenderwindow.h
@@ -58,6 +58,18 @@ public:
     WBufferRenderer *currentRenderer() const;
     bool inRendering() const;
 
+    // Render a single item (its entire SG subtree: content + subsurfaces) into
+    // an offscreen buffer via the given WBufferRenderer. The item is
+    // temporarily re-parented under a transient root node for isolation.
+    // Must be called during the render pass (e.g. in afterRendering signal).
+    // Returns the rendered buffer (same as renderer->lastBuffer()), or
+    // nullptr on failure.
+    wlr_buffer *renderItemToBuffer(WBufferRenderer *renderer,
+                                   QQuickItem *item,
+                                   const QSize &pixelSize,
+                                   qreal dpr,
+                                   uint32_t format);
+
     void setRenderEnabled(bool enabled);
 
     static QList<QPointer<QQuickItem>> paintOrderItemList(QQuickItem *root, std::function<bool(QQuickItem*)> filter);

--- a/waylib/src/server/utils/wextimagecapturesourcev1impl.cpp
+++ b/waylib/src/server/utils/wextimagecapturesourcev1impl.cpp
@@ -9,11 +9,10 @@
 #include "woutput.h"
 #include "wtools.h"
 #include "wayliblogging.h"
+#include "wbufferrenderer_p.h"
 
 #include <wlr_all.h>
 #include <wcontainerof.h>
-
-#include <memory>
 
 extern "C" {
 #include <pixman.h>
@@ -120,53 +119,82 @@ const struct wlr_ext_image_capture_source_v1_interface WExtImageCaptureSourceV1I
     .get_pointer_cursor = WExtImageCaptureSourceV1Impl::get_pointer_cursor,
 };
 
-WExtImageCaptureSourceV1Impl::WExtImageCaptureSourceV1Impl(WSurfaceItemContent *surfaceContent, WOutput *output)
-    : QObject(surfaceContent) // TODO: Check if Qt object tree destruction timing is appropriate
-    , m_surfaceContent(surfaceContent)
+WExtImageCaptureSourceV1Impl::WExtImageCaptureSourceV1Impl(QQuickItem *surfaceItem, WOutput *output)
+    : QObject(surfaceItem)
+    , m_surfaceItem(surfaceItem)
     , m_output(output)
     , m_capturing(false)
-    , m_renderEndConnection()
 {
-    Q_ASSERT(m_surfaceContent);
+    Q_ASSERT(m_surfaceItem);
+    Q_ASSERT(m_output);
 
     // Initialize wlr_ext_image_capture_source_v1
     wlr_ext_image_capture_source_v1_init(&source, &impl);
     s_captureSourceMap.insert(&source, this);
 
-    // Get actual surface size and set constraints directly
-    auto surface = m_surfaceContent->surface();
-    if (surface && surface->handle()) {
-        auto wlr_surface = surface->handle();
-        int width = wlr_surface->current.width;
-        int height = wlr_surface->current.height;
+    // Set initial constraints from the surfaceItem's bounding rect * dpr
+    const auto pixelSize = computePixelSize();
+    if (pixelSize.isValid() && !pixelSize.isEmpty()) {
+        ConstraintBuilder builder(&source, m_output);
+        builder.setSize(pixelSize.width(), pixelSize.height());
+        builder.buildShmFormats();
+        builder.buildDmabufFormats();
+        builder.apply();
 
-        // Validate dimensions before setting constraints
-        if (width > 0 && height > 0) {
-            // Use constraint builder helper directly
-            ConstraintBuilder builder(&source, m_output);
-            builder.setSize(width, height);
-            builder.buildShmFormats();
-            builder.buildDmabufFormats();
-            builder.apply();
-
-            qCDebug(lcWlImageCapture) << "Initial constraints set successfully:";
-            qCDebug(lcWlImageCapture) << "  - Width:" << width;
-            qCDebug(lcWlImageCapture) << "  - Height:" << height;
-        } else {
-            qCWarning(lcWlImageCapture) << "Invalid surface dimensions for constraints:" << width << "x" << height;
-        }
+        qCDebug(lcWlImageCapture) << "Initial constraints set:" << pixelSize;
     } else {
-        qCWarning(lcWlImageCapture) << "No valid surface available for setting initial constraints";
+        qCWarning(lcWlImageCapture) << "Invalid surface dimensions for constraints:" << pixelSize;
     }
 }
 
 WExtImageCaptureSourceV1Impl::~WExtImageCaptureSourceV1Impl()
 {
     if (m_capturing) {
-        qCDebug(lcWlImageCapture) << "WExtImageCaptureSourceV1Impl destroyed while capturing";
+        stop();
     }
+    // WBufferRenderer has no source items or proxy — just delete it.
+    delete m_captureRenderer;
+
     wlr_ext_image_capture_source_v1_finish(&source);
     s_captureSourceMap.remove(&source);
+}
+
+WOutputRenderWindow *WExtImageCaptureSourceV1Impl::renderWindow() const
+{
+    if (!m_surfaceItem)
+        return nullptr;
+    return qobject_cast<WOutputRenderWindow *>(m_surfaceItem->window());
+}
+
+qreal WExtImageCaptureSourceV1Impl::computeDpr() const
+{
+    auto rw = renderWindow();
+    return rw ? rw->effectiveDevicePixelRatio() : 1.0;
+}
+
+QSize WExtImageCaptureSourceV1Impl::computePixelSize() const
+{
+    if (!m_surfaceItem)
+        return { };
+
+    const auto sz = m_surfaceItem->size();
+    if (sz.isEmpty())
+        return { };
+
+    const qreal dpr = computeDpr();
+    return QSize(qCeil(sz.width() * dpr), qCeil(sz.height() * dpr));
+}
+
+void WExtImageCaptureSourceV1Impl::updateConstraints(const QSize &pixelSize)
+{
+    if (!pixelSize.isValid() || pixelSize.isEmpty())
+        return;
+
+    ConstraintBuilder builder(handle(), m_output);
+    builder.setSize(pixelSize.width(), pixelSize.height());
+    builder.buildShmFormats();
+    builder.buildDmabufFormats();
+    builder.apply();
 }
 
 void WExtImageCaptureSourceV1Impl::start(struct wlr_ext_image_capture_source_v1 *source, bool with_cursors)
@@ -178,48 +206,35 @@ void WExtImageCaptureSourceV1Impl::start(struct wlr_ext_image_capture_source_v1 
 
 void WExtImageCaptureSourceV1Impl::start(bool with_cursors)
 {
-    // TODO: Implement cursor capture if needed
     m_capturing = true;
     qCDebug(lcWlImageCapture) << "WExtImageCaptureSourceV1Impl::start() with_cursors:" << with_cursors;
 
-    // TODO: Optimize multiple clients capturing the same window
-    // Currently each client creates its own WExtImageCaptureSourceV1Impl instance,
-    // which means multiple render listeners for the same surface. Consider implementing
-    // a manager to share render events among multiple capture sources.
-
-    if (!m_surfaceContent) {
-        qCWarning(lcWlImageCapture) << "No surface content available for capture";
-        return;
-    }
-
-    // Get render window
-    auto textureProvider = m_surfaceContent->wTextureProvider();
-    if (!textureProvider) {
-        qCWarning(lcWlImageCapture) << "No texture provider available for start";
-        return;
-    }
-
-    auto renderWindow = textureProvider->window();
-    if (!renderWindow) {
+    auto rw = renderWindow();
+    if (!rw) {
         qCWarning(lcWlImageCapture) << "No render window available for start";
         return;
     }
 
-    // Connect to renderEnd signal
-    m_renderEndConnection = connect(renderWindow,
-                                   &WOutputRenderWindow::renderEnd,
-                                   this,
-                                   &WExtImageCaptureSourceV1Impl::handleRenderEnd,
-                                   Qt::AutoConnection);
-
-    if (!m_renderEndConnection) {
-        qCWarning(lcWlImageCapture) << "Cannot connect to render end of output render window";
+    if (!m_captureRenderer) {
+        m_captureRenderer = new WBufferRenderer(rw->contentItem());
+        m_captureRenderer->setOutput(m_output);
+        m_captureRenderer->setVisible(false);
     }
 
-    // If not currently rendering, trigger immediately
-    if (!renderWindow->inRendering()) {
-        QMetaObject::invokeMethod(this, &WExtImageCaptureSourceV1Impl::handleRenderEnd, Qt::AutoConnection);
-    }
+    m_afterRenderingConnection = connect(rw,
+                                         &QQuickWindow::afterRendering,
+                                         this,
+                                         &WExtImageCaptureSourceV1Impl::doOffscreenRender,
+                                         Qt::AutoConnection);
+
+    m_renderEndConnection = connect(rw,
+                                    &WOutputRenderWindow::renderEnd,
+                                    this,
+                                    &WExtImageCaptureSourceV1Impl::handleRenderEnd,
+                                    Qt::AutoConnection);
+
+    // Trigger first frame
+    wlr_output_update_needs_frame(m_output->handle());
 }
 
 void WExtImageCaptureSourceV1Impl::stop(struct wlr_ext_image_capture_source_v1 *source)
@@ -234,11 +249,19 @@ void WExtImageCaptureSourceV1Impl::stop()
     m_capturing = false;
     qCDebug(lcWlImageCapture) << "WExtImageCaptureSourceV1Impl::stop()";
 
-    // Disconnect render end connection
+    if (m_afterRenderingConnection) {
+        disconnect(m_afterRenderingConnection);
+        m_afterRenderingConnection = QMetaObject::Connection();
+    }
     if (m_renderEndConnection) {
         disconnect(m_renderEndConnection);
         m_renderEndConnection = QMetaObject::Connection();
     }
+
+    if (m_renderedBuffer) {
+        wlr_buffer_unlock(m_renderedBuffer);
+    }
+    m_renderedBuffer = nullptr;
 }
 
 void WExtImageCaptureSourceV1Impl::schedule_frame(struct wlr_ext_image_capture_source_v1 *source)
@@ -257,52 +280,82 @@ void WExtImageCaptureSourceV1Impl::schedule_frame()
         return;
     }
 
-    if (!m_surfaceContent) {
-        qCWarning(lcWlImageCapture) << "No surface content available for frame scheduling";
+    // Request output update to ensure next frame will be rendered.
+    // doOffscreenRender fires via afterRendering, handleRenderEnd via renderEnd.
+    wlr_output_update_needs_frame(m_output->handle());
+}
+
+void WExtImageCaptureSourceV1Impl::doOffscreenRender()
+{
+    if (!m_capturing || !m_surfaceItem || !m_captureRenderer)
+        return;
+
+    auto rw = renderWindow();
+    if (!rw)
+        return;
+
+    const auto pixelSize = computePixelSize();
+    if (pixelSize.isEmpty()) {
+        qCWarning(lcWlImageCapture) << "Invalid pixel size for offscreen render:" << pixelSize;
         return;
     }
 
-    // Request output update to ensure next frame will be rendered
-    wlr_output_update_needs_frame(m_output->handle());
+    const qreal dpr = computeDpr();
 
-    // Get render window to check if currently rendering
-    auto textureProvider = m_surfaceContent->wTextureProvider();
-    if (textureProvider) {
-        auto renderWindow = textureProvider->window();
-        if (renderWindow && !renderWindow->inRendering()) {
-            QMetaObject::invokeMethod(this, &WExtImageCaptureSourceV1Impl::handleRenderEnd, Qt::AutoConnection);
-        }
+    if (m_renderedBuffer) {
+        wlr_buffer_unlock(m_renderedBuffer);
+        m_renderedBuffer = nullptr;
     }
 
-    qCDebug(lcWlImageCapture) << "Scheduled frame capture";
+    // Render the surface item's subtree (content + subsurfaces) into an
+    // offscreen FBO via transient root-node re-parenting.  No layer.enabled
+    // on m_surfaceItem — avoids the double-resampling blur.
+    m_renderedBuffer = rw->renderItemToBuffer(m_captureRenderer,
+                                              m_surfaceItem,
+                                              pixelSize,
+                                              dpr,
+                                              DRM_FORMAT_ARGB8888);
+
+    if (m_renderedBuffer) {
+        // Lock to prevent swapchain from recycling before copy_frame
+        wlr_buffer_lock(m_renderedBuffer);
+    }
+
+    qCDebug(lcWlImageCapture) << "Offscreen render done, buffer:"
+                              << (m_renderedBuffer ? m_renderedBuffer.get() : nullptr)
+                              << "size:" << pixelSize;
 }
 
 void WExtImageCaptureSourceV1Impl::handleRenderEnd()
 {
-    qCDebug(lcWlImageCapture) << "WExtImageCaptureSourceV1Impl::handleRenderEnd() - triggering frame event";
-
     if (!m_capturing) {
         qCWarning(lcWlImageCapture) << "handleRenderEnd called but not capturing";
         return;
     }
 
-    // Get surface size and validate it
-    QSize surfaceSize = m_surfaceContent->size().toSize();
-    if (surfaceSize.width() <= 0 || surfaceSize.height() <= 0) {
-        qCWarning(lcWlImageCapture) << "Invalid surface size for damage region:" << surfaceSize;
+    if (!m_renderedBuffer) {
+        qCWarning(lcWlImageCapture) << "No rendered buffer available for frame event";
         return;
     }
 
-    // Create damage region with RAII
-    WPixmanRegion fullDamage(0, 0, surfaceSize.width(), surfaceSize.height());
+    auto wlr_buf = m_renderedBuffer.get();
+    const int bufferWidth = wlr_buf->width;
+    const int bufferHeight = wlr_buf->height;
+    if (bufferWidth <= 0 || bufferHeight <= 0) {
+        qCWarning(lcWlImageCapture) << "Invalid buffer size:" << bufferWidth << "x" << bufferHeight;
+        return;
+    }
 
-    // Create frame event and emit
+    // TODO: partial damage
+    WPixmanRegion fullDamage(0, 0, bufferWidth, bufferHeight);
+
     wlr_ext_image_capture_source_v1_frame_event event {
         .damage = fullDamage.get(),
     };
     wl_signal_emit_mutable(&source.events.frame, &event);
 
-    qCDebug(lcWlImageCapture) << "Frame event emitted with damage region:" << surfaceSize;
+    qCDebug(lcWlImageCapture) << "Frame event emitted with damage:" << bufferWidth << "x"
+                              << bufferHeight;
 }
 
 void WExtImageCaptureSourceV1Impl::copy_frame(struct wlr_ext_image_capture_source_v1 *source,
@@ -314,8 +367,9 @@ void WExtImageCaptureSourceV1Impl::copy_frame(struct wlr_ext_image_capture_sourc
     self->copy_frame(dst_frame, frame_event);
 }
 
-void WExtImageCaptureSourceV1Impl::copy_frame(wlr_ext_image_copy_capture_frame_v1 *dst_frame,
-                                              [[maybe_unused]] wlr_ext_image_capture_source_v1_frame_event *frame_event)
+void WExtImageCaptureSourceV1Impl::copy_frame(
+    wlr_ext_image_copy_capture_frame_v1 *dst_frame,
+    [[maybe_unused]] wlr_ext_image_capture_source_v1_frame_event *frame_event)
 {
     qCDebug(lcWlImageCapture) << "WExtImageCaptureSourceV1Impl::copy_frame()";
 
@@ -325,39 +379,8 @@ void WExtImageCaptureSourceV1Impl::copy_frame(wlr_ext_image_copy_capture_frame_v
         return;
     }
 
-    if (!m_surfaceContent) {
-        qCWarning(lcWlImageCapture) << "No surface content available for frame copy";
-        wlr_ext_image_copy_capture_frame_v1_fail(dst_frame, EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
-        return;
-    }
-
-    // Get texture provider
-    auto textureProvider = m_surfaceContent->wTextureProvider();
-    if (!textureProvider) {
-        qCWarning(lcWlImageCapture) << "No texture provider available";
-        wlr_ext_image_copy_capture_frame_v1_fail(dst_frame, EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
-        return;
-    }
-
-    auto buffer = textureProvider->qwBuffer();
-    if (!buffer) {
-        qCWarning(lcWlImageCapture) << "No internal buffer available";
-        wlr_ext_image_copy_capture_frame_v1_fail(dst_frame, EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
-        return;
-    }
-
-    // Lock the buffer for the duration of the copy to prevent races during resize
-    if (!wlr_buffer_lock(buffer)) {
-        qCWarning(lcWlImageCapture) << "Failed to lock internal buffer";
-        wlr_ext_image_copy_capture_frame_v1_fail(dst_frame, EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
-        return;
-    }
-    WBufferUnlockPtr bufferGuard(buffer);
-
-    // Get renderer
-    auto renderWindow = textureProvider->window();
-    if (!renderWindow) {
-        qCWarning(lcWlImageCapture) << "No render window available";
+    if (!m_renderedBuffer) {
+        qCWarning(lcWlImageCapture) << "No rendered buffer available for copy";
         wlr_ext_image_copy_capture_frame_v1_fail(dst_frame, EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
         return;
     }
@@ -368,60 +391,46 @@ void WExtImageCaptureSourceV1Impl::copy_frame(wlr_ext_image_copy_capture_frame_v
         wlr_ext_image_copy_capture_frame_v1_fail(dst_frame, EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
         return;
     }
-
-    // Prefer the client buffer source if present
-    wlr_buffer *src = buffer;
-    if (auto clientBuf = wlr_client_buffer_get(buffer)) {
-        src = clientBuf->source;
-    }
-
-    // Critical safety checks: validate all required pointers and buffers before copying
-    if (!src) {
-        qCWarning(lcWlImageCapture) << "Source buffer is null, cannot copy frame";
-        if (dst_frame) {
-            wlr_ext_image_copy_capture_frame_v1_fail(dst_frame, EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_BUFFER_CONSTRAINTS);
-        }
-        return;
-    }
+    auto src = m_renderedBuffer.get();
+    // Buffer is already locked in doOffscreenRender; unlock after copy.
+    // copy_buffer calls fail() + frame_destroy + free internally on failure,
+    // so do NOT touch dst_frame afterwards.
 
     if (!dst_frame || !dst_frame->buffer) {
-        qCWarning(lcWlImageCapture) << "Destination frame or buffer is null, cannot copy";
+        qCWarning(lcWlImageCapture) << "Destination frame or buffer is null";
         if (dst_frame) {
             wlr_ext_image_copy_capture_frame_v1_fail(dst_frame, EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_BUFFER_CONSTRAINTS);
         }
+        wlr_buffer_unlock(src);
+        m_renderedBuffer = nullptr;
         return;
     }
 
-    // Validate buffer dimensions to prevent crashes during resize
+    // Validate buffer dimensions
     if (dst_frame->buffer->width != src->width || dst_frame->buffer->height != src->height) {
-        qCWarning(lcWlImageCapture) << "Buffer size mismatch during resize (dst:" << dst_frame->buffer->width << "x" << dst_frame->buffer->height
-                                   << ", src:" << src->width << "x" << src->height << "), updating constraints";
+        qCWarning(lcWlImageCapture) << "Buffer size mismatch (dst:" << dst_frame->buffer->width
+                                    << "x" << dst_frame->buffer->height << ", src:" << src->width
+                                    << "x" << src->height << "), updating constraints";
 
-        // Update constraints when we detect a size mismatch
-        ConstraintBuilder builder(&source, m_output);
-        builder.setSize(src->width, src->height);
-        builder.buildShmFormats();
-        builder.buildDmabufFormats();
-        builder.apply();
+        updateConstraints(QSize(src->width, src->height));
 
-        qCDebug(lcWlImageCapture) << "Constraints updated to new size:" << src->width << "x" << src->height;
-
-        // Check again after constraints update - the client might have already provided a correctly sized buffer
         if (dst_frame->buffer->width != src->width || dst_frame->buffer->height != src->height) {
-            qCDebug(lcWlImageCapture) << "Buffer size still mismatched after constraint update, skipping frame";
+            qCDebug(lcWlImageCapture) << "Buffer size still mismatched after constraint update";
             wlr_ext_image_copy_capture_frame_v1_fail(dst_frame, EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_BUFFER_CONSTRAINTS);
+            wlr_buffer_unlock(src);
+            m_renderedBuffer = nullptr;
             return;
         }
-
-        qCDebug(lcWlImageCapture) << "Buffer size now matches after constraint update, proceeding with copy";
     }
 
-    // Use wlroots image copy function with validated buffers
     bool success = wlr_ext_image_copy_capture_frame_v1_copy_buffer(dst_frame, src, renderer);
     qCDebug(lcWlImageCapture) << "Copy result:" << success;
 
+    // Unlock regardless of success/failure.
+    wlr_buffer_unlock(src);
+    m_renderedBuffer = nullptr;
+
     if (success) {
-        // Successfully copied, mark frame as ready
         struct timespec now;
         clock_gettime(CLOCK_MONOTONIC, &now);
 
@@ -429,24 +438,6 @@ void WExtImageCaptureSourceV1Impl::copy_frame(wlr_ext_image_copy_capture_frame_v
         qCDebug(lcWlImageCapture) << "Frame copy successful";
     } else {
         qCWarning(lcWlImageCapture) << "Failed to copy frame buffer";
-        qCWarning(lcWlImageCapture) << "Possible reasons:";
-        qCWarning(lcWlImageCapture) << "  - Buffer size mismatch";
-        qCWarning(lcWlImageCapture) << "  - Unsupported buffer format";
-        qCWarning(lcWlImageCapture) << "  - Renderer issues";
-        qCWarning(lcWlImageCapture) << "  - Memory access problems";
-
-        // Check if it's a buffer constraints issue
-        if (dst_frame->buffer && buffer) {
-            if (dst_frame->buffer->width != buffer->width ||
-                dst_frame->buffer->height != buffer->height) {
-                qCWarning(lcWlImageCapture) << "Buffer size mismatch detected, using BUFFER_CONSTRAINTS failure reason";
-                wlr_ext_image_copy_capture_frame_v1_fail(dst_frame, EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_BUFFER_CONSTRAINTS);
-                return;
-            }
-        }
-
-        // For other failures, use UNKNOWN reason
-        wlr_ext_image_copy_capture_frame_v1_fail(dst_frame, EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
     }
 }
 
@@ -461,9 +452,6 @@ wlr_ext_image_capture_source_v1_cursor *WExtImageCaptureSourceV1Impl::get_pointe
 wlr_ext_image_capture_source_v1_cursor *WExtImageCaptureSourceV1Impl::get_pointer_cursor([[maybe_unused]] wlr_seat *seat)
 {
     qCDebug(lcWlImageCapture) << "WExtImageCaptureSourceV1Impl::get_pointer_cursor()";
-    // TODO: Implement cursor retrieval logic
-    // This needs to get cursor information from seat and create corresponding cursor structure
-    // Currently return nullptr to indicate no cursor information
     return nullptr;
 }
 

--- a/waylib/src/server/utils/wextimagecapturesourcev1impl.h
+++ b/waylib/src/server/utils/wextimagecapturesourcev1impl.h
@@ -3,22 +3,28 @@
 
 #pragma once
 
-#include <wlr_fwd.h>
 #include <wglobal.h>
 #include <wlr_all.h>
+#include <wlr_fwd.h>
+#include <wpointer.h>
 
 #include <QObject>
+#include <QPointer>
+#include <QQuickItem>
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
-class WSurfaceItemContent;
 class WOutput;
+class WOutputRenderWindow;
+class WBufferRenderer;
 
 class WAYLIB_SERVER_EXPORT WExtImageCaptureSourceV1Impl : public QObject
 {
     Q_OBJECT
 public:
-    explicit WExtImageCaptureSourceV1Impl(WSurfaceItemContent *surfaceContent, WOutput *output);
+    // surfaceItem is the WSurfaceItem (includes surface content + subsurfaces + titleBar,
+    // but excludes shadow/decoration which live on the parent SurfaceWrapper).
+    explicit WExtImageCaptureSourceV1Impl(QQuickItem *surfaceItem, WOutput *output);
     ~WExtImageCaptureSourceV1Impl();
 
     wlr_ext_image_capture_source_v1 *handle() { return &source; }
@@ -41,15 +47,28 @@ private:
         struct wlr_ext_image_capture_source_v1 *source, struct wlr_seat *seat);
 
 private Q_SLOTS:
+    // Phase 1 (afterRendering): offscreen render via WBufferRenderer
+    void doOffscreenRender();
+    // Phase 2 (renderEnd): emit frame event, copy_frame uses m_renderedBuffer
     void handleRenderEnd();
 
 private:
     wlr_ext_image_capture_source_v1 source;
 
-    QPointer<WSurfaceItemContent> m_surfaceContent;
+    WOutputRenderWindow *renderWindow() const;
+    qreal computeDpr() const;
+    QSize computePixelSize() const;
+    void updateConstraints(const QSize &pixelSize);
+
+    QPointer<QQuickItem> m_surfaceItem;
     WOutput *m_output;
     bool m_capturing;
+    QMetaObject::Connection m_afterRenderingConnection;
     QMetaObject::Connection m_renderEndConnection;
+
+    QPointer<WBufferRenderer> m_captureRenderer;
+    // Buffer from offscreen render, valid between doOffscreenRender and copy_frame
+    WPointer<wlr_buffer> m_renderedBuffer;
 };
 
 WAYLIB_SERVER_END_NAMESPACE


### PR DESCRIPTION
## Summary by Sourcery

Refactor window recording to capture surface items through an isolated offscreen rendering path.

New Features:
- Support capturing complete window item subtrees, including content and subsurfaces, into offscreen buffers.

Bug Fixes:
- Improve capture buffer lifetime and frame-copy handling by retaining rendered buffers until they are copied.

Enhancements:
- Refactor foreign toplevel image capture to render directly from the surface item and derive capture dimensions from item size and device pixel ratio.