### PR TITLE
fix(xsettings): format XResources with tab separators

### DIFF
--- a/src/xsettings/xresource.cpp
+++ b/src/xsettings/xresource.cpp
@@ -125,7 +125,8 @@ void XResource::apply()
     QByteArray text;
     for (auto it = m_resources.constBegin(); it != m_resources.constEnd(); ++it) {
         text.append(it.key());
-        text.append(": ");
+        text.append(':');
+        text.append('\t');
         text.append(it.value().toString().toUtf8());
         text.append('\n');
     }


### PR DESCRIPTION
Serialize RESOURCE_MANAGER entries as key:\tvalue\n to match the expected X resource format used by X11 clients.

Log: fix XSettings resource manager formatting
PMS: BUG-371243
Influence: X11 resource loading and toolkit settings synchronization

## Summary by Sourcery

Bug Fixes:
- Correct XSettings RESOURCE_MANAGER serialization to use key:\tvalue formatting instead of key: value.