### PR TITLE
fix(multitaskview): skip hover-driven focus during animation and exit

### DIFF
--- a/src/plugins/multitaskview/qml/WindowSelectionGrid.qml
+++ b/src/plugins/multitaskview/qml/WindowSelectionGrid.qml
@@ -245,7 +245,11 @@ Item {
                     }
 
                     property bool hovered: hvhdlr.hovered || surfaceCloseBtn.hovered
+                    // During animation/exit, hover is driven by geometry changes;
+                    // skip focus handling to avoid interfering with normal focus restoration.
                     onHoveredChanged: {
+                        if (root.exited || root.inProgress)
+                            return;
                         if (hovered) {
                             surfaceItemDelegate.forceActiveFocus()
                         } else {
@@ -266,7 +270,7 @@ Item {
                     }
                     HoverHandler {
                         id: hvhdlr
-                        enabled: !drg.active
+                        enabled: !drg.active // Disable during drag to avoid conflict with hover
                         blocking: true
                     }
                     TapHandler {


### PR DESCRIPTION
During multitaskview animation/exit, the surface rectangle resizes and may cause spurious hover events. Skip focus handling in onHoveredChanged when inProgress or exited is true to avoid interfering with normal focus restoration.

多任务视图动画/退出期间，surface 矩形变化会驱动 hover 事件。
在 onHoveredChanged 中跳过 inProgress/exited 状态的焦点操作，
避免干扰正常焦点恢复流程。

Log: 修复三指左滑进入多任务视图后，点击缩略图概率焦点丢失，ESC退出后窗口焦点丢失的问题
PMS: BUG-370259 BUG-372071
Influence: 多任务视图动画/退出期间 hover 不再触发焦点切换，避免焦点恢复异常

## Summary by Sourcery

Guard hover-driven focus changes in multitask view window grid during animations and exit states to prevent focus loss and conflicts with drag interactions.

Bug Fixes:
- Prevent window focus loss when exiting multitask view or interacting with thumbnails during animation-driven hover events.

Enhancements:
- Disable hover handling while dragging in the multitask view grid to avoid conflicts between drag and hover interactions.