### PR TITLE
fix: restore declarativeData cleanup in WObject::teardown

### DIFF
--- a/waylib/src/server/kernel/wglobal.cpp
+++ b/waylib/src/server/kernel/wglobal.cpp
@@ -76,6 +76,23 @@ QList<std::pair<const void *, void *>> &WObject::attachedDatas()
 void WObject::teardown()
 {
     W_D(WObject);
+
+    // Clean up the QML engine's declarativeData before detaching listeners.
+    // If the QML engine has already freed QQmlData without zeroing the
+    // declarativeData pointer, any later Qt signal emission (doActivate)
+    // reads a stale pointer and crashes inside QQmlData::signalHasEndpoint().
+    // teardown() runs from the most-derived destructor, i.e. before ~QObject,
+    // so clearing the pointer here prevents the stale read when ~QObject
+    // emits destroyed(). WObject is a non-QObject mixin, so only act when this
+    // object is also a QObject (the common case for wayland wrappers).
+    if (auto *obj = dynamic_cast<QObject *>(this)) {
+        auto *od = QObjectPrivate::get(obj);
+        if (!od->isDeletingChildren && od->declarativeData && QAbstractDeclarativeData::destroyed) {
+            QAbstractDeclarativeData::destroyed(od->declarativeData, obj);
+            od->declarativeData = nullptr;
+        }
+    }
+
     const auto targets = d->attachedListenerTargets;
     d->attachedListenerTargets.clear();
 


### PR DESCRIPTION
## 根因

提交 `9582881`（移除 qwlroots 依赖）将旧的 `WWrapObjectPrivate::invalidate()` 重构为 `WObject::teardown()` 时，遗漏迁移其中对 `QObjectPrivate::declarativeData` 的清理逻辑。缺少该清理后，若 QML 引擎已释放 `QQmlData` 但未将 `declarativeData` 指针置空，后续 `~QObject` 发射信号（`doActivate`）会读到悬空指针，在 `QQmlData::signalHasEndpoint()` 崩溃。

## 修复方案

在 `WObject::teardown()` 开头补回该清理：通过 `dynamic_cast<QObject*>(this)` 适配 WObject 非 QObject mixin 设计，对 QObject 派生类调用 `QAbstractDeclarativeData::destroyed` 释放并置空 `declarativeData`，保留原有 `isDeletingChildren` 守卫。非 QObject 派生类安全跳过。

## 改动安全评估

低风险：函数签名不变，仅新增带守卫的清理逻辑，所有调用方不受影响，行为严格可加。

## Summary by Sourcery

Bug Fixes:
- Prevent crashes caused by stale QQmlData pointers when QObject signals are emitted after QML engine cleanup.