### PR TITLE
WM-242: fix HoverMove UB from invalid static_cast<QMouseEvent*>

### DIFF
--- a/examples/test_pinch_handler/eventitem.cpp
+++ b/examples/test_pinch_handler/eventitem.cpp
@@ -23,10 +23,10 @@ bool EventItem::event(QEvent *event)
     case MouseButtonRelease:
         Q_FALLTHROUGH();
     case MouseMove:
-        Q_FALLTHROUGH();
-    case HoverMove:
         if (static_cast<QMouseEvent *>(event)->source() != Qt::MouseEventNotSynthesized)
             return true; // The non-native events don't send to WSeat
+        Q_FALLTHROUGH();
+    case HoverMove:
         Q_FALLTHROUGH();
     case HoverEnter:
         Q_FALLTHROUGH();

--- a/waylib/src/server/kernel/wseat.cpp
+++ b/waylib/src/server/kernel/wseat.cpp
@@ -953,8 +953,8 @@ bool WSeat::sendEvent(WSurface *target, QObject *shellObject, QObject *eventObje
     }
     case QEvent::HoverMove: Q_FALLTHROUGH();
     case QEvent::MouseMove: {
-        auto e = static_cast<QMouseEvent*>(event);
-        Q_ASSERT(e->source() == Qt::MouseEventNotSynthesized);
+        auto e = static_cast<QSinglePointEvent*>(event);
+        Q_ASSERT(event->type() != QEvent::MouseMove || static_cast<QMouseEvent*>(event)->source() == Qt::MouseEventNotSynthesized);
         // When begin drag, the wlroots will grab pointer event for drag, and the pointer focus is nullptr.
         if (d->pointerFocusEventObject) {
             // received HoverEnter event of next eventObject before HoverLeave event of last eventObject,
@@ -1700,10 +1700,11 @@ bool WSeat::filterUnacceptedEvent(QWindow *targetWindow, QInputEvent *event)
     // Maybe this seat has grabbed in wlroots, should send these events to graber.
     case QEvent::MouseButtonPress: Q_FALLTHROUGH();
     case QEvent::MouseButtonRelease: Q_FALLTHROUGH();
-    case QEvent::HoverMove: Q_FALLTHROUGH();
     case QEvent::MouseMove:
         if (static_cast<QMouseEvent*>(event)->source() != Qt::MouseEventNotSynthesized)
             return false;
+        Q_FALLTHROUGH();
+    case QEvent::HoverMove:
         if (d->handle()->pointer_has_grab())
             return sendEvent(nullptr, nullptr, nullptr, event);
         break;

--- a/waylib/src/server/qtquick/wsurfaceitem.cpp
+++ b/waylib/src/server/qtquick/wsurfaceitem.cpp
@@ -122,11 +122,11 @@ private:
         // Don't insert events before MouseButtonPress
         case MouseButtonPress: Q_FALLTHROUGH();
         case MouseButtonRelease: Q_FALLTHROUGH();
-        case MouseMove: Q_FALLTHROUGH();
-        case HoverMove:
+        case MouseMove:
             if (static_cast<QMouseEvent*>(event)->source() != Qt::MouseEventNotSynthesized)
                 return true; // The non-native events don't send to WSeat
             Q_FALLTHROUGH();
+        case HoverMove: Q_FALLTHROUGH();
         case HoverEnter: Q_FALLTHROUGH();
         case HoverLeave: Q_FALLTHROUGH();
         case KeyPress: Q_FALLTHROUGH();

--- a/waylib/tests/manual/pinchhandler/eventitem.cpp
+++ b/waylib/tests/manual/pinchhandler/eventitem.cpp
@@ -19,11 +19,11 @@ bool EventItem::event(QEvent *event) {
   case MouseButtonRelease:
     Q_FALLTHROUGH();
   case MouseMove:
-    Q_FALLTHROUGH();
-  case HoverMove:
     if (static_cast<QMouseEvent *>(event)->source() !=
         Qt::MouseEventNotSynthesized)
       return true; // The non-native events don't send to WSeat
+    Q_FALLTHROUGH();
+  case HoverMove:
     Q_FALLTHROUGH();
   case HoverEnter:
     Q_FALLTHROUGH();


### PR DESCRIPTION
## Summary

Eliminate undefined behavior where `HoverMove` (a `QHoverEvent`) was `static_cast`-ed to `QMouseEvent*` and its `source()` was read. `QHoverEvent` and `QMouseEvent` are sibling classes (both derive from `QSinglePointEvent`), so the cast is UB and `source()` reads the wrong memory offset.

The fix is behavior-equivalent: `QHoverEvent::m_source` is always `Qt::MouseEventNotSynthesized`, so the `source()` filter was a no-op for hover events. Moving `HoverMove` out of the `source()` check groups makes this explicit and removes the UB.

## Changes

**Production code (2 files, 3 sites):**

1. `waylib/src/server/qtquick/wsurfaceitem.cpp` `EventItem::event()` (~L125): moved `case HoverMove:` after the `source()` check so `static_cast<QMouseEvent*>` only applies to `MouseButtonPress/Release/MouseMove`.
2. `waylib/src/server/kernel/wseat.cpp` `WSeat::filterUnacceptedEvent()` (~L1700): moved `case HoverMove:` after the `source()` check, before the `pointer_has_grab()` check; mouse events fall through via `Q_FALLTHROUGH()`.
3. `waylib/src/server/kernel/wseat.cpp` `WSeat::sendEvent()` (~L954): changed `static_cast<QMouseEvent*>` to `static_cast<QSinglePointEvent*>` for `position()`/`timestamp()` (valid for both `HoverMove` and `MouseMove`); the `source()` assertion is now guarded to `MouseMove` only.

**Test/example copies (kept consistent):**

4. `waylib/tests/manual/pinchhandler/eventitem.cpp` `EventItem::event()`: same reorder as #1.
5. `examples/test_pinch_handler/eventitem.cpp` `EventItem::event()`: same reorder as #1.

## Constraints

- `QSinglePointEvent::m_source` is protected with no public `source()`; `QSinglePointEvent` is used only for `position()`/`timestamp()`.
- The switch at `wseat.cpp` ~L1056 groups `HoverMove` with mouse events but does **no** `static_cast<QMouseEvent*>` — no UB, left untouched.
- Pure UB elimination + type-safety convergence; no functional/interface changes.

Closes WM-242

## Summary by Sourcery

Eliminate undefined behavior when handling hover events by ensuring they are no longer treated as mouse events and tightening type usage for pointer events.

Bug Fixes:
- Prevent invalid static_cast from hover events to QMouseEvent when filtering and sending pointer events.

Enhancements:
- Use QSinglePointEvent for shared pointer event handling to align type usage across hover and mouse move events and clarify source checks.
- Reorder event switch cases so hover events bypass mouse-specific source filtering while retaining existing behavior.

Tests:
- Update example and manual test event handlers to mirror the corrected hover and mouse event handling logic.