### PR TITLE
refactor(output): centralize output ID generation

### DIFF
--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -10,7 +10,6 @@
 #include "surface/surfacewrapper.h"
 #include "treelandconfig.hpp"
 #include "treelanduserconfig.hpp"
-#include "wallpaper/wallpapermanager.h"
 #include "workspace/workspace.h"
 
 #include <wcursor.h>
@@ -40,8 +39,7 @@ void setPrimaryOutputConfig(Output *output)
 
     auto *config = helper->globalConfig();
     auto setConfig = [config, output = QPointer<Output>(output)] {
-        const QString outputId = output ? WallpaperManager::getOutputId(output) : QString();
-        config->setPrimaryOutputId(outputId);
+        config->setPrimaryOutputId(output->getOutputId());
     };
 
     if (config->isInitializeSucceeded()) {

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -12,7 +12,6 @@
 #include "treelandconfig.hpp"
 #include "treelanduserconfig.hpp"
 #include "workspace/workspace.h"
-#include "wallpapermanager.h"
 
 #include <wcursor.h>
 #include <winputpopupsurface.h>
@@ -38,6 +37,22 @@
 #define SAME_APP_OFFSET_FACTOR 1.0
 #define DIFF_APP_OFFSET_FACTOR 2.0
 #define POPUP_EDGE_MARGIN 10
+
+QString Output::getOutputId(wlr_output *output)
+{
+    const QString model = QString::fromUtf8(output->model);
+    const QString serial = QString::fromUtf8(output->serial);
+    if (!model.isEmpty() && !serial.isEmpty()) {
+        return model + serial;
+    }
+
+    return QString::fromUtf8(output->name);
+}
+
+QString Output::getOutputId()
+{
+    return getOutputId(output()->nativeHandle());
+}
 
 Output *Output::create(WOutput *output, QQmlEngine *engine, QObject *parent)
 {
@@ -151,7 +166,7 @@ Output::Output(WOutputItem *output, QObject *parent)
 {
     m_outputViewport = output->property("screenViewport").value<WOutputViewport *>();
 
-    QString outputName = WallpaperManager::getOutputId(output->output()->nativeHandle());
+    QString outputName = Output::getOutputId(output->output()->nativeHandle());
     m_config = OutputConfig::createByName("org.deepin.dde.treeland.output",
                                     "org.deepin.dde.treeland",
                                     "/" + outputName, this);

--- a/src/output/output.h
+++ b/src/output/output.h
@@ -11,8 +11,11 @@
 #include <QMargins>
 #include <QObject>
 #include <QQmlComponent>
+#include <QString>
 
 Q_MOC_INCLUDE(<woutputitem.h>)
+
+struct wlr_output;
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 class WOutput;
@@ -66,6 +69,8 @@ public:
                               Output *proxy,
                               QQmlEngine *engine,
                               QObject *parent = nullptr);
+    static QString getOutputId(wlr_output *output);
+    QString getOutputId();
 
     explicit Output(WOutputItem *output, QObject *parent = nullptr);
     ~Output() override;

--- a/src/output/outputmanager.cpp
+++ b/src/output/outputmanager.cpp
@@ -8,7 +8,6 @@
 #include "output.h"
 #include "surface/surfacewrapper.h"
 #include "treelandconfig.hpp"
-#include "wallpaper/wallpapermanager.h"
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QPointer>
@@ -166,14 +165,14 @@ QStringList OutputManager::currentOutputIds(Output *primaryOutput) const
 {
     QStringList ids;
     if (primaryOutput) {
-        ids.append(outputId(primaryOutput));
+        ids.append(primaryOutput->getOutputId());
     }
     if (!m_rootContainer) {
         return ids;
     }
     for (auto *output : std::as_const(m_rootContainer->outputs())) {
         if (output && output != primaryOutput) {
-            ids.append(outputId(output));
+            ids.append(output->getOutputId());
         }
     }
     ids.removeAll(QString());
@@ -212,7 +211,7 @@ void OutputManager::storeSingleOutputConfig()
 
             enabledOutputCount++;
             if (enabledOutputCount == 1) {
-                singleOutputId = outputId(output);
+                singleOutputId = output->getOutputId();
             } else {
                 singleOutputId.clear();
                 break;
@@ -292,18 +291,13 @@ Output *OutputManager::findFirstAvailableOutput(Output *excludeOutput) const
     return nullptr;
 }
 
-QString OutputManager::outputId(Output *output) const
-{
-    return output ? WallpaperManager::getOutputId(output) : QString();
-}
-
 Output *OutputManager::findOutputById(const QString &id) const
 {
     if (!m_rootContainer) {
         return nullptr;
     }
     for (auto *output : std::as_const(m_rootContainer->outputs())) {
-        if (outputId(output) == id) {
+        if (output && output->getOutputId() == id) {
             return output;
         }
     }
@@ -331,7 +325,7 @@ void OutputManager::runWhenConfigInitialized(std::function<void()> callback)
 
 void OutputManager::markScreenAsPrimaryIntent(Output *output)
 {
-    const QString id = outputId(output);
+    const QString id = output->getOutputId();
     if (!id.isEmpty()) {
         m_primaryRestoreIntents[id] = true;
     }
@@ -364,7 +358,7 @@ void OutputManager::onScreenAdded(Output *output, const QList<SurfaceWrapper *> 
         return;
     }
 
-    const QString id = outputId(output);
+    const QString id = output->getOutputId();
     const bool wasPrimary = m_primaryRestoreIntents.value(id);
     const bool hasPrimaryOutput = m_rootContainer->primaryOutput() != nullptr;
 
@@ -389,9 +383,9 @@ bool OutputManager::onScreenRemoved(Output *output,
     }
 
     const bool isCurrentPrimary = (m_rootContainer->primaryOutput() == output);
-    const bool wasPrimaryBeforeRemoval = m_primaryRestoreIntents.value(outputId(output));
+    const bool wasPrimaryBeforeRemoval = m_primaryRestoreIntents.value(output->getOutputId());
 
-    if (m_config && outputId(output) == m_config->singleOutputId()) {
+    if (m_config && output->getOutputId() == m_config->singleOutputId()) {
         return true;
     }
 
@@ -439,7 +433,7 @@ void OutputManager::onScreenEnabled(Output *output)
         return;
     }
 
-    const QString id = outputId(output);
+    const QString id = output->getOutputId();
     const bool wasPrimary = m_primaryRestoreIntents.value(id);
     if (wasPrimary && m_mode == Mode::Extension && m_rootContainer->primaryOutput()) {
         restoreScreenAsPrimary(output);

--- a/src/output/outputmanager.h
+++ b/src/output/outputmanager.h
@@ -75,7 +75,6 @@ private:
     void markScreenAsPrimaryIntent(Output *output);
     void restoreScreenAsPrimary(Output *output);
     void switchPrimaryOutput(Output *from, Output *to, const QList<SurfaceWrapper *> &surfaces);
-    QString outputId(Output *output) const;
     Output *findOutputById(const QString &id) const;
     void runWhenConfigInitialized(std::function<void()> callback);
 

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -276,7 +276,7 @@ static wlr_output_mode *closestOutputMode(WOutput *output,
 static bool outputMatchesId(Output *output, const QString &outputId)
 {
     return output && output->output() && output->output()->isEnabled()
-        && WallpaperManager::getOutputId(output) == outputId;
+        && output->getOutputId() == outputId;
 }
 
 static bool currentPrimaryMatchesId(RootSurfaceContainer *rootContainer, const QString &outputId)
@@ -522,7 +522,7 @@ void Helper::onOutputAdded(WOutput *output)
     Output *o = nullptr;
     const bool isInitialOutput = !scanned;
     qCInfo(lcTlOutput) << "Output added" << output->name()
-                       << "id:" << WallpaperManager::getOutputId(output->nativeHandle())
+                       << "id:" << Output::getOutputId(output->nativeHandle())
                        << "scan complete:" << scanned
                        << "mode:" << static_cast<int>(m_mode);
 
@@ -555,14 +555,14 @@ void Helper::onOutputAdded(WOutput *output)
 
     if (scanned && m_mode == OutputMode::Copy) {
         QStringList copyOutputs = m_outputManagerHelper->copyOutputIds();
-        const QString addedOutputId = WallpaperManager::getOutputId(o);
+        const QString addedOutputId = o->getOutputId();
         if (!copyOutputs.contains(addedOutputId)) {
             copyOutputs.append(addedOutputId);
             m_outputManagerHelper->storeCopyOutputConfig(true, {}, copyOutputs);
         }
     }
     if (scanned && m_mode == OutputMode::Extension) {
-        const QString addedOutputId = WallpaperManager::getOutputId(o);
+        const QString addedOutputId = o->getOutputId();
         runWhenTreelandConfigInitialized(m_globalConfig.get(), this, [this, addedOutputId] {
             QMetaObject::invokeMethod(this, [this, addedOutputId] {
                 if (m_mode != OutputMode::Extension || !m_globalConfig->createCopyOutput()) {
@@ -637,7 +637,7 @@ void Helper::onOutputAdded(WOutput *output)
 
         const QString singleOutputId = m_globalConfig->singleOutputId();
         if (!singleOutputId.isEmpty()
-            && WallpaperManager::getOutputId(outputObject) != singleOutputId) {
+            && outputObject->getOutputId() != singleOutputId) {
             if (output->isEnabled()) {
                 qw_output_state disabledState;
                 disabledState.set_enabled(false);
@@ -665,7 +665,7 @@ void Helper::onOutputAdded(WOutput *output)
         });
 
         auto *config = outputObject->config();
-        const QString outputId = WallpaperManager::getOutputId(outputObject);
+        const QString outputId = outputObject->getOutputId();
         const QString primaryOutputId = m_globalConfig->primaryOutputId();
         if (primaryOutputId == outputId) {
             m_rootSurfaceContainer->setPrimaryOutput(outputObject);
@@ -758,10 +758,10 @@ void Helper::onOutputRemoved(WOutput *output)
 
     const auto &surfaces = getWorkspaceSurfaces(o);
     const QStringList copyOutputs = m_outputManagerHelper->copyOutputIds();
-    const bool removedCopyOutput = copyOutputs.contains(WallpaperManager::getOutputId(o));
+    const bool removedCopyOutput = copyOutputs.contains(o->getOutputId());
     if (m_mode == OutputMode::Copy && removedCopyOutput) {
         const bool removedCopySource = !copyOutputs.isEmpty()
-            && copyOutputs.constFirst() == WallpaperManager::getOutputId(o);
+            && copyOutputs.constFirst() == o->getOutputId();
 
         if (removedCopySource && !m_outputList.isEmpty()) {
             Output *newCopySource = nullptr;
@@ -775,7 +775,7 @@ void Helper::onOutputRemoved(WOutput *output)
                 newCopySource = m_outputList.constFirst();
             }
 
-            const auto newCopySourceId = WallpaperManager::getOutputId(newCopySource);
+            const auto newCopySourceId = newCopySource->getOutputId();
             QStringList updatedCopyOutputs{ newCopySourceId };
             for (const auto &outputId : std::as_const(copyOutputs)) {
                 if (outputId != newCopySourceId && findOutputById(outputId)) {
@@ -793,7 +793,7 @@ void Helper::onOutputRemoved(WOutput *output)
             for (int i = 0; i < m_outputList.size(); ++i) {
                 Output *copyOutput = m_outputList.at(i);
                 if (copyOutput == normalCopySource
-                    || !copyOutputs.contains(WallpaperManager::getOutputId(copyOutput))) {
+                    || !copyOutputs.contains(copyOutput->getOutputId())) {
                     continue;
                 }
 
@@ -1090,7 +1090,7 @@ void Helper::onOutputTestOrApply(qw_output_configuration_v1 *config, bool onlyTe
         for (const auto &state : std::as_const(states)) {
             if (state.enabled && !state.output->isEnabled()) {
                 Output *output = getOutput(state.output);
-                if (output && WallpaperManager::getOutputId(output) != singleOutputId) {
+                if (output && output->getOutputId() != singleOutputId) {
                     m_outputManagerHelper->clearSingleOutputConfig();
                     enableAllOutput();
                     break;
@@ -1531,7 +1531,7 @@ void Helper::onSetCopyOutput(VirtualOutputInterfaceV1 *interface)
     requestedOutputIds.reserve(requestedOutputs.size());
     for (const auto &outputName : std::as_const(requestedOutputs)) {
         if (auto *output = findOutputByName(outputName)) {
-            requestedOutputIds.append(WallpaperManager::getOutputId(output));
+            requestedOutputIds.append(output->getOutputId());
         }
     }
     m_outputManagerHelper->storeCopyOutputConfig(true, interface->name(), requestedOutputIds);
@@ -3062,7 +3062,7 @@ Output *Helper::findOutputByName(const QString &name) const
 Output *Helper::findOutputById(const QString &id) const
 {
     for (auto *output : std::as_const(m_outputList)) {
-        if (output && output->output() && WallpaperManager::getOutputId(output) == id) {
+        if (output && output->output() && output->getOutputId() == id) {
             return output;
         }
     }
@@ -3582,7 +3582,7 @@ void Helper::applyCopyModeToOutputs(Output *primaryOutput,
         if (existingOutput == primaryOutput) {
             continue;
         }
-        if (!outputIds.isEmpty() && !outputIds.contains(WallpaperManager::getOutputId(existingOutput))) {
+        if (!outputIds.isEmpty() && !outputIds.contains(existingOutput->getOutputId())) {
             continue;
         }
 

--- a/src/wallpaper/wallpapermanager.cpp
+++ b/src/wallpaper/wallpapermanager.cpp
@@ -48,30 +48,14 @@ WallpaperManager::~WallpaperManager()
 
 }
 
-QString WallpaperManager::getOutputId(wlr_output *output)
-{
-    const QString model = QString::fromUtf8(output->model);
-    const QString serial = QString::fromUtf8(output->serial);
-    if (!model.isEmpty() && !serial.isEmpty()) {
-        return model + serial;
-    }
-
-    return QString::fromUtf8(output->name);
-}
-
-QString WallpaperManager::getOutputId(Output *output)
-{
-    return getOutputId(output->output()->nativeHandle());
-}
-
 WallpaperOutputConfig WallpaperManager::getOutputConfig(Output *output)
 {
-    return getOutputConfig(getOutputId(output));
+    return getOutputConfig(output->getOutputId());
 }
 
 WallpaperOutputConfig WallpaperManager::getOutputConfig(wlr_output *output)
 {
-    return getOutputConfig(getOutputId(output));
+    return getOutputConfig(Output::getOutputId(output));
 }
 
 WallpaperOutputConfig WallpaperManager::getOutputConfig(const QString &id)
@@ -112,7 +96,7 @@ void WallpaperManager::defaultWallpaperConfig()
     for (Output *output : std::as_const(Helper::instance()->m_outputList)) {
         WallpaperOutputConfig outputConfig;
         outputConfig.lockscreenWallpaper = Helper::instance()->m_config->defaultBackground();
-        outputConfig.outputName = WallpaperManager::getOutputId(output);
+        outputConfig.outputName = output->getOutputId();
         WallpaperType type = detectWallpaperType(outputConfig.lockscreenWallpaper);
         if (type == WallpaperType::Unknown) {
             outputConfig.lockscreenWallpaper = DEFAULT_WALLPAPER;
@@ -157,7 +141,7 @@ void WallpaperManager::ensureWallpaperConfigForOutput(Output *output)
         WallpaperOutputConfig outputConfig;
         outputConfig.lockscreenWallpaper = refConfig.lockscreenWallpaper;
         outputConfig.lockScreenWallpapertype = refConfig.lockScreenWallpapertype;
-        outputConfig.outputName = getOutputId(output);
+        outputConfig.outputName = output->getOutputId();
         for (int i = 0; i < workspace->count(); i++) {
             WallpaperWorkspaceConfig workspaceConfig;
             workspaceConfig.desktopWallpaper = refWorkspaceConfig.desktopWallpaper;
@@ -168,7 +152,7 @@ void WallpaperManager::ensureWallpaperConfigForOutput(Output *output)
         m_wallpaperConfig.append(outputConfig);
         update = true;
     } else {
-        QString outputId = getOutputId(output);
+        QString outputId = output->getOutputId();
         Workspace *workspace = Helper::instance()->workspace();
         Q_ASSERT(workspace);
 
@@ -214,7 +198,7 @@ bool WallpaperManager::configContainsOutput(Output *output)
         return false;
     }
 
-    QString outputId = getOutputId(output);
+    QString outputId = output->getOutputId();
     for (const WallpaperOutputConfig& output : std::as_const(m_wallpaperConfig)) {
         if (output.outputName == outputId) {
             return true;
@@ -240,7 +224,7 @@ void WallpaperManager::setOutputWallpaper(wlr_output *output, [[maybe_unused]] i
 {
     bool update = false;
     for (WallpaperOutputConfig &outputConfig : m_wallpaperConfig) {
-        if (outputConfig.outputName == getOutputId(output)) {
+        if (outputConfig.outputName == Output::getOutputId(output)) {
             if (roles.testFlag(TreelandWallpaperInterfaceV1::Lockscreen)) {
                 if (outputConfig.lockscreenWallpaper != fileSource) {
                     update = true;
@@ -274,13 +258,13 @@ QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> WallpaperManager::glo
     for (const WallpaperOutputConfig& output : std::as_const(m_wallpaperConfig)) {
         bool outputConnected = false;
         for (Output *connectedOutput : std::as_const(Helper::instance()->m_outputList)) {
-            if (output.outputName == getOutputId(connectedOutput)) {
+            if (output.outputName == connectedOutput->getOutputId()) {
                 outputConnected = true;
                 break;
             }
         }
         if (!outputConnected ||
-            (excludedOutput && output.outputName == getOutputId(excludedOutput))) {
+            (excludedOutput && output.outputName == Output::getOutputId(excludedOutput))) {
             continue;
         }
 
@@ -335,7 +319,7 @@ void WallpaperManager::syncAddWorkspace()
 void WallpaperManager::removeOutputWallpaper(wlr_output *output)
 {
     for (int i = 0; i < m_wallpaperConfig.size(); ++i) {
-        if (m_wallpaperConfig[i].outputName == getOutputId(output)) {
+        if (m_wallpaperConfig[i].outputName == Output::getOutputId(output)) {
             WallpaperOutputConfig &outputConfig = m_wallpaperConfig[i];
             QMap<QString, TreelandWallpaperInterfaceV1::WallpaperType> globalWallpapers = globalValidWallpaper(output);
             if (!globalWallpapers.contains(outputConfig.lockscreenWallpaper)) {
@@ -356,7 +340,7 @@ QString WallpaperManager::currentWorkspaceWallpaper(WOutput *output)
     Workspace *workspace = Helper::instance()->workspace();
     Q_ASSERT(workspace);
     for (int i = 0; i < m_wallpaperConfig.size(); ++i) {
-        if (m_wallpaperConfig[i].outputName == getOutputId(output->nativeHandle())) {
+        if (m_wallpaperConfig[i].outputName == Output::getOutputId(output->nativeHandle())) {
             return m_wallpaperConfig[i].workspaces[workspace->currentIndex()].desktopWallpaper;
         }
     }
@@ -367,7 +351,7 @@ QString WallpaperManager::currentWorkspaceWallpaper(WOutput *output)
 QString WallpaperManager::currentLockScreenWallpaper(WOutput *output)
 {
     for (int i = 0; i < m_wallpaperConfig.size(); ++i) {
-        if (m_wallpaperConfig[i].outputName == getOutputId(output->nativeHandle())) {
+        if (m_wallpaperConfig[i].outputName == Output::getOutputId(output->nativeHandle())) {
             return m_wallpaperConfig[i].lockscreenWallpaper;
         }
     }
@@ -402,7 +386,7 @@ void WallpaperManager::onWallpaperAdded(TreelandWallpaperInterfaceV1 *interface)
     Workspace *workspace = Helper::instance()->workspace();
     Q_ASSERT(workspace);
     for (int i = 0; i < m_wallpaperConfig.size(); ++i) {
-        if (m_wallpaperConfig[i].outputName == getOutputId(output->nativeHandle())) {
+        if (m_wallpaperConfig[i].outputName == Output::getOutputId(output->nativeHandle())) {
             WallpaperOutputConfig outputConfig = m_wallpaperConfig[i];
             interface->sendChanged(TreelandWallpaperInterfaceV1::Lockscreen, outputConfig.lockScreenWallpapertype, outputConfig.lockscreenWallpaper);
             for (WallpaperWorkspaceConfig workspaceConfig : std::as_const(outputConfig.workspaces)) {

--- a/src/wallpaper/wallpapermanager.h
+++ b/src/wallpaper/wallpapermanager.h
@@ -23,8 +23,6 @@ public:
 
     explicit WallpaperManager(QObject *parent = nullptr);
     ~WallpaperManager() override;
-    static QString getOutputId(wlr_output *output);
-    static QString getOutputId(Output *output);
     WallpaperOutputConfig getOutputConfig(Output *output);
     WallpaperOutputConfig getOutputConfig(wlr_output *output);
     WallpaperOutputConfig getOutputConfig(const QString &id);


### PR DESCRIPTION
Move output ID generation from WallpaperManager to Output so output configuration, topology restoration, and wallpaper handling share one implementation.

Preserve the existing model/serial/name fallback behavior, update all call sites, and keep output ID lookup safe during hotplug and teardown.

Log: centralize output ID generation
PMS: BUG-300647
Influence: Output identification, per-output configuration, topology restoration, and wallpaper restoration

## Summary by Sourcery

Centralize output identifier generation in the Output class and update all callers to use the shared implementation for consistent per-output configuration, topology handling, and wallpaper management.

Enhancements:
- Move output ID generation logic from WallpaperManager and OutputManager into static and instance methods on Output to provide a single source of truth for output identifiers.
- Update helper, wallpaper, output management, and root surface code paths to rely on Output::getOutputId for logging, configuration lookup, and primary/copy mode handling.