### PR TITLE
docs: recommend ci build preset for daily development in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,12 +16,12 @@
 
 ## Build & Test
 ```bash
-cmake --preset default
-cmake --build --preset default
-ctest --test-dir build --output-on-failure
+cmake --preset ci
+cmake --build --preset ci
+ctest --preset ci
 ```
 
-- Presets in `CMakePresets.json`: `default`, `clang`, `ci`, `ci-clang`.
+- For daily development prefer the `ci` preset: it mirrors CI's `-Wall -Wextra -Werror` flags, so warnings that would fail CI are caught locally before push. Other presets in `CMakePresets.json`: `default`, `clang`, `ci-clang`.
 - `WITH_SUBMODULE_WAYLIB=ON|OFF` selects submodule vs system waylib. Default preference is `ON`.
 
 ## Project Rules


### PR DESCRIPTION
## Summary

Switch the Build & Test instructions in `AGENTS.md` from the `default` preset to the `ci` preset, matching what CI runs (`-Wall -Wextra -Werror`). This lets warnings that would fail CI be caught locally before push.

Documentation-only change (1 file, 4+/4-). No code or build logic changes.

## Changes

- **AGENTS.md**: replace `cmake --preset default` / `cmake --build --preset default` / `ctest --test-dir build --output-on-failure` with `cmake --preset ci` / `cmake --build --preset ci` / `ctest --preset ci`; add a note recommending the `ci` preset for daily development.

## Review

Passed Code Review (commit `2d948d5ae`). Pure documentation change, no compilation needed.

## Multica issue

[WM-293](https://agent-dev.uniontech.com/wm/issues/WM-293)

## Summary by Sourcery

Documentation:
- Recommend the CI CMake preset for daily development and update the documented build and test commands to match CI’s warning flags.