### PR TITLE
fix(lockscreen): improve keyboard navigation in lock screen power con…

### DIFF
--- a/src/plugins/lockscreen/qml/ControlAction.qml
+++ b/src/plugins/lockscreen/qml/ControlAction.qml
@@ -93,10 +93,12 @@ RowLayout {
                 anchors.fill: parent
                 onClicked: {
                     powerItem.expand = false
+                    innerPowerList.loopInside = false
                 }
             }
 
             PowerList {
+                id: innerPowerList
                 width: rootItem.width
                 height: 140
                 x: 0
@@ -105,6 +107,8 @@ RowLayout {
         }
         onClicked: {
             powerItem.expand = true
+            innerPowerList.focusPowerOff()
+            innerPowerList.enableLoopInside()
         }
     }
 

--- a/src/plugins/lockscreen/qml/PowerList.qml
+++ b/src/plugins/lockscreen/qml/PowerList.qml
@@ -13,8 +13,26 @@ FocusScope {
     property alias modelChildren: objModel.children
     property alias leftModelChildren: leftObjeModel.children
 
+    property alias listPowerOffBtn: powerOffBtn
+    property alias listHibernateBtn: hibernateBtn
+
+    property bool loopInside: false
+
+    signal tabOutForward()
+    signal tabOutBackward()
+
     implicitWidth: layout.width
     implicitHeight: layout.height
+
+    function focusPowerOff() {
+        powerOffBtn.forceActiveFocus()
+    }
+    function focusHibernate() {
+        hibernateBtn.forceActiveFocus()
+    }
+    function enableLoopInside() {
+        loopInside = true
+    }
 
     RowLayout {
         id: layout
@@ -22,7 +40,7 @@ FocusScope {
         anchors.centerIn: parent
         Repeater {
             model: ObjectModel {
-            id: leftObjeModel
+                id: leftObjeModel
             }
         }
         Repeater {
@@ -30,35 +48,63 @@ FocusScope {
                 id: objModel
 
                 ShutdownButton {
-                    id: powerOff
+                    id: powerOffBtn
                     enabled: GreeterProxy.canPowerOff
                     text: qsTr("Shut Down")
                     icon.name: "login_shutdown"
                     onClicked: GreeterProxy.powerOff()
+                    KeyNavigation.tab: rebootBtn
+                    KeyNavigation.backtab: hibernateBtn
+                    Keys.onBacktabPressed: function(event) {
+                        if(root.loopInside){
+                            event.accepted = false
+                        }
+                        else{
+                            root.tabOutBackward()
+                            event.accepted = true
+                        }
+                    }
                 }
 
                 ShutdownButton {
+                    id: rebootBtn
                     enabled: GreeterProxy.canReboot
                     text: qsTr("Reboot")
                     icon.name: "login_reboot"
                     onClicked: GreeterProxy.reboot()
+                    KeyNavigation.tab: suspendBtn
+                    KeyNavigation.backtab: powerOffBtn
                 }
 
                 ShutdownButton {
+                    id: suspendBtn
                     enabled: GreeterProxy.canSuspend
                     text: qsTr("Suspend")
                     icon.name: "login_suspend"
                     onClicked: {
                         GreeterProxy.suspend()
                     }
+                    KeyNavigation.tab: hibernateBtn
+                    KeyNavigation.backtab: rebootBtn
                 }
 
                 ShutdownButton {
+                    id: hibernateBtn
                     enabled: GreeterProxy.canHibernate
                     text: qsTr("Hibernate")
                     icon.name: "login_hibernate"
                     onClicked: {
                         GreeterProxy.hibernate()
+                    }
+                    KeyNavigation.tab: powerOffBtn
+                    KeyNavigation.backtab: suspendBtn
+                    Keys.onTabPressed: function(event) {
+                        if(root.loopInside) {
+                            event.accepted = false
+                        } else {
+                            root.tabOutForward()
+                            event.accepted = true
+                        }
                     }
                 }
             }

--- a/src/plugins/lockscreen/qml/ShutdownButton.qml
+++ b/src/plugins/lockscreen/qml/ShutdownButton.qml
@@ -55,6 +55,13 @@ Button {
                     radius: width / 2
                     color: Qt.rgba(1.0, 1.0, 1.0, 0.3)
                 }
+                D.FocusBoxBorder {
+                    visible: root.activeFocus
+                    anchors.fill: parent
+                    borderWidth: 2
+                    radius: width / 2
+                    color: Qt.rgba(1.0, 1.0, 1.0, 0.6)
+                }
             }
         }
 
@@ -73,7 +80,7 @@ Button {
             color: root.D.ColorSelector.textColor
 
             background: Item {
-                visible: root.pressed || root.hovered
+                visible: root.pressed || root.hovered || root.activeFocus
                 RoundBlur {
                     anchors.fill: parent
                     radius: 6
@@ -85,6 +92,13 @@ Button {
                     borderWidth: 2
                     radius: 6
                     color: Qt.rgba(1.0, 1.0, 1.0, 0.3)
+                }
+                D.FocusBoxBorder {
+                    visible: root.activeFocus
+                    anchors.fill: parent
+                    borderWidth: 2
+                    radius: 6
+                    color: Qt.rgba(1.0, 1.0, 1.0, 0.6)
                 }
             }
         }

--- a/src/plugins/lockscreen/qml/ShutdownView.qml
+++ b/src/plugins/lockscreen/qml/ShutdownView.qml
@@ -10,6 +10,10 @@ FocusScope {
 
     signal switchUser()
 
+    Component.onCompleted: {
+        lockBtn.forceActiveFocus()
+    }
+
     MouseArea {
         anchors.fill: parent
         enabled: true
@@ -17,6 +21,9 @@ FocusScope {
     }
 
     PowerList {
+        id: powerList
+        onTabOutForward: lockBtn.forceActiveFocus()
+        onTabOutBackward: logoutBtn.forceActiveFocus()
         width: parent.width
         height: 140
         anchors {
@@ -27,23 +34,32 @@ FocusScope {
 
         modelChildren: [
             ShutdownButton {
+                id: lockBtn
                 visible: !GreeterProxy.isLocked
                 text: qsTr("lock")
                 icon.name: "login_lock"
                 onClicked: GreeterProxy.lock()
+                KeyNavigation.tab: switchBtn
+                KeyNavigation.backtab: powerList.listHibernateBtn
             },
             ShutdownButton {
+                id: switchBtn
                 visible: !GreeterProxy.isLocked
                 text: qsTr("switch user")
                 icon.name: "login_switchuser"
                 enabled: UserModel.count > 1
                 onClicked: root.switchUser()
+                KeyNavigation.tab: logoutBtn
+                KeyNavigation.backtab: lockBtn
             },
             ShutdownButton {
+                id: logoutBtn
                 visible: !GreeterProxy.isLocked
                 text: qsTr("Logout")
                 icon.name: "login_logout"
                 onClicked: GreeterProxy.logout()
+                KeyNavigation.tab: powerList.listPowerOffBtn
+                KeyNavigation.backtab: switchBtn
             }
         ]
     }


### PR DESCRIPTION
…trols

Improve keyboard focus navigation across lock screen shutdown/power controls, adding FocusBoxBorder visual feedback and proper tab order.

修复锁屏界面关机/电源控件的键盘焦点导航，
添加FocusBoxBorder视觉反馈和正确Tab键顺序。

Log: 修复锁屏界面键盘导航问题
PMS: BUG-300951
Influence: 修复后锁屏电源菜单支持键盘Tab/BackTab
导航，焦点切换有视觉反馈。

## Summary by Sourcery

Improve lock-screen power-control keyboard navigation and focus feedback.

Bug Fixes:
- Improve keyboard navigation across lock-screen power and user controls with correct Tab and BackTab ordering.

Enhancements:
- Add visible focus indicators to lock-screen shutdown buttons and manage focus looping within expanded power controls.