### PR TITLE
fix(session): guard null active session in xwayland primary output sync

### DIFF
--- a/src/session/session.cpp
+++ b/src/session/session.cpp
@@ -136,8 +136,12 @@ void SessionManager::syncActiveSessionXWaylandPrimaryOutput()
     if (!primaryOutput)
         return;
 
+    auto session = m_activeSession.lock();
+    if (!session)
+        return;
+
     const QString primaryOutputName = primaryOutput->output()->name();
-    auto *xwayland = activeSession().lock()->xwayland();
+    auto *xwayland = session->xwayland();
     auto *connection = xwayland ? xwayland->xcbConnection() : nullptr;
     auto *screen = xwayland ? xwayland->xcbScreen() : nullptr;
     if (!connection || !screen)


### PR DESCRIPTION
Check the weak_ptr lock result before dereferencing the active session. When an output is removed, primaryOutputChanged is delivered synchronously; if the active session was already reset (e.g. after a logind session was removed), calling ->xwayland() on the null session crashes the compositor.

输出移除时同步触发primaryOutputChanged，若活动会话已被重置，
对空指针调用->xwayland()会导致合成器崩溃，增加空指针守卫。

Log: 修复输出移除时活动会话为空导致的崩溃

## Summary by Sourcery

Bug Fixes:
- Prevent compositor crashes when the active session is unavailable during Xwayland primary-output synchronization.