### PR TITLE
fix(lockscreen): use loginGroup.width for leftPadding binding to fix binding loop

### DIFF
--- a/src/plugins/lockscreen/qml/UserInput.qml
+++ b/src/plugins/lockscreen/qml/UserInput.qml
@@ -144,23 +144,17 @@ Item {
             echoMode: loginGroup.enteringOtherUser ? TextInput.Normal
                       : (showPasswordBtn.hiddenPWD ? TextInput.Password : TextInput.Normal)
             rightPadding: 22
-            leftPadding: 22
+            leftPadding: {
+                var remaining = loginGroup.width - contentWidth - rightPadding
+                if (capsIndicator.visible)
+                    return rightPadding
+                return Math.max(8, remaining > rightPadding ? rightPadding : remaining)
+            }
             maximumLength: 510
             placeholderText: loginGroup.enteringOtherUser ? qsTr("Username") : qsTr("Password")
             placeholderTextColor: Qt.rgba(1.0, 1.0, 1.0, 0.6)
             color: palette.windowText
             font: D.DTK.fontManager.t8
-            onContentWidthChanged: updateLeftPadding()
-            onWidthChanged: updateLeftPadding()
-            Component.onCompleted: updateLeftPadding()
-
-            function updateLeftPadding() {
-                var remaining = width - contentWidth - rightPadding
-                if (capsIndicator.visible)
-                    leftPadding = rightPadding
-                else
-                    leftPadding = Math.max(8, remaining > rightPadding ? rightPadding : remaining)
-            }
             Keys.onPressed: function (event) {
                 if (event.key === Qt.Key_CapsLock) {
                     capsIndicatorVisible = !capsIndicatorVisible
@@ -183,7 +177,6 @@ Item {
                     verticalCenter: parent.verticalCenter
                 }
                 visible: passwordField.capsIndicatorVisible && !loginGroup.enteringOtherUser
-                onVisibleChanged: passwordField.updateLeftPadding()
                 palette.windowText: undefined
                 icon {
                     name: "login_capslock"


### PR DESCRIPTION
## 修复内容

将 `UserInput.qml` 中 `passwordField.leftPadding` 从命令式 `updateLeftPadding()` 恢复为声明式属性绑定，但改用 `loginGroup.width`（常量）替代 `width` 进行计算，切断 `implicitWidth -> leftPadding -> {width, contentWidth}` 的循环绑定。

同时移除 `onContentWidthChanged` / `onWidthChanged` / `Component.onCompleted` 触发器、`updateLeftPadding()` 函数，以及 `capsIndicator` 中 `onVisibleChanged` 调用，保留原有超长密码与大写指示器显隐的动态 padding 行为。

改动文件：`src/plugins/lockscreen/qml/UserInput.qml`（+6 / −13）

## 关联 Issue

[WM-296](https://agent-dev.uniontech.com/wm/issues/WM-296)

## Summary by Sourcery

Fix lock-screen password padding calculations to avoid binding loops and retain correct indicator and long-password behavior.

Bug Fixes:
- Fix the lock-screen password field's padding binding loop while preserving dynamic padding for long passwords and the Caps Lock indicator.

Enhancements:
- Simplify password-field padding updates by replacing imperative change handlers with a declarative binding based on the login group's width.