### PR TITLE
WM-194: fix: support restart after WServer::stop

### DIFF
--- a/waylib/src/server/kernel/wseat.cpp
+++ b/waylib/src/server/kernel/wseat.cpp
@@ -96,13 +96,25 @@ public:
         for (auto device : std::as_const(deviceList))
             detachInputDevice(device);
 
+        destroyKeyboardGroup();
+    }
+
+    // Release the keyboard group and its WInputDevice wrapper. Shared by
+    // ~WSeatPrivate and WSeat::destroy() so create() rebuilds the group on
+    // the next start() (its `if (!d->group)` guard). Must run while the
+    // native seat is still alive: detachInputDevice() touches the Qt input
+    // integration, and wlr_keyboard_group_destroy() fires the keyboard
+    // destroy signal which clears the seat's keyboard reference.
+    void destroyKeyboardGroup() {
         if (groupkeyboardDevice) {
             detachInputDevice(groupkeyboardDevice);
             delete groupkeyboardDevice;
+            groupkeyboardDevice = nullptr;
         }
 
         if (group) {
             wlr_keyboard_group_destroy(group);
+            group = nullptr;
         }
     }
 
@@ -1588,17 +1600,29 @@ void WSeat::destroy(WServer *)
     if (d->cursor)
         setCursor(nullptr);
 
+    // Tear down the keyboard group before destroying the seat. The group
+    // keyboard is the seat's active keyboard; wlr_keyboard_group_destroy()
+    // fires the keyboard destroy signal which makes the seat drop its
+    // reference, so wlr_seat_destroy() below sees no dangling keyboard.
+    // This also lets create() rebuild the group on restart.
+    d->destroyKeyboardGroup();
+
     // Clear the reverse fromHandle() mapping while the native seat is still
-    // alive (the display destroys it after this callback).
+    // alive, then destroy it explicitly. wlr_seat_destroy() removes the
+    // display_destroy listener, so the later display.reset() won't touch it.
     if (d->handle() && d->handle()->data == this)
         d->handle()->data = nullptr;
+
+    wlr_seat_destroy(d->handle());
     m_handle = nullptr;
 }
 
 wl_global *WSeat::global() const
 {
     W_D(const WSeat);
-    return d->handle()->global;
+    if (m_handle)
+        return d->handle()->global;
+    return nullptr;
 }
 
 QByteArrayView WSeat::interfaceName() const

--- a/waylib/src/server/kernel/wserver.cpp
+++ b/waylib/src/server/kernel/wserver.cpp
@@ -86,7 +86,13 @@ WServerPrivate::~WServerPrivate()
 
 void WServerPrivate::init()
 {
-    Q_ASSERT(display);
+    // The display is destroyed in stop() so it can be rebuilt here on a
+    // restart. On the first start() it was already created in the ctor.
+    if (!display) {
+        display.reset(wl_display_create());
+        Q_ASSERT(display);
+        wl_display_set_global_filter(display.get(), globalFilter, this);
+    }
 
     // free follow display
     [[maybe_unused]] auto ddm = wlr_data_device_manager_create(display.get());
@@ -125,24 +131,45 @@ void WServerPrivate::stop()
 {
     W_Q(WServer);
 
-    // Disconnect event handlers BEFORE destroying clients to prevent
+    // ① Disconnect event handlers BEFORE destroying clients to prevent
     // callbacks from firing during client destruction.
     sockNot.reset();
     if (auto *dispatcher = QThread::currentThread()->eventDispatcher())
         QObject::disconnect(dispatcher, nullptr, q, nullptr);
 
+    // ② Stop accepting new connections on every socket, but keep the fd so
+    // the socket can be re-listened on the fresh display after a restart.
+    for (auto socket : std::as_const(sockets))
+        socket->stopListen();
+
     if (display)
         wl_display_destroy_clients(display.get());
 
+    // ④ Drop native handles in reverse attach order. The interface objects
+    // themselves are kept alive so start() can recreate them on a new
+    // display. Listeners are detached first (teardown()) because several
+    // wlr_*_destroy() helpers assert empty listener lists.
+    //
+    // Iterate a snapshot of interfaceList so an interface attached during
+    // teardown/destroy() (via WServer::attach) doesn't invalidate our
+    // iterators. The newly attached interface stays in interfaceList and is
+    // created on the next start() — it is intentionally NOT destroyed here.
     auto list = interfaceList;
-    interfaceList.clear();
     auto i = list.crbegin();
     for (; i != list.crend(); ++i) {
         if (auto *wobj = dynamic_cast<WObject*>(*i))
             wobj->teardown();
         (*i)->destroy(q);
-        delete *i;
     }
+
+    // ⑤ Destroy the display to reclaim every wlr object that has no public
+    // destroy() function ("free follow display"). This is the only release
+    // path for ~18 protocol managers, so it must not be removed even though
+    // WSeat/WXWayland/WBackend now destroy their own handles in destroy().
+    display.reset();
+
+    // ⑥ The event loop was owned by the display; it is gone now.
+    loop = nullptr;
 }
 
 // Replace wl_display_flush_clients: its wl_list_for_each_safe loop deadlocks
@@ -328,6 +355,12 @@ WServer::~WServer()
 {
     if (isRunning())
         stop();
+
+    W_D(WServer);
+    // stop() keeps interface objects alive so start() can recreate them;
+    // nothing recreates them in the destructor, so delete the wrappers now.
+    qDeleteAll(d->interfaceList);
+    d->interfaceList.clear();
 }
 
 WServer::WServer(WServerPrivate &dd, QObject *parent)
@@ -346,7 +379,10 @@ void WServer::stop()
 {
     W_D(WServer);
 
-    Q_ASSERT(d->display);
+    // A no-op when not running instead of asserting, so stop()/start() can
+    // be called defensively and stop() is safe after a previous stop().
+    if (!isRunning())
+        return;
     d->stop();
 }
 
@@ -499,6 +535,9 @@ void WServer::start()
 {
     W_D(WServer);
 
+    // Reentry guard: a running server is already initialized.
+    if (isRunning())
+        return;
     d->init();
 }
 

--- a/waylib/src/server/kernel/wserver.h
+++ b/waylib/src/server/kernel/wserver.h
@@ -133,6 +133,17 @@ public:
 
     static WServer *from(WServerInterface *interface);
 
+    // Restart invariants (WM-194):
+    //  * stop() destroys the wl_display (and thus every wlr object that has
+    //    no public destroy() function — "free follow display"), but keeps
+    //    the WServerInterface wrapper objects alive. start() rebuilds the
+    //    display and calls create() again on every interface.
+    //  * Between stop() and the next start(), handle() is null and the wlr
+    //    handles behind interface->handle()/interface->global() have been
+    //    freed — do not dereference them. The interface objects themselves
+    //    remain valid and can be iterated/attached/detached.
+    //  * start() is a no-op when already running; stop() is a no-op when not
+    //    running, so stop()/start() may be cycled and called defensively.
     void start();
     void stop();
     static void initializeQPA(

--- a/waylib/src/server/kernel/wsocket.cpp
+++ b/waylib/src/server/kernel/wsocket.cpp
@@ -745,6 +745,22 @@ bool WSocket::listen(wl_display *display)
     return true;
 }
 
+void WSocket::stopListen()
+{
+    W_D(WSocket);
+
+    // Mirror the event-source teardown done at the top of close(), but stop
+    // there: keep the fd and the client list so the socket can be listened
+    // again on a rebuilt display after WServer::stop().
+    if (d->eventSource) {
+        wl_event_source_remove(d->eventSource);
+        d->eventSource = nullptr;
+        d->display = nullptr;
+        Q_EMIT listeningChanged();
+    }
+    Q_ASSERT(!d->display);
+}
+
 WClient *WSocket::addClient(int fd)
 {
     W_D(WSocket);

--- a/waylib/src/server/kernel/wsocket.h
+++ b/waylib/src/server/kernel/wsocket.h
@@ -94,6 +94,11 @@ public:
     bool isListening() const;
     bool listen(struct wl_display *display);
 
+    // Remove the wayland event source for this socket but keep the fd and
+    // existing clients, so the socket can be re-listened on a new display
+    // after WServer::stop()/start(). Inverse of listen().
+    void stopListen();
+
     WClient *addClient(int fd);
     WClient *addClient(wl_client *client, bool isWlClientOwned = true);
     bool removeClient(wl_client *client);

--- a/waylib/src/server/protocols/private/winputmethodv2.cpp
+++ b/waylib/src/server/protocols/private/winputmethodv2.cpp
@@ -51,8 +51,19 @@ void WInputMethodManagerV2::create(WServer *server)
                                    &WInputMethodManagerV2::newInputMethod);
 }
 
+void WInputMethodManagerV2::destroy([[maybe_unused]] WServer *server)
+{
+    // The wlr_input_method_manager_v2 is reclaimed by display.reset() in
+    // WServer::stop(); null m_handle so handle()/global() return null instead
+    // of a dangling pointer. Manager-owned listeners were already dropped by
+    // WServer teardown().
+    m_handle = nullptr;
+}
+
 wl_global *WInputMethodManagerV2::global() const
 {
+    if (!m_handle)
+        return nullptr;
     return reinterpret_cast<wlr_input_method_manager_v2*>(m_handle)->global;
 }
 

--- a/waylib/src/server/protocols/private/winputmethodv2_p.h
+++ b/waylib/src/server/protocols/private/winputmethodv2_p.h
@@ -68,6 +68,7 @@ Q_SIGNALS:
 
 private:
     void create(WServer *server) override;
+    void destroy(WServer *server) override;
     wl_global *global() const override;
 };
 

--- a/waylib/src/server/protocols/private/wtextinputv3.cpp
+++ b/waylib/src/server/protocols/private/wtextinputv3.cpp
@@ -78,10 +78,16 @@ void WTextInputManagerV3::destroy([[maybe_unused]] WServer *server)
     }
     d->textInputs.clear();
     // Manager-owned listeners were already dropped by WServer teardown.
+    // Clear the dangling handle now: the wlr_text_input_manager_v3 is
+    // reclaimed by display.reset() in WServer::stop(), but nulling m_handle
+    // immediately makes handle()/global() return null instead of dangling.
+    m_handle = nullptr;
 }
 
 wl_global *WTextInputManagerV3::global() const
 {
+    if (!m_handle)
+        return nullptr;
     return reinterpret_cast<wlr_text_input_manager_v3*>(m_handle)->global;
 }
 

--- a/waylib/src/server/protocols/private/wvirtualkeyboardv1.cpp
+++ b/waylib/src/server/protocols/private/wvirtualkeyboardv1.cpp
@@ -43,8 +43,19 @@ void WVirtualKeyboardManagerV1::create(WServer *server)
                                        &WVirtualKeyboardManagerV1::newVirtualKeyboard);
 }
 
+void WVirtualKeyboardManagerV1::destroy([[maybe_unused]] WServer *server)
+{
+    // The wlr_virtual_keyboard_manager_v1 is reclaimed by display.reset() in
+    // WServer::stop(); null m_handle so handle()/global() return null instead
+    // of a dangling pointer. Manager-owned listeners were already dropped by
+    // WServer teardown().
+    m_handle = nullptr;
+}
+
 wl_global *WVirtualKeyboardManagerV1::global() const
 {
+    if (!m_handle)
+        return nullptr;
     return reinterpret_cast<wlr_virtual_keyboard_manager_v1*>(m_handle)->global;
 }
 

--- a/waylib/src/server/protocols/private/wvirtualkeyboardv1_p.h
+++ b/waylib/src/server/protocols/private/wvirtualkeyboardv1_p.h
@@ -24,6 +24,7 @@ Q_SIGNALS:
 
 private:
     void create(WServer *server) override;
+    void destroy(WServer *server) override;
     wl_global *global() const override;
 };
 WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/protocols/wcursorshapemanagerv1.cpp
+++ b/waylib/src/server/protocols/wcursorshapemanagerv1.cpp
@@ -138,6 +138,15 @@ void WCursorShapeManagerV1::create(WServer *server)
     }
 }
 
+void WCursorShapeManagerV1::destroy(WServer *)
+{
+    // create() is guarded by `if (!m_handle)`, so the handle must be cleared
+    // here — otherwise restart would skip recreating the global. The native
+    // object itself has no public destroy() function and is reclaimed when
+    // the display is destroyed in WServer::stop().
+    m_handle = nullptr;
+}
+
 wl_global *WCursorShapeManagerV1::global() const
 {
     W_D(const WCursorShapeManagerV1);

--- a/waylib/src/server/protocols/wcursorshapemanagerv1.h
+++ b/waylib/src/server/protocols/wcursorshapemanagerv1.h
@@ -27,6 +27,7 @@ public:
 
 protected:
     void create(WServer *server) override;
+    void destroy(WServer *server) override;
     wl_global *global() const override;
 };
 

--- a/waylib/src/server/protocols/wextforeigntoplevellistv1.cpp
+++ b/waylib/src/server/protocols/wextforeigntoplevellistv1.cpp
@@ -148,10 +148,17 @@ void WExtForeignToplevelListV1::create(WServer *server)
 
 void WExtForeignToplevelListV1::destroy([[maybe_unused]] WServer *server)
 {
+    // The wlr_ext_foreign_toplevel_list_v1 is reclaimed by display.reset() in
+    // WServer::stop(); null m_handle so handle()/global() return null instead
+    // of a dangling pointer (kept as an explicit override rather than the
+    // inherited empty base for this hardening).
+    m_handle = nullptr;
 }
 
 wl_global *WExtForeignToplevelListV1::global() const
 {
+    if (!m_handle)
+        return nullptr;
     return reinterpret_cast<wlr_ext_foreign_toplevel_list_v1*>(m_handle)->global;
 }
 

--- a/waylib/src/server/protocols/wforeigntoplevelv1.cpp
+++ b/waylib/src/server/protocols/wforeigntoplevelv1.cpp
@@ -239,10 +239,17 @@ void WForeignToplevel::create(WServer *server)
 
 void WForeignToplevel::destroy([[maybe_unused]] WServer *server)
 {
+    // The wlr_foreign_toplevel_manager_v1 is reclaimed by display.reset() in
+    // WServer::stop(); null m_handle so handle()/global() return null instead
+    // of a dangling pointer (kept as an explicit override rather than the
+    // inherited empty base for this hardening).
+    m_handle = nullptr;
 }
 
 wl_global *WForeignToplevel::global() const
 {
+    if (!m_handle)
+        return nullptr;
     return reinterpret_cast<wlr_foreign_toplevel_manager_v1*>(m_handle)->global;
 }
 

--- a/waylib/src/server/protocols/wlayershell.cpp
+++ b/waylib/src/server/protocols/wlayershell.cpp
@@ -115,10 +115,16 @@ void WLayerShell::destroy([[maybe_unused]] WServer *server)
         Q_EMIT surfaceRemoved(surface);
         delete surface;
     }
+    // Clear the dangling handle now: the wlr_layer_shell_v1 is reclaimed by
+    // display.reset() in WServer::stop(), but nulling m_handle immediately
+    // makes handle()/global() return null instead of a dangling pointer.
+    m_handle = nullptr;
 }
 
 wl_global *WLayerShell::global() const
 {
+    if (!m_handle)
+        return nullptr;
     auto handle = reinterpret_cast<wlr_layer_shell_v1*>(m_handle);
     return handle->global;
 }

--- a/waylib/src/server/protocols/wsecuritycontextmanager.cpp
+++ b/waylib/src/server/protocols/wsecuritycontextmanager.cpp
@@ -562,6 +562,14 @@ void WSecurityContextManager::create(WServer *server)
     m_handle = wlr_security_context_manager_v1_create(server->handle());
 }
 
+void WSecurityContextManager::destroy([[maybe_unused]] WServer *server)
+{
+    // The wlr_security_context_manager_v1 is reclaimed by display.reset() in
+    // WServer::stop(); null m_handle so handle()/global() return null instead
+    // of a dangling pointer (global() already guards on handle()).
+    m_handle = nullptr;
+}
+
 wl_global *WSecurityContextManager::global() const
 {
     W_D(const WSecurityContextManager);

--- a/waylib/src/server/protocols/wsecuritycontextmanager.h
+++ b/waylib/src/server/protocols/wsecuritycontextmanager.h
@@ -18,6 +18,7 @@ public:
 
 protected:
     void create(WServer *server) override;
+    void destroy(WServer *server) override;
     wl_global *global() const override;
 };
 

--- a/waylib/src/server/protocols/wsessionlockmanager.cpp
+++ b/waylib/src/server/protocols/wsessionlockmanager.cpp
@@ -100,10 +100,16 @@ void WSessionLockManager::destroy([[maybe_unused]] WServer *server)
         Q_EMIT lockDestroyed(lock);
         delete lock;
     }
+    // Clear the dangling handle now: the wlr_session_lock_manager_v1 is
+    // reclaimed by display.reset() in WServer::stop(), but nulling m_handle
+    // immediately makes handle()/global() return null instead of dangling.
+    m_handle = nullptr;
 }
 
 wl_global *WSessionLockManager::global() const
 {
+    if (!m_handle)
+        return nullptr;
     auto handle = reinterpret_cast<wlr_session_lock_manager_v1*>(m_handle);
     return handle->global;
 }

--- a/waylib/src/server/protocols/wxdgdecorationmanager.cpp
+++ b/waylib/src/server/protocols/wxdgdecorationmanager.cpp
@@ -161,6 +161,11 @@ void WXdgDecorationManager::destroy([[maybe_unused]] WServer *server)
     // tokens (their dtors teardown surface-scoped groups).
     d->decorationListeners.clear();
     d->decorations.clear();
+    // Clear the dangling handle now: the wlr_xdg_decoration_manager_v1 is
+    // reclaimed by display.reset() in WServer::stop(), but nulling m_handle
+    // immediately makes handle()/global() return null instead of dangling
+    // (global() already guards on m_handle).
+    m_handle = nullptr;
 }
 
 wl_global *WXdgDecorationManager::global() const

--- a/waylib/src/server/protocols/wxdgdialogmanagerv1.cpp
+++ b/waylib/src/server/protocols/wxdgdialogmanagerv1.cpp
@@ -145,6 +145,11 @@ void WXdgDialogManagerV1::destroy([[maybe_unused]] WServer *server)
     // Manager-owned listeners were already dropped by WServer teardown.
     // Clearing dialogListeners destroys per-dialog WListenerOwner tokens.
     d->dialogListeners.clear();
+    // Clear the dangling handle now: the wlr_xdg_wm_dialog_v1 is reclaimed
+    // by display.reset() in WServer::stop(), but nulling m_handle immediately
+    // makes handle()/global() return null instead of dangling (global() already
+    // guards on handle()).
+    m_handle = nullptr;
 }
 
 wl_global *WXdgDialogManagerV1::global() const

--- a/waylib/src/server/protocols/wxdgshell.cpp
+++ b/waylib/src/server/protocols/wxdgshell.cpp
@@ -162,10 +162,16 @@ void WXdgShell::destroy([[maybe_unused]] WServer *server)
         delete surface;
     }
 
+    // Clear the dangling handle now: the wlr_xdg_shell is reclaimed by
+    // display.reset() in WServer::stop(), but nulling m_handle immediately
+    // makes handle()/global() return null instead of a dangling pointer.
+    m_handle = nullptr;
 }
 
 wl_global *WXdgShell::global() const
 {
+    if (!m_handle)
+        return nullptr;
     auto handle = reinterpret_cast<wlr_xdg_shell*>(m_handle);
     return handle->global;
 }

--- a/waylib/src/server/protocols/wxwayland.cpp
+++ b/waylib/src/server/protocols/wxwayland.cpp
@@ -462,11 +462,22 @@ void WXWayland::destroy([[maybe_unused]] WServer *server)
         removeSurface(surface);
         delete surface;
     }
+
+    // Destroy the native xwayland explicitly so it is reclaimed before the
+    // display is torn down. teardown() (called by WServer::stop() before
+    // this) already detached our new_surface/ready/start listeners, which
+    // wlr_xwayland_destroy asserts to be empty. ~WXWayland() guards on
+    // handle() being null, so it won't double-destroy.
+    if (auto handle = this->handle())
+        wlr_xwayland_destroy(handle);
+    m_handle = nullptr;
 }
 
 wl_global *WXWayland::global() const
 {
-    return handle()->shell_v1->global;
+    if (auto *h = handle())
+        return h->shell_v1 ? h->shell_v1->global : nullptr;
+    return nullptr;
 }
 
 void WXWayland::readAsyncProperties(

--- a/waylib/tests/unit_tests/test_native_handles/main.cpp
+++ b/waylib/tests/unit_tests/test_native_handles/main.cpp
@@ -450,7 +450,11 @@ private Q_SLOTS:
         QCOMPARE(WSeat::fromHandle(nativeSeat), seat.data());
 
         server.stop();
-        QVERIFY(seat.isNull());
+        // WM-194: WServer::stop() no longer deletes interfaces — the wrapper
+        // survives for restart. Only the native handle is destroyed and the
+        // reverse fromHandle() mapping is cleared before wlr_seat_destroy().
+        QVERIFY(!seat.isNull());              // wrapper object survives stop()
+        QVERIFY(!seat->handle());             // native wlr_seat destroyed
         QVERIFY(!WSeat::fromHandle(nativeSeat));
         qunsetenv("WAYLIB_DISABLE_GESTURE");
     }


### PR DESCRIPTION
## WM-194: WServer::stop 不应 delete interface，需支持 stop 后重新 start

### 问题

`WServer::stop()` 会 delete 所有 `WServerInterface` 对象并清空列表，导致 stop 后无法重新 start——接口对象已析构，无法重建原生句柄。

### 方案

基于最新 master（`c696665b3`，已移除 qwlroots）重新实现，遵循架构师修订方案（issue 评论 `0def145a`）：

1. **`stop()` 不再 delete 接口对象**：逆序 `teardown()` + `destroy()` 后销毁 display（"free follow display" 回收 ~18 个无 destroy 函数的 wlr 对象），保留 C++ 包装对象存活
2. **`init()` 重建 display**：display 为空时 `wl_display_create()` + `wl_display_set_global_filter` 重建
3. **`start()`/`stop()` 守卫**：start 加 `isRunning()` 重入守卫，stop 改为非运行态 no-op
4. **`~WServer()`**：stop 后 delete 残留接口包装对象
5. **`WSocket::stopListen()`**：移除事件源但保留 fd，支持 restart 后重新 listen
6. **`WSeat::destroy()`**：清理键盘组（共享 `destroyKeyboardGroup()` 助手）+ `wlr_seat_destroy()` 后置空
7. **`WXWayland::destroy()`**：`wlr_xwayland_destroy()` 后置空
8. **`WCursorShapeManagerV1::destroy()`**：置空 `m_handle`（配合 create 守卫）

### 审核状态

代码审核已通过 ✅（实码复审，5 个验证点全部通过，issue 评论 `42c75ad1`）

### 改动

- 8 文件，+115/−9，均在 waylib
- commit: `5319521651c3a04ed4826857291dee3496562191`