### PR TITLE
fix(output): persist single-output display settings

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1327,11 +1327,10 @@ void Helper::onOutputCommitFinished(qw_output_configuration_v1 *config, bool suc
                         return;
                     }
 
-                    if (preservePosition) {
-                        return;
+                    if (!preservePosition) {
+                        outputConfig->setX(x);
+                        outputConfig->setY(y);
                     }
-                    outputConfig->setX(x);
-                    outputConfig->setY(y);
                     outputConfig->setWidth(width);
                     outputConfig->setHeight(height);
                     outputConfig->setRefresh(refresh);


### PR DESCRIPTION
该PR修复了: 当只有单屏时(例如没有外接屏幕的笔记本电脑), 无法持久化保存dde-control-center里设置的屏幕分辨率和缩放信息

When an output-management apply left only one output enabled, onOutputCommitFinished() returned early to preserve the saved X/Y coordinates. This unintentionally skipped all remaining OutputConfig writes as well. The new mode took effect for the current session, but width, height, refresh rate, transform, scale and adaptive-sync state were not stored in DConfig, so resolution and scale reverted after Treeland restarted.

Keep preserving X/Y for a single-output topology, but continue saving the other properties after a successful commit. Multi-output applies still save X/Y and all display properties exactly as before, and disabled outputs remain untouched. This preserves extension-layout restoration while making single-output display settings survive a restart.

Log: fix single-output resolution and scale resetting after restart
Influence: single-output display configuration persistence

## Summary by Sourcery

Bug Fixes:
- Fix single-output resolution, scale and related display properties not being saved to configuration after successful output commit.