### PR TITLE
fix(xwayland): displayed incorrectly when maximized during initializa…

### DIFF
--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -755,6 +755,16 @@ void ShellHandler::ensureXwaylandWrapper(WXWaylandSurface *surface, const QStrin
                          updateSurfaceWithParentContainer);
     updateSurfaceWithParentContainer();
     Q_ASSERT(wrapper->parentItem());
+    const auto initialState = surface->handle()->fullscreen
+        ? SurfaceWrapper::State::Fullscreen
+        : (surface->handle()->maximized_horz && surface->handle()->maximized_vert)
+        ? SurfaceWrapper::State::Maximized : SurfaceWrapper::State::Normal;
+    if (isNewWrapper && initialState != SurfaceWrapper::State::Normal) {
+        if (initialState == SurfaceWrapper::State::Fullscreen)
+            wrapper->enterFullscreen();
+        else
+            wrapper->maximize();
+    }
     setupSurfaceWindowMenu(wrapper);
     // Only setup active watcher for newly created wrappers;
     // prelaunch splash wrappers already have it set up in createPrelaunchSplash

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -592,6 +592,22 @@ void SurfaceWrapper::syncPrelaunchMappedState()
         m_prelaunchOutputs.clear();
     }
 
+    if (auto *xwaylandSurface = qobject_cast<WXWaylandSurface *>(m_shellSurface.data())) {
+        if (xwaylandSurface->handle()->fullscreen) {
+            setSurfaceStateDirectly(State::Fullscreen);
+        } else if ((xwaylandSurface->handle()->maximized_horz && xwaylandSurface->handle()->maximized_vert) &&
+                   isMaximizable()) {
+            setSurfaceStateDirectly(State::Maximized);
+        }
+
+        const QRectF stateGeometry = targetGeometryForState(m_surfaceState);
+        if ((m_surfaceState == State::Maximized || m_surfaceState == State::Fullscreen)
+            && stateGeometry.isValid()) {
+            setPosition(alignToPixelGrid(stateGeometry.topLeft()));
+            setSize(stateGeometry.size());
+        }
+    }
+
     updateActiveState();
 }
 
@@ -624,8 +640,13 @@ void SurfaceWrapper::startPrelaunchSplashHideSequence()
 
     // Use surfaceItem's scene-space implicit size: for XWayland, surf->size() is
     // buffer-space and differs from scene-space after DPR scaling via surfaceSizeRatio.
-    const QSizeF targetImplicitSize(m_surfaceItem->implicitWidth(),
-                                    m_surfaceItem->implicitHeight());
+    const QRectF stateGeometry = targetGeometryForState(m_surfaceState);
+    const bool useStateGeometry = (m_surfaceState == State::Maximized
+                                   || m_surfaceState == State::Fullscreen)
+        && stateGeometry.isValid();
+    const QSizeF targetImplicitSize = useStateGeometry
+        ? stateGeometry.size()
+        : QSizeF(m_surfaceItem->implicitWidth(), m_surfaceItem->implicitHeight());
     const bool hasValidTargetImplicitSize =
         targetImplicitSize.width() > 0 && targetImplicitSize.height() > 0;
     if (!hasValidTargetImplicitSize) {
@@ -712,6 +733,22 @@ void SurfaceWrapper::completeSplashTransition(const QSizeF &targetImplicitSize, 
     }
 
     m_surfaceItem->setVisible(true);
+    if (m_type == Type::XWayland
+        && (m_surfaceState == State::Maximized || m_surfaceState == State::Fullscreen)) {
+        QMetaObject::invokeMethod(
+            this,
+            [this] {
+                if (m_wrapperAboutToRemove || !m_surfaceItem)
+                    return;
+                updateSurfaceSizeRatio();
+                const QRectF stateGeometry = targetGeometryForState(m_surfaceState);
+                if (stateGeometry.isValid()) {
+                    setPosition(alignToPixelGrid(stateGeometry.topLeft()));
+                    resize(stateGeometry.size());
+                }
+            },
+            Qt::QueuedConnection);
+    }
     Q_ASSERT(m_prelaunchSplash);
     m_prelaunchSplash->setVisible(false);
     m_prelaunchSplash->deleteLater();


### PR DESCRIPTION
…tion

Apply the initial maximized or fullscreen state when an XWayland window replaces its prelaunch splash, and synchronize the wrapper geometry before completing the splash transition.

Log: fix displayed incorrectly when maximized during initialization
PMS: BUG-373597
Influence: XWayland prelaunch startup state and splash transitions

## Summary by Sourcery

Ensure XWayland surfaces start in the correct maximized or fullscreen state when replacing their prelaunch splash and keep geometry synchronized through the splash transition.

Bug Fixes:
- Apply initial maximized or fullscreen state to new XWayland wrappers based on the window handle during prelaunch startup.
- Correct XWayland window geometry when maximized or fullscreen so that wrapper position and size match the target state during and after splash transitions.

Enhancements:
- Synchronize wrapper geometry with target state for maximized and fullscreen XWayland surfaces when updating prelaunch mapped state and completing the splash transition.