### PR TITLE
分屏动效与四分屏

### DIFF
--- a/misc/dconfig/org.deepin.dde.treeland.user.json
+++ b/misc/dconfig/org.deepin.dde.treeland.user.json
@@ -574,6 +574,17 @@
             "permissions": "readwrite",
             "visibility": "public"
         },
+        "edgeQuadrantZoneRatio": {
+            "value": 0.25,
+            "serial": 0,
+            "flags": [],
+            "name": "Edge Quadrant Zone Ratio",
+            "name[zh_CN]": "四分之一屏触发区域比例",
+            "description": "Ratio of the edge length forming the corner (quadrant) tiling zone. Cursor within this ratio of the top/bottom of a side edge tiles to the corner quadrant, the middle zone keeps half-screen tiling",
+            "description[zh_CN]": "边缘长度中形成四分之一屏（角落）平铺区域的比值。光标位于左右边缘的上/下该比例范围内时平铺到对应角落象限，中间区域保持半屏平铺",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
         "edgeInnerDelayMs": {
             "value": 250,
             "serial": 0,

--- a/src/core/qml/EdgeTilePreview.qml
+++ b/src/core/qml/EdgeTilePreview.qml
@@ -4,6 +4,60 @@
 import QtQuick
 
 Rectangle {
+    id: root
     visible: false
     color: Qt.alpha(Helper.config.activeColor, 0.25)
+
+    // The dragged surface's geometry (starting point) and the target tile
+    // geometry, set from RootSurfaceContainer::updateEdgeTilePreview().
+    property rect sourceGeometry: Qt.rect(0, 0, 0, 0)
+    property rect targetGeometry: Qt.rect(0, 0, 0, 0)
+
+    // Animation duration mirrors KWin's outline effect (Kirigami longDuration).
+    property int animationDuration: 250
+    // Animations stay disabled until the first show, so the initial transition
+    // from the dragged surface to the target tile is animated (like KWin's
+    // outline growing from the window being moved).
+    property bool animationEnabled: false
+
+    function applyGeometry(geometry) {
+        x = geometry.x
+        y = geometry.y
+        width = geometry.width
+        height = geometry.height
+    }
+
+    onVisibleChanged: {
+        if (visible) {
+            // Jump to the dragged surface first, then animate to the target.
+            animationEnabled = false
+            applyGeometry(sourceGeometry)
+            animationEnabled = true
+            applyGeometry(targetGeometry)
+        } else {
+            animationEnabled = false
+        }
+    }
+
+    onTargetGeometryChanged: {
+        if (visible)
+            applyGeometry(targetGeometry)
+    }
+
+    Behavior on x {
+        enabled: root.animationEnabled
+        NumberAnimation { duration: root.animationDuration; easing.type: Easing.InOutCubic }
+    }
+    Behavior on y {
+        enabled: root.animationEnabled
+        NumberAnimation { duration: root.animationDuration; easing.type: Easing.InOutCubic }
+    }
+    Behavior on width {
+        enabled: root.animationEnabled
+        NumberAnimation { duration: root.animationDuration; easing.type: Easing.InOutCubic }
+    }
+    Behavior on height {
+        enabled: root.animationEnabled
+        NumberAnimation { duration: root.animationDuration; easing.type: Easing.InOutCubic }
+    }
 }

--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -898,6 +898,7 @@ void RootSurfaceContainer::detectEdgeTilingForSeat(WSeat *seat)
     auto *cfg = Helper::instance()->config();
     const qreal sideTrigger = cfg ? qreal(cfg->edgeSideTriggerDistance()) : 20.0;
     const qreal topTrigger = cfg ? qreal(cfg->edgeTopTriggerDistance()) : 5.0;
+    const qreal quadRatio = cfg ? qreal(cfg->edgeQuadrantZoneRatio()) : 0.25;
     auto &mrState = container->moveResizeState();
     QuickTile::Mode mode = QuickTile::Mode::None;
     Output *out = nullptr;
@@ -910,11 +911,27 @@ void RootSurfaceContainer::detectEdgeTilingForSeat(WSeat *seat)
         out = outputAt(pos);
         if (out) {
             const QRectF area = out->validGeometry();
+            const qreal quadTop = area.top() + area.height() * quadRatio;
+            const qreal quadBottom = area.bottom() - area.height() * quadRatio;
             if (pos.x() <= area.left() + sideTrigger) {
-                mode = QuickTile::Mode::Left;
+                // Left edge: the top/bottom quadrant zones tile to the corner.
+                if (pos.y() <= quadTop)
+                    mode = QuickTile::Mode::TopLeft;
+                else if (pos.y() >= quadBottom)
+                    mode = QuickTile::Mode::BottomLeft;
+                else
+                    mode = QuickTile::Mode::Left;
             } else if (pos.x() >= area.right() - sideTrigger) {
-                mode = QuickTile::Mode::Right;
+                // Right edge: the top/bottom quadrant zones tile to the corner.
+                if (pos.y() <= quadTop)
+                    mode = QuickTile::Mode::TopRight;
+                else if (pos.y() >= quadBottom)
+                    mode = QuickTile::Mode::BottomRight;
+                else
+                    mode = QuickTile::Mode::Right;
             } else if (pos.y() <= area.top() + topTrigger) {
+                // Top edge: maximize only; quadrant zones are exclusive to
+                // the left/right edges.
                 mode = QuickTile::Mode::Maximize;
             }
 
@@ -928,9 +945,13 @@ void RootSurfaceContainer::detectEdgeTilingForSeat(WSeat *seat)
                     samplePt = QPointF(pos.x(), area.top() - 1.0);
                     break;
                 case QuickTile::Mode::Left:
+                case QuickTile::Mode::TopLeft:
+                case QuickTile::Mode::BottomLeft:
                     samplePt = QPointF(area.left() - 1.0, pos.y());
                     break;
                 case QuickTile::Mode::Right:
+                case QuickTile::Mode::TopRight:
+                case QuickTile::Mode::BottomRight:
                     samplePt = QPointF(area.right(), pos.y());
                     break;
                 case QuickTile::Mode::None:

--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -865,7 +865,7 @@ QQuickItem *RootSurfaceContainer::ensureEdgeTilePreview()
     return m_edgeTilePreview;
 }
 
-void RootSurfaceContainer::updateEdgeTilePreview(QuickTile::Mode mode, Output *out)
+void RootSurfaceContainer::updateEdgeTilePreview(QuickTile::Mode mode, Output *out, WSeat *seat)
 {
     auto *preview = ensureEdgeTilePreview();
     if (!preview)
@@ -882,10 +882,16 @@ void RootSurfaceContainer::updateEdgeTilePreview(QuickTile::Mode mode, Output *o
         return;
     }
 
-    preview->setX(geo.x());
-    preview->setY(geo.y());
-    preview->setWidth(geo.width());
-    preview->setHeight(geo.height());
+    // Use the dragged surface's current geometry as the animation starting
+    // point, so the preview grows from the window (mirrors KWin's outline).
+    QRectF sourceGeo;
+    if (auto *container = getSeatContainerOrDefault(seat)) {
+        if (SurfaceWrapper *surface = container->moveResizeSurface())
+            sourceGeo = surface->geometry();
+    }
+
+    preview->setProperty("sourceGeometry", QVariant::fromValue(sourceGeo));
+    preview->setProperty("targetGeometry", QVariant::fromValue(geo));
     preview->setVisible(true);
 }
 
@@ -989,7 +995,7 @@ void RootSurfaceContainer::detectEdgeTilingForSeat(WSeat *seat)
         } else {
             container->stopEdgeTileDelay();
             mrState.edgeTilePreviewActive = true;
-            updateEdgeTilePreview(mode, out);
+            updateEdgeTilePreview(mode, out, seat);
         }
     }
 }

--- a/src/core/rootsurfacecontainer.h
+++ b/src/core/rootsurfacecontainer.h
@@ -90,7 +90,7 @@ public:
 
     Output *cursorOutput() const;
     Output *outputAt(const QPointF &pos) const;
-    void updateEdgeTilePreview(QuickTile::Mode mode, Output *out);
+    void updateEdgeTilePreview(QuickTile::Mode mode, Output *out, WSeat *seat = nullptr);
     Output *primaryOutput() const;
     void setPrimaryOutput(Output *newPrimaryOutput, bool updateDconfig = false);
     const QList<Output *> &outputs() const;

--- a/src/surface/quicktile.cpp
+++ b/src/surface/quicktile.cpp
@@ -14,14 +14,23 @@ QRectF geometry(Mode mode, Output *output)
         return QRectF();
 
     const QRectF area = output->validGeometry();
+    const QSizeF half(area.width() / 2, area.height());
+    const QSizeF quad(area.width() / 2, area.height() / 2);
     switch (mode) {
     case Mode::Left:
-        return QRectF(area.topLeft(), QSizeF(area.width() / 2, area.height()));
+        return QRectF(area.topLeft(), half);
     case Mode::Right:
-        return QRectF(QPointF(area.left() + area.width() / 2, area.top()),
-                      QSizeF(area.width() / 2, area.height()));
+        return QRectF(QPointF(area.left() + area.width() / 2, area.top()), half);
     case Mode::Maximize:
         return area;
+    case Mode::TopLeft:
+        return QRectF(area.topLeft(), quad);
+    case Mode::TopRight:
+        return QRectF(QPointF(area.left() + area.width() / 2, area.top()), quad);
+    case Mode::BottomLeft:
+        return QRectF(QPointF(area.left(), area.top() + area.height() / 2), quad);
+    case Mode::BottomRight:
+        return QRectF(QPointF(area.left() + area.width() / 2, area.top() + area.height() / 2), quad);
     case Mode::None:
         break;
     }

--- a/src/surface/quicktile.h
+++ b/src/surface/quicktile.h
@@ -16,6 +16,10 @@ enum class Mode
     Left,
     Right,
     Maximize,
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
 };
 
 QRectF geometry(Mode mode, Output *output);

--- a/src/surface/seatsurfacemanager.cpp
+++ b/src/surface/seatsurfacemanager.cpp
@@ -329,7 +329,7 @@ void SeatSurfaceManager::startEdgeTileDelay()
                 if (m_rootContainer && m_seat && m_seat->cursor())
                     out = m_rootContainer->outputAt(m_seat->cursor()->position());
                 if (m_rootContainer)
-                    m_rootContainer->updateEdgeTilePreview(mr.detectedTileMode, out);
+                    m_rootContainer->updateEdgeTilePreview(mr.detectedTileMode, out, m_seat);
             }
         });
     }


### PR DESCRIPTION
## Summary by Sourcery

Support animated edge previews and configurable four-way screen tiling for dragged windows.

New Features:
- Add four-corner window tiling zones alongside existing half-screen and maximize edge tiling.
- Animate the edge-tile preview from the dragged window’s current geometry to its target tile.

Enhancements:
- Make quadrant detection configurable through a bounded edge-zone ratio setting.