### PR TITLE
WM-117: remove redundant D. prefix for dtk-provided Qt controls

### DIFF
--- a/src/core/qml/WindowMenu.qml
+++ b/src/core/qml/WindowMenu.qml
@@ -3,9 +3,9 @@
 
 import Waylib.Server
 import Treeland
-import org.deepin.dtk 1.0 as D
+import QtQuick.Controls
 
-D.Menu {
+Menu {
     id: menu
     modal: true
 
@@ -29,34 +29,34 @@ D.Menu {
         menu.popup(pos)
     }
 
-    D.MenuItem {
+    MenuItem {
         text: qsTr("Minimize")
         onTriggered: surface.minimize()
     }
 
-    D.MenuItem {
+    MenuItem {
         text: surface?.surfaceState === SurfaceWrapper.State.Maximized ? qsTr("Unmaximize") : qsTr("Maximize")
         enabled: menu.canToggleMaximize
         onTriggered: surface.toggleMaximized()
     }
 
-    D.MenuItem {
+    MenuItem {
         text: qsTr("Move")
         onTriggered: surface.moveRequested()
     }
 
-    D.MenuItem {
+    MenuItem {
         text: qsTr("Resize")
         onTriggered: Helper.fakePressSurfaceBottomRightToReszie(surface)
     }
 
-    D.MenuItem {
+    MenuItem {
         checked: surface ? surface.alwaysOnTop : false
         text: qsTr("Always on Top")
         onTriggered: surface.alwaysOnTop = !surface.alwaysOnTop;
     }
 
-    D.MenuItem {
+    MenuItem {
         checked: surface ? surface.showOnAllWorkspace : false
         text: qsTr("Always on Visible Workspace")
         onTriggered: {
@@ -70,7 +70,7 @@ D.Menu {
         }
     }
 
-    D.MenuItem {
+    MenuItem {
         property int leftWorkspaceId: surface ? Helper.workspace.getLeftWorkspaceId(surface.workspaceId) : -1
         text: qsTr("Move to Left Work Space")
         enabled: leftWorkspaceId >= 0
@@ -80,7 +80,7 @@ D.Menu {
         }
     }
 
-    D.MenuItem {
+    MenuItem {
         property int rightWorkspaceId: surface ? Helper.workspace.getRightWorkspaceId(surface.workspaceId) : -1
         text: qsTr("Move to Right Work Space")
         enabled: rightWorkspaceId >= 0
@@ -90,7 +90,7 @@ D.Menu {
         }
     }
 
-    D.MenuItem {
+    MenuItem {
         text: qsTr("Close")
         onTriggered: surface.shellSurface.close()
     }

--- a/src/plugins/lockscreen/qml/ControlAction.qml
+++ b/src/plugins/lockscreen/qml/ControlAction.qml
@@ -23,7 +23,7 @@ RowLayout {
     /**************/
 
     // TODO: Design the interface of session selection
-    D.Button {
+    Button {
         id: sessionItem
         Layout.alignment: Qt.AlignHCenter
         visible: !GreeterProxy.hasActiveSession
@@ -77,7 +77,7 @@ RowLayout {
             powerList.close()
         }
 
-        D.ToolTip {
+        ToolTip {
             enabled: true
             visible: powerItem.hovered
             text: qsTr("Power")
@@ -111,7 +111,7 @@ RowLayout {
         signal clicked()
         implicitWidth: bottomGroup.buttonSize + 6
         implicitHeight: bottomGroup.buttonSize + 6
-        D.RoundButton {
+        RoundButton {
             id: button
             icon {
                 width: 16

--- a/src/plugins/lockscreen/qml/HintLabel.qml
+++ b/src/plugins/lockscreen/qml/HintLabel.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import QtQuick
@@ -8,7 +8,7 @@ import LockScreen
 import org.deepin.dtk 1.0 as D
 import QtQuick.Controls
 
-D.Popup {
+Popup {
     property string hintText
     modal: true
     background: D.FloatingPanel {

--- a/src/plugins/lockscreen/qml/ShutdownButton.qml
+++ b/src/plugins/lockscreen/qml/ShutdownButton.qml
@@ -7,7 +7,7 @@ import org.deepin.dtk as D
 import QtQuick.Controls
 import QtQuick.Layouts
 
-D.Button {
+Button {
     id: root
     visible: enabled
 

--- a/src/plugins/lockscreen/qml/UserInput.qml
+++ b/src/plugins/lockscreen/qml/UserInput.qml
@@ -266,7 +266,7 @@ Item {
         }
         height: passwordField.height
 
-        D.RoundButton {
+        RoundButton {
             id: langBtn
             text: 'L' // TODO: replace with icon
             visible: false
@@ -284,7 +284,7 @@ Item {
             }
         }
 
-        D.RoundButton {
+        RoundButton {
             id: hintBtn
             icon {
                 name: "login_hint"

--- a/src/plugins/lockscreen/qml/UserList.qml
+++ b/src/plugins/lockscreen/qml/UserList.qml
@@ -56,7 +56,7 @@ Popup {
             normal: D.DTK.makeColor(D.Color.Highlight)
         }
 
-        delegate: D.CheckDelegate {
+        delegate: CheckDelegate {
             id: singleUser
             height: 44
             width: 220
@@ -202,7 +202,7 @@ Popup {
             checked: UserModel.currentUserName === model.name
         }
 
-        footer: D.CheckDelegate {
+        footer: CheckDelegate {
             id: otherUserItem
             height: Helper.globalConfig.showOtherUserOption ? 44 : 0
             width: 220

--- a/src/plugins/multitaskview/qml/WindowSelectionGrid.qml
+++ b/src/plugins/multitaskview/qml/WindowSelectionGrid.qml
@@ -297,7 +297,7 @@ Item {
                                            }
                                        }
                     }
-                    D.RoundButton {
+                    RoundButton {
                         id: surfaceCloseBtn
                         icon.name: "multitaskview_close"
                         icon.width: 26

--- a/src/plugins/multitaskview/qml/WorkspaceSelectionList.qml
+++ b/src/plugins/multitaskview/qml/WorkspaceSelectionList.qml
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import QtQuick
@@ -283,7 +283,7 @@ Item {
                     }
                 }
 
-                D.RoundButton {
+                RoundButton {
                     id: wsDestroyBtn
                     icon.name: "multitaskview_close"
                     icon.width: 26
@@ -350,7 +350,7 @@ Item {
         }
     }
 
-    D.RoundButton {
+    RoundButton {
         id: wsCreateBtn
         visible: Helper.workspace.count < Helper.config.maxWorkspace
         anchors {


### PR DESCRIPTION
## Background

WM-117: 移除 QML 代码中对 dtk 提供的 Qt 控件不必要的 `D.` 前缀引用。

Treeland 已在 `src/main.cpp` 设置 `QQuickStyle::setStyle("Chameleon")`。chameleon 是 dtkdeclarative 提供的 QtQuick.Controls 样式，裸用 Qt 控件名（`Button`/`Menu`/…）会经样式解析命中 chameleon 的 dtk 实现，与显式写 `D.Button`/`D.Menu` 完全等价。因此对 dtk 所提供、且 chameleon 已发布的 Qt 控件，`D.` 前缀是冗余的，按架构师方案移除。

## Changes

对 `src/` 下 8 个文件、22 处做 `D.<控件>` → 裸控件名的文本替换（B 类 7 种控件：`Button`、`Menu`、`MenuItem`、`Popup`、`RoundButton`、`ToolTip`、`CheckDelegate`）：

| 文件 | 改动 |
|------|------|
| `src/core/qml/WindowMenu.qml` | `D.Menu`×1、`D.MenuItem`×9 → 裸控件名；删除 `import org.deepin.dtk 1.0 as D`，新增 `import QtQuick.Controls` |
| `src/plugins/multitaskview/qml/WindowSelectionGrid.qml` | `D.RoundButton`×1 → `RoundButton` |
| `src/plugins/multitaskview/qml/WorkspaceSelectionList.qml` | `D.RoundButton`×2 → `RoundButton` |
| `src/plugins/lockscreen/qml/ControlAction.qml` | `D.Button`×1、`D.ToolTip`×1、`D.RoundButton`×1 → 裸控件名 |
| `src/plugins/lockscreen/qml/ShutdownButton.qml` | `D.Button`(根)×1 → `Button` |
| `src/plugins/lockscreen/qml/UserList.qml` | `D.CheckDelegate`×2 → `CheckDelegate` |
| `src/plugins/lockscreen/qml/UserInput.qml` | `D.RoundButton`×2 → `RoundButton` |
| `src/plugins/lockscreen/qml/HintLabel.qml` | `D.Popup`(根)×1 → `Popup` |

## Notes

- dtk 自有控件/类型（`D.Palette`、`D.DciIcon`、`D.ColorSelector`、`D.DTK`、`D.IconLabel`、`D.BoxShadow`、`D.OutsideBoxBorder`、`D.FloatingPanel`、`D.OpacityMask`、`D.QtIcon`、`D.Color`、`D.ActionButton` 等）保持不动；因此除 `WindowMenu.qml` 外其余 7 个文件仍保留 `import org.deepin.dtk as D`。
- `D.ToolButton` 因 chameleon 未发布 `ToolButton.qml`，裸用会回退 Basic 样式丢失 dtk 渲染，故保留 `src/core/qml/DockPreview.qml` 不动（分类 C 例外）。
- `ShutdownButton.qml` 的 `textColor: D.Palette {...}` 绑定不受影响：chameleon 的 `Button` 即 dtk `Button`（声明了 `property D.Palette textColor`），仍按原样生效。建议重点回归锁屏关机按钮的文字与各颜色态。
- 仅限 `src/`，`tests/`、`examples/` 等未改动；纯 QML 文本替换 + 1 处 import 调整，无 C++/CMake/协议改动。

## Summary by Sourcery

Align QML code with Chameleon QtQuick.Controls style by using unprefixed standard control types instead of dtk `D.` aliases for published controls.

Bug Fixes:
- Ensure window and lockscreen menus, buttons, popups, and delegates use the Chameleon-styled QtQuick.Controls implementations without redundant dtk prefixes.

Enhancements:
- Simplify QML usage of common controls (Button, Menu, MenuItem, Popup, RoundButton, ToolTip, CheckDelegate) by dropping unnecessary `D.` prefixes now provided via the global style.
- Adjust WindowMenu imports to use QtQuick.Controls directly instead of the dtk alias, keeping dtk-specific types unchanged elsewhere.