### PR TITLE
fix: show desktop — fade decoration shadow with the restore animation

### DIFF
--- a/src/core/qml/Animations/ShowDesktopAnimation.qml
+++ b/src/core/qml/Animations/ShowDesktopAnimation.qml
@@ -16,19 +16,39 @@ Item {
     required property bool showDesktop
     property int duration: 500 * Helper.animationSpeed //500: Initial design requirements
 
+    // The real Decoration (XdgShadow + Border) is a child of `target` laid out at
+    // the shadow's bounding rect, which extends beyond the target's
+    // [0,0,width,height] by the shadow blur margin. ShaderEffectSource only
+    // captures the target's own rect, so the shadow is clipped out of the
+    // texture, and `hideSource` simultaneously hides the original shadow. Without
+    // a replacement the shadow would pop in/out only after the fade animation
+    // finishes instead of following it. Mirror MinimizeAnimation/GeometryAnimation
+    // and render a shadow that fades together with the captured content.
+    readonly property bool showShadow: target.visibleDecoration && !target.noDecoration
+
     function start() {
         animation.start();
     }
 
-    ShaderEffectSource {
+    Item {
         id: effect
-        live: false
-        hideSource: true
-        sourceItem: root.target
         x: root.target.x
         y: root.target.y
         width: root.target.width
         height: root.target.height
+
+        XdgShadow {
+            anchors.fill: parent
+            visible: root.showShadow
+            cornerRadius: root.target.radius
+        }
+
+        ShaderEffectSource {
+            anchors.fill: parent
+            live: false
+            hideSource: true
+            sourceItem: root.target
+        }
     }
 
     ParallelAnimation {


### PR DESCRIPTION
## Summary

Fix the show-desktop restore animation: when windows fade back in after
showing the desktop, the window decoration shadow (XdgShadow) did not
follow the fade and popped in only after the animation finished. Mirror
`MinimizeAnimation.qml`/`GeometryAnimation.qml` and render a replacement
`XdgShadow` inside the animation `effect` that fades together with the
captured content.

## Root Cause

`ShowDesktopAnimation.qml` fades the target via a `ShaderEffectSource`
that only samples the target's own `[0,0,width,height]` rect. The real
`XdgShadow` decoration is a child of `target` laid out at the shadow's
`boundingRect`, which extends beyond the target by the `shadowBlur`
margin (40px), so the shadow is clipped out of the texture. `hideSource:
true` simultaneously hides the original shadow. The decoration thus
appeared only after the fade finished (`onShowDesktopAnimationFinished` →
`updateVisible` re-shows the real window) instead of following the fade.
The border is inside the window rect and is already captured, so it needs
no change.

## Changes

- `src/core/qml/Animations/ShowDesktopAnimation.qml` (+24 / -4, no C++):
  - Wrap the bare `ShaderEffectSource` in an `Item { id: effect }`,
    preserving the original `x/y/width/height` bindings; the existing
    `OpacityAnimator` now drives this item so its opacity propagates to
    both children.
  - Add a replacement `XdgShadow` (`anchors.fill: parent`,
    `visible: target.visibleDecoration && !target.noDecoration`,
    `cornerRadius: target.radius`) declared before the `ShaderEffectSource`
    so it renders beneath the captured content and fades with it. The
    visibility condition matches `GeometryAnimation.qml`, so
    maximized/fullscreen/tiled windows do not show a shadow.
  - `ShaderEffectSource` switches from explicit geometry to
    `anchors.fill: parent` (equivalent to the old `effect` geometry).

## Testing

Local full build passed (`cmake --preset default` + `ninja -C build`,
450/450 targets, exit 0). `qmllint` on the file exits 0; warnings are the
same known DTK/Treeland import false-positives present in the mirrored
`MinimizeAnimation.qml`/`GeometryAnimation.qml`.

## Review

Code review passed (100/100, approved for merge): root cause accurate,
visibility condition consistent with the C++ `SurfaceWrapper` decoration
state, no security surface, no hot-path impact (transient animation
object). Non-blocking note: the `XdgShadow`+`ShaderEffectSource` block
duplicates `MinimizeAnimation.qml`; a shared snapshot component could be
extracted later, out of scope for this fix.

Multica issue: WM-291 (`1b2cb603-3cbe-4a19-bfef-33a7a75097ee`)

## Summary by Sourcery

Bug Fixes:
- Ensure window decoration shadows fade in and out with the show-desktop restore animation instead of appearing only after the animation completes.