### PR TITLE
feat: add containerOf utility for struct member offset calculation

### DIFF
--- a/waylib/src/server/CMakeLists.txt
+++ b/waylib/src/server/CMakeLists.txt
@@ -291,6 +291,8 @@ set(HEADERS
     utils/wextimagecapturesourcev1impl.h
     utils/wbufferdumper.h
     utils/WBufferDumper
+    utils/wcontainerof.h
+    utils/WContainerOf
 
     protocols/wxdgshell.h
     protocols/WXdgShell

--- a/waylib/src/server/utils/WContainerOf
+++ b/waylib/src/server/utils/WContainerOf
@@ -1,0 +1,4 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "wcontainerof.h"

--- a/waylib/src/server/utils/wcontainerof.h
+++ b/waylib/src/server/utils/wcontainerof.h
@@ -1,0 +1,21 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+template<typename T, typename M>
+static inline constexpr T *containerOf(M *ptr, M T::*member) noexcept
+{
+  static_assert(std::is_standard_layout_v<T>,
+                 "T must be standard-layout");
+
+  return reinterpret_cast<T *>(
+      reinterpret_cast<std::uintptr_t>(ptr)
+      - reinterpret_cast<std::uintptr_t>(
+          &(reinterpret_cast<T const volatile *>(0)->*member))
+      );
+}


### PR DESCRIPTION
Added a new utility header wcontainerof.h that provides containerOf and offsetOf functions for calculating struct member offsets and obtaining container struct pointers from member pointers. This is useful for implementing type-safe container-of patterns commonly needed in Wayland protocol implementations where we need to get the parent struct from embedded protocol objects.

The implementation includes:
1. containerOf template function to get container struct pointer from member pointer
2. Standard layout type checking for safety
3. Compile-time evaluation support with constexpr

Log: Added containerOf utility for safer struct member access

Influence:
1. Verify compilation with various standard layout structs
2. Test offsetOf with different member types and alignments
3. Test containerOf with nested struct scenarios
4. Check type safety with non-standard layout types
5. Verify constexpr evaluation in compile-time contexts
6. Test with different pointer types and alignments

## Summary by Sourcery

Introduce a reusable utility for computing container structs from member pointers and register it in the server build headers.

New Features:
- Add a constexpr containerOf helper for obtaining a containing struct pointer from a member pointer in standard-layout types.

Build:
- Register the new wcontainerof utility headers in the waylib server CMake header list.