### PR TITLE
fix(surface): set maximized on initial surface commit

### DIFF
--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -623,6 +623,14 @@ void ShellHandler::ensureXdgWrapper(WXdgToplevelSurface *surface, const QString 
                          updateSurfaceWithParentContainer);
     updateSurfaceWithParentContainer();
     Q_ASSERT(wrapper->parentItem());
+    if (surface->isInitialized()) {
+        const auto initialState = surface->handle()->requested.fullscreen
+            ? SurfaceWrapper::State::Fullscreen
+            : surface->handle()->requested.maximized ? SurfaceWrapper::State::Maximized
+                                                     : SurfaceWrapper::State::Normal;
+        if (initialState != SurfaceWrapper::State::Normal)
+            wrapper->setSurfaceStateDirectly(initialState);
+    }
     setupSurfaceWindowMenu(wrapper);
     // Only setup active watcher for newly created wrappers;
     // prelaunch splash wrappers already have it set up in createPrelaunchSplash

--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -608,6 +608,14 @@ void ShellHandler::ensureXdgWrapper(WXdgToplevelSurface *surface, const QString 
                          updateSurfaceWithParentContainer);
     updateSurfaceWithParentContainer();
     Q_ASSERT(wrapper->parentItem());
+    if (surface->isInitialized()) {
+        const auto initialState = surface->handle()->requested.fullscreen
+            ? SurfaceWrapper::State::Fullscreen
+            : surface->handle()->requested.maximized ? SurfaceWrapper::State::Maximized
+                                                     : SurfaceWrapper::State::Normal;
+        if (initialState != SurfaceWrapper::State::Normal)
+            wrapper->setSurfaceStateDirectly(initialState);
+    }
     setupSurfaceWindowMenu(wrapper);
     // Only setup active watcher for newly created wrappers;
     // prelaunch splash wrappers already have it set up in createPrelaunchSplash

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -10,6 +10,7 @@
 #include "treelanduserconfig.hpp"
 #include "workspace/workspace.h"
 #include "wtoplevelsurface.h"
+#include "wxdgtoplevelsurface.h"
 
 #include <winputpopupsurfaceitem.h>
 #include <wlayersurface.h>
@@ -346,6 +347,23 @@ void SurfaceWrapper::setup()
     QObject::connect(m_shellSurface->surface(), &WSurface::mappedChanged,
                                            this,
                                            &SurfaceWrapper::onMappedChanged);
+    if (m_type == Type::XdgToplevel) {
+        QObject::connect(m_shellSurface->surface(), &WSurface::commit, this, [this] {
+            if (!surface() || surface()->mapped())
+                return;
+
+            auto *xdgSurface = qobject_cast<WXdgToplevelSurface *>(m_shellSurface.data());
+            if (!xdgSurface || !xdgSurface->isInitialized())
+                return;
+            if (xdgSurface->handle()->requested.fullscreen) {
+                setSurfaceStateDirectly(State::Fullscreen);
+            } else if (xdgSurface->handle()->requested.maximized && isMaximizable()) {
+                setSurfaceStateDirectly(State::Maximized);
+            } else if (m_surfaceState == State::Maximized || m_surfaceState == State::Fullscreen) {
+                setSurfaceStateDirectly(State::Normal);
+            }
+        });
+    }
 
     Q_EMIT surfaceItemCreated();
 
@@ -592,11 +610,25 @@ void SurfaceWrapper::syncPrelaunchMappedState()
         m_prelaunchOutputs.clear();
     }
 
-    if (auto *xwaylandSurface = qobject_cast<WXWaylandSurface *>(m_shellSurface.data())) {
-        if (xwaylandSurface->handle()->fullscreen) {
+    const bool fullscreenRequested = [this] {
+        if (auto *surface = qobject_cast<WXWaylandSurface *>(m_shellSurface.data()))
+            return surface->handle()->fullscreen;
+        if (auto *surface = qobject_cast<WXdgToplevelSurface *>(m_shellSurface.data()))
+            return surface->handle()->requested.fullscreen;
+        return false;
+    }();
+    const bool maximizeRequested = [this] {
+        if (auto *surface = qobject_cast<WXWaylandSurface *>(m_shellSurface.data()))
+            return surface->handle()->maximized_horz && surface->handle()->maximized_vert;
+        if (auto *surface = qobject_cast<WXdgToplevelSurface *>(m_shellSurface.data()))
+            return surface->handle()->requested.maximized;
+        return false;
+    }();
+
+    if (m_type == Type::XWayland || m_type == Type::XdgToplevel) {
+        if (fullscreenRequested) {
             setSurfaceStateDirectly(State::Fullscreen);
-        } else if ((xwaylandSurface->handle()->maximized_horz && xwaylandSurface->handle()->maximized_vert) &&
-                   isMaximizable()) {
+        } else if (maximizeRequested && isMaximizable()) {
             setSurfaceStateDirectly(State::Maximized);
         }
 
@@ -1827,6 +1859,13 @@ void SurfaceWrapper::restoreFromMinimized(bool onAnimation)
 
 void SurfaceWrapper::maximize()
 {
+    if (m_type == Type::XdgToplevel && surface() && !surface()->mapped()) {
+        auto *xdgSurface = qobject_cast<WXdgToplevelSurface *>(m_shellSurface.data());
+        if (xdgSurface->isInitialized())
+            setSurfaceStateDirectly(State::Maximized);
+        return;
+    }
+
     if (m_surfaceState == State::Minimized || m_surfaceState == State::Fullscreen
         || !isMaximizable())
         return;
@@ -1836,6 +1875,13 @@ void SurfaceWrapper::maximize()
 
 void SurfaceWrapper::unmaximize()
 {
+    if (m_type == Type::XdgToplevel && surface() && !surface()->mapped()) {
+        auto *xdgSurface = qobject_cast<WXdgToplevelSurface *>(m_shellSurface.data());
+        if (xdgSurface->isInitialized())
+            setSurfaceStateDirectly(State::Normal);
+        return;
+    }
+
     if (m_surfaceState != State::Maximized)
         return;
 
@@ -1852,6 +1898,13 @@ void SurfaceWrapper::toggleMaximized()
 
 void SurfaceWrapper::enterFullscreen()
 {
+    if (m_type == Type::XdgToplevel && surface() && !surface()->mapped()) {
+        auto *xdgSurface = qobject_cast<WXdgToplevelSurface *>(m_shellSurface.data());
+        if (xdgSurface->isInitialized())
+            setSurfaceStateDirectly(State::Fullscreen);
+        return;
+    }
+
     if (m_surfaceState == State::Minimized)
         return;
 
@@ -1860,6 +1913,13 @@ void SurfaceWrapper::enterFullscreen()
 
 void SurfaceWrapper::leaveFullscreen()
 {
+    if (m_type == Type::XdgToplevel && surface() && !surface()->mapped()) {
+        auto *xdgSurface = qobject_cast<WXdgToplevelSurface *>(m_shellSurface.data());
+        if (xdgSurface->isInitialized())
+            setSurfaceStateDirectly(m_previousSurfaceState);
+        return;
+    }
+
     if (m_surfaceState != State::Fullscreen)
         return;
 

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -10,6 +10,7 @@
 #include "treelanduserconfig.hpp"
 #include "workspace/workspace.h"
 #include "wtoplevelsurface.h"
+#include "wxdgtoplevelsurface.h"
 
 #include <winputpopupsurfaceitem.h>
 #include <wlayersurface.h>
@@ -25,6 +26,8 @@
 
 #include <QColor>
 #include <QVariant>
+
+#include <memory>
 
 #define OPEN_ANIMATION 1
 #define CLOSE_ANIMATION 2
@@ -346,6 +349,29 @@ void SurfaceWrapper::setup()
     QObject::connect(m_shellSurface->surface(), &WSurface::mappedChanged,
                                            this,
                                            &SurfaceWrapper::onMappedChanged);
+    if (m_type == Type::XdgToplevel) {
+        m_xdgToplevelCommitConnection = QObject::connect(m_shellSurface->surface(), &WSurface::commit, this, [this] {
+            if (!surface())
+                return;
+
+            if (surface()->mapped()) {
+                QObject::disconnect(m_xdgToplevelCommitConnection);
+                return;
+            }
+
+            auto *xdgSurface = qobject_cast<WXdgToplevelSurface *>(m_shellSurface.data());
+            if (!xdgSurface || !xdgSurface->isInitialized())
+                return;
+            if (xdgSurface->handle()->requested.fullscreen) {
+                setSurfaceStateDirectly(State::Fullscreen);
+            } else if (xdgSurface->handle()->requested.maximized && isMaximizable()) {
+                setSurfaceStateDirectly(State::Maximized);
+            } else if (m_surfaceState == State::Maximized || m_surfaceState == State::Fullscreen) {
+                setSurfaceStateDirectly(State::Normal);
+            }
+            QObject::disconnect(m_xdgToplevelCommitConnection);
+        });
+    }
 
     Q_EMIT surfaceItemCreated();
 
@@ -592,11 +618,25 @@ void SurfaceWrapper::syncPrelaunchMappedState()
         m_prelaunchOutputs.clear();
     }
 
-    if (auto *xwaylandSurface = qobject_cast<WXWaylandSurface *>(m_shellSurface.data())) {
-        if (xwaylandSurface->handle()->fullscreen) {
+    const bool fullscreenRequested = [this] {
+        if (auto *surface = qobject_cast<WXWaylandSurface *>(m_shellSurface.data()))
+            return surface->handle()->fullscreen;
+        if (auto *surface = qobject_cast<WXdgToplevelSurface *>(m_shellSurface.data()))
+            return surface->handle()->requested.fullscreen;
+        return false;
+    }();
+    const bool maximizeRequested = [this] {
+        if (auto *surface = qobject_cast<WXWaylandSurface *>(m_shellSurface.data()))
+            return surface->handle()->maximized_horz && surface->handle()->maximized_vert;
+        if (auto *surface = qobject_cast<WXdgToplevelSurface *>(m_shellSurface.data()))
+            return surface->handle()->requested.maximized;
+        return false;
+    }();
+
+    if (m_type == Type::XWayland || m_type == Type::XdgToplevel) {
+        if (fullscreenRequested) {
             setSurfaceStateDirectly(State::Fullscreen);
-        } else if ((xwaylandSurface->handle()->maximized_horz && xwaylandSurface->handle()->maximized_vert) &&
-                   isMaximizable()) {
+        } else if (maximizeRequested && isMaximizable()) {
             setSurfaceStateDirectly(State::Maximized);
         }
 
@@ -1827,6 +1867,13 @@ void SurfaceWrapper::restoreFromMinimized(bool onAnimation)
 
 void SurfaceWrapper::maximize()
 {
+    if (m_type == Type::XdgToplevel && surface() && !surface()->mapped()) {
+        auto *xdgSurface = qobject_cast<WXdgToplevelSurface *>(m_shellSurface.data());
+        if (xdgSurface->isInitialized())
+            setSurfaceStateDirectly(State::Maximized);
+        return;
+    }
+
     if (m_surfaceState == State::Minimized || m_surfaceState == State::Fullscreen
         || !isMaximizable())
         return;
@@ -1836,6 +1883,13 @@ void SurfaceWrapper::maximize()
 
 void SurfaceWrapper::unmaximize()
 {
+    if (m_type == Type::XdgToplevel && surface() && !surface()->mapped()) {
+        auto *xdgSurface = qobject_cast<WXdgToplevelSurface *>(m_shellSurface.data());
+        if (xdgSurface->isInitialized())
+            setSurfaceStateDirectly(State::Normal);
+        return;
+    }
+
     if (m_surfaceState != State::Maximized)
         return;
 
@@ -1852,6 +1906,13 @@ void SurfaceWrapper::toggleMaximized()
 
 void SurfaceWrapper::enterFullscreen(WOutput *targetOutput)
 {
+    if (m_type == Type::XdgToplevel && surface() && !surface()->mapped()) {
+        auto *xdgSurface = qobject_cast<WXdgToplevelSurface *>(m_shellSurface.data());
+        if (xdgSurface->isInitialized())
+            setSurfaceStateDirectly(State::Fullscreen);
+        return;
+    }
+
     if (m_surfaceState == State::Minimized)
         return;
 
@@ -1873,6 +1934,13 @@ void SurfaceWrapper::enterFullscreen(WOutput *targetOutput)
 
 void SurfaceWrapper::leaveFullscreen()
 {
+    if (m_type == Type::XdgToplevel && surface() && !surface()->mapped()) {
+        auto *xdgSurface = qobject_cast<WXdgToplevelSurface *>(m_shellSurface.data());
+        if (xdgSurface->isInitialized())
+            setSurfaceStateDirectly(m_previousSurfaceState);
+        return;
+    }
+
     if (m_surfaceState != State::Fullscreen)
         return;
 

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -467,6 +467,7 @@ private:
     QPointer<QQuickItem> m_windowAnimation;
     QPointer<QQuickItem> m_minimizeAnimation;
     QPointer<QQuickItem> m_showDesktopAnimation;
+    QMetaObject::Connection m_xdgToplevelCommitConnection;
     Q_OBJECT_BINDABLE_PROPERTY_WITH_ARGS(SurfaceWrapper,
                                          SurfaceWrapper::State,
                                          m_previousSurfaceState,

--- a/waylib/src/server/qtquick/wxdgtoplevelsurfaceitem.cpp
+++ b/waylib/src/server/qtquick/wxdgtoplevelsurfaceitem.cpp
@@ -76,7 +76,9 @@ void WXdgToplevelSurfaceItem::onSurfaceCommit()
     }
 
     auto xdg_surface = toplevelSurface()->handle()->base;
-    if (xdg_surface->initial_commit) {
+    if (xdg_surface->initial_commit &&
+        !toplevelSurface()->handle()->requested.maximized &&
+        !toplevelSurface()->handle()->requested.fullscreen) {
         /* When an xdg_surface performs an initial commit, the compositor must
          * reply with a configure so the client can map the surface.
          * configures the xdg_toplevel with 0,0 size to let the client pick the


### PR DESCRIPTION
Move initial commit handling from WXdgToplevelSurfaceItem to SurfaceWrapper to properly configure window geometry when the client requests maximized or fullscreen state at first commit.

Log: set maximized/fullscreen geometry on initial surface commit PMS: BUG-366199
Influence:

## Summary by Sourcery

Configure XDG toplevel geometry correctly when clients request maximized or fullscreen state on their initial commit.

Bug Fixes:
- Apply maximized and fullscreen geometry when an XDG toplevel requests those states during its initial surface commit.

Enhancements:
- Centralize initial XDG toplevel state handling in SurfaceWrapper and support pre-map maximize, unmaximize, fullscreen, and restore transitions.