### PR TITLE
fix(output): sync output item DPR on scale change synchronously

### DIFF
--- a/src/core/qml/CopyOutput.qml
+++ b/src/core/qml/CopyOutput.qml
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import QtQuick

--- a/src/core/qml/CopyOutput.qml
+++ b/src/core/qml/CopyOutput.qml
@@ -97,7 +97,6 @@ OutputItem {
 
         anchors.centerIn: parent
         depends: [primaryScreenViewport]
-        devicePixelRatio: outputItem.devicePixelRatio
         input: content
         output: outputItem.output
 

--- a/src/core/qml/CopyOutput.qml
+++ b/src/core/qml/CopyOutput.qml
@@ -41,8 +41,6 @@ OutputItem {
         return rotatedSize;
     }
 
-    devicePixelRatio: output?.scale ?? devicePixelRatio
-
     Rectangle {
         id: content
         anchors.fill: parent

--- a/src/core/qml/PrimaryOutput.qml
+++ b/src/core/qml/PrimaryOutput.qml
@@ -47,7 +47,6 @@ OutputItem {
         id: outputViewport
 
         output: rootOutputItem.output
-        devicePixelRatio: parent.devicePixelRatio
         anchors.centerIn: parent
 
         RotationAnimation {

--- a/src/core/qml/PrimaryOutput.qml
+++ b/src/core/qml/PrimaryOutput.qml
@@ -11,8 +11,6 @@ OutputItem {
     readonly property OutputViewport screenViewport: outputViewport
     property bool forceSoftwareCursor: false
 
-    devicePixelRatio: output?.scale ?? devicePixelRatio
-
     cursorDelegate: Cursor {
         id: cursorItem
 

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -93,6 +93,20 @@ Output *Output::create(WOutput *output, QQmlEngine *engine, QObject *parent)
     o->m_type = Type::Primary;
     obj->setParent(o);
 
+    // Keep the OutputViewport's devicePixelRatio in sync with the output scale
+    // synchronously, for the same reason as the output item above. The viewport's
+    // implicit size is output->size() / DPR, so a stale (too-small) DPR makes the
+    // viewport larger than its parent OutputItem. With anchors.centerIn the viewport
+    // is then offset, and renderMatrix() maps content to the wrong screen position —
+    // the greeter/lock screen flashes from the bottom-right toward center at startup
+    // under fractional scales (e.g. 1.25).
+    if (auto *viewport = o->screenViewport()) {
+        QObject::connect(output, &WOutput::scaleChanged, viewport, [viewport, output] {
+            viewport->setDevicePixelRatio(output->scale());
+        });
+        viewport->setDevicePixelRatio(output->scale());
+    }
+
     o->minimizedSurfaces->setFilter([](SurfaceWrapper *s) {
         return s->isMinimized();
     });
@@ -163,6 +177,14 @@ Output *Output::createCopy(WOutput *output, Output *proxy, QQmlEngine *engine, Q
     o->m_type = Type::Proxy;
     o->m_proxy = proxy;
     obj->setParent(o);
+
+    // Same synchronous DPR sync for the copy output's viewport (see Output::create).
+    if (auto *viewport = o->screenViewport()) {
+        QObject::connect(output, &WOutput::scaleChanged, viewport, [viewport, output] {
+            viewport->setDevicePixelRatio(output->scale());
+        });
+        viewport->setDevicePixelRatio(output->scale());
+    }
 
     o->updateOutputHardwareLayers();
     connect(proxy->screenViewport(),

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -70,6 +70,16 @@ Output *Output::create(WOutput *output, QQmlEngine *engine, QObject *parent)
     outputItem->setParentItem(contentItem);
     outputItem->setOutput(output);
 
+    // Keep the item devicePixelRatio in sync with the output scale synchronously.
+    // The old QML binding (devicePixelRatio: output?.scale) was evaluated lazily,
+    // so after the scale is committed the render window's effectiveDevicePixelRatio
+    // (updated in C++ on scaleChanged) already reflected the new scale while the
+    // output item was still at the old size. That transient mismatch made the
+    // greeter/lock screen render at the wrong size at startup.
+    QObject::connect(output, &WOutput::scaleChanged, outputItem, [outputItem, output] {
+        outputItem->setDevicePixelRatio(output->scale());
+    });
+    outputItem->setDevicePixelRatio(output->scale());
     connect(Helper::instance()->globalConfig(),
             &TreelandConfig::forceSoftwareCursorChanged,
             obj,
@@ -143,6 +153,12 @@ Output *Output::createCopy(WOutput *output, Output *proxy, QQmlEngine *engine, Q
     outputItem->setParentItem(contentItem);
     outputItem->setOutput(output);
 
+    // Keep the item devicePixelRatio in sync with the output scale synchronously
+    // (same as the PrimaryOutput path in Output::create).
+    QObject::connect(output, &WOutput::scaleChanged, outputItem, [outputItem, output] {
+        outputItem->setDevicePixelRatio(output->scale());
+    });
+    outputItem->setDevicePixelRatio(output->scale());
     auto o = new Output(outputItem, parent);
     o->m_type = Type::Proxy;
     o->m_proxy = proxy;


### PR DESCRIPTION
## Summary

Fix the greeter/login window appearing at the wrong size (first larger, then smaller) at treeland startup when screen scaling is not 100%.

### Root cause

The `OutputItem`'s `devicePixelRatio` was bound in QML to `output?.scale`. QML bindings are evaluated lazily. When the output scale is committed (e.g. 150%) at startup, the render window's `effectiveDevicePixelRatio` was updated synchronously in C++ (via `updateSceneDPR` on `scaleChanged`), while the output item's size still reflected the old scale for a frame or more. Since the greeter/lock screen binds its size to the output item, this transient mismatch made the login window render at the wrong size first, then shrink to the correct size. At 100% scaling there is no scale change, so no glitch occurs.

### Fix

- Remove the lazily-evaluated QML `devicePixelRatio` binding in `PrimaryOutput.qml` and `CopyOutput.qml`.
- Synchronously update the output item `devicePixelRatio` from C++ in `Output::create()` and `Output::createCopy()`, in lockstep with the window DPR change on `WOutput::scaleChanged`.

## Test Plan

1. Boot treeland with fractional screen scaling (125%/150%): the greeter must appear at the correct size immediately.
2. Switch screen scale at runtime: no transient wrong-size frame.
3. Verify copy (mirror) output displays correctly at non-100% scale.

issue-key: WM-306

## Summary by Sourcery

Bug Fixes:
- Synchronize primary and mirrored output item and viewport device pixel ratios with scale changes to prevent transiently incorrect greeter and lock-screen sizing or positioning.