### PR TITLE
WM-259: fix(waylib): drop invalid rect count assertion in toPixmanRegion

### DIFF
--- a/waylib/src/server/utils/wtools.cpp
+++ b/waylib/src/server/utils/wtools.cpp
@@ -263,7 +263,14 @@ bool WTools::toPixmanRegion(const QRegion &region, pixman_region32 *pixmanRegion
         box.y2 = r.bottom() + 1;
     }
     bool ok = pixman_region32_init_rects(pixmanRegion, rects.constData(), rects.count());
-    Q_ASSERT(!ok || pixman_region32_n_rects(pixmanRegion) == rects.count());
+    // NOTE: Do not assert pixman_region32_n_rects(pixmanRegion) == rects.count().
+    // pixman_region32_init_rects always normalizes the input boxes (merges
+    // horizontally adjacent rects, splits interleaving bands), while the
+    // QRegion's rect list (e.g. built via QTransform::map -> setRects) is not
+    // guaranteed to be in pixman canonical form, so the final rect count may
+    // legitimately differ from the input count.
+    // Note: The counterpart assertion in fromPixmanRegion() is safe because
+    // pixman's output rectangles are always in canonical form.
     return ok;
 }
 


### PR DESCRIPTION
[WM-259](http://agentapi-dev.uniontech.com/workspaces/e1c725b6-7c31-4790-a381-3262f282537c/issues/e3f95bea-1397-40c8-8821-54efb442b5e9)

Remove the Q_ASSERT in WTools::toPixmanRegion that asserted pixman_region32_n_rects == rects.count(). This assertion is incorrect because pixman_region32_init_rects normalizes the input (merges adjacent rects, splits interleaving bands), while QRegion's rect list may not be in pixman canonical form (e.g. when built via QTransform::map -> setRects).

The counterpart assertion in fromPixmanRegion is safe because pixman's output rectangles are always in canonical form.

## Summary by Sourcery

Bug Fixes:
- Avoid spurious assertion failures in WTools::toPixmanRegion when pixman normalizes input rectangles and changes the rect count compared to the original QRegion.