### PR TITLE
feat: add privileged overlay surface support

### DIFF
--- a/src/common/treelandlogging.cpp
+++ b/src/common/treelandlogging.cpp
@@ -87,3 +87,5 @@ Q_LOGGING_CATEGORY(lcTlDdm, "treeland.ddm")
 
 // Popup focus management
 Q_LOGGING_CATEGORY(lcTlPopupFocus, "treeland.popup.focus")
+// Privileged surface
+Q_LOGGING_CATEGORY(lcTlPrivilegedSurface, "treeland.privileged.surface", QtInfoMsg)

--- a/src/common/treelandlogging.h
+++ b/src/common/treelandlogging.h
@@ -90,5 +90,7 @@ Q_DECLARE_LOGGING_CATEGORY(lcTlDdm)
 
 // Popup focus management
 Q_DECLARE_LOGGING_CATEGORY(lcTlPopupFocus)
+// Privileged surface
+Q_DECLARE_LOGGING_CATEGORY(lcTlPrivilegedSurface)
 
 #endif // TREELAND_LOGGING_H

--- a/src/core/imcandidatepanelmanager.cpp
+++ b/src/core/imcandidatepanelmanager.cpp
@@ -78,27 +78,22 @@ xcb_atom_t IMCandidatePanelManager::imCandidatePanelAtom() const
 {
     return m_imCandidatePanelAtom;
 }
-
-bool IMCandidatePanelManager::checkAndApplyIMCandidatePanel(
-    SurfaceWrapper *wrapper,
-    WAYLIB_SERVER_NAMESPACE::WXdgToplevelSurface *surface)
+bool IMCandidatePanelManager::checkAndApplyIMCandidatePanel(SurfaceWrapper *wrapper)
 {
-    if (surface->tag() != IM_CANDIDATE_PANEL)
+    auto *shellSurface = wrapper->shellSurface();
+    if (auto *xdgSurface = qobject_cast<WAYLIB_SERVER_NAMESPACE::WXdgToplevelSurface *>(shellSurface)) {
+        if (xdgSurface->tag() != IM_CANDIDATE_PANEL)
+            return false;
+    } else if (auto *xwaylandSurface = qobject_cast<WAYLIB_SERVER_NAMESPACE::WXWaylandSurface *>(shellSurface)) {
+        if (!isIMCandidatePanel(xwaylandSurface))
+            return false;
+    } else {
         return false;
+    }
+
     if (wrapper->isIMCandidatePanel())
         return false;
-    applyIMCandidatePanel(wrapper);
-    return true;
-}
 
-bool IMCandidatePanelManager::checkAndApplyIMCandidatePanel(
-    SurfaceWrapper *wrapper,
-    WAYLIB_SERVER_NAMESPACE::WXWaylandSurface *surface)
-{
-    if (!isIMCandidatePanel(surface))
-        return false;
-    if (wrapper->isIMCandidatePanel())
-        return false;
     applyIMCandidatePanel(wrapper);
     return true;
 }
@@ -244,7 +239,7 @@ void IMCandidatePanelManager::onXwaylandPropertyChanged(
             bool value = IMCandidatePanelManager::parseIMCandidatePanelProperty(result, atom);
             s->setProperty("imCandidatePanel", value);
             if (wrapper) {
-                self->checkAndApplyIMCandidatePanel(wrapper, s);
+                self->checkAndApplyIMCandidatePanel(wrapper);
             }
         });
 }

--- a/src/core/imcandidatepanelmanager.h
+++ b/src/core/imcandidatepanelmanager.h
@@ -17,7 +17,6 @@ class Output;
 
 namespace WAYLIB_SERVER_NAMESPACE {
 class WInputMethodHelper;
-class WXdgToplevelSurface;
 class WXWayland;
 class WXWaylandSurface;
 } // namespace WAYLIB_SERVER_NAMESPACE
@@ -35,10 +34,7 @@ public:
 
     bool isIMCandidatePanel(SurfaceWrapper *wrapper) const;
     bool isIMCandidatePanel(WAYLIB_SERVER_NAMESPACE::WXWaylandSurface *surface) const;
-    bool checkAndApplyIMCandidatePanel(SurfaceWrapper *wrapper,
-                                       WAYLIB_SERVER_NAMESPACE::WXdgToplevelSurface *surface);
-    bool checkAndApplyIMCandidatePanel(SurfaceWrapper *wrapper,
-                                       WAYLIB_SERVER_NAMESPACE::WXWaylandSurface *surface);
+    bool checkAndApplyIMCandidatePanel(SurfaceWrapper *wrapper);
     xcb_atom_t imCandidatePanelAtom() const;
 
     // Parse IM candidate panel property from async result map

--- a/src/core/rootsurfacecontainer.h
+++ b/src/core/rootsurfacecontainer.h
@@ -58,6 +58,7 @@ public:
         PopupZOrder = 5,
         CaptureLayerZOrder = 6,
         LockScreenZOrder = 7,
+        PrivilegedOverlayZOrder = 8, // Privileged overlay, above lock screen & lock screen popups
     };
 
     void init(WServer *server);

--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -51,6 +51,7 @@
 WAYLIB_SERVER_USE_NAMESPACE
 
 #define TREELAND_XDG_SHELL_VERSION 5
+const QLatin1String PRIVILEGED_OVERLAY_TAG("org.deepin.treeland.privileged-overlay");
 
 ShellHandler::ShellHandler(RootSurfaceContainer *rootContainer, WServer *server)
     : m_rootSurfaceContainer(rootContainer)
@@ -60,6 +61,7 @@ ShellHandler::ShellHandler(RootSurfaceContainer *rootContainer, WServer *server)
     , m_topContainer(new LayerSurfaceContainer(rootContainer))
     , m_overlayContainer(new LayerSurfaceContainer(rootContainer))
     , m_popupContainer(new SurfaceContainer(rootContainer))
+    , m_privilegedOverlayContainer(new SurfaceContainer(rootContainer))
     , m_windowConfigStore(new WindowConfigStore(this))
 {
     m_treelandForeignToplevel = server->attach<ForeignToplevelManagerInterfaceV1>();
@@ -84,10 +86,16 @@ ShellHandler::ShellHandler(RootSurfaceContainer *rootContainer, WServer *server)
     m_overlayContainer->setObjectName(QStringLiteral("OverlayContainer"));
     m_popupContainer->setZ(RootSurfaceContainer::PopupZOrder);
     m_popupContainer->setObjectName(QStringLiteral("PopupContainer"));
+    m_privilegedOverlayContainer->setZ(RootSurfaceContainer::PrivilegedOverlayZOrder);
+    m_privilegedOverlayContainer->setObjectName(QStringLiteral("PrivilegedOverlayContainer"));
 }
 
 void ShellHandler::updateWrapperContainer(SurfaceWrapper *wrapper, WSurface *parentSurface)
 {
+    // Privileged overlays live in their own container; parent changes of the
+    // underlying xdg-toplevel must not move them back into the workspace.
+    if (wrapper->surfaceRole() == SurfaceWrapper::SurfaceRole::PrivilegedOverlay)
+        return;
     if (wrapper->parentSurface())
         wrapper->parentSurface()->removeSubSurface(wrapper);
 
@@ -283,6 +291,11 @@ RootSurfaceContainer *ShellHandler::rootSurfaceContainer() const
 ForeignToplevelManagerInterfaceV1 *ShellHandler::foreignToplevel() const
 {
     return m_treelandForeignToplevel;
+}
+
+SurfaceContainer *ShellHandler::privilegedOverlayContainer() const
+{
+    return m_privilegedOverlayContainer;
 }
 
 void ShellHandler::createComponent(QmlEngine *engine, QQuickItem *parentItem)
@@ -490,14 +503,45 @@ void ShellHandler::ensureXdgWrapper(WXdgToplevelSurface *surface, const QString 
     }
     Q_EMIT surfaceWrapperAdded(wrapper);
 
-    // IM candidate panel detection via xdg-toplevel-tag
-    if (m_imCandidatePanelManager) {
-        QPointer<SurfaceWrapper> wrapperPtr(wrapper);
-        QObject::connect(surface, &WXdgToplevelSurface::tagChanged, this, [this, surface, wrapperPtr]() {
-            if (wrapperPtr)
-                m_imCandidatePanelManager->checkAndApplyIMCandidatePanel(wrapperPtr, surface);
-        });
-    }
+    QPointer<SurfaceWrapper> wrapperPtr(wrapper);
+    QObject::connect(surface, &WXdgToplevelSurface::tagChanged, this, [this, wrapperPtr]() {
+        if (wrapperPtr){
+            m_imCandidatePanelManager->checkAndApplyIMCandidatePanel(wrapperPtr);
+            checkAndApplyPrivilegedOverlay(wrapperPtr);
+        } 
+    });
+}
+
+bool ShellHandler::checkAndApplyPrivilegedOverlay(SurfaceWrapper *wrapper)
+{
+    auto *xdgSurface = static_cast<WXdgToplevelSurface *>(wrapper->shellSurface());
+    if (xdgSurface->tag() != PRIVILEGED_OVERLAY_TAG)
+        return false;
+    if (wrapper->surfaceRole() == SurfaceWrapper::SurfaceRole::PrivilegedOverlay)
+        return false;
+    applyPrivilegedOverlay(wrapper);
+    return true;
+}
+
+void ShellHandler::applyPrivilegedOverlay(SurfaceWrapper *wrapper)
+{
+    qCInfo(lcTlPrivilegedSurface) << "Privileged overlay promoted (tag)"
+                                  << "wrapper =" << wrapper << "appId =" << wrapper->appId();
+    wrapper->setSurfaceRole(SurfaceWrapper::SurfaceRole::PrivilegedOverlay);
+    // If a geometry animation (e.g. fullscreen transition) is in progress, abort it
+    // and apply the pending state immediately. The animation is bound to the old
+    // container's scene graph and cannot complete after the container change below.
+    wrapper->flushPendingGeometryAnimation();
+
+    // Move from the original container to the privileged overlay container
+    if (auto *oldContainer = wrapper->container())
+        oldContainer->removeSurface(wrapper);
+    m_privilegedOverlayContainer->addSurface(wrapper);
+
+    wrapper->setPositionAutomatic(false);
+    wrapper->setHasInitializeContainer(true);
+    wrapper->setSkipDockPreView(true);
+    wrapper->setSkipMutiTaskView(true);
 }
 
 void ShellHandler::onXdgToplevelSurfaceRemoved(WXdgToplevelSurface *surface)
@@ -741,7 +785,7 @@ void ShellHandler::ensureXwaylandWrapper(WXWaylandSurface *surface, const QStrin
 
     // IM candidate panel detection via XWayland xprop
     if (m_imCandidatePanelManager
-        && m_imCandidatePanelManager->checkAndApplyIMCandidatePanel(wrapper, surface)) {
+        && m_imCandidatePanelManager->checkAndApplyIMCandidatePanel(wrapper)) {
         Q_EMIT surfaceWrapperAdded(wrapper);
         return;
     }
@@ -840,7 +884,8 @@ void ShellHandler::onDockPreviewTooltip(
 void ShellHandler::onSurfaceInactivationRequested(SurfaceWrapper *wrapper)
 {
     Q_ASSERT(wrapper);
-    if (wrapper->type() != SurfaceWrapper::Type::Layer)
+    if (wrapper->type() != SurfaceWrapper::Type::Layer
+        && wrapper->surfaceRole() != SurfaceWrapper::SurfaceRole::PrivilegedOverlay)
         m_workspace->removeActivedSurface(wrapper);
 
     auto *helper = Helper::instance();

--- a/src/core/shellhandler.h
+++ b/src/core/shellhandler.h
@@ -71,6 +71,7 @@ public:
                           WAYLIB_SERVER_NAMESPACE::WServer *server);
     [[nodiscard]] Workspace *workspace() const;
     [[nodiscard]] SurfaceContainer *popupContainer() const;
+    [[nodiscard]] SurfaceContainer *privilegedOverlayContainer() const;
     [[nodiscard]] RootSurfaceContainer *rootSurfaceContainer() const;
     [[nodiscard]] ForeignToplevelManagerInterfaceV1 *foreignToplevel() const;
 
@@ -165,6 +166,10 @@ private:
     void onInitialPropertiesReady(WAYLIB_SERVER_NAMESPACE::WXWaylandSurface *surface,
                                   const QString &appId,
                                   const QMap<xcb_atom_t, QByteArray> &result);
+    // Privileged overlay demo: promote a wrapper whose xdg_toplevel carries the
+    // privileged-overlay tag (see PRIVILEGED_OVERLAY_TAG).
+    void applyPrivilegedOverlay(SurfaceWrapper *wrapper);
+    bool checkAndApplyPrivilegedOverlay(SurfaceWrapper *wrapper);
 
     WAYLIB_SERVER_NAMESPACE::WXdgShell *m_xdgShell = nullptr;
     WAYLIB_SERVER_NAMESPACE::WLayerShell *m_layerShell = nullptr;
@@ -183,6 +188,7 @@ private:
     LayerSurfaceContainer *m_topContainer = nullptr;
     LayerSurfaceContainer *m_overlayContainer = nullptr;
     SurfaceContainer *m_popupContainer = nullptr;
+    SurfaceContainer *m_privilegedOverlayContainer = nullptr;
     IMCandidatePanelManager *m_imCandidatePanelManager = nullptr;
     QObject *m_windowMenu = nullptr;
     // Prelaunch wrappers created before binding to a real shell surface

--- a/src/plugins/lockscreen/qml/ControlAction.qml
+++ b/src/plugins/lockscreen/qml/ControlAction.qml
@@ -12,6 +12,8 @@ RowLayout {
     id: bottomGroup
     spacing: 15
 
+    signal powerListClosed()
+
     required property Item rootItem
     property int buttonSize: 30
     property bool powerVisible: powerList.visible
@@ -73,33 +75,39 @@ RowLayout {
         Layout.alignment: Qt.AlignHCenter
         iconName: "login_power"
 
-        function closePopup() {
-            powerList.close()
-        }
-
         ToolTip {
             enabled: true
             visible: powerItem.hovered
             text: qsTr("Power")
         }
 
-        Popup {
+        Item {
             id: powerList
-            width: rootItem.width
-            height: 140
             parent: rootItem
+            visible: powerItem.expand
+            width: rootItem.width
+            height: rootItem.height
             x: 0
-            y: rootItem.height / 5 * 2
-            modal: true
-            contentItem: PowerList { }
-            background: MouseArea {
-                onClicked: powerItem.closePopup()
+            y: 0
+
+            // Click outside the PowerList to close
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    powerItem.expand = false
+                    bottomGroup.powerListClosed()
+                }
             }
-            onClosed: powerItem.expand = false
+
+            PowerList {
+                width: rootItem.width
+                height: 140
+                x: 0
+                y: rootItem.height / 5 * 2
+            }
         }
         onClicked: {
             powerItem.expand = true
-            powerList.open()
         }
     }
 

--- a/src/plugins/lockscreen/qml/LockView.qml
+++ b/src/plugins/lockscreen/qml/LockView.qml
@@ -177,6 +177,9 @@ FocusScope {
         function onOtherUserRequested() {
             userInput.startOtherUserMode()
         }
+        function onPowerListClosed() {
+            userInput.forceActiveFocus()
+        }
     }
 
     Connections {

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2856,7 +2856,9 @@ void Helper::setActivatedSurface(SurfaceWrapper *newActivateSurface, WSeat *seat
         oldPrimarySurface->setActivate(false);
 
     if (newActivateSurface) {
-        Q_ASSERT(newActivateSurface->showOnWorkspace(workspace()->current()->id()));
+        Q_ASSERT(newActivateSurface->showOnWorkspace(workspace()->current()->id())
+                 || newActivateSurface->surfaceRole()
+                     == SurfaceWrapper::SurfaceRole::PrivilegedOverlay);
         newActivateSurface->stackToLast();
         if (newActivateSurface->type() == SurfaceWrapper::Type::XWayland) {
             auto xwaylandSurface =

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -1093,6 +1093,26 @@ void SurfaceWrapper::abortGeometryAnimation()
     }
 }
 
+void SurfaceWrapper::flushPendingGeometryAnimation()
+{
+    if (!m_geometryAnimation)
+        return;
+
+    const State targetState = m_pendingState;
+    const QRectF targetGeometry = m_pendingGeometry;
+
+    abortGeometryAnimation();
+
+    if (m_surfaceState == targetState)
+        return;
+
+    if (targetGeometry.isValid()) {
+        applySurfaceStateGeometry(targetState, targetGeometry);
+    } else {
+        doSetSurfaceState(targetState);
+    }
+}
+
 QBindable<SurfaceWrapper::State> SurfaceWrapper::bindableSurfaceState()
 {
     return &m_surfaceState;

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -131,6 +131,7 @@ public:
     {
         Normal,
         Overlay,
+        PrivilegedOverlay, // Privileged overlay, exempt from lock-screen hiding
     };
     Q_ENUM(SurfaceRole)
 
@@ -196,6 +197,7 @@ public:
     void resetWidth();
     void resetHeight();
 
+    void flushPendingGeometryAnimation();
     State previousSurfaceState() const;
     State surfaceState() const;
     void setSurfaceState(State newSurfaceState);

--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -403,6 +403,8 @@ void Workspace::pushActivedSurface(SurfaceWrapper *surface)
         qCWarning(lcTlWorkspace) << "XdgPopup can't participate in focus fallback!";
         return;
     }
+    if (surface->surfaceRole() == SurfaceWrapper::SurfaceRole::PrivilegedOverlay)
+        return;
     if (surface->showOnAllWorkspace()) [[unlikely]] {
         for (auto wpModel : std::as_const(m_models->objects()))
             wpModel->pushActivedSurface(surface);


### PR DESCRIPTION
Add privileged overlay container and surface role for surfaces that should remain visible above the lock screen. Introduce logging category, z-order, tag-based detection, and geometry animation flush.

新增特权叠加层容器和表面角色，使特定表面在锁屏状态下仍保持可见。
添加日志分类、Z轴层级、基于tag的检测和几何动画冲刷逻辑。

Log: 添加特权叠加层表面支持
PMS: TASK-393961
Influence: 拥有 org.deepin.treeland.privileged-overlay tag 的 xdg-toplevel surface 将自动提升为特权叠加层，在锁屏时仍可见且不受 workspace 切换影响。

## Summary by Sourcery

Add support for privileged overlay surfaces that remain visible above the lock screen and are managed separately from normal workspace surfaces.

New Features:
- Introduce a privileged overlay surface role and dedicated container with a z-order above the lock screen for tagged xdg-toplevel surfaces.

Enhancements:
- Add tag-based detection and promotion of eligible xdg-toplevel wrappers into the privileged overlay container, including focus and workspace activation exemptions.
- Add logic to flush pending geometry animations when a surface is promoted to privileged overlay to ensure consistent state after container changes.
- Introduce a dedicated logging category for privileged surfaces.
- Adjust lock screen power control UI to use an inline item with custom mouse handling instead of a modal popup.