### PR TITLE
fix(output): skip configuration callbacks on initialization failure

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -182,7 +182,7 @@ static void runWhenTreelandConfigInitialized(TreelandConfig *config,
         return;
     }
 
-    if (config->isInitializeSucceeded() || config->isInitializeFailed()) {
+    if (config->isInitializeSucceeded()) {
         callback();
         return;
     }
@@ -190,10 +190,6 @@ static void runWhenTreelandConfigInitialized(TreelandConfig *config,
     auto sharedCallback = std::make_shared<std::function<void()>>(std::move(callback));
     QObject::connect(config,
                      &TreelandConfig::configInitializeSucceed,
-                     context,
-                     [sharedCallback] { (*sharedCallback)(); });
-    QObject::connect(config,
-                     &TreelandConfig::configInitializeFailed,
                      context,
                      [sharedCallback] { (*sharedCallback)(); });
 }
@@ -707,17 +703,14 @@ void Helper::onOutputAdded(WOutput *output)
     if (outputConfig->isInitializeFailed()) {
         publishOutput();
     } else {
-        if (!outputConfig->isInitializeSucceeded()) {
-            connect(outputConfig, &OutputConfig::configInitializeFailed, o, publishOutput);
-        }
         runWhenOutputConfigInitialized(outputConfig,
                                        o,
                                        [this,
                                         restoreOutputConfig = std::move(restoreOutputConfig),
                                         outputObject = QPointer<Output>(o)]() mutable {
                                            runWhenTreelandConfigInitialized(m_globalConfig.get(),
-                                                                           outputObject,
-                                                                           std::move(restoreOutputConfig));
+                                                                            outputObject,
+                                                                            std::move(restoreOutputConfig));
                                        });
     }
 }


### PR DESCRIPTION
Run Treeland configuration callbacks only after initialization succeeds. Do not treat initialization failure as a completed state that permits dependent output configuration logic to continue.

Remove the failure-signal connection to avoid unnecessary signal and callback overhead, and preserve the actual initialization failure instead of masking it with invalid follow-up operations.

Log: skip output configuration callbacks when initialization fails
Influence: output configuration restoration and initialization handling

## Summary by Sourcery

Ensure output configuration callbacks are only executed after successful Treeland configuration and output initialization, avoiding follow-up configuration logic on initialization failures.

Bug Fixes:
- Prevent output configuration restoration from running when Treeland configuration initialization fails by only invoking callbacks on successful initialization.
- Stop treating output initialization failure as a completed state by removing failure-based callback connections for output and global configuration.