### PR TITLE
fix(xwayland): synchronize EWMH desktop properties

### DIFF
--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -12,8 +12,10 @@
 #include "modules/dde-shell/ddeshellmanagerinterfacev1.h"
 #include "modules/foreign-toplevel/foreigntoplevelmanagerv1.h"
 #include "modules/prelaunch-splash/prelaunchsplash.h"
+#include "modules/window-management/windowmanagementinterfacev1.h"
 #include "modules/wine-window-management/winewindowmanagement.h"
 #include "modules/wine-window-state/winewindowstate.h"
+#include "output/output.h"
 #include "rootsurfacecontainer.h"
 #include "seat/helper.h"
 #include "seat/seatsmanager.h"
@@ -24,6 +26,7 @@
 #include "treelanduserconfig.hpp"
 #include "wallpapershellinterfacev1.h"
 #include "workspace/workspace.h"
+#include "workspace/workspacemodel.h"
 
 #include <xcb/xcb.h>
 
@@ -32,7 +35,10 @@
 #include <wlayershell.h>
 #include <wlayersurface.h>
 #include <woutputrenderwindow.h>
+#include <woutputitem.h>
+#include <woutputlayout.h>
 #include <wserver.h>
+#include <wxdgoutput.h>
 #include <wxdgpopupsurface.h>
 #include <wxdgshell.h>
 #include <wxdgtoplevelsurface.h>
@@ -89,6 +95,122 @@ ShellHandler::ShellHandler(RootSurfaceContainer *rootContainer, WServer *server)
     m_overlayContainer->setObjectName(QStringLiteral("OverlayContainer"));
     m_popupContainer->setZ(RootSurfaceContainer::PopupZOrder);
     m_popupContainer->setObjectName(QStringLiteral("PopupContainer"));
+
+    connect(m_rootSurfaceContainer->outputModel(),
+            &QAbstractItemModel::rowsInserted,
+            this,
+            [this] {
+                for (auto *output : m_rootSurfaceContainer->outputs()) {
+                    watchXWaylandDesktopOutput(output);
+                }
+                updateXWaylandDesktopProperties();
+            });
+    connect(m_rootSurfaceContainer->outputModel(),
+            &QAbstractItemModel::rowsRemoved,
+            this,
+            &ShellHandler::updateXWaylandDesktopProperties);
+    connect(m_workspace, &Workspace::currentIndexChanged,
+            this, &ShellHandler::updateXWaylandDesktopProperties);
+    connect(Helper::instance(), &Helper::showDesktopStateChanged,
+            this, &ShellHandler::updateXWaylandDesktopProperties);
+    connect(m_workspace, &Workspace::countChanged, this, [this] {
+        watchXWaylandWorkspaceNames();
+        updateXWaylandDesktopProperties();
+    });
+    watchXWaylandWorkspaceNames();
+}
+
+void ShellHandler::watchXWaylandDesktopOutput(Output *output)
+{
+    connect(output,
+            &Output::exclusiveZoneChanged,
+            this,
+            &ShellHandler::updateXWaylandDesktopProperties,
+            Qt::UniqueConnection);
+    connect(output->outputItem(),
+            &WOutputItem::geometryChanged,
+            this,
+            &ShellHandler::updateXWaylandDesktopProperties,
+            Qt::UniqueConnection);
+    connect(output->output(),
+            &WOutput::enabledChanged,
+            this,
+            &ShellHandler::updateXWaylandDesktopProperties,
+            Qt::UniqueConnection);
+}
+
+void ShellHandler::watchXWaylandWorkspaceNames()
+{
+    for (int i = 0; i < m_workspace->count(); ++i) {
+        connect(m_workspace->modelAt(i),
+                &WorkspaceModel::nameChanged,
+                this,
+                &ShellHandler::updateXWaylandDesktopProperties,
+                Qt::UniqueConnection);
+    }
+}
+
+void ShellHandler::updateXWaylandDesktopProperties()
+{
+    auto *outputManager = Helper::instance()->xwaylandOutputManager();
+    connect(outputManager,
+            &WXdgOutputManager::scaleOverrideChanged,
+            this,
+            &ShellHandler::updateXWaylandDesktopProperties,
+            Qt::UniqueConnection);
+    connect(outputManager->layout(),
+            &WOutputLayout::outputsChanged,
+            this,
+            &ShellHandler::updateXWaylandDesktopProperties,
+            Qt::UniqueConnection);
+
+    QRect geometry;
+    QRect workarea;
+    for (auto *xwaylandOutput : outputManager->layout()->outputs()) {
+        if (!xwaylandOutput->isEnabled())
+            continue;
+
+        auto *output = Helper::instance()->getOutput(xwaylandOutput);
+        if (!output)
+            continue;
+
+        const QRect outputGeometry = outputManager->outputGeometry(xwaylandOutput);
+        if (outputGeometry.isEmpty())
+            continue;
+
+        const QRectF treelandGeometry = output->geometry();
+        const qreal xScale = outputGeometry.width() / treelandGeometry.width();
+        const qreal yScale = outputGeometry.height() / treelandGeometry.height();
+        const QMargins exclusiveZone = output->exclusiveZone();
+        const QMargins xwaylandExclusiveZone(qCeil(exclusiveZone.left() * xScale),
+                                             qCeil(exclusiveZone.top() * yScale),
+                                             qCeil(exclusiveZone.right() * xScale),
+                                             qCeil(exclusiveZone.bottom() * yScale));
+        geometry = geometry.united(outputGeometry);
+        workarea = workarea.united(outputGeometry.marginsRemoved(xwaylandExclusiveZone));
+    }
+
+    if (geometry.isEmpty() || workarea.isEmpty())
+        return;
+
+    const int count = m_workspace->count();
+    QStringList names;
+    names.reserve(count);
+    for (int i = 0; i < count; ++i)
+        names.append(m_workspace->modelAt(i)->name());
+
+    const QVector<QPoint> viewports(count, QPoint(0, 0));
+    const QVector<QRect> workareas(count, workarea);
+    for (auto *xwayland : std::as_const(m_xwaylands)) {
+        xwayland->setDesktopProperties(count,
+                                       geometry.size(),
+                                       m_workspace->currentIndex(),
+                                       names,
+                                       viewports,
+                                       workareas,
+                                       Helper::instance()->showDesktopState()
+                                           == WindowManagementInterfaceV1::DesktopState::Show);
+    }
 }
 
 void ShellHandler::updateWrapperContainer(SurfaceWrapper *wrapper, WSurface *parentSurface)
@@ -380,6 +502,11 @@ WXWayland *ShellHandler::createXWayland(WServer *server,
         xwayland->setAtomSupported(atomPid, true);
         auto atomNoTitlebar = xwayland->atom("_DEEPIN_NO_TITLEBAR");
         xwayland->setAtomSupported(atomNoTitlebar, true);
+
+        for (auto *output : m_rootSurfaceContainer->outputs()) {
+            watchXWaylandDesktopOutput(output);
+        }
+        updateXWaylandDesktopProperties();
 
         if (m_imCandidatePanelManager)
             m_imCandidatePanelManager->setupXWayland(xwayland);

--- a/src/core/shellhandler.h
+++ b/src/core/shellhandler.h
@@ -31,6 +31,7 @@ class Helper;
 class SurfaceWrapper;
 class RootSurfaceContainer;
 class LayerSurfaceContainer;
+class Output;
 class Workspace;
 class SurfaceContainer;
 class IMCandidatePanelManager;
@@ -144,6 +145,9 @@ private:
                                     SurfaceWrapper *wrapper);
     void setResourceManagerAtom(WAYLIB_SERVER_NAMESPACE::WXWayland *xwayland,
                                 const QByteArray &value);
+    void updateXWaylandDesktopProperties();
+    void watchXWaylandDesktopOutput(Output *output);
+    void watchXWaylandWorkspaceNames();
     // Prelaunch splash related: creates a prelaunch SurfaceWrapper when
     // PrelaunchSplash::splashRequested
     void handlePrelaunchSplashRequested(const QString &appId,

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1468,6 +1468,7 @@ void Helper::onShowDesktop()
         return;
 
     m_showDesktop = s;
+    Q_EMIT showDesktopStateChanged();
     const auto &surfaces = getWorkspaceSurfaces();
     for (auto &surface : surfaces) {
         if (surface->isMinimized()) {
@@ -3184,6 +3185,11 @@ bool Helper::toggleDebugMenuBar()
 WindowManagementInterfaceV1::DesktopState Helper::showDesktopState() const
 {
     return m_showDesktop;
+}
+
+WXdgOutputManager *Helper::xwaylandOutputManager() const
+{
+    return m_xwaylandOutputManager;
 }
 
 bool Helper::isLaunchpad(WLayerSurface *surface) const

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -198,6 +198,7 @@ public:
     WOutputRenderWindow *window() const;
     ShellHandler *shellHandler() const;
     Workspace *workspace() const;
+    WXdgOutputManager *xwaylandOutputManager() const;
 
     void init(Treeland::Treeland *treeland);
 
@@ -312,6 +313,7 @@ Q_SIGNALS:
 
     void launchpadMappedChanged(WOutput *output, bool mapped);
     void showDesktopRequested(WOutput *output);
+    void showDesktopStateChanged();
     void startLockscreened(WOutput *output, bool showAnimation);
     void modifierKeyReleased(QKeyEvent *event);
 

--- a/waylib/src/server/protocols/wxdgoutput.cpp
+++ b/waylib/src/server/protocols/wxdgoutput.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wxdgoutput.h"
+#include "woutput.h"
 #include "woutputlayout.h"
 #include "wsocket.h"
 #include "wayliblogging.h"
@@ -412,6 +413,22 @@ qreal WXdgOutputManager::scaleOverride() const
 void WXdgOutputManager::resetScaleOverride()
 {
     setScaleOverride(0.0);
+}
+
+QRect WXdgOutputManager::outputGeometry(WOutput *output) const
+{
+    W_DC(WXdgOutputManager);
+    auto *layoutOutput = wlr_output_layout_get(d->layout->handle()->handle(), output->nativeHandle());
+
+    int width = 0;
+    int height = 0;
+    wlr_output_effective_resolution(layoutOutput->output, &width, &height);
+
+    const qreal scale = d->scaleOverride > 0.0 ? d->scaleOverride : 1.0;
+    return QRect(qFloor(layoutOutput->x * scale),
+                 qFloor(layoutOutput->y * scale),
+                 qCeil(width * scale),
+                 qCeil(height * scale));
 }
 
 QByteArrayView WXdgOutputManager::interfaceName() const

--- a/waylib/src/server/protocols/wxdgoutput.h
+++ b/waylib/src/server/protocols/wxdgoutput.h
@@ -5,9 +5,12 @@
 
 #include <wserver.h>
 
+#include <QRect>
+
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
 class WOutputLayout;
+class WOutput;
 class WXdgOutputManagerPrivate;
 class WAYLIB_SERVER_EXPORT WXdgOutputManager : public QObject, public WObject, public WServerInterface
 {
@@ -22,6 +25,7 @@ public:
     void setScaleOverride(qreal scaleOverride);
     qreal scaleOverride() const;
     void resetScaleOverride();
+    QRect outputGeometry(WOutput *output) const;
 
     QByteArrayView interfaceName() const override;
 

--- a/waylib/src/server/protocols/wxwayland.cpp
+++ b/waylib/src/server/protocols/wxwayland.cpp
@@ -19,9 +19,13 @@
 #include <qwxwaylandshellv1.h>
 #include <qwxwaylandsurface.h>
 
+#include <wlr/util/box.h>
+#include <wlr/xwayland/xwayland.h>
+
 #include <QCoreApplication>
 #include <QTimer>
 
+#include <array>
 #include <utility>
 
 QW_USE_NAMESPACE
@@ -270,6 +274,7 @@ QVarLengthArray<xcb_atom_t> WXWayland::supportedAtoms() const
 
     QVarLengthArray<xcb_atom_t> atomList;
     atomList.append(atoms, atoms_len);
+    free(reply);
 
     return atomList;
 }
@@ -299,6 +304,109 @@ void WXWayland::setAtomSupported(xcb_atom_t atom, bool supported)
         atoms.removeOne(atom);
         setSupportedAtoms(atoms);
     }
+}
+
+void WXWayland::setWorkareas(const QVector<QRect> &workareas)
+{
+    QVector<wlr_box> boxes;
+    boxes.reserve(workareas.size());
+    for (const QRect &workarea : workareas) {
+        boxes.append({ workarea.x(), workarea.y(), workarea.width(), workarea.height() });
+    }
+
+    wlr_xwayland_set_workareas(handle()->handle(), boxes.constData(), boxes.size());
+}
+
+void WXWayland::setDesktopProperties(uint32_t count,
+                                     const QSize &geometry,
+                                     uint32_t current,
+                                     const QStringList &names,
+                                     const QVector<QPoint> &viewports,
+                                     const QVector<QRect> &workareas,
+                                     bool showingDesktop)
+{
+    auto *connection = xcbConnection();
+    if (!xcbScreen()) {
+        return;
+    }
+    const xcb_window_t root = xcbScreen()->root;
+    const auto cardinal = XCB_ATOM_CARDINAL;
+    const auto setCardinals = [this, connection, root, cardinal](const QByteArray &name,
+                                                                 const uint32_t *data,
+                                                                 size_t size) {
+        xcb_change_property(connection,
+                            XCB_PROP_MODE_REPLACE,
+                            root,
+                            atom(name),
+                            cardinal,
+                            32,
+                            size,
+                            data);
+    };
+
+    const QByteArray numberOfDesktops("_NET_NUMBER_OF_DESKTOPS");
+    const QByteArray desktopGeometry("_NET_DESKTOP_GEOMETRY");
+    const QByteArray currentDesktop("_NET_CURRENT_DESKTOP");
+    const QByteArray desktopNames("_NET_DESKTOP_NAMES");
+    const QByteArray desktopViewport("_NET_DESKTOP_VIEWPORT");
+    const QByteArray desktopLayout("_NET_DESKTOP_LAYOUT");
+    const QByteArray workarea("_NET_WORKAREA");
+    const QByteArray showingDesktopProperty("_NET_SHOWING_DESKTOP");
+    const QByteArray utf8String("UTF8_STRING");
+
+    const std::array<QByteArray, 8> supportedNames {
+        numberOfDesktops,
+        desktopGeometry,
+        currentDesktop,
+        desktopNames,
+        desktopViewport,
+        desktopLayout,
+        workarea,
+        showingDesktopProperty,
+    };
+    auto supported = supportedAtoms();
+    for (const auto &name : supportedNames) {
+        const xcb_atom_t propertyAtom = atom(name);
+        if (!supported.contains(propertyAtom))
+            supported.append(propertyAtom);
+    }
+    setSupportedAtoms(supported);
+
+    setCardinals(numberOfDesktops, &count, 1);
+    const uint32_t geometryData[] = { uint32_t(geometry.width()), uint32_t(geometry.height()) };
+    setCardinals(desktopGeometry, geometryData, std::size(geometryData));
+    setCardinals(currentDesktop, &current, 1);
+
+    QByteArray encodedNames;
+    for (const QString &name : names) {
+        encodedNames.append(name.toUtf8());
+        encodedNames.append('\0');
+    }
+    xcb_change_property(connection,
+                        XCB_PROP_MODE_REPLACE,
+                        root,
+                        atom(desktopNames),
+                        atom(utf8String),
+                        8,
+                        encodedNames.size(),
+                        encodedNames.constData());
+
+    QVector<uint32_t> viewportData;
+    viewportData.reserve(viewports.size() * 2);
+    for (const QPoint &viewport : viewports) {
+        viewportData.append(uint32_t(viewport.x()));
+        viewportData.append(uint32_t(viewport.y()));
+    }
+    setCardinals(desktopViewport, viewportData.constData(), viewportData.size());
+
+    // Horizontal, count columns, one row, starting at the top-left corner.
+    const uint32_t layoutData[] = { 0, count, 1, 0 };
+    setCardinals(desktopLayout, layoutData, std::size(layoutData));
+    const uint32_t showingDesktopData = showingDesktop;
+    setCardinals(showingDesktopProperty, &showingDesktopData, 1);
+
+    setWorkareas(workareas);
+    xcb_flush(connection);
 }
 
 void WXWayland::setSeat(WSeat *seat)

--- a/waylib/src/server/protocols/wxwayland.h
+++ b/waylib/src/server/protocols/wxwayland.h
@@ -9,6 +9,10 @@
 
 #include <QByteArray>
 #include <QMap>
+#include <QPoint>
+#include <QRect>
+#include <QSize>
+#include <QStringList>
 #include <QVector>
 
 #include <functional>
@@ -68,6 +72,14 @@ public:
     QVarLengthArray<xcb_atom_t> supportedAtoms() const;
     void setSupportedAtoms(const QVarLengthArray<xcb_atom_t> &atoms);
     void setAtomSupported(xcb_atom_t atom, bool supported);
+    void setWorkareas(const QVector<QRect> &workareas);
+    void setDesktopProperties(uint32_t count,
+                              const QSize &geometry,
+                              uint32_t current,
+                              const QStringList &names,
+                              const QVector<QPoint> &viewports,
+                              const QVector<QRect> &workareas,
+                              bool showingDesktop);
 
     void setSeat(WSeat *seat);
     WSeat *seat() const;


### PR DESCRIPTION
Publish the XWayland desktop count, geometry, current desktop, names, viewports, layout, workareas, and showing-desktop state on the root window, and advertise them through _NET_SUPPORTED.

Derive desktop geometry from the XWayland XDG output manager so the values use the same scale and coordinate space visible to X11 clients. Convert each enabled output's layer-shell exclusive zone into that coordinate space before calculating the per-workspace workarea.

Refresh the properties when outputs, output geometry, scale overrides, exclusive zones, workspace metadata, or showing-desktop state change. Also release the XCB property reply after reading the supported atom list.

Log: synchronize XWayland EWMH desktop state with outputs and workspaces PMS: BUG-369703
Influence: X11 desktop discovery, window placement, maximization, workspace state, and showing-desktop state

## Summary by Sourcery

Synchronize XWayland EWMH desktop properties with current outputs, workspaces, and showing-desktop state.

Bug Fixes:
- Ensure XWayland publishes up-to-date EWMH desktop count, geometry, names, viewports, layout, workareas, and showing-desktop state on the root window.
- Fix mismatched coordinate scaling by deriving X11-facing desktop geometry and workareas from the XDG output manager with scale overrides and exclusive zones applied correctly.
- Prevent leaks when querying XCB-supported atoms by releasing the property reply after use.

Enhancements:
- Expose a helper API to retrieve the XWayland XDG output manager and compute per-output geometry for reuse.
- Propagate workspace name and show-desktop state changes to XWayland so X11 clients see accurate desktop metadata.