### PR TITLE
fix(output): persist output settings while preserving saved position

### DIFF
--- a/src/output/output.h
+++ b/src/output/output.h
@@ -85,6 +85,7 @@ public:
     QRectF validGeometry() const;
     WOutputViewport *screenViewport() const;
     void updatePositionFromLayout();
+    void applyOutputColorConfig();
     QQuickItem *debugMenuBar() const;
 
     static double calcPreferredScale(double widthPx,
@@ -123,7 +124,6 @@ private:
     void arrangePopupSurface(SurfaceWrapper *surface);
     void arrangeNonLayerSurfaces(ArrangeReason reason);
     void arrangeAllSurfaces();
-    void applyOutputColorConfig();
     std::pair<WOutputViewport *, QQuickItem *> getOutputItemProperty();
     void placeUnderCursor(SurfaceWrapper *surface, quint32 yOffset);
     void placeClientRequstPos(SurfaceWrapper *surface, QPoint clientRequstPos);

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -622,9 +622,9 @@ void Helper::onOutputAdded(WOutput *output)
             return;
         }
 
-        // Saved geometry belongs exclusively to the initial backend scan.
-        // A hot-plugged output keeps outputLayout's auto-added position, which
-        // extends the current topology to the right.
+        // Only the initial backend scan restores saved geometry. A hot-plugged
+        // output keeps outputLayout's auto-added position, while its mode,
+        // transform, scale, brightness, and color temperature are restored.
         if (!isInitialOutput) {
             const bool restoreAsExtensionOutput =
                 m_mode == OutputMode::Extension
@@ -633,7 +633,6 @@ void Helper::onOutputAdded(WOutput *output)
             if (restoreAsExtensionOutput && !output->isEnabled()) {
                 outputObject->enable();
             }
-            return;
         }
 
         const QString singleOutputId = m_globalConfig->singleOutputId();
@@ -658,6 +657,12 @@ void Helper::onOutputAdded(WOutput *output)
                                << "selected output id:" << singleOutputId;
             return;
         }
+
+        auto restoreColorConfig = qScopeGuard([outputObject] {
+            if (outputObject && outputObject->output() && outputObject->output()->isEnabled()) {
+                outputObject->applyOutputColorConfig();
+            }
+        });
 
         auto *config = outputObject->config();
         const QString outputId = WallpaperManager::getOutputId(outputObject);
@@ -1346,11 +1351,10 @@ void Helper::onOutputCommitFinished(qw_output_configuration_v1 *config, bool suc
                         return;
                     }
 
-                    if (preservePosition) {
-                        return;
+                    if (!preservePosition) {
+                        outputConfig->setX(x);
+                        outputConfig->setY(y);
                     }
-                    outputConfig->setX(x);
-                    outputConfig->setY(y);
                     outputConfig->setWidth(width);
                     outputConfig->setHeight(height);
                     outputConfig->setRefresh(refresh);


### PR DESCRIPTION
Persist resolution, refresh rate, transform, scale, and adaptive sync changes when applying a single-output configuration. Ignore only the temporary x and y coordinates used in single-output mode so they do not overwrite the saved extension layout.

Restore the configured mode, transform, scale, brightness, and color temperature after restart or output reconnect, while keeping the auto-assigned position for hot-plugged outputs.

Log: persist output settings except single-output position
PMS: BUG-372513
Influence: Output setting persistence across restart, reconnect, and single-output changes

## Summary by Sourcery

Preserve per-output visual settings across restarts and hot‑plug events while avoiding overwriting saved multi‑monitor positions when using single‑output mode.

New Features:
- Restore mode, transform, scale, brightness, and color temperature for hot‑plugged outputs without altering their auto‑assigned layout position.

Bug Fixes:
- Avoid overwriting saved output positions when applying single‑output configurations that should only temporarily change geometry.
- Ensure output color configuration is consistently re-applied after outputs are (re)enabled and added.