### PR TITLE
docs: drop qwlroots references from agent docs and fix build instructions

### DIFF
--- a/.agents/skills/logging-guidelines/SKILL.md
+++ b/.agents/skills/logging-guidelines/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: logging-guidelines
-description: Use this skill whenever a task adds, changes, reviews, or removes logging in treeland, waylib, or qwlroots code. Trigger on logging categories, Q_LOGGING_CATEGORY, Q_DECLARE_LOGGING_CATEGORY, qCDebug, qCInfo, qCWarning, qCCritical, log level selection, category naming, or requests to clean up log messages. For treeland code, prefer centralized categories in src/common/treelandlogging.h/.cpp. For waylib code, prefer centralized categories in waylib/src/server/wayliblogging.h/.cpp.
+description: Use this skill whenever a task adds, changes, reviews, or removes logging in treeland or waylib code. Trigger on logging categories, Q_LOGGING_CATEGORY, Q_DECLARE_LOGGING_CATEGORY, qCDebug, qCInfo, qCWarning, qCCritical, log level selection, category naming, or requests to clean up log messages. For treeland code, prefer centralized categories in src/common/treelandlogging.h/.cpp. For waylib code, prefer centralized categories in waylib/src/server/wayliblogging.h/.cpp.
 ---
 
 # Logging Guidelines

--- a/.agents/skills/treeland-private-wayland-protocol/SKILL.md
+++ b/.agents/skills/treeland-private-wayland-protocol/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treeland-private-wayland-protocol
-description: Use this skill for treeland private Wayland server-side protocol integration. Trigger whenever the task involves treeland-owned xml, `treeland_*` interfaces, `src/modules/*`, QtWayland scanner output, `QtWaylandServer::*`, `local_qtwayland_server_protocol_treeland(...)`, `globalRemove()`, `destroy_resource(...)`, or wiring a private compositor protocol into `Helper::init`. Do not use it for upstream wlroots/waylib protocol wrappers.
+description: Use this skill for treeland private Wayland server-side protocol integration. Trigger whenever the task involves treeland-owned xml, `treeland_*` interfaces, `src/modules/*`, QtWayland scanner output, `QtWaylandServer::*`, `waylib_generate_qtwayland_server_protocol(...)`, `globalRemove()`, `destroy_resource(...)`, or wiring a private compositor protocol into `Helper::init`. Do not use it for upstream wlroots/waylib protocol wrappers.
 ---
 
 # Treeland Private Protocol Integration
@@ -13,7 +13,7 @@ Use this skill when any of these are true:
 - the protocol xml is maintained by treeland
 - the interface name is typically `treeland_*`
 - the code lives under `src/modules/*`
-- CMake uses `local_qtwayland_server_protocol_treeland(...)`
+- CMake uses `waylib_generate_qtwayland_server_protocol(...)`
 - the generated type is `QtWaylandServer::*`
 
 If the protocol is a standard/ext/unstable/wlr upstream protocol, stop and use the upstream protocol skill instead.
@@ -57,9 +57,11 @@ These details affect implementation boundaries:
 - if the manager interface in xml has no destructor request, generated code will not provide `handle_destroy(...)` or `virtual void destroy(Resource *resource)` for that manager; do not assume you can override manager destroy in that case
 
 ## Build Path
-Prefer the existing helper:
+Prefer the existing helper (defined in `waylib/tools/CMakeLists.txt`):
 
-`local_qtwayland_server_protocol_treeland(...)`
+`waylib_generate_qtwayland_server_protocol(<target> PROTOCOL <xml> BASENAME <basename> [PREFIX <prefix>])`
+
+The first argument is the CMake target that owns the generated sources (usually `libtreeland`); `PROTOCOL` is the xml path and `BASENAME` derives the generated filenames. The optional `PREFIX` sets the generated C++ type/namespace prefix (e.g. `PREFIX "/"` in `src/modules/personalization/`); omit it for the default empty prefix.
 
 Typical outputs:
 
@@ -139,12 +141,11 @@ The public class usually implements:
 Recommended pattern:
 
 ```cpp
-// Required: #include <qwdisplay.h>
-// operator* on QWDisplay returns the underlying wl_display&,
-// which is equivalent to server->handle()->handle() but preferred.
+// WServer::handle() returns the raw wl_display*. Pass it directly to the
+// generated manager's init().
 void Manager::create(WServer *server)
 {
-    d->init(*server->handle(), InterfaceVersion);
+    d->init(server->handle(), InterfaceVersion);
 }
 
 void Manager::destroy(WServer *server)
@@ -344,9 +345,9 @@ That still counts as a protocol registration entry point. The real criteria are:
 If a protocol is neither registered directly from `Helper::init` nor initialized through a higher-level object such as `ShellHandler`, it is usually still not fully integrated.
 
 ## Samples To Avoid
-`capture` uses `ws_generate_local` (raw wayland-scanner) instead of the preferred `local_qtwayland_server_protocol_treeland(...)` path, and does not use `QtWaylandServer::*` at all. Do not use it as a template.
+`capture` uses `ws_generate_local` (raw wayland-scanner) instead of the preferred `waylib_generate_qtwayland_server_protocol(...)` path, and does not use `QtWaylandServer::*` at all. Do not use it as a template.
 
-`foreign-toplevel` has been fully migrated to the `QtWaylandServer::*` plus `local_qtwayland_server_protocol_treeland(...)` path. It is a valid reference for protocols that need public child wrappers (`ForeignToplevelHandleV1`, `DockPreviewContextV1`), but is too large and complex to be a starting point for simple new protocols.
+`foreign-toplevel` has been fully migrated to the `QtWaylandServer::*` plus `waylib_generate_qtwayland_server_protocol(...)` path. It is a valid reference for protocols that need public child wrappers (`ForeignToplevelHandleV1`, `DockPreviewContextV1`), but is too large and complex to be a starting point for simple new protocols.
 
 For new private protocols, prefer `appidresolver`, `prelaunch-splash`, or `screensaver` as templates.
 

--- a/.agents/skills/upstream-wayland-protocol-wrapper/SKILL.md
+++ b/.agents/skills/upstream-wayland-protocol-wrapper/SKILL.md
@@ -26,7 +26,7 @@ If the task is about treeland-owned xml, `QtWaylandServer::*`, or a new private 
 ## Read First
 1. `waylib/src/server/protocols`
 2. `waylib/src/server/kernel`
-3. `qwlroots/src`
+3. `3rdparty/wlroots/include/wlr` (raw wlroots C API headers — read for native `wlr_*` types and `wl_signal` events; include via `<wlr_all.h>`)
 4. `src/seat/helper.cpp`
 
 Search for an existing wrapper first. Do not assume treeland should reimplement a manager locally.
@@ -52,9 +52,11 @@ Provide a `WServerInterface` subclass that implements at least:
 Typical creation:
 
 ```cpp
+// WServer::handle() returns the raw wl_display*. Use the wlroots C
+// constructor directly; the returned pointer is stored in m_handle (void*).
 void WFoo::create(WServer *server)
 {
-    m_handle = qw_foo_manager_v1::create(*server->handle(), FOO_MANAGER_V1_VERSION);
+    m_handle = wlr_foo_manager_v1_create(server->handle(), FOO_MANAGER_V1_VERSION);
 }
 ```
 
@@ -63,24 +65,27 @@ Typical `global()`:
 ```cpp
 wl_global *WFoo::global() const
 {
-    return nativeInterface<qw_foo_manager_v1>()->handle()->global;
+    // nativeInterface<T>() reinterpret_casts m_handle (void*) to T*.
+    // The raw wlroots C struct exposes `global` directly.
+    return nativeInterface<wlr_foo_manager_v1>()->global;
+    // equivalently: return reinterpret_cast<wlr_foo_manager_v1*>(m_handle)->global;
 }
 ```
 
 ## How To Judge Destruction
 Do not mechanically copy `globalRemove()` from treeland private protocols.
 
-Decide destruction based on native ownership:
+The native handle is a raw wlroots C pointer stored in `m_handle` (a `void*`). Decide destruction based on native ownership:
 
-- if `qw_*::create(...)` returns an object owned by the wrapper or `WObject`, `destroy()` may stay empty
-- if wlroots or the native wrapper exposes an explicit destroy/reset/listener cleanup API, call it from `destroy()`
-- if destruction happens naturally through QObject/wrapper destruction, do not free it twice
+- if `wlr_*_create(...)` returns an object with no public destroy function, `destroy()` typically just clears `m_handle = nullptr` — the native object is reclaimed when the `wl_display` is destroyed in `WServer::stop()`
+- if the wlroots type exposes an explicit `wlr_*_destroy(...)` / reset / listener-cleanup API, call it from `destroy()`
+- waylib's `WObject` scoped listener lists (`listeners()->add(...)`) are detached automatically by `WServer::stop()`/`teardown()` before `destroy()` runs; do not free native state that the display teardown already owns
 
 How to determine that:
 
 1. read nearby `W...` wrappers in the same directory
-2. read whether the corresponding `qw_*` type exposes explicit `destroy()` or similar APIs
-3. read whether wlroots native objects expose a destroy API
+2. read whether the corresponding `wlr_*` type exposes explicit `destroy()` or similar APIs in `3rdparty/wlroots/include/wlr`
+3. confirm whether `create()` is guarded by `if (!m_handle)`; if so, `destroy()` must clear `m_handle` so a restart can recreate the global
 
 Core rule: destruction must match native handle ownership.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,8 @@
 
 ## Big Picture
 - `treeland` is a Wayland compositor built on `wlroots` + Qt6/QtQuick (Scene Graph rendering).
-- `qwlroots/` provides Qt-style C++ bindings for `wlroots`.
-- `waylib/` builds on `wlroots`/`qwlroots` to provide a QtQuick-friendly compositor framework (outputs <-> `QQuickWindow`, surfaces <-> `QQuickItem`).
+- `wlroots` is vendored in-tree: upstream sources under `3rdparty/wlroots`, built as a CMake module by `wlroots/CMakeLists.txt` (CMake target `Wlroots::wlroots`). waylib talks to wlroots through its raw C API directly — include `<wlr_all.h>`, not individual `<wlr/...>` headers — and supplies the Qt/C++ object/lifetime layer (`WObject`/`WServerInterface`, `WPointer`, scoped `wl_signal` listeners).
+- `waylib/` builds on `wlroots` to provide a QtQuick-friendly compositor framework (outputs <-> `QQuickWindow`, surfaces <-> `QQuickItem`).
 - Treeland-specific policies live in `src/` (workspace/seat/input/output, effects/plugins, XWayland integration).
 
 ## Where to Look

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -106,12 +106,6 @@ precedence = "aggregate"
 SPDX-FileCopyrightText = "None"
 SPDX-License-Identifier = "GPL-2.0-only"
 
-[[annotations]]
-path = ["qwlroots/**"]
-precedence = "aggregate"
-SPDX-FileCopyrightText = "None"
-SPDX-License-Identifier = "Apache-2.0"
-
 # ===== WAYLIB REUSE Configuration =====
 # CI and build files for waylib
 [[annotations]]
@@ -236,62 +230,3 @@ path = ["waylib/src/server/protocols/private/text-input-unstable-v2.xml"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "None"
 SPDX-License-Identifier = "HPND"
-
-# ===== QWLROOTS REUSE Configuration =====
-# CI for qwlroots
-[[annotations]]
-path = ["qwlroots/.github/**", "qwlroots/.obs/**.yml", "qwlroots/garnix.yaml"]
-precedence = "aggregate"
-SPDX-FileCopyrightText = "None"
-SPDX-License-Identifier = "CC0-1.0"
-
-# Project files for qwlroots
-[[annotations]]
-path = [
-    "qwlroots/**.cmake",
-    "qwlroots/*CMakeLists.txt",
-    "qwlroots/**.pc.in",
-    "qwlroots/**cmake.in",
-    "qwlroots/.gitignore",
-    "qwlroots/.cursorindexingignore",
-    "qwlroots/.cursor/rules/**.mdc",
-    "qwlroots/.gitmodules"
-]
-precedence = "aggregate"
-SPDX-FileCopyrightText = "None"
-SPDX-License-Identifier = "CC0-1.0"
-
-# Simple header files for qwlroots
-[[annotations]]
-path = [
-    "qwlroots/**/qwkeyboard.h",
-    "qwlroots/**/qwpointer.h",
-    "qwlroots/**/qwswitch.h",
-    "qwlroots/**/qwtablet.h",
-    "qwlroots/**/qwtabletpad.h",
-    "qwlroots/**/qwtouch.h"
-]
-precedence = "aggregate"
-SPDX-FileCopyrightText = "None"
-SPDX-License-Identifier = "CC0-1.0"
-
-# README and documentation for qwlroots
-[[annotations]]
-path = ["qwlroots/README.md", "qwlroots/README.zh_CN.md", "qwlroots/doc/ai/**.md"]
-precedence = "aggregate"
-SPDX-FileCopyrightText = "JiDe Zhang"
-SPDX-License-Identifier = "CC-BY-4.0"
-
-# Nix Develop files for qwlroots
-[[annotations]]
-path = ["qwlroots/**.nix", "qwlroots/.envrc", "qwlroots/flake.lock"]
-precedence = "aggregate"
-SPDX-FileCopyrightText = "None"
-SPDX-License-Identifier = "CC0-1.0"
-
-# Debian package for qwlroots
-[[annotations]]
-path = ["qwlroots/debian/**"]
-precedence = "aggregate"
-SPDX-FileCopyrightText = "2023 rewine <luhongxu@outlook.com>"
-SPDX-License-Identifier = "Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only"

--- a/waylib/README.md
+++ b/waylib/README.md
@@ -55,7 +55,7 @@ You can also packaging by using the command "nix build -v -L".
 Step 3: Execute the following commands
 
 ```bash
-cmake -B build -DWITH_SUBMODULE_QWLROOTS=ON
+cmake -B build
 cmake --build build
 ```
 

--- a/waylib/README.zh_CN.md
+++ b/waylib/README.zh_CN.md
@@ -55,7 +55,7 @@ NixOS
 步骤三：运行以下命令
 
 ```bash
-cmake -B build -DWITH_SUBMODULE_QWLROOTS=ON
+cmake -B build
 cmake --build build
 ```
 

--- a/waylib/src/server/CMakeLists.txt
+++ b/waylib/src/server/CMakeLists.txt
@@ -444,7 +444,7 @@ set_target_properties(${TARGET}
         POSITION_INDEPENDENT_CODE ON
 )
 
-# Replace qwlroots' qwconfig.h: forward wlroots feature/version vars
+# Forward wlroots feature/version vars
 # exported by the wlroots CMake build.
 if(NOT DEFINED WLROOTS_VERSION)
     message(FATAL_ERROR "WLROOTS_VERSION not set; wlroots CMake export missing")

--- a/waylib/src/server/kernel/wpointer.h
+++ b/waylib/src/server/kernel/wpointer.h
@@ -34,13 +34,13 @@
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
-// RAII deleter for wlr_buffer references (replaces qwlroots' qw_buffer::unlocker).
+// RAII deleter for wlr_buffer references.
 struct WBufferUnlocker {
     static inline void cleanup(wlr_buffer *buffer) { if (buffer) wlr_buffer_unlock(buffer); }
     void operator()(wlr_buffer *buffer) const { cleanup(buffer); }
 };
 
-// RAII deleter that drops a wlr_buffer reference (replaces qwlroots' qw_buffer::droper).
+// RAII deleter that drops a wlr_buffer reference.
 struct WBufferDroper {
     static inline void cleanup(wlr_buffer *buffer) { if (buffer) wlr_buffer_drop(buffer); }
     void operator()(wlr_buffer *buffer) const { cleanup(buffer); }

--- a/waylib/src/server/utils/wlogging.h
+++ b/waylib/src/server/utils/wlogging.h
@@ -1,10 +1,10 @@
 // Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
-// Routes wlroots' C logging into the Qt logging system (successor of the
-// qwlroots qw_log wrapper). Instead of letting wlroots write to stderr, every
-// wlr_log call is forwarded to the "wlroots" QLoggingCategory so it honors
-// QT_LOGGING_RULES filtering and Qt's message pattern.
+// Routes wlroots' C logging into the Qt logging system. Instead of letting
+// wlroots write to stderr, every wlr_log call is forwarded to the "wlroots"
+// QLoggingCategory so it honors QT_LOGGING_RULES filtering and Qt's message
+// pattern.
 
 #pragma once
 

--- a/wlroots/CMakeLists.txt
+++ b/wlroots/CMakeLists.txt
@@ -577,7 +577,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/waylib-wlroots.pc
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 # ---------------------------------------------------------------------------
-# Export version / feature vars for qwlroots (lowercase true/false)
+# Export version / feature vars for waylib (lowercase true/false)
 # ---------------------------------------------------------------------------
 macro(wlr_export_bool _name _value01)
     if(${_value01})

--- a/wlroots/cmake/WlrootsProtocols.cmake
+++ b/wlroots/cmake/WlrootsProtocols.cmake
@@ -147,7 +147,7 @@ function(wlroots_generate_protocols target)
     endforeach()
 
     target_sources(${target} PRIVATE ${_wlr_proto_sources} ${_wlr_proto_headers})
-    # BEFORE: parent projects (qwlroots) may inject older system wlr-protocols
+    # BEFORE: parent projects may inject older system wlr-protocols
     # headers via global include_directories(); those must not win.
     target_include_directories(${target} BEFORE PRIVATE "${_wlr_proto_dir}")
 


### PR DESCRIPTION
## Summary

After the qwlroots removal refactor (`9582881dd`), waylib consumes wlroots through its raw C API and wlroots is vendored in-tree under `3rdparty/wlroots`. This PR removes **all** remaining qwlroots references from agent documentation, skills, code comments and build config so new sessions never see qwlroots as something that existed. Documentation and config only — no code or build logic changes.

## Changes

- **AGENTS.md**: replace the obsolete `qwlroots/` bullet with the in-tree wlroots / raw C API (`<wlr_all.h>`) / `WObject`+`WServerInterface` layer; drop the "former qwlroots bindings no longer exist" sentence entirely.
- **treeland-private-wayland-protocol/SKILL.md**: update CMake helper name to `waylib_generate_qtwayland_server_protocol` (target-based signature) and the manager wiring example.
- **upstream-wayland-protocol-wrapper/SKILL.md**: use raw wlroots C constructors and rework destruction guidance for the raw-C-pointer + `WObject` scoped-listener model.
- **logging-guidelines/SKILL.md**: drop the defunct "qwlroots code" trigger.
- **waylib/README.md, waylib/README.zh_CN.md**: remove the long-removed `WITH_SUBMODULE_QWLROOTS` build flag; wlroots is vendored in-tree, so plain `cmake -B build` is correct.
- **wlroots/CMakeLists.txt, WlrootsProtocols.cmake, waylib CMakeLists.txt, wpointer.h, wlogging.h**: remove qwlroots from explanatory comments (no logic change).
- **REUSE.toml**: remove dead `qwlroots/**` annotation blocks (directory no longer exists).

12 files changed, 39 insertions(+), 98 deletions(-).

## Review

已通过两轮 Code Review（100 分 / 优秀，0 安全漏洞）。纯文档改动，无需编译。

## Multica issue

[WM-293](https://multica.uniontech.com/workspaces/e1c725b6-7c31-4790-a381-3262f282537c/issues/WM-293)
