### PR TITLE
fix(greeter): fall back to NSS when logged-in user missing from UserModel

### DIFF
--- a/src/greeter/greeterproxy.cpp
+++ b/src/greeter/greeterproxy.cpp
@@ -521,6 +521,13 @@ void GreeterProxy::readyRead()
             // This will happen after a crash recovery of treeland
             qCInfo(lcTlGreeter) << "User " << user << " is already logged in";
             auto userPtr = userModel()->getUser(user);
+
+            // TODO: persist users entered via "Other" so they survive in UserModel; then remove
+            // this fallback
+            if (!userPtr && userModel()->tryAddNssUser(user)) {
+                userPtr = userModel()->getUser(user);
+            }
+
             if (userPtr) {
                 userModel()->updateUserLoginState(user, true);
                 Q_EMIT userModel()->userLoggedIn(user, sessionId);


### PR DESCRIPTION
When treeland restarts, ddm sends UserLoggedIn for crash recovery. If the user (e.g. LDAP/NSS) is not in DAccountsManager's list, getUser returns null, loggedIn is never set, and QML sends Login instead of Unlock — hitting "Existing authentication ongoing" in ddm.

treeland 重启后 ddm 发送 UserLoggedIn 做崩溃恢复。若用户（如
LDAP/NSS 用户）不在 DAccountsManager 列表中，getUser 返回 null， loggedIn 未设置，QML 发送 Login 而非 Unlock，导致 ddm 报
"Existing authentication ongoing" 错误。

Log: 修复域用户重登后 greeter 走 login 而非 unlock 的问题
Influence: 不在 DAccountsManager 列表中的用户（如域用户）重启 treeland 后可正常解锁，不再触发 ddm 认证冲突。

## Summary by Sourcery

Bug Fixes:
- Ensure logged-in users not present in DAccountsManager (e.g., LDAP/NSS domain users) are correctly treated as already logged in after treeland restart instead of triggering a new login flow.