### PR TITLE
refactor(wallpaper): simplify native output conversion

### DIFF
--- a/src/modules/wallpaper/wallpapermanagerinterfacev1.cpp
+++ b/src/modules/wallpaper/wallpapermanagerinterfacev1.cpp
@@ -27,8 +27,7 @@ static WOutput *outputFromResource(wl_resource *resource)
     if (!nativeOutput)
         return nullptr;
 
-    auto *output = nativeOutput;
-    return output ? WOutput::fromHandle(output) : nullptr;
+    return WOutput::fromHandle(nativeOutput);
 }
 
 static const char *usernameFromUid(uid_t uid)


### PR DESCRIPTION
Return the WOutput wrapper directly after validating the native output, removing the redundant local variable and duplicate null check.

Log: simplify wallpaper output resource conversion
Influence: Wallpaper output lookup; no functional change

## Summary by Sourcery

Enhancements:
- Refactor wallpaper output lookup helper to remove unnecessary local variable and duplicate null check while preserving behavior.