### PR TITLE
fix(output): remove disabled outputs from single-output layout

### DIFF
--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -193,8 +193,15 @@ bool Output::isPrimary() const
 void Output::updatePositionFromLayout()
 {
     WOutputLayout *layout = output()->layout();
-    Q_ASSERT(layout);
+    if (!layout) {
+        return;
+    }
+
     auto *layoutOutput = layout->handle()->get(output()->nativeHandle());
+    if (!layoutOutput) {
+        return;
+    }
+
     QPointF pos(layoutOutput->x, layoutOutput->y);
     m_item->setPosition(pos);
 }

--- a/src/output/outputmanager.cpp
+++ b/src/output/outputmanager.cpp
@@ -16,6 +16,7 @@
 #include <utility>
 
 #include <qwoutput.h>
+#include <woutputlayout.h>
 
 namespace {
 QString serializeOutputIds(const QStringList &outputs)
@@ -91,6 +92,12 @@ bool OutputManager::restoreConfiguredSingleOutput(const QList<SurfaceWrapper *> 
             if (!output->output()->isEnabled()) {
                 output->enable();
             }
+            if (auto *layout = m_rootContainer->outputLayout();
+                output->output()->isEnabled()
+                && layout
+                && !layout->outputs().contains(output->output())) {
+                layout->autoAdd(output->output());
+            }
             continue;
         }
         if (output->output()->isEnabled()) {
@@ -103,6 +110,12 @@ bool OutputManager::restoreConfiguredSingleOutput(const QList<SurfaceWrapper *> 
                 qCWarning(lcTlOutput) << "Failed to disable non-selected output while restoring single-output display"
                                       << output->output()->name();
             }
+        }
+        if (auto *layout = m_rootContainer->outputLayout();
+            !output->output()->isEnabled()
+            && layout
+            && layout->outputs().contains(output->output())) {
+            layout->remove(output->output());
         }
     }
 

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -649,6 +649,10 @@ void Helper::onOutputAdded(WOutput *output)
                     return;
                 }
             }
+            if (auto *layout = m_rootSurfaceContainer->outputLayout();
+                layout && layout->outputs().contains(output)) {
+                layout->remove(output);
+            }
             qCInfo(lcTlOutput) << "Disabled non-selected output while restoring single-output display"
                                << output->name()
                                << "selected output id:" << singleOutputId;
@@ -1159,14 +1163,14 @@ void Helper::onOutputTestOrApply(qw_output_configuration_v1 *config, bool onlyTe
 
         if (state.enabled) {
             auto *layout = m_rootSurfaceContainer->outputLayout();
-            if (!ensureOutputInRootContainer(output)) {
-                qCWarning(lcTlCore) << "Cannot apply enabled output configuration; output is not in root layout"
+            if (!layout || !m_rootSurfaceContainer->outputs().contains(output)) {
+                qCWarning(lcTlCore) << "Cannot apply enabled output configuration; output is not in root container"
                                     << state.output->name();
                 m_outputManager->sendResult(config, false);
                 m_pendingOutputConfig = {};
                 return;
             }
-            if (layout) {
+            if (layout->outputs().contains(state.output)) {
                 layout->move(state.output, QPoint(state.x, state.y));
             }
         }
@@ -1213,16 +1217,31 @@ void Helper::onOutputTestOrApply(qw_output_configuration_v1 *config, bool onlyTe
             return;
         }
         auto config = m_pendingOutputConfig.config;
-        const QString outputName = state.output->name();
         const bool enabled = state.enabled;
+        const QPoint outputPosition(state.x, state.y);
         QPointer<Helper> self(this);
         outputHelper->scheduleCommitJob(
-            [self, config, extraState, renderWindow, viewport, outputName, enabled](bool success, WOutputHelper::ExtraState committedState) {
+            [self,
+             config,
+             extraState,
+             renderWindow,
+             viewport,
+             output = QPointer<WOutput>(state.output),
+             outputPosition,
+             enabled](bool success, WOutputHelper::ExtraState committedState) {
                 if (!self) {
                     return;
                 }
 
                 if (committedState == extraState) {
+                    if (success && output) {
+                        auto *layout = self->m_rootSurfaceContainer->outputLayout();
+                        if (layout && enabled && !layout->outputs().contains(output)) {
+                            layout->add(output, outputPosition);
+                        } else if (layout && !enabled && layout->outputs().contains(output)) {
+                            layout->remove(output);
+                        }
+                    }
                     self->onOutputCommitFinished(config, success);
                     if (success && committedState) {
                         bool wasStateOnlyCommit = (committedState->committed & (WLR_OUTPUT_STATE_MODE |
@@ -1341,7 +1360,7 @@ void Helper::onOutputCommitFinished(qw_output_configuration_v1 *config, bool suc
                 });
             }
         }
-        m_outputManager->sendResult(config, ok);
+        m_outputManager->sendResult(config, ok, m_pendingOutputConfig.states);
         m_pendingOutputConfig = {};
     }
 }
@@ -3541,6 +3560,13 @@ void Helper::applyCopyModeToOutputs(Output *primaryOutput,
     if (primaryOutput->output() && !primaryOutput->output()->isEnabled()) {
         primaryOutput->enable();
     }
+    if (auto *layout = m_rootSurfaceContainer->outputLayout();
+        primaryOutput->output()
+        && primaryOutput->output()->isEnabled()
+        && layout
+        && !layout->outputs().contains(primaryOutput->output())) {
+        layout->autoAdd(primaryOutput->output());
+    }
 
     // Convert existing outputs to copy outputs
     for (int i = 0; i < m_outputList.size(); i++) {
@@ -3622,6 +3648,12 @@ void Helper::restoreExtensionModeFromConfig(bool preserveSingleOutputConfig)
         // saved mode and geometry may wait for DConfig initialization, but
         // enabling an output must not depend on that initialization succeeding.
         outputObject->enable();
+        if (auto *layout = m_rootSurfaceContainer->outputLayout();
+            outputObject->output()->isEnabled()
+            && layout
+            && !layout->outputs().contains(outputObject->output())) {
+            layout->autoAdd(outputObject->output());
+        }
 
         auto restoreOutput = [this, outputObject = QPointer<Output>(outputObject)] {
             if (!outputObject || !outputObject->output()) {
@@ -3871,6 +3903,12 @@ void Helper::enableAllOutput()
 
         if (!ok) {
             qCWarning(lcTlOutput) << "Failed to enable output" << output->output()->name();
+            continue;
+        }
+
+        if (auto *layout = m_rootSurfaceContainer->outputLayout();
+            layout && !layout->outputs().contains(output->output())) {
+            layout->autoAdd(output->output());
         }
     }
 }

--- a/waylib/src/server/protocols/woutputmanagerv1.cpp
+++ b/waylib/src/server/protocols/woutputmanagerv1.cpp
@@ -123,14 +123,22 @@ void WOutputManagerV1::updateConfig()
 void WOutputManagerV1::sendResult(qw_output_configuration_v1 *config, bool ok)
 {
     W_D(WOutputManagerV1);
+    sendResult(config, ok, d->pendingStateLists.value(config));
+}
 
-    const QList<WOutputState> pendingStates = d->pendingStateLists.take(config);
+void WOutputManagerV1::sendResult(qw_output_configuration_v1 *config,
+                                  bool ok,
+                                  const QList<WOutputState> &appliedStates)
+{
+    W_D(WOutputManagerV1);
+
+    d->pendingStateLists.remove(config);
     if (d->currentPendingConfig == config)
         d->currentPendingConfig = nullptr;
 
     if (ok) {
         config->send_succeeded();
-        d->stateList = pendingStates;
+        d->stateList = appliedStates;
     } else {
         config->send_failed();
     }

--- a/waylib/src/server/protocols/woutputmanagerv1.h
+++ b/waylib/src/server/protocols/woutputmanagerv1.h
@@ -54,6 +54,9 @@ public:
         QW_NAMESPACE::qw_output_configuration_v1 *config = nullptr) const;
 
     void sendResult(QW_NAMESPACE::qw_output_configuration_v1 *config, bool ok);
+    void sendResult(QW_NAMESPACE::qw_output_configuration_v1 *config,
+                    bool ok,
+                    const QList<WOutputState> &appliedStates);
     void newOutput(WOutput *output);
     void removeOutput(WOutput *output);
     QW_NAMESPACE::qw_output_manager_v1 *handle() const;


### PR DESCRIPTION
Remove disabled outputs from the output layout when switching to a single-output topology, while keeping their saved configuration intact. Re-add outputs to the layout when they are enabled again by extension, copy, reconnect, or output-management operations.

Keep output position updates safe while an output is absent from the layout, and publish the actual applied output-management state so zwlr_output_head_v1 reports the restored coordinates correctly.

Log: remove disabled output from layout in single-output mode
PMS: BUG-366981
Influence: Single-output switching, output reconnect, and display topology restoration

## Summary by Sourcery

Ensure display layouts correctly exclude disabled outputs during single-output configurations while preserving and restoring their positions when re-enabled.

Bug Fixes:
- Prevent disabled outputs from remaining in the layout when switching to single-output mode, avoiding inconsistent topology state.
- Fix output position updates so they do not assert or fail when an output is temporarily absent from the layout.
- Ensure zwlr_output_head_v1 reports correct restored coordinates by publishing the actually applied output-management state.

Enhancements:
- Automatically re-add enabled outputs to the layout on extension, copy mode, reconnect, or bulk-enable operations to keep topology in sync.
- Adjust output configuration result handling to propagate the applied output states instead of pending states for more accurate client visibility.