### PR TITLE
WM-263: feat(systemd): set GTK_IM_MODULE=fcitx in treeland-sd service

### DIFF
--- a/misc/systemd/dde-session-pre.target.wants/treeland-sd.service.in
+++ b/misc/systemd/dde-session-pre.target.wants/treeland-sd.service.in
@@ -26,6 +26,8 @@ ExecStartPost=-/usr/bin/systemctl --user set-environment QT_IM_MODULE=fcitx
 ExecStartPost=-/usr/bin/systemctl --user set-environment QT_IM_MODULES=wayland;fcitx
 ExecStartPost=-/usr/bin/systemctl --user set-environment SDL_IM_MODULE=fcitx
 ExecStartPost=-/usr/bin/systemctl --user set-environment XMODIFIERS=@im=fcitx
+ExecStartPost=-/usr/bin/systemctl --user set-environment GTK_IM_MODULE=fcitx
+ExecStop=-/usr/bin/systemctl --user unset-environment GTK_IM_MODULE
 ExecStop=-/usr/bin/systemctl --user unset-environment XMODIFIERS
 ExecStop=-/usr/bin/systemctl --user unset-environment SDL_IM_MODULE
 ExecStop=-/usr/bin/systemctl --user unset-environment QT_IM_MODULES


### PR DESCRIPTION
[WM-263](http://agentapi-dev.uniontech.com/workspaces/e1c725b6-7c31-4790-a381-3262f282537c/issues/54a92b7d-b9ab-4ace-b4a7-b46ca9e26666)

Add `GTK_IM_MODULE=fcitx` environment variable to `treeland-sd.service.in`:

- `ExecStartPost` sets `GTK_IM_MODULE=fcitx` after existing IM module variables
- `ExecStop` unsets `GTK_IM_MODULE` following LIFO cleanup order

## Summary by Sourcery

Enhancements:
- Extend treeland-sd.service to export GTK_IM_MODULE=fcitx during startup and unset it during shutdown to maintain consistent input method state.