### PR TITLE
fix(waylib): adapt native handles after qwlroots removal

### DIFF
--- a/waylib/src/server/protocols/wxdgoutput.cpp
+++ b/waylib/src/server/protocols/wxdgoutput.cpp
@@ -415,7 +415,7 @@ void WXdgOutputManager::resetScaleOverride()
 QRect WXdgOutputManager::outputGeometry(WOutput *output) const
 {
     W_DC(WXdgOutputManager);
-    auto *layoutOutput = wlr_output_layout_get(d->layout->handle()->handle(), output->nativeHandle());
+    auto *layoutOutput = wlr_output_layout_get(d->layout->handle(), output->handle());
 
     int width = 0;
     int height = 0;

--- a/waylib/src/server/protocols/wxwayland.cpp
+++ b/waylib/src/server/protocols/wxwayland.cpp
@@ -329,7 +329,7 @@ void WXWayland::setWorkareas(const QVector<QRect> &workareas)
         boxes.append({ workarea.x(), workarea.y(), workarea.width(), workarea.height() });
     }
 
-    wlr_xwayland_set_workareas(handle()->handle(), boxes.constData(), boxes.size());
+    wlr_xwayland_set_workareas(handle(), boxes.constData(), boxes.size());
 }
 
 void WXWayland::setDesktopProperties(uint32_t count,


### PR DESCRIPTION
Pass the wlroots output layout, output, and XWayland handles directly to the C APIs instead of dereferencing the obsolete qwlroots wrappers.

Align XDG output geometry lookup and XWayland workarea updates with the native handle types introduced after removing the qwlroots dependency.

Log: fix Waylib native handle access after qwlroots removal
PMS: BUG-369703
Influence: XDG output geometry and XWayland workarea synchronization

## Summary by Sourcery

Update Waylib to use native wlroots and XWayland handles directly after qwlroots removal.

Bug Fixes:
- Fix XDG output geometry lookup by passing the correct layout and output native handles.
- Fix XWayland workarea synchronization by using the updated XWayland handle type.