### PR TITLE
郭垚(guoyao): treeland test PR for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ $ cmake -Bbuild -DWITH_SUBMODULE_WAYLIB=ON
 $ cmake --build build
 ```
 
+> Tip: `build` is a generated output directory created by cmake; there is no need to create it manually and it should not be committed.
+
 ## Packaging
 
 A `debian` folder is provided to build the package under the *deepin* linux desktop distribution. To build the package, use the following command:

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -38,6 +38,8 @@ $ cmake -Bbuild -DWITH_SUBMODULE_WAYLIB=ON
 $ cmake --build build
 ```
 
+> 提示：`build` 为构建产物目录，由 cmake 生成，无需手动创建，也不应纳入版本控制。
+
 ## 打包
 
 在 *deepin* 桌面发行版进行此软件包的构建，我们还提供了一个 `debian` 目录。若要构建软件包，可参照下面的命令进行构建：


### PR DESCRIPTION
## 说明

这是一条用于测试的 PR（由 Multica 标准-代码提交bot 代为提交，提交人：郭垚 / guoyao）。

### 变更内容
- 在 `README.md` 与 `README.zh_CN.md` 的构建章节补充说明：`build` 目录由 cmake 生成，无需手动创建，也不应纳入版本控制。
- 中英文 README 同步更新，保持内容一致。

### 提交信息
- 分支：`agent/bot/8bef8816`
- 提交人：guoyao <guoyao@uniontech.com>
- Commit：`docs: clarify build output directory in README`

### 关联 Multica Issue
- Multica Issue：[WM-193](https://agent-dev.uniontech.com/workspace/e1c725b6-7c31-4790-a381-3262f282537c/issues/WM-193)

> 本 PR 为测试 PR，仅包含文档微调，不影响功能行为。

## Summary by Sourcery

Documentation:
- Update English and Chinese README build sections to explain that the cmake-generated `build` directory should not be manually created or committed to version control.