### PR TITLE
WM-241: remove WBackend::activateSession/deactivateSession hack

### DIFF
--- a/src/modules/ddm/ddminterfacev1.cpp
+++ b/src/modules/ddm/ddminterfacev1.cpp
@@ -27,8 +27,6 @@ protected:
     void bind_resource(Resource *resource) override;
     void switch_to_greeter(Resource *resource) override;
     void switch_to_user(Resource *resource, const QString &username) override;
-    void activate_session(Resource *resource) override;
-    void deactivate_session(Resource *resource) override;
     void enable_render(Resource *resource) override;
     void disable_render(Resource *resource, uint32_t callback) override;
 };
@@ -70,18 +68,6 @@ void DDMInterfaceV1Private::switch_to_user([[maybe_unused]] Resource *resource, 
         helper->userModel()->setCurrentUserName(username);
         helper->showLockScreen(false);
     }
-}
-
-void DDMInterfaceV1Private::activate_session([[maybe_unused]] Resource *resource)
-{
-    qCWarning(lcTlCore) << "DDM protocol: activate_session";
-    Helper::instance()->activateSession();
-}
-
-void DDMInterfaceV1Private::deactivate_session([[maybe_unused]] Resource *resource)
-{
-    qCWarning(lcTlCore) << "DDM protocol: deactivate_session";
-    Helper::instance()->deactivateSession();
 }
 
 void DDMInterfaceV1Private::enable_render([[maybe_unused]] Resource *resource)

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -3490,11 +3490,6 @@ DDMInterfaceV1 *Helper::ddmInterfaceV1() const {
     return m_ddmInterfaceV1;
 }
 
-void Helper::activateSession() {
-    if (!m_backend->isSessionActive())
-        m_backend->activateSession();
-}
-
 bool Helper::activateUserSession(const QString &username, int sessionId)
 {
     if (!m_userModel->getUser(username))
@@ -3507,11 +3502,6 @@ bool Helper::activateUserSession(const QString &username, int sessionId)
     m_userModel->setCurrentUserName(username);
     m_sessionManager->commitActiveUserSession(update);
     return true;
-}
-
-void Helper::deactivateSession() {
-    if (m_backend->isSessionActive())
-        m_backend->deactivateSession();
 }
 
 void Helper::enableRender() {

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -258,9 +258,7 @@ public:
     inline SessionModel *sessionModel() const { return m_sessionModel; };
     DDMInterfaceV1 *ddmInterfaceV1() const;
 
-    void activateSession();
     bool activateUserSession(const QString &username, int sessionId);
-    void deactivateSession();
     void enableRender();
     void disableRender();
 

--- a/waylib/src/server/kernel/wbackend.cpp
+++ b/waylib/src/server/kernel/wbackend.cpp
@@ -204,26 +204,6 @@ bool WBackend::isSessionActive() const
     return d->session && d->session->handle()->active;
 }
 
-void WBackend::activateSession()
-{
-    W_D(WBackend);
-    if (d->session) {
-        struct wlr_session *session = d->session->handle();
-        session->active = true;
-        wl_signal_emit_mutable(&session->events.active, nullptr);
-    }
-}
-
-void WBackend::deactivateSession()
-{
-    W_D(WBackend);
-    if (d->session) {
-        struct wlr_session *session = d->session->handle();
-        session->active = false;
-        wl_signal_emit_mutable(&session->events.active, nullptr);
-    }
-}
-
 void WBackend::create(WServer *server)
 {
     W_D(WBackend);

--- a/waylib/src/server/kernel/wbackend.h
+++ b/waylib/src/server/kernel/wbackend.h
@@ -41,8 +41,6 @@ public:
     bool hasWayland() const;
 
     bool isSessionActive() const;
-    void activateSession();
-    void deactivateSession();
 
     QByteArrayView interfaceName() const override;
 


### PR DESCRIPTION
Closes WM-241

Remove the activateSession/deactivateSession hack introduced during the
dde-seatd migration. VT switching is now handled natively by
wlroots/libseat (dde-seatd), and ddm never sends activate_session /
deactivate_session requests, so the entire call chain is dead code.

Removed (A1-A5):
- WBackend::activateSession/deactivateSession (waylib/src/server/kernel/wbackend.{h,cpp})
- Helper::activateSession/deactivateSession (src/seat/helper.{h,cpp})
- activate_session/deactivate_session overrides (src/modules/ddm/ddminterfacev1.cpp)

Preserved:
- WBackend::isSessionActive() — read-only, used by the Ctrl+Alt+Fn VT
  shortcut guard (helper.cpp:2385)
- Helper::activateUserSession(username, sessionId) — greeter user-session
  switch flow, unrelated to this hack

QtWaylandServer provides empty default implementations for un-overridden
requests, so dropping the overrides leaves the (never-sent) requests silently
ignored — no behavior change.

## Summary by Sourcery

Enhancements:
- Drop WBackend, Helper, and DDM interface methods related to manual session activate/deactivate handling that are no longer invoked.