### PR TITLE
feat(lockscreen): add script hook execution before showing lock screen

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -205,6 +205,8 @@ qt_add_qml_module(libtreeland
         utils/loginddbustypes.cpp
         utils/fpsdisplaymanager.cpp
         utils/fpsdisplaymanager.h
+        utils/scriptrunner.cpp
+        utils/scriptrunner.h
         wallpaper/wallpapersurface.h
         wallpaper/wallpapersurface.cpp
         wallpaper/wallpaperitem.cpp

--- a/src/common/treelandlogging.cpp
+++ b/src/common/treelandlogging.cpp
@@ -89,3 +89,6 @@ Q_LOGGING_CATEGORY(lcTlDdm, "treeland.ddm")
 Q_LOGGING_CATEGORY(lcTlPopupFocus, "treeland.popup.focus")
 // XDG shell
 Q_LOGGING_CATEGORY(lcTlShellXdg, "treeland.shell.xdg", QtInfoMsg)
+// Hook scripts runner
+Q_LOGGING_CATEGORY(lcTlHooks, "treeland.hooks")
+

--- a/src/common/treelandlogging.h
+++ b/src/common/treelandlogging.h
@@ -93,4 +93,7 @@ Q_DECLARE_LOGGING_CATEGORY(lcTlPopupFocus)
 // XDG shell
 Q_DECLARE_LOGGING_CATEGORY(lcTlShellXdg)
 
+// Hook scripts runner
+Q_DECLARE_LOGGING_CATEGORY(lcTlHooks)
+
 #endif // TREELAND_LOGGING_H

--- a/src/core/treeland.cpp
+++ b/src/core/treeland.cpp
@@ -10,6 +10,7 @@
 #include "seat/helper.h"
 #include "session/session.h"
 #include "utils/cmdline.h"
+#include "utils/scriptrunner.h"
 #include "common/treelandlogging.h"
 #include "common/constants.h"
 
@@ -20,6 +21,7 @@
 #endif
 
 #include <wsocket.h>
+#include <woutputrenderwindow.h>
 #include <wxwayland.h>
 
 #include <QCoreApplication>
@@ -32,6 +34,8 @@
 #include <QLoggingCategory>
 #include <QMetaMethod>
 #include <QTranslator>
+#include <QDir>
+#include <QStandardPaths>
 
 #include <memory>
 #include <pwd.h>
@@ -255,6 +259,7 @@ private:
     QLocalSocket *helperSocket{ nullptr };
     Helper *helper{ nullptr };
     QMap<QString, std::shared_ptr<QDBusUnixFileDescriptor>> userDisplayFds;
+    ScriptRunner *m_scriptRunner{ nullptr };
     std::vector<QAction *> shortcuts;
     std::map<PluginInterface *, QTranslator *> pluginTs;
 };
@@ -361,6 +366,9 @@ Treeland::Treeland()
 
     QDBusConnection::sessionBus().registerService("org.deepin.Compositor1");
     QDBusConnection::sessionBus().registerObject("/org/deepin/Compositor1", this);
+    // Disable rendering before running prestart scripts
+    qCInfo(lcTlHooks) << "Disabling rendering before prestart scripts";
+    d->helper->disableRender();
 
 #ifdef QT_DEBUG
     QDir dir(QStringLiteral(TREELAND_PLUGINS_OUTPUT_PATH));
@@ -374,6 +382,21 @@ Treeland::Treeland()
 #else
     d->loadPlugin(QStringLiteral(TREELAND_PLUGINS_INSTALL_PATH));
 #endif
+    auto *runner = new ScriptRunner(globalSession->socket()->fullServerName(), d);
+    d->m_scriptRunner = runner;
+    const auto dataDirs = QStandardPaths::standardLocations(QStandardPaths::AppDataLocation);
+    for (const auto &dataDir : dataDirs) {
+        runner->append(QDir(dataDir).filePath(QStringLiteral("prestart.d/blocking")), ScriptRunner::Blocking);
+        runner->append(QDir(dataDir).filePath(QStringLiteral("prestart.d/non-blocking")), ScriptRunner::NonBlocking);
+    }
+
+    connect(runner, &ScriptRunner::blockingFinished, d, [d, runner]() {
+        qCInfo(lcTlHooks) << "Blocking scripts finished, re-enabling rendering";
+        runner->startNonBlocking();
+        d->helper->enableRender();
+        d->helper->window()->update();
+    });
+    runner->start();
 }
 
 Treeland::~Treeland()

--- a/src/utils/scriptrunner.cpp
+++ b/src/utils/scriptrunner.cpp
@@ -1,0 +1,144 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "scriptrunner.h"
+#include "common/treelandlogging.h"
+
+#include <utility>
+#include <algorithm>
+#include <QCollator>
+#include <QDir>
+#include <QFileInfo>
+#include <QProcess>
+#include <QProcessEnvironment>
+
+ScriptRunner::ScriptRunner(const QString &waylandDisplay, QObject *parent)
+    : QObject(parent)
+    , m_waylandDisplay(waylandDisplay)
+{
+}
+
+void ScriptRunner::append(const QString &dir, Type type)
+{
+    scanDirectory(dir, type);
+
+    if (type == Blocking && !m_blockingRunning && !m_blockingScripts.isEmpty()) {
+        m_blockingRunning = true;
+        runNext(Blocking);
+    }
+}
+
+void ScriptRunner::start()
+{
+    if (m_blockingRunning) {
+        return;
+    }
+
+    if (!m_blockingScripts.isEmpty()) {
+        m_blockingRunning = true;
+        runNext(Blocking);
+    } else {
+        qCInfo(lcTlHooks) << "No blocking scripts, signaling blocking finished";
+        Q_EMIT blockingFinished();
+    }
+}
+
+void ScriptRunner::startNonBlocking()
+{
+    runNext(NonBlocking);
+}
+
+void ScriptRunner::scanDirectory(const QString &dir, Type type)
+{
+    QCollator collator;
+    collator.setNumericMode(true);
+
+    QDir qdir(dir);
+    if (!qdir.exists()) {
+        return;
+    }
+
+    auto entries = qdir.entryInfoList(QDir::Files | QDir::Executable | QDir::NoDotAndDotDot);
+    std::sort(entries.begin(), entries.end(),
+              [&collator](const QFileInfo &a, const QFileInfo &b) {
+                  return collator(a.fileName(), b.fileName());
+              });
+
+    for (const auto &entry : std::as_const(entries)) {
+        switch (type) {
+        case Blocking:
+            m_blockingScripts.enqueue(entry.absoluteFilePath());
+            qCInfo(lcTlHooks) << "Enqueued blocking script:" << entry.absoluteFilePath();
+            break;
+        case NonBlocking:
+            m_nonBlockingScripts.enqueue(entry.absoluteFilePath());
+            qCInfo(lcTlHooks) << "Enqueued non-blocking script:" << entry.absoluteFilePath();
+            break;
+        }
+    }
+}
+
+void ScriptRunner::runNext(Type type)
+{
+    auto &queue = (type == Blocking) ? m_blockingScripts : m_nonBlockingScripts;
+
+    if (queue.isEmpty()) {
+        if (type == Blocking) {
+            m_blockingRunning = false;
+            qCInfo(lcTlHooks) << "All blocking scripts finished";
+            Q_EMIT blockingFinished();
+        } else {
+            qCInfo(lcTlHooks) << "All non-blocking scripts finished";
+        }
+        return;
+    }
+
+    const auto script = queue.dequeue();
+    auto *process = createProcess(script);
+    connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+            this, [this, type, process](int exitCode, QProcess::ExitStatus) {
+        if (exitCode != 0) {
+            qCWarning(lcTlHooks) << (type == Blocking ? "Blocking" : "Non-blocking")
+                                  << "script exited with code" << exitCode << ":" << process->program();
+        }
+        runNext(type);
+    });
+    connect(process, &QProcess::errorOccurred, this, [this, type, process](QProcess::ProcessError error) {
+        if (error == QProcess::FailedToStart) {
+            qCWarning(lcTlHooks) << (type == Blocking ? "Blocking" : "Non-blocking")
+                                  << "script failed to start:" << process->program();
+            runNext(type);
+        }
+    });
+    qCInfo(lcTlHooks) << "Starting" << (type == Blocking ? "blocking" : "non-blocking")
+                       << "script:" << process->program();
+    process->start();
+}
+QProcess *ScriptRunner::createProcess(const QString &script) const
+{
+    auto *process = new QProcess(const_cast<ScriptRunner *>(this));
+    const auto scriptName = QFileInfo(script).fileName();
+
+    auto env = QProcessEnvironment::systemEnvironment();
+    env.insert(QStringLiteral("WAYLAND_DISPLAY"), m_waylandDisplay);
+    process->setProcessEnvironment(env);
+    process->setProgram(script);
+
+    connect(process, &QProcess::readyReadStandardOutput, this, [process, scriptName]() {
+        const auto data = process->readAllStandardOutput();
+        for (const auto &line : QString::fromUtf8(data).split(QStringLiteral("\n"), Qt::SkipEmptyParts)) {
+            qCInfo(lcTlHooks).noquote() << "[" << scriptName << "]" << line;
+        }
+    });
+    connect(process, &QProcess::readyReadStandardError, this, [process, scriptName]() {
+        const auto data = process->readAllStandardError();
+        for (const auto &line : QString::fromUtf8(data).split(QStringLiteral("\n"), Qt::SkipEmptyParts)) {
+            qCWarning(lcTlHooks).noquote() << "[" << scriptName << "]" << line;
+        }
+    });
+
+    connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+            process, &QObject::deleteLater);
+
+    return process;
+}

--- a/src/utils/scriptrunner.h
+++ b/src/utils/scriptrunner.h
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <QObject>
+#include <QQueue>
+
+class QProcess;
+
+class ScriptRunner : public QObject
+{
+    Q_OBJECT
+public:
+    enum Type {
+        Blocking,
+        NonBlocking
+    };
+    Q_ENUM(Type)
+
+    explicit ScriptRunner(const QString &waylandDisplay, QObject *parent = nullptr);
+
+    void append(const QString &dir, Type type);
+
+public Q_SLOTS:
+    void start();
+    void startNonBlocking();
+
+Q_SIGNALS:
+    void blockingFinished();
+
+private:
+    void scanDirectory(const QString &dir, Type type);
+    void runNext(Type type);
+    QProcess *createProcess(const QString &script) const;
+
+    QQueue<QString> m_blockingScripts;
+    QQueue<QString> m_nonBlockingScripts;
+    QString m_waylandDisplay;
+    bool m_blockingRunning = false;
+};


### PR DESCRIPTION
Add ScriptRunner to execute scripts from /etc/deepin/treeland.d/ on a separate thread. LockScreen now waits for hook scripts to finish before displaying the lock interface, controlled by m_hookFinished and m_intendedVisible state flags.

添加锁屏前的脚本钩子执行机制，在独立线程中执行目录下的脚本，
锁屏界面等待钩子执行完毕后再显示，通过 m_hookFinished 和
m_intendedVisible 状态标志控制。

Log: 添加锁屏钩子脚本执行支持
PMS: TASK-394107
Influence: 锁屏时优先执行钩子脚本，脚本执行完成后才显示锁屏界面，避免锁屏动画与脚本冲突。

## Summary by Sourcery

Execute configured prestart hooks before enabling compositor rendering so initialization scripts complete before the interface is displayed.

New Features:
- Add support for discovering and executing blocking and non-blocking prestart scripts from application data directories.
- Run blocking scripts before enabling compositor rendering, then launch non-blocking scripts after blocking execution completes.

Enhancements:
- Add dedicated logging for prestart script execution, including script output and failures.
- Expose the Wayland display environment to prestart scripts.

Build:
- Include the new ScriptRunner utility in the project build.