### PR TITLE
fix(waylib): commit a buffer for capture on static screens

### DIFF
--- a/waylib/src/server/qtquick/woutputrenderwindow.cpp
+++ b/waylib/src/server/qtquick/woutputrenderwindow.cpp
@@ -1477,7 +1477,11 @@ WOutputRenderWindowPrivate::doRenderOutputs(wlr_output *needsFrameOutput, const 
             if (!(helper->needsFrame() || helper->contentIsDirty()))
                 continue;
 
-            if (!helper->contentIsDirty()) {
+            // Capture sessions (ext-image-copy-capture etc.) lock the output
+            // via wlr_output_lock_attach_render() and need a buffer commit to
+            // complete, even if the content didn't change.
+            bool captureLocked = helper->qwoutput()->attach_render_locks > 0;
+            if (!helper->contentIsDirty() && !captureLocked) {
                 renderResults.append(helper);
                 continue;
             }


### PR DESCRIPTION
Render and commit a new output buffer even if the scene content didn't change when the output is locked by a capture session (ext-image-copy-capture, screencopy, etc.). Otherwise the first frame of a screenshot on a static screen waits indefinitely for the content to change, which the protocol forbids.

当输出被捕获会话（ext-image-copy-capture、screencopy等）锁定时，即使场景内容 未变化也渲染并提交新的输出缓冲区，修复画面静止时首帧截图无限等待的问题。

Log: 修复画面静止时首帧截图无限等待
Influence: 画面静止时截图/录屏首帧可立即完成；无捕获会话时渲染行为不变，性能不受影响。

## Summary by Sourcery

Bug Fixes:
- Prevent capture sessions from hanging indefinitely on static screens by forcing a buffer commit when the output is locked but content has not changed.