### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.25.0)
 
 project(Treeland
-    VERSION 0.8.18
+    VERSION 0.9.0
     LANGUAGES CXX C)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+treeland (0.9.0) unstable; urgency=medium
+
+  * feat: support pointer-constraints protocol
+  * feat: support relative pointer motion
+  * feat: gate dev file installation behind TREELAND_INSTALL_DEV option
+    (default OFF)
+  * chore: update wlroots to 0.20.0
+  * fix: use WPointer for cursorClient and skip redundant cursor updates
+
+ -- rewine <luhongxu@deepin.org>  Fri, 21 Aug 2026 14:49:32 +0800
+
 treeland (0.8.18) unstable; urgency=medium
 
   * fix(output): skip configuration callbacks on initialization failure


### PR DESCRIPTION
Log: bump

## Summary by Sourcery

Build:
- Bump the project version from 0.8.18 to 0.9.0 and update the Debian changelog.