### PR TITLE
fix(xsettings): store cursor size and DPI as integers

### DIFF
--- a/src/xsettings/settingmanager.cpp
+++ b/src/xsettings/settingmanager.cpp
@@ -84,10 +84,12 @@ QString SettingManager::cursorTheme() const
 
 void SettingManager::setCursorSize(qreal value)
 {
-    m_resource->setPropertyValue(XResource::toByteArray(XResource::Xcursor_Size), value);
-    m_resource->setPropertyValue(XResource::toByteArray(XResource::Gtk_CursorThemeSize), value);
-    m_settings->setPropertyValue(XSettings::toByteArray(XSettings::Xcursor_Size), value);
-    m_settings->setPropertyValue(XSettings::toByteArray(XSettings::Gtk_CursorThemeSize), value);
+    const int size = qRound(value);
+
+    m_resource->setPropertyValue(XResource::toByteArray(XResource::Xcursor_Size), size);
+    m_resource->setPropertyValue(XResource::toByteArray(XResource::Gtk_CursorThemeSize), size);
+    m_settings->setPropertyValue(XSettings::toByteArray(XSettings::Xcursor_Size), size);
+    m_settings->setPropertyValue(XSettings::toByteArray(XSettings::Gtk_CursorThemeSize), size);
 }
 
 qreal SettingManager::cursorSize() const
@@ -110,13 +112,13 @@ void SettingManager::setGlobalScale(qreal scale)
 {
     m_resource->setPropertyValue(XResource::toByteArray(XResource::Xft_DPI), scale * BASE_DPI);
     m_settings->setPropertyValue(XSettings::toByteArray(XSettings::Gdk_WindowScalingFactor), qFloor(scale));
-    m_settings->setPropertyValue(XSettings::toByteArray(XSettings::Gdk_UnscaledDPI), scale * XSETTINGS_BASE_DPI_FIXED);
-    m_settings->setPropertyValue(XSettings::toByteArray(XSettings::Xft_DPI), scale * XSETTINGS_BASE_DPI_FIXED);
+    m_settings->setPropertyValue(XSettings::toByteArray(XSettings::Gdk_UnscaledDPI), XSETTINGS_BASE_DPI_FIXED);
+    m_settings->setPropertyValue(XSettings::toByteArray(XSettings::Xft_DPI), qRound(scale * XSETTINGS_BASE_DPI_FIXED));
 }
 
 qreal SettingManager::globalScale() const
 {
-    return m_settings->getPropertyValue(XSettings::toByteArray(XSettings::Gdk_UnscaledDPI)).toReal() / XSETTINGS_BASE_DPI_FIXED;
+    return m_settings->getPropertyValue(XSettings::toByteArray(XSettings::Xft_DPI)).toReal() / XSETTINGS_BASE_DPI_FIXED;
 }
 
 void SettingManager::apply()


### PR DESCRIPTION
Store cursor sizes as rounded integers in XResources and XSettings so X11 clients receive the expected integer values.

Keep Gdk/UnscaledDPI at the fixed base DPI, serialize Xft/DPI as an integer, and derive the global scale from the effective Xft/DPI value.

Log: fix XSettings cursor size and DPI values
PMS: BUG-371243
Influence: Cursor scaling and global scale synchronization for X11 clients

## Summary by Sourcery

Ensure cursor size and DPI values exposed via XResources and XSettings are integer-based and derive global scale from the effective Xft/DPI for consistent X11 client behavior.

Bug Fixes:
- Store cursor size in XResources and XSettings as rounded integers so X11 clients receive consistent cursor size values.
- Serialize Xft/DPI as an integer and keep Gdk/UnscaledDPI at a fixed base DPI to provide stable DPI values to X11 clients.
- Derive global scale from the effective Xft/DPI value to keep global scaling in sync with X11 DPI settings.