### PR TITLE
feat: add build-tree wallpaper factory option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,13 @@ add_feature_info(ASanSupport ADDRESS_SANITIZER "https://github.com/google/saniti
 option(BUILD_TREELAND_EXAMPLES "Build clients demo to test treeland" OFF)
 add_feature_info(DemoClents BUILD_TEST_CLIENTS "clients demo for testing")
 
+option(USE_BUILD_TREE_WALLPAPER_FACTORY
+       "Use the wallpaper factory executable from the build tree"
+       OFF)
+add_feature_info(build_tree_wallpaper_factory
+                 USE_BUILD_TREE_WALLPAPER_FACTORY
+                 "Use the wallpaper factory executable from the build tree")
+
 option(DISABLE_DDM "Disable DDM and greeter" OFF)
 
 if (DISABLE_DDM)
@@ -108,7 +115,6 @@ add_compile_definitions("QT_FORCE_ASSERTS")
 
 add_compile_definitions("TREELAND_PLUGINS_INSTALL_PATH=\"${TREELAND_FULL_PLUGINS_INSTALL_PATH}\"")
 add_compile_definitions("TREELAND_PLUGINS_OUTPUT_PATH=\"${TREELAND_PLUGINS_OUTPUT_PATH}\"")
-add_compile_definitions("TREELAND_WALLPAPER_FACTORY_OUTPUT_PATH=\"${CMAKE_BINARY_DIR}/wallpaper-factory/treeland-wallpaper-factory\"")
 
 add_compile_definitions("TREELAND_COMPONENTS_TRANSLATION_DIR=\"${TREELAND_FULL_COMPONENTS_TRANSLATION_DIR}\"")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -282,6 +282,14 @@ target_compile_definitions(libtreeland
     WLR_USE_UNSTABLE
 )
 
+if (USE_BUILD_TREE_WALLPAPER_FACTORY)
+    target_compile_definitions(libtreeland
+        PRIVATE
+        TREELAND_USE_BUILD_TREE_WALLPAPER_FACTORY
+        "TREELAND_WALLPAPER_FACTORY_OUTPUT_PATH=\"${CMAKE_BINARY_DIR}/wallpaper-factory/treeland-wallpaper-factory\""
+    )
+endif()
+
 qt_add_shaders(libtreeland "treeland_shaders_ng"
     BATCHABLE
     PRECOMPILE

--- a/src/wallpaper/wallpaperlauncher.cpp
+++ b/src/wallpaper/wallpaperlauncher.cpp
@@ -29,7 +29,7 @@ WallpaperLauncher::~WallpaperLauncher()
 }
 QString WallpaperLauncher::wallpaperProgram()
 {
-#ifdef QT_DEBUG
+#ifdef TREELAND_USE_BUILD_TREE_WALLPAPER_FACTORY
     return QStringLiteral(TREELAND_WALLPAPER_FACTORY_OUTPUT_PATH);
 #else
     return QStringLiteral("treeland-wallpaper-factory");


### PR DESCRIPTION
Added a CMake option to use the wallpaper factory executable from the build tree instead of the installed executable.

The implementation includes:
1. Added USE_BUILD_TREE_WALLPAPER_FACTORY configuration option
2. Added conditional compile definitions for the build-tree path
3. Updated WallpaperLauncher to use the option instead of QT_DEBUG
4. Kept the installed wallpaper factory as the default

Log: Added configurable build-tree wallpaper factory support

Influence:

## Summary by Sourcery

Add a configurable option to run the wallpaper factory from the build tree instead of the installed binary, and wire it through CMake and the wallpaper launcher.

New Features:
- Introduce USE_BUILD_TREE_WALLPAPER_FACTORY CMake option to select the build-tree wallpaper factory executable.

Enhancements:
- Gate build-tree wallpaper factory path definitions behind a dedicated compile-time flag and decouple the launcher logic from QT_DEBUG.