### PR TITLE
fix: use wlr_xdg_toplevel_tag_v1 API instead of custom C implementation

### DIFF
--- a/waylib/src/server/CMakeLists.txt
+++ b/waylib/src/server/CMakeLists.txt
@@ -102,28 +102,11 @@ ws_generate(
     security-context-v1-protocol
 )
 
-#TODO: Remove after wlroots 0.20
-ws_generate(
-    server
-    wayland-protocols
-    staging/xdg-toplevel-tag/xdg-toplevel-tag-v1.xml
-    xdg-toplevel-tag-v1-protocol
-)
-
-#TODO: Remove after wlroots 0.20
 ws_generate(
     server
     wayland-protocols
     stable/xdg-shell/xdg-shell.xml
     xdg-shell-protocol
-)
-
-#TODO: Remove after wlroots 0.20
-ws_generate(
-    server
-    wayland-protocols
-    staging/ext-foreign-toplevel-list/ext-foreign-toplevel-list-v1.xml
-    ext-foreign-toplevel-list-v1-protocol
 )
 
 set(SOURCES
@@ -184,9 +167,7 @@ set(SOURCES
     ${WAYLAND_PROTOCOLS_OUTPUTDIR}/text-input-unstable-v2-protocol.c
     ${WAYLAND_PROTOCOLS_OUTPUTDIR}/xdg-output-unstable-v1-protocol.c
     ${WAYLAND_PROTOCOLS_OUTPUTDIR}/security-context-v1-protocol.c
-    ${WAYLAND_PROTOCOLS_OUTPUTDIR}/xdg-toplevel-tag-v1-protocol.c #TODO: Remove after wlroots 0.20
-    ${WAYLAND_PROTOCOLS_OUTPUTDIR}/xdg-shell-protocol.c #TODO: Remove after wlroots 0.20
-    ${WAYLAND_PROTOCOLS_OUTPUTDIR}/ext-foreign-toplevel-list-v1-protocol.c #TODO Remove after wlroots 0.20
+    ${WAYLAND_PROTOCOLS_OUTPUTDIR}/xdg-shell-protocol.c
 
     utils/wtools.cpp
     utils/wthreadutils.cpp
@@ -204,7 +185,7 @@ set(SOURCES
     protocols/wxdgshell.cpp
     protocols/wxdgsurface.cpp
     protocols/wxdgtoplevelsurface.cpp
-    protocols/wxdgtopleveltagmanager.cpp #TODO: Remove after wlroots 0.20
+    protocols/wxdgtopleveltagmanager.cpp
     protocols/wxdgpopupsurface.cpp
 
     protocols/wxwayland.cpp
@@ -376,9 +357,7 @@ set(PRIVATE_HEADERS
     ${WAYLAND_PROTOCOLS_OUTPUTDIR}/text-input-unstable-v1-protocol.h
     ${WAYLAND_PROTOCOLS_OUTPUTDIR}/text-input-unstable-v2-protocol.h
     ${WAYLAND_PROTOCOLS_OUTPUTDIR}/xdg-output-unstable-v1-protocol.h
-    ${WAYLAND_PROTOCOLS_OUTPUTDIR}/xdg-toplevel-tag-v1-protocol.h #TODO: Remove after wlroots 0.20
-    ${WAYLAND_PROTOCOLS_OUTPUTDIR}/xdg-shell-protocol.h #TODO: Remove after wlroots 0.20
-    ${WAYLAND_PROTOCOLS_OUTPUTDIR}/ext-foreign-toplevel-list-v1-protocol.h #TODO: Remove after wlroots 0.20
+    ${WAYLAND_PROTOCOLS_OUTPUTDIR}/xdg-shell-protocol.h
 
     protocols/private/winputmethodv2_p.h
     protocols/private/wtextinput_p.h

--- a/waylib/src/server/kernel/wlr_all.h
+++ b/waylib/src/server/kernel/wlr_all.h
@@ -122,6 +122,7 @@ extern "C" {
 #include <wlr/types/wlr_xdg_decoration_v1.h>
 #include <wlr/types/wlr_xdg_dialog_v1.h>
 #include <wlr/types/wlr_xdg_shell.h>
+#include <wlr/types/wlr_xdg_toplevel_tag_v1.h>
 #include <wlr/util/box.h>
 #include <wlr/util/edges.h>
 #include <wlr/util/log.h>

--- a/waylib/src/server/protocols/wxdgtopleveltagmanager.cpp
+++ b/waylib/src/server/protocols/wxdgtopleveltagmanager.cpp
@@ -7,168 +7,8 @@
 #include "wsurface.h"
 #include "wxdgtoplevelsurface.h"
 #include <wayland-server-core.h>
-#include <wcontainerof.h>
 
 #include <wlr_all.h>
-
-#include <assert.h>
-#include <stdlib.h>
-#include "xdg-toplevel-tag-v1-protocol.h"
-
-// Copy from wlroots
-struct Q_DECL_HIDDEN way_xdg_toplevel_tag_manager_v1
-{
-    struct wl_global *global;
-
-    struct
-    {
-        struct wl_signal set_tag; // struct way_xdg_toplevel_tag_manager_v1_set_tag_event
-        struct wl_signal
-            set_description; // struct way_xdg_toplevel_tag_manager_v1_set_description_event
-        struct wl_signal destroy;
-    } events;
-
-    struct
-    {
-        struct wl_listener display_destroy;
-    } WLR_PRIVATE;
-};
-
-struct Q_DECL_HIDDEN way_xdg_toplevel_tag_manager_v1_set_tag_event
-{
-    struct wlr_xdg_toplevel *toplevel;
-    const char *tag;
-};
-
-struct Q_DECL_HIDDEN way_xdg_toplevel_tag_manager_v1_set_description_event
-{
-    struct wlr_xdg_toplevel *toplevel;
-    const char *description;
-};
-
-struct way_xdg_toplevel_tag_manager_v1 *
-way_xdg_toplevel_tag_manager_v1_create(struct wl_display *display, uint32_t version);
-
-#define MANAGER_VERSION 1
-
-extern const struct xdg_toplevel_tag_manager_v1_interface manager_impl;
-
-static struct way_xdg_toplevel_tag_manager_v1 *manager_from_resource(struct wl_resource *resource)
-{
-    assert(
-        wl_resource_instance_of(resource, &xdg_toplevel_tag_manager_v1_interface, &manager_impl));
-    return static_cast<way_xdg_toplevel_tag_manager_v1 *>(wl_resource_get_user_data(resource));
-}
-
-static void manager_handle_set_tag([[maybe_unused]] struct wl_client *client,
-                                   struct wl_resource *manager_resource,
-                                   struct wl_resource *toplevel_resource,
-                                   const char *tag)
-{
-    struct way_xdg_toplevel_tag_manager_v1 *manager = manager_from_resource(manager_resource);
-    auto *toplevel = wlr_xdg_toplevel_from_resource(toplevel_resource);
-    if (!toplevel) {
-        return;
-    }
-
-    struct way_xdg_toplevel_tag_manager_v1_set_tag_event event = {
-        .toplevel = toplevel,
-        .tag = tag,
-    };
-    wl_signal_emit_mutable(&manager->events.set_tag, &event);
-}
-
-static void manager_handle_set_description([[maybe_unused]] struct wl_client *client,
-                                           struct wl_resource *manager_resource,
-                                           struct wl_resource *toplevel_resource,
-                                           const char *description)
-{
-    struct way_xdg_toplevel_tag_manager_v1 *manager = manager_from_resource(manager_resource);
-    auto *toplevel = wlr_xdg_toplevel_from_resource(toplevel_resource);
-    if (!toplevel) {
-        return;
-    }
-
-    struct way_xdg_toplevel_tag_manager_v1_set_description_event event = {
-        .toplevel = toplevel,
-        .description = description,
-    };
-    wl_signal_emit_mutable(&manager->events.set_description, &event);
-}
-
-static void manager_handle_destroy([[maybe_unused]] struct wl_client *client, struct wl_resource *manager_resource)
-{
-    wl_resource_destroy(manager_resource);
-}
-
-const struct xdg_toplevel_tag_manager_v1_interface manager_impl = {
-    .destroy = manager_handle_destroy,
-    .set_toplevel_tag = manager_handle_set_tag,
-    .set_toplevel_description = manager_handle_set_description,
-};
-
-static void manager_bind(struct wl_client *client, void *data, uint32_t version, uint32_t id)
-{
-    struct way_xdg_toplevel_tag_manager_v1 *manager =
-        static_cast<way_xdg_toplevel_tag_manager_v1 *>(data);
-
-    struct wl_resource *resource =
-        wl_resource_create(client, &xdg_toplevel_tag_manager_v1_interface, version, id);
-    if (resource == NULL) {
-        wl_client_post_no_memory(client);
-        return;
-    }
-    wl_resource_set_implementation(resource, &manager_impl, manager, NULL);
-}
-
-static void manager_handle_display_destroy(struct wl_listener *listener, [[maybe_unused]] void *data)
-{
-    struct way_xdg_toplevel_tag_manager_v1 *manager =
-        W_CONTAINER_OF(listener, way_xdg_toplevel_tag_manager_v1, display_destroy);
-
-    wl_signal_emit_mutable(&manager->events.destroy, NULL);
-
-    assert(wl_list_empty(&manager->events.set_tag.listener_list));
-    assert(wl_list_empty(&manager->events.set_description.listener_list));
-    assert(wl_list_empty(&manager->events.destroy.listener_list));
-
-    wl_list_remove(&manager->display_destroy.link);
-    wl_global_destroy(manager->global);
-    free(manager);
-}
-
-struct way_xdg_toplevel_tag_manager_v1 *
-way_xdg_toplevel_tag_manager_v1_create(struct wl_display *display, uint32_t version)
-{
-    assert(version <= MANAGER_VERSION);
-
-    struct way_xdg_toplevel_tag_manager_v1 *manager =
-        static_cast<way_xdg_toplevel_tag_manager_v1 *>(calloc(1, sizeof(*manager)));
-    if (manager == NULL) {
-        return NULL;
-    }
-
-    manager->global = wl_global_create(display,
-                                       &xdg_toplevel_tag_manager_v1_interface,
-                                       version,
-                                       manager,
-                                       manager_bind);
-    if (manager->global == NULL) {
-        free(manager);
-        return NULL;
-    }
-
-    wl_signal_init(&manager->events.set_tag);
-    wl_signal_init(&manager->events.set_description);
-    wl_signal_init(&manager->events.destroy);
-
-    manager->display_destroy.notify = manager_handle_display_destroy;
-    wl_display_add_destroy_listener(display, &manager->display_destroy);
-
-    return manager;
-}
-
-// Copy end from wlroots
 
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
@@ -182,13 +22,13 @@ public:
 
     W_DECLARE_PUBLIC(WXdgToplevelTagManagerV1)
 
-    struct way_xdg_toplevel_tag_manager_v1 *manager{ nullptr };
+    struct wlr_xdg_toplevel_tag_manager_v1 *manager{ nullptr };
     struct wl_listener set_tag_listener;
     struct wl_listener set_description_listener;
 
     static void handle_set_tag([[maybe_unused]]struct wl_listener *listener, void *data)
     {
-        auto *event = static_cast<way_xdg_toplevel_tag_manager_v1_set_tag_event *>(data);
+        auto *event = static_cast<wlr_xdg_toplevel_tag_manager_v1_set_tag_event *>(data);
         auto *wsurface = WSurface::fromHandle(event->toplevel->base->surface);
         if (!wsurface) {
             return;
@@ -203,7 +43,7 @@ public:
 
     static void handle_set_description([[maybe_unused]] struct wl_listener *listener, void *data)
     {
-        auto *event = static_cast<way_xdg_toplevel_tag_manager_v1_set_description_event *>(data);
+        auto *event = static_cast<wlr_xdg_toplevel_tag_manager_v1_set_description_event *>(data);
         auto *wsurface = WSurface::fromHandle(event->toplevel->base->surface);
         if (!wsurface) {
             return;
@@ -224,7 +64,7 @@ void WXdgToplevelTagManagerV1::create([[maybe_unused]] WServer *wserver)
 {
     W_D(WXdgToplevelTagManagerV1);
 
-    d->manager = way_xdg_toplevel_tag_manager_v1_create(server()->handle(), MANAGER_VERSION);
+    d->manager = wlr_xdg_toplevel_tag_manager_v1_create(server()->handle(), 1);
     m_handle = d->manager;
 
     if (d->manager) {


### PR DESCRIPTION
Replace the hand-copied way_xdg_toplevel_tag_manager_v1 C protocol implementation with wlr_xdg_toplevel_tag_manager_v1_create() from wlroots. The custom code referenced xdg_toplevel_tag_manager_v1_interface which lives in libwaylib-wlroots.so, causing undefined reference at link time.

Log: fix undefined reference to xdg_toplevel_tag_manager_v1_interface
PMS: TASK-393657
Influence: tinywl-qtquick links successfully

## Summary by Sourcery

Use wlroots' native xdg toplevel tag manager and remove the duplicated protocol implementation to restore successful linking.

Bug Fixes:
- Fix undefined-reference link failures by using wlroots' supported xdg toplevel tag manager API.

Enhancements:
- Remove the locally generated xdg toplevel tag and foreign toplevel protocol implementations now provided by wlroots.
- Adopt wlroots' native xdg toplevel tag manager types and creation API.