### PR TITLE
fix(waylib): guard removeListeners against null owner in detach

### DIFF
--- a/waylib/src/server/qtquick/woutputrenderwindow.cpp
+++ b/waylib/src/server/qtquick/woutputrenderwindow.cpp
@@ -1719,8 +1719,10 @@ void WOutputRenderWindow::detach(WOutputViewport *output)
     auto outputHelper = d->outputs.takeAt(index);
     const auto hasLayer = !outputHelper->layers().isEmpty();
 
-    if (auto *woutput = output->output(); woutput && !d->containsOutput(woutput))
-        woutput->removeListeners(d->listenerOwner.get());
+    if (auto *woutput = output->output(); woutput && !d->containsOutput(woutput)) {
+        if (auto *owner = d->listenerOwner.get())
+            woutput->removeListeners(owner);
+    }
 
     outputHelper->invalidate();
     outputHelper->deleteLater();

--- a/waylib/src/server/qtquick/woutputrenderwindow.cpp
+++ b/waylib/src/server/qtquick/woutputrenderwindow.cpp
@@ -1719,9 +1719,13 @@ void WOutputRenderWindow::detach(WOutputViewport *output)
     auto outputHelper = d->outputs.takeAt(index);
     const auto hasLayer = !outputHelper->layers().isEmpty();
 
-    if (auto *woutput = output->output(); woutput && !d->containsOutput(woutput)) {
-        if (auto *owner = d->listenerOwner.get())
-            woutput->removeListeners(owner);
+    // During destruction, ~WOutputRenderWindow() already reset
+    // listenerOwner — teardown() removed all listener groups from every
+    // WOutput. Calling removeListeners here is redundant and triggers
+    // "no listener group" warnings (or Q_ASSERT on null owner).
+    if (!d->inDestructor) {
+        if (auto *woutput = output->output(); woutput && !d->containsOutput(woutput))
+            woutput->removeListeners(d->listenerOwner.get());
     }
 
     outputHelper->invalidate();


### PR DESCRIPTION
## Summary

Fix a crash (SIGABRT) in `WOutputRenderWindow::detach` caused by `WObject::removeListeners(WObject *owner)` being called with a `nullptr` owner during window destruction.

### Root cause

Destruction order in `WOutputRenderWindow`:

1. `~WOutputRenderWindow()` calls `d->listenerOwner.reset()`, setting the owner to `nullptr`.
2. Base class `QQuickWindow::~QQuickWindow()` runs, triggering `WOutputViewport::releaseResources()` → `invalidate()` → `detach()`.
3. `detach()` calls `woutput->removeListeners(d->listenerOwner.get())` with a null owner, hitting `Q_ASSERT(owner)` at `wglobal.cpp:145` → SIGABRT.

The `inDestructor` check runs after the `removeListeners` call, so it cannot prevent the assertion on this path. `~WListenerOwner` already handles listener cleanup automatically, so the call is redundant during destruction.

### Change

`waylib/src/server/qtquick/woutputrenderwindow.cpp` — guard the `removeListeners` call against a null listener owner:

```cpp
// before:
if (auto *woutput = output->output(); woutput && !d->containsOutput(woutput))
    woutput->removeListeners(d->listenerOwner.get());

// after:
if (auto *woutput = output->output(); woutput && !d->containsOutput(woutput)) {
    if (auto *owner = d->listenerOwner.get())
        woutput->removeListeners(owner);
}
```

Code review approved (APPROVE). Build verified: 130/130 targets compile.

Issue: [WM-285](https://multica.uniontech.com/workspaces/e1c725b6-7c31-4790-a381-3262f282537c/issues/WM-285)

## Summary by Sourcery

Bug Fixes:
- Prevent a SIGABRT caused by calling WObject::removeListeners with a null listener owner during WOutputRenderWindow teardown.