### PR TITLE
fix: use WPointer for cursorClient and skip redundant cursor updates

### DIFF
--- a/waylib/src/server/kernel/wseat.cpp
+++ b/waylib/src/server/kernel/wseat.cpp
@@ -7,6 +7,7 @@
 #include "woutput.h"
 #include "wsurface.h"
 #include "wscoplistener.h"
+#include "wpointer.h"
 #include "platformplugin/qwlrootsintegration.h"
 #include "private/wglobal_p.h"
 #include "wayliblogging.h"
@@ -446,7 +447,7 @@ public:
     // for cursor data
     // TODO: make to QWSeatClient in wlroots
     // Don't access its member, maybe is a invalid pointer
-    wlr_seat_client *cursorClient = nullptr;
+    WPointer<wlr_seat_client> cursorClient;
     QPointer<WSurface> cursorSurface;
     QPoint cursorSurfaceHotspot;
     WGlobal::CursorShape cursorShape = WGlobal::CursorShape::Invalid;
@@ -467,13 +468,26 @@ void WSeatPrivate::on_request_set_cursor(wlr_seat_pointer_request_set_cursor_eve
          * on the output that it's currently on and continue to do so as the
          * cursor moves between outputs. */
         auto *surface = event->surface;
-        cursorClient = event->seat_client;
         cursorShape = WGlobal::CursorShape::Invalid;
+
+        W_Q(WSeat);
+
+        if (cursorClient == event->seat_client && cursorSurface
+            && cursorSurface->handle() == surface) {
+            if (cursorSurfaceHotspot.x() != event->hotspot_x
+                || cursorSurfaceHotspot.y() != event->hotspot_y) {
+                cursorSurfaceHotspot.rx() = event->hotspot_x;
+                cursorSurfaceHotspot.ry() = event->hotspot_y;
+                Q_EMIT q->requestCursorSurface(cursorSurface, cursorSurfaceHotspot);
+            }
+            return;
+        }
+
+        cursorClient = event->seat_client;
 
         if (cursorSurface)
             delete cursorSurface;
 
-        W_Q(WSeat);
         if (surface) {
             cursorSurface = new WSurface(surface);
             // The seat created the surface, so it releases it when the


### PR DESCRIPTION
1. Switch cursorClient from raw pointer to WPointer for safer lifetime management
2. Early-return when same client/surface re-requests cursor with only hotspot change, avoiding unnecessary WSurface recreation
3. Move W_Q(WSeat) earlier to support the new check

Log: Fix potential use-after-free of cursorClient and reduce cursor surface churn under repeated hotspot-only requests.

Influence:
1. Verify cursor shape/surface still works correctly on all outputs
2. Test rapid cursor hotspot changes (e.g. resize cursors) for performance and correctness
3. Verify no crashes or dangling pointer issues when seat client is destroyed

fix: 使用 WPointer 管理 cursorClient 并跳过冗余光标更新

1. 将 cursorClient 从裸指针改为 WPointer 以安全管理生命周期
2. 同一客户端/表面仅改变热点时提前返回，避免重复创建 WSurface
3. 提前 W_Q(WSeat) 以支持新的检查逻辑

Log: 修复 cursorClient 可能的悬空指针问题，减少热点变化时的
     光标表面重建开销

Influence:
1. 验证所有输出上的光标形状/表面功能正常
2. 测试快速光标热点变化（如调整大小光标）的性能和正确性
3. 验证 seat client 销毁时无崩溃或悬空指针问题

PMS: BUG-374347 BUG-374351

## Summary by Sourcery

Safely manage the cursor client and skip unnecessary cursor surface recreation for hotspot-only updates.

Bug Fixes:
- Prevent cursor client lifetime issues by tracking it with a managed pointer.
- Avoid redundant cursor surface updates when the same client and surface only change hotspot coordinates.

Enhancements:
- Reduce cursor surface recreation during repeated hotspot-only cursor requests while still propagating hotspot changes.