### PR TITLE
chore(examples): use hyphens in example binary names

### DIFF
--- a/examples/test_data_control_manager/CMakeLists.txt
+++ b/examples/test_data_control_manager/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(BIN_NAME test_data_control_manager)
+set(BIN_NAME test-data-control-manager)
 
 find_package(Qt6 REQUIRED COMPONENTS Core Gui WaylandClient)
 find_package(PkgConfig REQUIRED)

--- a/examples/test_glass/CMakeLists.txt
+++ b/examples/test_glass/CMakeLists.txt
@@ -71,11 +71,11 @@ target_link_libraries(treeland_stub PUBLIC
     PkgConfig::WAYLAND
 )
 
-# ── test_glass executable ────────────────────────────────────────────────
-add_executable(test_glass
+# ── test-glass executable ────────────────────────────────────────────────
+add_executable(test-glass
     main.cpp
 )
-qt_add_qml_module(test_glass
+qt_add_qml_module(test-glass
     URI GlassExample
     VERSION "1.0"
     QML_FILES
@@ -83,13 +83,13 @@ qt_add_qml_module(test_glass
     RESOURCES
         assets/default-glass-background.jpg
 )
-target_compile_definitions(test_glass
+target_compile_definitions(test-glass
     PRIVATE
     SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
     $<$<BOOL:${START_DEMO}>:START_DEMO>
     WLR_USE_UNSTABLE
 )
-target_link_libraries(test_glass
+target_link_libraries(test-glass
     PRIVATE
     Qt6::Quick
     Qt6::QuickControls2
@@ -97,4 +97,4 @@ target_link_libraries(test_glass
     PkgConfig::PIXMAN
     PkgConfig::WAYLAND
 )
-install(TARGETS test_glass DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS test-glass DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/examples/test_idle_inhibit_v1/CMakeLists.txt
+++ b/examples/test_idle_inhibit_v1/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(BIN_NAME test_idle_inhibit_v1)
+set(BIN_NAME test-idle-inhibit-v1)
 
 find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets WaylandClient)
 if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10)

--- a/examples/test_input_manager/CMakeLists.txt
+++ b/examples/test_input_manager/CMakeLists.txt
@@ -5,7 +5,7 @@ endif()
 
 find_package(TreelandProtocols REQUIRED)
 
-set(BIN_NAME test_input_manager)
+set(BIN_NAME test-input-manager)
 
 qt_add_executable(${BIN_NAME}
     main.cpp

--- a/examples/test_monitor_active_event/CMakeLists.txt
+++ b/examples/test_monitor_active_event/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(Qt6 REQUIRED COMPONENTS WaylandClient)
 find_package(TreelandProtocols REQUIRED)
 
-set(BIN_NAME test-monitor-active_event)
+set(BIN_NAME test-monitor-active-event)
 
 qt_add_executable(${BIN_NAME}
     main.cpp

--- a/examples/test_set_wallpaper/CMakeLists.txt
+++ b/examples/test_set_wallpaper/CMakeLists.txt
@@ -5,7 +5,7 @@ endif()
 
 find_package(TreelandProtocols REQUIRED)
 
-set(BIN_NAME test_set_wallpaper)
+set(BIN_NAME test-set-wallpaper)
 
 qt_add_executable(${BIN_NAME}
     main.cpp


### PR DESCRIPTION
## Summary

将 `examples/` 目录下仍使用下划线的 6 个示例二进制统一改为中划线，与其余示例的命名风格保持一致（仅改生成的二进制目标名，目录名不变）。

Rename the six example executables that still used underscores to the hyphen convention already used by the other examples, so every generated example binary follows a single naming style.

## Renamed targets

| 目录 | 旧二进制名 | 新二进制名 |
| --- | --- | --- |
| `examples/test_data_control_manager` | `test_data_control_manager` | `test-data-control-manager` |
| `examples/test_glass` | `test_glass` | `test-glass` |
| `examples/test_idle_inhibit_v1` | `test_idle_inhibit_v1` | `test-idle-inhibit-v1` |
| `examples/test_input_manager` | `test_input_manager` | `test-input-manager` |
| `examples/test_monitor_active_event` | `test-monitor-active_event` | `test-monitor-active-event` |
| `examples/test_set_wallpaper` | `test_set_wallpaper` | `test-set-wallpaper` |

同时更新 `docs/liquid-glass-dispersion.md` 中对 `test_glass` 的引用。

## 说明

- 仅改 CMake 目标名，无源码/逻辑变更；目录名保持不变。
- `examples/test_glass` 内部的 `treeland_stub` 辅助库未 install 到 BINDIR，不属于示例二进制，保持不动。
- `debian/treeland-examples.install` 使用 `usr/bin/test*` 通配，打包不受影响。
- 已通过 Code Review 审核。

## Multica issue

[WM-261](https://multica.uniontech.com/workspaces/e1c725b6-7c31-4790-a381-3262f282537c/issues/WM-261)

## Summary by Sourcery

Align example executable names with the hyphenated naming convention across the project.

Enhancements:
- Rename remaining underscore-based example binaries to hyphenated names for consistent executable naming.

Documentation:
- Update liquid glass dispersion documentation to reference the renamed test-glass example binary.