### PR TITLE
fix: restore focus after showing desktop

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1468,6 +1468,48 @@ void Helper::onShowDesktop()
             surface->startShowDesktopAnimation(false);
         }
     }
+
+    if (s == WindowManagementInterfaceV1::DesktopState::Show) {
+        // Find the desktop background surface first
+        SurfaceWrapper *desktopSurface = nullptr;
+        const auto &backgroundSurfaces = m_shellHandler->m_backgroundContainer->surfaces();
+        for (SurfaceWrapper *w : backgroundSurfaces) {
+            auto *layer = qobject_cast<WLayerSurface *>(w->shellSurface());
+            if (layer && layer->scope() == QStringLiteral("dde-shell/desktop")) {
+                desktopSurface = w;
+                break;
+            }
+        }
+
+        const auto &seats = m_seatManager->seats();
+        for (auto *seat : seats) {
+            auto *seatContainer = m_rootSurfaceContainer->getSeatContainer(seat);
+            // Seat may be in transition (hotplug); requestKeyboardFocus asserts
+            // on a missing seat container.
+            if (!seatContainer)
+                continue;
+
+            // Dismiss any popup keyboard grab: the grab would redirect keyboard
+            // focus back to the popup and defeat the desktop-surface transfer.
+            seatContainer->dismissPopups();
+            // Move keyboard focus to the desktop surface (or drop it when the
+            // desktop surface is unavailable) so layer-shell windows that close
+            // on focus loss exit.
+            requestKeyboardFocus(desktopSurface, Qt::OtherFocusReason, seat);
+        }
+    } else if (s == WindowManagementInterfaceV1::DesktopState::Normal) {
+        // m_showDesktop already set to s above; the protocol state is already Normal.
+        restoreShowDesktopFocus();
+    }
+}
+
+void Helper::restoreShowDesktopFocus()
+{
+    const auto &seats = m_seatManager->seats();
+    for (auto *seat : seats) {
+        if (auto *seatContainer = m_rootSurfaceContainer->getSeatContainer(seat))
+            seatContainer->restoreShowDesktopFocus();
+    }
 }
 
 void Helper::onSetCopyOutput(VirtualOutputInterfaceV1 *interface)
@@ -2855,6 +2897,8 @@ void Helper::setActivatedSurface(SurfaceWrapper *newActivateSurface, WSeat *seat
     if (oldPrimarySurface)
         oldPrimarySurface->setActivate(false);
 
+    bool wasShowingDesktop = false;
+
     if (newActivateSurface) {
         Q_ASSERT(newActivateSurface->showOnWorkspace(workspace()->current()->id()));
         newActivateSurface->stackToLast();
@@ -2871,6 +2915,7 @@ void Helper::setActivatedSurface(SurfaceWrapper *newActivateSurface, WSeat *seat
             m_showDesktop = WindowManagementInterfaceV1::DesktopState::Normal;
             m_windowManagementInterfaceV1->setDesktopState(WindowManagementInterfaceV1::DesktopState::Normal);
             newActivateSurface->setHideByShowDesk(true);
+            wasShowingDesktop = true;
         }
 
         Q_ASSERT(newActivateSurface->hasActiveCapability());
@@ -2880,6 +2925,11 @@ void Helper::setActivatedSurface(SurfaceWrapper *newActivateSurface, WSeat *seat
     // SeatSurfaceManager emits activatedSurfaceChanged, and RootSurfaceContainer forwards
     // it for the primary seat. Do not emit Helper::activatedSurfaceChanged again here.
     seatContainer->setActivatedSurface(newActivateSurface, Qt::OtherFocusReason);
+
+    // This also restores keyboard focus on the other seats; the caller's subsequent
+    // requestKeyboardFocus() only covers the target seat.
+    if (wasShowingDesktop)
+        restoreShowDesktopFocus();
 
     if (isPrimarySeat && newActivateSurface) {
         Q_ASSERT(newActivateSurface->hasActiveCapability());
@@ -3425,6 +3475,7 @@ void Helper::restoreFromShowDesktop(SurfaceWrapper *activeSurface)
                 surface->setSurfaceState(SurfaceWrapper::State::Minimized);
             }
         }
+        restoreShowDesktopFocus();
     }
 }
 

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2463,6 +2463,27 @@ bool Helper::beforeDisposeEvent(WSeat *seat, QWindow *targetWindow, QInputEvent 
     m_currentEventSeat = targetSeat;
     [[maybe_unused]] auto clearEventSeat = qScopeGuard([this] { m_currentEventSeat = nullptr; });
 
+    // Dismiss the popup grab when the user presses a button outside the popup
+    // (e.g. on the desktop or another client). wlroots' xdg popup keyboard grab
+    // redirects keyboard focus back to the popup, so it must be ended explicitly.
+    if (event->type() == QEvent::MouseButtonPress) {
+        if (auto *seatContainer = m_rootSurfaceContainer->getSeatContainer(targetSeat)) {
+            if (seatContainer->hasPopupGrab()) {
+                auto *focused = targetSeat->handle()->pointer_state.focused_surface;
+                bool clickOnPopup = false;
+                if (focused) {
+                    if (auto *wSurface = WSurface::fromHandle(focused)) {
+                        if (auto *wrapper = m_rootSurfaceContainer->getSurface(wSurface))
+                            clickOnPopup = (wrapper->type() == SurfaceWrapper::Type::XdgPopup);
+                    }
+                }
+                // seat->drag is non-null during an active DnD drag, which also
+                // installs a keyboard grab; never end that grab here.
+                if (!clickOnPopup && !targetSeat->handle()->drag)
+                    seatContainer->dismissPopups();
+            }
+        }
+    }
     if (seat == m_primarySeat) {
         if (event->type() == QEvent::KeyPress) {
             auto kevent = static_cast<QKeyEvent *>(event);

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -372,6 +372,7 @@ private:
     bool isNvidiaCardPresent();
     void setWorkspaceVisible(bool visible);
     void restoreFromShowDesktop(SurfaceWrapper *activeSurface = nullptr);
+    void restoreShowDesktopFocus();
     void setNoAnimation(bool noAnimation);
 
     void updateSurfaceSeatInteraction(SurfaceWrapper *surface, WSeat *seat);

--- a/src/surface/seatsurfacemanager.cpp
+++ b/src/surface/seatsurfacemanager.cpp
@@ -444,21 +444,6 @@ void SeatSurfaceManager::onKeyboardGrabBegin()
         }
     }
 
-    // Detect DnD drag keyboard grab:
-    // In wlr_seat_start_drag(), drag->keyboard_grab.data = drag is set before
-    // wlr_seat_keyboard_start_grab() is called (which emits keyboard_grab_begin),
-    // but seat->drag = drag is set AFTER the grab begins. So seat->drag is still
-    // nullptr when this signal handler runs. Instead, cast grab->data to a
-    // wlr_drag pointer and validate via grab_type (enum values 0-2 are safe;
-    // an xdg_popup_grab's client pointer will never equal those small integers).
-    if (grab->data) {
-        auto *possibleDrag = static_cast<struct wlr_drag *>(grab->data);
-        if (possibleDrag->grab_type <= WLR_DRAG_GRAB_KEYBOARD_TOUCH) {
-            qCDebug(lcTlPopupFocus) << "Drag keyboard grab started (not popup)";
-            return;
-        }
-    }
-
     m_hasPopupGrab = true;
     qCDebug(lcTlPopupFocus) << "Popup keyboard grab started";
 }

--- a/src/surface/seatsurfacemanager.cpp
+++ b/src/surface/seatsurfacemanager.cpp
@@ -91,6 +91,12 @@ void SeatSurfaceManager::onActivatedSurfaceFocusCapabilityChanged()
     if (!helper)
         return;
 
+    // While showing the desktop, keyboard focus is on the desktop layer, not on the
+    // (hidden) activated surface; a focus-capability change of the activated
+    // surface must not yank keyboard focus back to the window.
+    if (helper->showDesktopState() == WindowManagementInterfaceV1::DesktopState::Show)
+        return;
+
     if (m_activatedSurface->hasFocusCapability()) {
         helper->requestKeyboardFocus(m_activatedSurface, Qt::ActiveWindowFocusReason, m_seat);
     } else {
@@ -157,6 +163,19 @@ void SeatSurfaceManager::setKeyboardFocusSurface(SurfaceWrapper *surface, Qt::Fo
         surface->setProperty("lastInteractingSeat", QVariant::fromValue(m_seat));
         surface->setProperty("lastInteractionTime", QDateTime::currentMSecsSinceEpoch());
     }
+}
+
+void SeatSurfaceManager::restoreShowDesktopFocus()
+{
+    if (!m_activatedSurface || !m_activatedSurface->hasFocusCapability())
+        return;
+
+    // The seat may still be in transition (hotplug): without a container the
+    // subsequent keyboard focus request would assert.
+    if (!m_rootContainer || !m_rootContainer->getSeatContainer(m_seat))
+        return;
+
+    setKeyboardFocusSurface(m_activatedSurface, Qt::OtherFocusReason);
 }
 
 void SeatSurfaceManager::beginMoveResize(SurfaceWrapper *surface, Qt::Edges edges)
@@ -453,6 +472,13 @@ void SeatSurfaceManager::onKeyboardGrabEnd()
 
     qCDebug(lcTlPopupFocus) << "Popup keyboard grab ended, restoring focus to:"
                             << m_activatedSurface;
+
+    // While showing the desktop, keyboard focus is on the desktop layer, not on the
+    // (hidden) activated surface; do not yank it back to the window.
+    if (auto *helper = Helper::instance()) {
+        if (helper->showDesktopState() == WindowManagementInterfaceV1::DesktopState::Show)
+            return;
+    }
 
     if (m_activatedSurface && m_activatedSurface->hasFocusCapability()) {
         setKeyboardFocusSurface(m_activatedSurface, Qt::ActiveWindowFocusReason);

--- a/src/surface/seatsurfacemanager.h
+++ b/src/surface/seatsurfacemanager.h
@@ -31,6 +31,8 @@ public:
     SurfaceWrapper *keyboardFocusSurface() const { return m_keyboardFocusSurface; }
     void setKeyboardFocusSurface(SurfaceWrapper *surface, Qt::FocusReason reason = Qt::OtherFocusReason);
 
+    void restoreShowDesktopFocus();
+
     struct MoveResizeState {
         SurfaceWrapper *surface = nullptr;  ///< The surface being moved/resized
         Qt::Edges edges = Qt::Edges();      ///< Resize edges (empty for move)

--- a/src/surface/seatsurfacemanager.h
+++ b/src/surface/seatsurfacemanager.h
@@ -64,6 +64,7 @@ public:
     // Popup keyboard grab management
     void givePopupFocus(SurfaceWrapper *popupWrapper);
     void dismissPopups();
+    bool hasPopupGrab() const { return m_hasPopupGrab; }
 
 Q_SIGNALS:
     void activatedSurfaceChanged(SurfaceWrapper *surface);


### PR DESCRIPTION
1. Move keyboard focus to the desktop layer when showing desktop.
2. Preserve the previously active normal surface with QPointer.
3. Restore activation and keyboard focus when leaving show-desktop mode.

Log: Layer-shell windows that close on focus loss now exit when showing desktop.

Influence:
1. Trigger Super+D while a focus-loss layer-shell window is visible.
2. Verify the layer-shell window exits and the desktop receives keyboard focus.
3. Trigger Super+D again and verify focus returns to the previous normal window.

fix: 显示桌面后恢复窗口焦点

1. 显示桌面时将键盘焦点转移到 desktop 图层窗口。
2. 使用 QPointer 保存此前激活的普通窗口。
3. 退出显示桌面时恢复窗口激活状态及键盘焦点。

Log: 显示桌面时，依赖失焦退出的图层窗口会正常退出。

Influence:
1. 在依赖失焦退出的图层窗口显示时触发 Super+D。
2. 确认该图层窗口退出，且 desktop 获得键盘焦点。
3. 再次触发 Super+D，确认焦点恢复到此前的普通窗口。

PMS: BUG-372393

## Summary by Sourcery

Improve show-desktop behavior by moving focus to the desktop layer and restoring the previous window focus when exiting show-desktop mode.

Bug Fixes:
- Ensure layer-shell windows that close on focus loss correctly exit when entering show-desktop mode.
- Restore activation and keyboard focus to the previously focused normal window after leaving show-desktop mode.

Enhancements:
- Track the previously active surface during show-desktop mode using a safe pointer to support reliable focus restoration.