### PR TITLE
fix(output): correct WOutputManagerV1::interfaceName return value

### DIFF
--- a/waylib/src/server/protocols/woutputmanagerv1.cpp
+++ b/waylib/src/server/protocols/woutputmanagerv1.cpp
@@ -189,7 +189,7 @@ qw_output_manager_v1 *WOutputManagerV1::handle() const
 
 QByteArrayView WOutputManagerV1::interfaceName() const
 {
-    return "zwlr_output_head_v1";
+    return "zwlr_output_manager_v1";
 }
 
 void WOutputManagerV1::create(WServer *server)


### PR DESCRIPTION
## 修复内容

`WOutputManagerV1::interfaceName()` 之前返回 `"zwlr_output_head_v1"`（该协议里 head 资源的接口名），而 `WOutputManagerV1::create()` 实际创建的 wl_global 接口名是 `"zwlr_output_manager_v1"`。

## 影响

- Debug 构建（`QT_NO_DEBUG` 未定义）下，`waylib/src/server/kernel/wserver.cpp` 中两处 `Q_ASSERT(wl_global_get_interface(global)->name == i->interfaceName())` 将真实全局名 `zwlr_output_manager_v1` 与错误值 `zwlr_output_head_v1` 比较，断言触发，导致 `Helper::init()` 启动即崩。
- Release 构建 `Q_ASSERT` 为空操作；`findInterface(wl_global)` 中 `pendingInterface->interfaceName() == wl_global_get_interface(global)->name` 比较语义错误且脆弱（当前因 `WOutputManagerV1` 未设置 filter 而无可观测差异）。

## 改动

仅一行字符串字面量纠正：`waylib/src/server/protocols/woutputmanagerv1.cpp`
`"zwlr_output_head_v1"` → `"zwlr_output_manager_v1"`，函数签名 / 头文件 / 协议 XML / QML / CMake 均无改动。

Ref: Multica issue WM-108

## Summary by Sourcery

Bug Fixes:
- Fix WOutputManagerV1::interfaceName() to return the zwlr_output_manager_v1 interface name instead of the head resource name, preventing assertion failures in debug builds.