### PR TITLE
refactor: extract WWaylandResource from WObject

### DIFF
--- a/waylib/src/server/CMakeLists.txt
+++ b/waylib/src/server/CMakeLists.txt
@@ -144,6 +144,7 @@ set(SOURCES
     kernel/wserver.cpp
     kernel/wsurface.cpp
     kernel/wtoplevelsurface.cpp
+    kernel/wwaylandresource.cpp
 
 
     kernel/wtypes.cpp
@@ -241,6 +242,7 @@ set(HEADERS
     wayliblogging.h
 
     kernel/wglobal.h
+    kernel/wwaylandresource.h
     kernel/wlr_all.h
     kernel/wlr_fwd.h
     kernel/wpointer.h
@@ -357,6 +359,7 @@ set(PRIVATE_HEADERS
     platformplugin/qwlrootscursor.h
     platformplugin/types.h
     kernel/private/wglobal_p.h
+    kernel/private/wwaylandresource_p.h
     kernel/private/wsurface_p.h
     kernel/private/wprivateaccessor_p.h
     qtquick/private/woutputviewport_p.h

--- a/waylib/src/server/kernel/private/wglobal_p.h
+++ b/waylib/src/server/kernel/private/wglobal_p.h
@@ -21,9 +21,6 @@ public:
     bool removeListenersInternal(WObject *owner);
 
     virtual ~WObjectPrivate();
-    virtual wl_client *waylandClient() const {
-        return nullptr;
-    }
 
     // Live listener graph; public so unit tests can assert ownership edges
     // without friending WObjectPrivate.

--- a/waylib/src/server/kernel/private/wsurface_p.h
+++ b/waylib/src/server/kernel/private/wsurface_p.h
@@ -5,7 +5,7 @@
 
 #include <wlr_fwd.h>
 #include "wsurface.h"
-#include "private/wglobal_p.h"
+#include "private/wwaylandresource_p.h"
 #include "wpointer.h"
 #include "wscoplistener.h"
 
@@ -16,7 +16,7 @@
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
-class Q_DECL_HIDDEN WSurfacePrivate : public WObjectPrivate {
+class Q_DECL_HIDDEN WSurfacePrivate : public WWaylandResourcePrivate {
 public:
     WSurfacePrivate(WSurface *qq, wlr_surface *handle);
     ~WSurfacePrivate();

--- a/waylib/src/server/kernel/private/wtoplevelsurface_p.h
+++ b/waylib/src/server/kernel/private/wtoplevelsurface_p.h
@@ -3,15 +3,15 @@
 #pragma once
 
 #include "wtoplevelsurface.h"
-#include "wglobal_p.h"
+#include "private/wwaylandresource_p.h"
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
-class WAYLIB_SERVER_EXPORT WToplevelSurfacePrivate : public WObjectPrivate
+class WAYLIB_SERVER_EXPORT WToplevelSurfacePrivate : public WWaylandResourcePrivate
 {
 public:
     inline WToplevelSurfacePrivate(WToplevelSurface *q)
-        : WObjectPrivate(q) {}
+        : WWaylandResourcePrivate(q) {}
 };
 
 WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/kernel/private/wwaylandresource_p.h
+++ b/waylib/src/server/kernel/private/wwaylandresource_p.h
@@ -1,0 +1,19 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+#pragma once
+
+#include "wwaylandresource.h"
+#include "wglobal_p.h"
+
+WAYLIB_SERVER_BEGIN_NAMESPACE
+
+class WAYLIB_SERVER_EXPORT WWaylandResourcePrivate : public WObjectPrivate
+{
+public:
+    using WObjectPrivate::WObjectPrivate;
+    ~WWaylandResourcePrivate() override = default;
+
+    virtual wl_client *waylandClient() const { return nullptr; }
+};
+
+WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/kernel/wglobal.cpp
+++ b/waylib/src/server/kernel/wglobal.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wglobal.h"
-#include "wsocket.h"
 #include "wscoplistener.h"
 #include "private/wglobal_p.h"
 #include "wayliblogging.h"
@@ -13,37 +12,6 @@
 #include <utility>
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
-
-WClient *WObject::waylandClient() const
-{
-    auto client = w_d_ptr->waylandClient();
-    if (!client)
-        return nullptr;
-
-    auto wclient = WClient::get(client);
-    Q_ASSERT(wclient);
-
-    return wclient;
-}
-
-pid_t WObject::pid() const
-{
-    auto client = waylandClient();
-    if (!client)
-        return 0;
-    auto credentials = client->credentials();
-    if (!credentials)
-        return 0;
-    return credentials->pid;
-}
-
-int WObject::pidFD() const
-{
-    auto client = waylandClient();
-    if (!client)
-        return -1;
-    return client->pidFD();
-}
 
 WObject::WObject()
     : w_d_ptr(new WObjectPrivate(this))

--- a/waylib/src/server/kernel/wglobal.h
+++ b/waylib/src/server/kernel/wglobal.h
@@ -102,10 +102,6 @@ public:
         removeAttachedData<T>(owner);
     }
 
-    [[nodiscard]] WClient *waylandClient() const;
-    [[nodiscard]] virtual pid_t pid() const;
-    [[nodiscard]] virtual int pidFD() const;
-
     // Default construction for mixin use (e.g. QObject + WObject) without a
     // dedicated *Private subclass.
     WObject();

--- a/waylib/src/server/kernel/wsurface.cpp
+++ b/waylib/src/server/kernel/wsurface.cpp
@@ -14,7 +14,7 @@
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
 WSurfacePrivate::WSurfacePrivate(WSurface *qq, wlr_surface *handle)
-    : WObjectPrivate(qq)
+    : WWaylandResourcePrivate(qq)
 {
     Q_ASSERT(handle);
     handle->data = qq;
@@ -210,7 +210,7 @@ WSurface::WSurface(wlr_surface *handle)
 
 WSurface::WSurface(WSurfacePrivate &dd)
     : QObject(nullptr)
-    , WObject(dd, nullptr)
+    , WWaylandResource(dd, nullptr)
 {
     dd.init();
 }

--- a/waylib/src/server/kernel/wsurface.h
+++ b/waylib/src/server/kernel/wsurface.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <wlr_fwd.h>
-#include <wglobal.h>
+#include <wwaylandresource.h>
 #include <wtypes.h>
 
 #include <QObject>
@@ -18,7 +18,7 @@ WAYLIB_SERVER_BEGIN_NAMESPACE
 class WServer;
 class WOutput;
 class WSurfacePrivate;
-class WAYLIB_SERVER_EXPORT WSurface : public QObject, public WObject
+class WAYLIB_SERVER_EXPORT WSurface : public QObject, public WWaylandResource
 {
     Q_OBJECT
     W_DECLARE_PRIVATE(WSurface)

--- a/waylib/src/server/kernel/wtoplevelsurface.cpp
+++ b/waylib/src/server/kernel/wtoplevelsurface.cpp
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "wtoplevelsurface.h"
+#include "private/wwaylandresource_p.h"
 #include "private/wtoplevelsurface_p.h"
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
 WToplevelSurface::WToplevelSurface(WToplevelSurfacePrivate &d)
     : QObject(nullptr)
-    , WObject(d, nullptr)
+    , WWaylandResource(d, nullptr)
 {
 
 }

--- a/waylib/src/server/kernel/wtoplevelsurface.h
+++ b/waylib/src/server/kernel/wtoplevelsurface.h
@@ -4,12 +4,13 @@
 #pragma once
 
 #include <WSurface>
+#include <wwaylandresource.h>
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
 class WSeat;
 class WToplevelSurfacePrivate;
-class WAYLIB_SERVER_EXPORT WToplevelSurface : public QObject, public WObject
+class WAYLIB_SERVER_EXPORT WToplevelSurface : public QObject, public WWaylandResource
 {
     Q_OBJECT
     W_DECLARE_PRIVATE(WToplevelSurface)

--- a/waylib/src/server/kernel/wwaylandresource.cpp
+++ b/waylib/src/server/kernel/wwaylandresource.cpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "wwaylandresource.h"
+#include "private/wwaylandresource_p.h"
+#include "wsocket.h"
+#include "wayliblogging.h"
+
+WAYLIB_SERVER_BEGIN_NAMESPACE
+
+WWaylandResource::WWaylandResource(WWaylandResourcePrivate &dd, WObject *parent)
+    : WObject(dd, parent)
+{
+}
+
+WClient *WWaylandResource::waylandClient() const
+{
+    W_DC(WWaylandResource);
+    auto client = d->waylandClient();
+    if (!client)
+        return nullptr;
+
+    auto wclient = WClient::get(client);
+    Q_ASSERT(wclient);
+
+    return wclient;
+}
+
+pid_t WWaylandResource::pid() const
+{
+    auto client = waylandClient();
+    if (!client)
+        return 0;
+    auto credentials = client->credentials();
+    if (!credentials)
+        return 0;
+    return credentials->pid;
+}
+
+int WWaylandResource::pidFD() const
+{
+    auto client = waylandClient();
+    if (!client)
+        return -1;
+    return client->pidFD();
+}
+
+WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/kernel/wwaylandresource.h
+++ b/waylib/src/server/kernel/wwaylandresource.h
@@ -1,0 +1,40 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <wglobal.h>
+
+#include <sys/types.h> // pid_t
+
+WAYLIB_SERVER_BEGIN_NAMESPACE
+
+class WWaylandResourcePrivate;
+
+// WWaylandResource extends WObject with wayland-client specific information
+// (waylandClient/pid/pidFD). Only objects that represent (or wrap) a
+// wl_client-owned resource should inherit this class; plain WObject
+// subclasses (outputs, seats, servers, protocol managers, ...) keep
+// inheriting WObject directly.
+class WAYLIB_SERVER_EXPORT WWaylandResource : public WObject
+{
+public:
+    [[nodiscard]] WClient *waylandClient() const;
+    [[nodiscard]] virtual pid_t pid() const;
+    [[nodiscard]] virtual int pidFD() const;
+
+protected:
+    // All wayland-resource subclasses have their own *Private; there is no
+    // default construction. A deleted default constructor prevents
+    // accidentally creating a WObjectPrivate where a
+    // WWaylandResourcePrivate is required (which would make d_func()'s
+    // reinterpret_cast produce undefined behaviour).
+    WWaylandResource() = delete;
+
+    WWaylandResource(WWaylandResourcePrivate &dd, WObject *parent = nullptr);
+    ~WWaylandResource() override = default;
+
+    W_DECLARE_PRIVATE(WWaylandResource)
+};
+
+WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/protocols/private/wtextinput_p.h
+++ b/waylib/src/server/protocols/private/wtextinput_p.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "wglobal.h"
-#include "private/wglobal_p.h"
+#include "wwaylandresource.h"
+#include "private/wwaylandresource_p.h"
 
 #include <QObject>
 #include <QQmlEngine>
@@ -83,7 +83,7 @@ class WSeat;
 class WSurface;
 class WInputMethodV2;
 class WTextInputPrivate;
-class WAYLIB_SERVER_EXPORT WTextInput : public QObject, public WObject
+class WAYLIB_SERVER_EXPORT WTextInput : public QObject, public WWaylandResource
 {
     Q_OBJECT
     W_DECLARE_PRIVATE(WTextInput)
@@ -116,11 +116,11 @@ public Q_SLOTS:
     virtual void handleIMCommitted(WInputMethodV2 *im) = 0;
 };
 
-class Q_DECL_HIDDEN WTextInputPrivate : public WObjectPrivate {
+class Q_DECL_HIDDEN WTextInputPrivate : public WWaylandResourcePrivate {
 public:
     W_DECLARE_PUBLIC(WTextInput)
     explicit WTextInputPrivate(WTextInput *qq)
-        : WObjectPrivate(qq)
+        : WWaylandResourcePrivate(qq)
     {}
 };
 
@@ -130,6 +130,6 @@ WTextInput::WTextInput(QObject *parent)
 
 inline WTextInput::WTextInput(WTextInputPrivate &d, QObject *parent)
     : QObject(parent)
-    , WObject(d)
+    , WWaylandResource(d)
 { }
 WAYLIB_SERVER_END_NAMESPACE

--- a/waylib/src/server/protocols/wxwayland.cpp
+++ b/waylib/src/server/protocols/wxwayland.cpp
@@ -4,6 +4,7 @@
 #include "wxwayland.h"
 
 #include "private/wglobal_p.h"
+#include "private/wwaylandresource_p.h"
 #include "private/wxwaylandsurface_p.h"
 #include "wseat.h"
 #include "wscoplistener.h"
@@ -22,11 +23,11 @@
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
-class Q_DECL_HIDDEN WXWaylandPrivate : public WObjectPrivate
+class Q_DECL_HIDDEN WXWaylandPrivate : public WWaylandResourcePrivate
 {
 public:
     WXWaylandPrivate(WXWayland *qq, wlr_compositor *compositor, bool lazy)
-        : WObjectPrivate(qq)
+        : WWaylandResourcePrivate(qq)
         , compositor(compositor)
         , lazy(lazy)
     {
@@ -211,7 +212,7 @@ void WXWaylandPrivate::on_surface_destroy(WXWaylandSurface *surface)
 
 WXWayland::WXWayland(wlr_compositor *compositor, bool lazy)
     : QObject(nullptr)
-    , WObject(*new WXWaylandPrivate(this, compositor, lazy))
+    , WWaylandResource(*new WXWaylandPrivate(this, compositor, lazy))
 {
     W_D(WXWayland);
     // TODO: Add setFreezeClientWhenDisable in WSocket

--- a/waylib/src/server/protocols/wxwayland.h
+++ b/waylib/src/server/protocols/wxwayland.h
@@ -7,6 +7,7 @@
 #include <xcb/xcb.h>
 
 #include <WServer>
+#include <wwaylandresource.h>
 
 #include <QByteArray>
 #include <QMap>
@@ -24,7 +25,7 @@ class WSeat;
 class WXWaylandSurface;
 class WXWaylandPrivate;
 
-class WAYLIB_SERVER_EXPORT WXWayland : public QObject, public WObject, public WServerInterface
+class WAYLIB_SERVER_EXPORT WXWayland : public QObject, public WWaylandResource, public WServerInterface
 {
     Q_OBJECT
     W_DECLARE_PRIVATE(WXWayland)

--- a/waylib/src/server/qtquick/private/wquicksocketattached.cpp
+++ b/waylib/src/server/qtquick/private/wquicksocketattached.cpp
@@ -3,6 +3,7 @@
 
 #include "wquicksocketattached_p.h"
 #include "wsocket.h"
+#include <wwaylandresource.h>
 
 #include <QQmlInfo>
 
@@ -26,7 +27,7 @@ WSocket *WQuickSocketAttached::rootSocket() const
 
 WQuickSocketAttached *WQuickSocketAttached::qmlAttachedProperties(QObject *target)
 {
-    if (auto wobject = dynamic_cast<WObject*>(target)) {
+    if (auto wobject = dynamic_cast<WWaylandResource*>(target)) {
         auto client = wobject->waylandClient();
         if (client) {
             auto socket = client->socket();


### PR DESCRIPTION
## Summary

将 `WObject` 中的 `waylandClient()`/`pid()`/`pidFD()` 拆分为独立的 `WWaylandResource` 中间类。

只有代表 `wl_client` 所拥有资源的对象（`WSurface`、`WToplevelSurface`、`WTextInput`、`WXWayland`）继承 `WWaylandResource`；其余 ~24 个 `WObject` 子类（WOutput、WSeat、WServer、协议管理器、QML item 等）继续直接继承 `WObject`，不再携带未使用的 wayland-client 语义。

关联 WM-247。

## Changes

**New files (3):**
- `waylib/src/server/kernel/wwaylandresource.h` — `WWaylandResource` 类声明
- `waylib/src/server/kernel/wwaylandresource.cpp` — 方法实现（从 `wglobal.cpp` 原样搬迁）
- `waylib/src/server/kernel/private/wwaylandresource_p.h` — `WWaylandResourcePrivate`

**Modified files (14):**
- `wglobal.h`/`wglobal_p.h`/`wglobal.cpp` — 从 `WObject`/`WObjectPrivate` 移除 wayland 相关代码
- `WSurface` (`.h`/`_p.h`/`.cpp`) — 继承链 `WObject → WWaylandResource`
- `WToplevelSurface` (`.h`/`_p.h`/`.cpp`) — 同上
- `WTextInput` (`_p.h`) — 同上
- `WXWayland` (`.h`/`.cpp`) — 同上
- `wquicksocketattached.cpp` — `dynamic_cast<WObject*>→dynamic_cast<WWaylandResource*>`
- `CMakeLists.txt` — 添加新文件

## ABI Break

本变更是 waylib 的 ABI 破坏性变更：`WObject` 移除 3 个公开方法（`waylandClient`/`pid`/`pidFD`），多个类的 vtable 布局变化。仓库内调用方均经具体类型访问、源码不受影响。out-of-tree 消费者若曾通过 `WObject*` 调用这些方法，升级后需迁移到 `WWaylandResource*`。

## Verification

- ✅ Full build: 538 targets, 0 errors, 0 warnings
- ✅ Unit tests: `test_wobject_listeners` (8 passed), `test_wpointer` (16 passed), `test_containerof` (7 passed), `test_wlog` (5 passed), `test_wscoplistener` (18 passed)

Pure refactor — no behaviour change.