### PR TITLE
chore: clean up Qt < 6.8 compatibility code

### DIFF
--- a/examples/test_pinch_handler/main.cpp
+++ b/examples/test_pinch_handler/main.cpp
@@ -11,12 +11,8 @@ int main(int argc, char *argv[])
     QGuiApplication app(argc, argv);
 
     QQmlApplicationEngine engine;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
     using namespace Qt::StringLiterals;
     const QUrl url(u"qrc:/qt/qml/pinchhandler/Main.qml"_s);
-#else
-    const QUrl url(u"qrc:/pinchhandler/Main.qml"_qs);
-#endif
     QObject::connect(
         &engine,
         &QQmlApplicationEngine::objectCreationFailed,

--- a/src/effects/tsgradiusimagenode.cpp
+++ b/src/effects/tsgradiusimagenode.cpp
@@ -95,9 +95,7 @@ public:
 };
 
 TSmoothTextureMaterialRhiShader::TSmoothTextureMaterialRhiShader()
-#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
     : QSGOpaqueTextureMaterialRhiShader(1) // TODO: support multiview
-#endif
 {
     setShaderFileName(VertexStage, QStringLiteral(":/shaders/radiussmoothtexture.vert.qsb"));
     setShaderFileName(FragmentStage, QStringLiteral(":/shaders/radiussmoothtexture.frag.qsb"));
@@ -143,9 +141,7 @@ QSGMaterialType *TSGRadiusSmoothTextureMaterial::type() const
 QSGMaterialShader *TSGRadiusSmoothTextureMaterial::createShader(
     [[maybe_unused]] QSGRendererInterface::RenderMode renderMode) const
 {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
     Q_ASSERT_X(viewCount() == 1, __func__, "Multiview not supported now.");
-#endif
     return new TSmoothTextureMaterialRhiShader();
 }
 

--- a/src/modules/item-selector/itemselector.cpp
+++ b/src/modules/item-selector/itemselector.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "itemselector.h"
@@ -16,9 +16,7 @@ ItemSelector::ItemSelector(QQuickItem *parent)
 {
     setAcceptHoverEvents(true);
     setFocus(false);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
     setFocusPolicy(Qt::NoFocus);
-#endif
     setKeepMouseGrab(true);
     QQuickItemPrivate::get(this)->anchors()->setFill(parentItem());
     m_defaultFilter = [](QQuickItem *item, ItemSelector::ItemTypes selectionHint) {

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -275,9 +275,7 @@ Helper::Helper(QObject *parent)
 
     m_renderWindow->setColor(Qt::black);
     m_rootSurfaceContainer->setFlag(QQuickItem::ItemIsFocusScope, true);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
     m_rootSurfaceContainer->setFocusPolicy(Qt::StrongFocus);
-#endif
 
     m_shellHandler = new ShellHandler(m_rootSurfaceContainer, m_server);
     connect(m_shellHandler->workspace(),

--- a/src/xsettings/xsettings.cpp
+++ b/src/xsettings/xsettings.cpp
@@ -168,11 +168,7 @@ QByteArray XSettings::depopulateSettings()
         const QByteArray &key = i.key();
         quint16 key_size = key.size();
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         switch (value.value.typeId()) {
-#else
-        switch (value.value.type()) {
-#endif
         case QMetaType::QColor:
             type = XSettingsTypeColor;
             break;

--- a/waylib/examples/tinywl/helper.cpp
+++ b/waylib/examples/tinywl/helper.cpp
@@ -87,9 +87,7 @@ Helper::Helper(QObject *parent)
 
     m_renderWindow->setColor(Qt::black);
     m_surfaceContainer->setFlag(QQuickItem::ItemIsFocusScope, true);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
     m_surfaceContainer->setFocusPolicy(Qt::StrongFocus);
-#endif
     m_backgroundContainer->setZ(RootSurfaceContainer::BackgroundZOrder);
     m_bottomContainer->setZ(RootSurfaceContainer::BottomZOrder);
     m_workspace->setZ(RootSurfaceContainer::NormalZOrder);

--- a/waylib/examples/tinywl/surfacewrapper.cpp
+++ b/waylib/examples/tinywl/surfacewrapper.cpp
@@ -91,9 +91,7 @@ SurfaceWrapper::SurfaceWrapper(QmlEngine *qmlEngine, WToplevelSurface *shellSurf
     setImplicitSize(m_surfaceItem->implicitWidth(), m_surfaceItem->implicitHeight());
 
     if (!shellSurface->hasCapability(WToplevelSurface::Capability::Focus)) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
         m_surfaceItem->setFocusPolicy(Qt::NoFocus);
-#endif
     }
 
     if (type == Type::XWayland) {

--- a/waylib/src/server/platformplugin/qwlrootsintegration.cpp
+++ b/waylib/src/server/platformplugin/qwlrootsintegration.cpp
@@ -479,12 +479,10 @@ void QWlrootsIntegration::setApplicationIcon(const QIcon &icon) const
     QPlatformIntegration::setApplicationIcon(icon);
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
 void QWlrootsIntegration::setApplicationBadge(qint64 number)
 {
     QPlatformIntegration::setApplicationBadge(number);
 }
-#endif
 
 void QWlrootsIntegration::beep() const
 {

--- a/waylib/src/server/platformplugin/qwlrootsintegration.h
+++ b/waylib/src/server/platformplugin/qwlrootsintegration.h
@@ -90,9 +90,7 @@ public:
 
     void sync() override;
     void setApplicationIcon(const QIcon &icon) const override;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
     void setApplicationBadge(qint64 number) override;
-#endif
     void beep() const override;
     void quit() const override;
 

--- a/waylib/src/server/platformplugin/qwlrootswindow.cpp
+++ b/waylib/src/server/platformplugin/qwlrootswindow.cpp
@@ -118,12 +118,7 @@ void QWlrootsRenderWindow::setDevicePixelRatio(qreal dpr)
 
     this->dpr = dpr;
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 6, 0)
-    QEvent event(QEvent::ScreenChangeInternal);
-    QCoreApplication::sendEvent(window(), &event);
-#else
     QWindowSystemInterface::handleWindowDevicePixelRatioChanged<QWindowSystemInterface::SynchronousDelivery>(window());
-#endif
 }
 
 bool QWlrootsRenderWindow::beforeDisposeEventFilter(QEvent *event)

--- a/waylib/src/server/qtquick/private/wrenderbuffernode.cpp
+++ b/waylib/src/server/qtquick/private/wrenderbuffernode.cpp
@@ -425,11 +425,7 @@ public:
             // If have a base QSGRenderer, we should inherit the depth test from
             // baseProjectionMatrix.
             renderer->setProjectionMatrix(baseProjectionMatrix);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
             renderer->setProjectionMatrixWithNativeNDC(base->projectionMatrixWithNativeNDC(0));
-#else
-            renderer->setProjectionMatrixWithNativeNDC(base->projectionMatrixWithNativeNDC());
-#endif
         } else {
             renderer->setDevicePixelRatio(1.0);
             renderer->setDeviceRect(QRect(QPoint(0, 0), pixelSize));
@@ -443,13 +439,8 @@ public:
         }
 
         if (Q_UNLIKELY(!matrix.isIdentity())) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
             renderer->setProjectionMatrix(renderer->projectionMatrix(0) * matrix);
             renderer->setProjectionMatrixWithNativeNDC(renderer->projectionMatrixWithNativeNDC(0) * matrix);
-#else
-            renderer->setProjectionMatrix(renderer->projectionMatrix() * matrix);
-            renderer->setProjectionMatrixWithNativeNDC(renderer->projectionMatrixWithNativeNDC() * matrix);
-#endif
         }
 
         renderer->setRootNode(rootNode);

--- a/waylib/src/server/qtquick/woutputrenderwindow.cpp
+++ b/waylib/src/server/qtquick/woutputrenderwindow.cpp
@@ -1369,10 +1369,8 @@ bool WOutputRenderWindowPrivate::initRCWithRhi()
         auto dev = wlr_vk_renderer_get_device(m_renderer);
         auto queue_family = wlr_vk_renderer_get_queue_family(m_renderer);
 
-#if QT_VERSION > QT_VERSION_CHECK(6, 6, 0)
         auto instance = wlr_vk_renderer_get_instance(m_renderer);
         vkInstance->setVkInstance(instance);
-#endif
         //        vkInstance->setExtensions(fromCStyleList(vkRendererAttribs.extension_count, vkRendererAttribs.extensions));
         //        vkInstance->setLayers(fromCStyleList(vkRendererAttribs.layer_count, vkRendererAttribs.layers));
         vkInstance->setApiVersion({1, 1, 0});

--- a/waylib/src/server/qtquick/wqmlcreator.cpp
+++ b/waylib/src/server/qtquick/wqmlcreator.cpp
@@ -209,20 +209,12 @@ void WQmlCreatorComponent::create(QSharedPointer<WQmlCreatorDelegateData> data)
     Q_ASSERT(m_delegate);
 
     auto d = QQmlComponentPrivate::get(m_delegate);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
 #if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
     if (W_PRIVATE_MEMBER(*d, QQmlComponentPrivate_m_state_tag{}).isCompletePending()) {
 #else
     if (d->state.isCompletePending()) {
 #endif
         QMetaObject::invokeMethod(this, "create", Qt::QueuedConnection, data, parent, data->data.lock()->properties);
-#else
-    if (d->state.completePending) {
-        QMetaObject::invokeMethod(this, "create", Qt::QueuedConnection,
-                                  Q_ARG(QSharedPointer<WQmlCreatorDelegateData>, data),
-                                  Q_ARG(QObject *, parent),
-                                  Q_ARG(const QJSValue &, data->data.lock()->properties));
-#endif
     } else {
         create(data, parent, data->data.lock()->properties);
     }
@@ -234,10 +226,8 @@ void WQmlCreatorComponent::create(QSharedPointer<WQmlCreatorDelegateData> data, 
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
     Q_ASSERT(!W_PRIVATE_MEMBER(*d, QQmlComponentPrivate_m_state_tag{}).isCompletePending());
-#elif QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
-    Q_ASSERT(!d->state.isCompletePending());
 #else
-    Q_ASSERT(!d->state.completePending);
+    Q_ASSERT(!d->state.isCompletePending());
 #endif
     // Don't use QVariantMap instead of QJSValue, because initial properties may be
     // contains some QObject property , if that QObjects is destroyed in future,
@@ -246,40 +236,10 @@ void WQmlCreatorComponent::create(QSharedPointer<WQmlCreatorDelegateData> data, 
     // you will get a null pointer if you using after it's destroyed.
     const auto tmp = qvariant_cast<QVariantMap>(initialProperties.toVariant());
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
     auto context = new QQmlContext(qmlContext(this), this);
     context->setContextProperties(m_contextProperties);
     data->object = d->createWithProperties(parent, tmp, context);
     context->setParent(data->object);
-#else
-    // The `createWithInitialProperties` provided by QQmlComponent cannot set parent
-    // during the creation process. use `setParent` will too late as the creation has
-    // complete, lead to the windows of WOutputRenderWindow get empty...
-
-    // for Qt 6.5 The createWithInitialProperties with the parent parameter provided by
-    // QQmlComponentPrivate can solve this problem.
-    // Qt 6.4 requires beginCreate -> setInitialProperties/setParent -> completeCreate
-
-    QObject *rv = m_delegate->beginCreate(qmlContext(this));
-    if (rv) {
-        m_delegate->setInitialProperties(rv, tmp);
-        rv->setParent(parent);
-        if (auto item = qobject_cast<QQuickItem*>(rv))
-            item->setParentItem(qobject_cast<QQuickItem*>(parent));
-        m_delegate->completeCreate();
-        const auto required = d->requiredProperties();
-        if (!required.empty()) {
-            for (const auto &unsetRequiredProperty : required) {
-                const QQmlError error = QQmlComponentPrivate::unsetRequiredPropertyToQQmlError(unsetRequiredProperty);
-                qmlWarning(rv, error);
-            }
-            d->requiredProperties().clear();
-            rv->deleteLater();
-            rv = nullptr;
-        }
-    }
-    data->object = rv;
-#endif
 
     if (data->object) {
         Q_EMIT objectAdded(data->object, initialProperties);

--- a/waylib/src/server/qtquick/wquickobserver.cpp
+++ b/waylib/src/server/qtquick/wquickobserver.cpp
@@ -39,9 +39,6 @@ public:
     QMetaObject::Connection windowXChangeConnection;
     QMetaObject::Connection windowYChangeConnection;
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
-    bool inDestructor = false;
-#endif
 };
 
 
@@ -50,14 +47,6 @@ WQuickObserver::WQuickObserver(QQuickItem *parent)
 {
     setFlag(ItemObservesViewport);
 }
-
-#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
-WQuickObserver::~WQuickObserver()
-{
-    Q_D(WQuickObserver);
-    d->inDestructor = true;
-}
-#endif
 
 const QPointF WQuickObserver::globalPosition() const
 {

--- a/waylib/src/server/qtquick/wquickobserver.h
+++ b/waylib/src/server/qtquick/wquickobserver.h
@@ -22,10 +22,6 @@ class WAYLIB_SERVER_EXPORT WQuickObserver : public QQuickItem
 public:
     explicit WQuickObserver(QQuickItem *parent = nullptr);
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
-    ~WQuickObserver();
-#endif
-
     const QPointF globalPosition() const;
     const QPointF scenePosition() const;
 

--- a/waylib/src/server/qtquick/wrenderhelper.cpp
+++ b/waylib/src/server/qtquick/wrenderhelper.cpp
@@ -54,7 +54,6 @@ struct Q_DECL_HIDDEN BufferData {
     bool colorPreserved = false;
 
     inline void resetWindowRenderTarget() {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
         {
             auto it = s_rhiRenderBuffers->begin();
             while (it != s_rhiRenderBuffers->end()) {
@@ -86,35 +85,6 @@ struct Q_DECL_HIDDEN BufferData {
             delete windowRenderTarget.sw.paintDevice;
 
         windowRenderTarget.sw = {};
-#else
-        {
-            auto it = s_rhiRenderBuffers->begin();
-            while (it != s_rhiRenderBuffers->end()) {
-                if (windowRenderTarget.renderTarget == it->renderTarget) {
-                    it = s_rhiRenderBuffers->erase(it);
-                    break;
-                }
-                ++it;
-            }
-        }
-
-        if (windowRenderTarget.owns) {
-            delete windowRenderTarget.renderTarget;
-            delete windowRenderTarget.rpDesc;
-            delete windowRenderTarget.texture;
-            delete windowRenderTarget.renderBuffer;
-            delete windowRenderTarget.depthStencil;
-            delete windowRenderTarget.paintDevice;
-        }
-
-        windowRenderTarget.renderTarget = nullptr;
-        windowRenderTarget.rpDesc = nullptr;
-        windowRenderTarget.texture = nullptr;
-        windowRenderTarget.renderBuffer = nullptr;
-        windowRenderTarget.depthStencil = nullptr;
-        windowRenderTarget.paintDevice = nullptr;
-        windowRenderTarget.owns = false;
-#endif
     }
 };
 
@@ -185,15 +155,9 @@ static QRhiTextureRenderTarget::Flags rhiRenderTargetFlags(WGlobal::ColorContent
 
 static bool recreateRhiRenderTarget(BufferData *data, QRhiTextureRenderTarget::Flags flags)
 {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
     auto renderTarget = static_cast<QRhiTextureRenderTarget *>(
         data->windowRenderTarget.rt.renderTarget);
     auto &rpDesc = data->windowRenderTarget.res.rpDesc;
-#else
-    auto renderTarget = static_cast<QRhiTextureRenderTarget *>(
-        data->windowRenderTarget.renderTarget);
-    auto &rpDesc = data->windowRenderTarget.rpDesc;
-#endif
     Q_ASSERT(renderTarget);
     renderTarget->destroy();
     renderTarget->setFlags(flags);
@@ -233,17 +197,10 @@ static bool createRhiRenderTarget(const QRhiColorAttachment &colorAttachment,
     }
 
     rt->setName(QByteArrayLiteral("WaylibTextureRenderTarget"));
-#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
     dst.rt.renderTarget = rt.release();
     dst.res.rpDesc = rp.release();
     dst.implicitBuffers.depthStencil = depthStencil.release();
     dst.rt.owns = true; // ownership of the native resource itself is not transferred but the QRhi objects are on us now
-#else
-    dst.renderTarget = rt.release();
-    dst.rpDesc = rp.release();
-    dst.depthStencil = depthStencil.release();
-    dst.owns = true; // ownership of the native resource itself is not transferred but the QRhi objects are on us now
-#endif
     return true;
 }
 
@@ -257,28 +214,16 @@ bool createRhiRenderTarget(QRhi *rhi, const QQuickRenderTarget &source, QQuickWi
         const auto format = rtd->u.nativeTexture.rhiFormat == QRhiTexture::UnknownFormat ? QRhiTexture::RGBA8
                                                                                          : QRhiTexture::Format(rtd->u.nativeTexture.rhiFormat);
         const auto textureFlags = QRhiTexture::RenderTarget | QRhiTexture::Flags(
-#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
                                rtd->u.nativeTexture.rhiFormatFlags
-#else
-                               rtd->u.nativeTexture.rhiFlags
-#endif
                                                                           );
         std::unique_ptr<QRhiTexture> texture(rhi->newTexture(format, rtd->pixelSize, rtd->sampleCount, textureFlags));
         texture->setName(QByteArrayLiteral("WaylibTexture"));
-#if QT_VERSION < QT_VERSION_CHECK(6, 6, 0)
-        if (!texture->createFrom({ rtd->u.nativeTexture.object, rtd->u.nativeTexture.layout }))
-#else
         if (!texture->createFrom({ rtd->u.nativeTexture.object, rtd->u.nativeTexture.layoutOrState }))
-#endif
             return false;
         QRhiColorAttachment att(texture.get());
         if (!createRhiRenderTarget(att, rtd->pixelSize, rtd->sampleCount, rhi, dst, flags))
             return false;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
         dst.res.texture = texture.release();
-#else
-        dst.texture = texture.release();
-#endif
         return true;
     }
     case QQuickRenderTargetPrivate::Type::NativeRenderbuffer: {
@@ -291,11 +236,7 @@ bool createRhiRenderTarget(QRhi *rhi, const QQuickRenderTarget &source, QQuickWi
         if (!createRhiRenderTarget(att, rtd->pixelSize, rtd->sampleCount, rhi, dst, flags))
             return false;
         renderbuffer->setName(QByteArrayLiteral("WaylibRenderBuffer"));
-#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
         dst.res.renderBuffer = renderbuffer.release();
-#else
-        dst.renderBuffer = renderbuffer.release();
-#endif
         return true;
     }
 
@@ -359,20 +300,12 @@ bool WRenderHelperPrivate::ensureRhiRenderTarget(QQuickRenderControl *rc, Buffer
                                                  QRhiTextureRenderTarget::Flags flags)
 {
     data->resetWindowRenderTarget();
-#if QT_VERSION < QT_VERSION_CHECK(6, 6, 0)
-    auto rhi = QQuickRenderControlPrivate::get(rc)->rhi;
-#else
     auto rhi = rc->rhi();
-#endif
     auto tmp = data->renderTarget;
     bool ok = createRhiRenderTarget(rhi, tmp, data->windowRenderTarget, flags);
     if (!ok)
         return false;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
     data->renderTarget = QQuickRenderTarget::fromRhiRenderTarget(data->windowRenderTarget.rt.renderTarget);
-#else
-    data->renderTarget = QQuickRenderTarget::fromRhiRenderTarget(data->windowRenderTarget.renderTarget);
-#endif
     data->renderTarget.setDevicePixelRatio(tmp.devicePixelRatio());
     data->renderTarget.setMirrorVertically(tmp.mirrorVertically());
 
@@ -753,11 +686,7 @@ WRenderHelper::RenderTarget WRenderHelper::acquireRenderTarget(QQuickRenderContr
                 } else
 #endif
                 {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
                     auto renderTarget = data->windowRenderTarget.rt.renderTarget;
-#else
-                    auto renderTarget = data->windowRenderTarget.renderTarget;
-#endif
                     if (renderTarget)
                         static_cast<QRhiTextureRenderTarget *>(renderTarget)->setFlags(flags);
                 }
@@ -895,22 +824,14 @@ void WRenderHelper::finishVulkanRenderTarget(QRhiCommandBuffer *cb, const Render
     if (!data || !data->buffer || !d->renderer || !wlr_renderer_is_vk(d->renderer))
         return;
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
     QRhiTexture *qtTexture = data->windowRenderTarget.res.texture;
-#else
-    QRhiTexture *qtTexture = data->windowRenderTarget.texture;
-#endif
     if (!qtTexture) {
         qCWarning(lcWlRenderHelper, "Vulkan render buffer release: missing Qt QRhiTexture");
         return;
     }
 
     const auto native = qtTexture->nativeTexture();
-#if QT_VERSION < QT_VERSION_CHECK(6, 6, 0)
     const auto oldLayout = VkImageLayout(native.layout);
-#else
-    const auto oldLayout = VkImageLayout(native.layout);
-#endif
     if (oldLayout == VK_IMAGE_LAYOUT_UNDEFINED) {
         qCWarning(lcWlRenderHelper, "Vulkan render buffer release: Qt texture layout is UNDEFINED");
         return;


### PR DESCRIPTION
## Summary

Treeland 适配的最低 Qt 版本为 6.8，清理所有 `QT_VERSION < 6.8` 的向后兼容守卫。

- 移除向后兼容守卫：`>= 6.0`、`>= 6.5`、`> 6.6`、`>= 6.7`、`>= 6.8`、`< 6.5`、`< 6.6`
- 保留前向守卫：`>= 6.9`、`>= 6.10`、`< 6.11`
- 16 个文件改动，删除 175 行
- 远程编译 1334/1334 全部通过
- Code Review 已通过（92 分）

## Multica Issue

[WM-308](https://agent-dev.uniontech.com/wm/issues/WM-308)

## Summary by Sourcery

Clean up legacy Qt compatibility code now that Qt 6.8 is the minimum supported version.

Enhancements:
- Remove obsolete Qt compatibility paths for versions below Qt 6.8 and standardize the code on the Qt 6.8+ APIs.

Chores:
- Update the item selector copyright range.