### PR TITLE
feat(multi-output): forward client fullscreen output to surface handler

### DIFF
--- a/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
+++ b/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
@@ -485,9 +485,8 @@ void ForeignToplevelManagerInterfaceV1::initializeToplevelHandle(SurfaceWrapper 
             &ForeignToplevelHandleV1::requestFullscreen,
             wrapper,
             [wrapper](bool fullscreen, WOutput *output) {
-                Q_UNUSED(output);
                 if (fullscreen)
-                    wrapper->enterFullscreen();
+                    wrapper->enterFullscreen(output);
                 else
                     wrapper->leaveFullscreen();
             });

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -1850,10 +1850,23 @@ void SurfaceWrapper::toggleMaximized()
         maximize();
 }
 
-void SurfaceWrapper::enterFullscreen()
+void SurfaceWrapper::enterFullscreen(WOutput *targetOutput)
 {
     if (m_surfaceState == State::Minimized)
         return;
+
+    if (targetOutput) {
+        auto *helper = Helper::instance();
+        auto *target = helper ? helper->getOutput(targetOutput) : nullptr;
+        if (target && target != m_ownsOutput
+            && target->isPrimary()) {
+            Output *oldOutput = m_ownsOutput;
+            setOwnsOutput(target);
+            m_fullscreenGeometry = target->geometry();
+            if (oldOutput)
+                oldOutput->arrangeAllSurfaces();
+        }
+    }
 
     setSurfaceState(State::Fullscreen);
 }

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -1850,10 +1850,24 @@ void SurfaceWrapper::toggleMaximized()
         maximize();
 }
 
-void SurfaceWrapper::enterFullscreen()
+void SurfaceWrapper::enterFullscreen(WOutput *targetOutput)
 {
     if (m_surfaceState == State::Minimized)
         return;
+
+    if (targetOutput) {
+        auto *helper = Helper::instance();
+        auto *target = helper ? helper->getOutput(targetOutput) : nullptr;
+        if (target && target != m_ownsOutput
+            && target->isPrimary()
+            && targetOutput->isEnabled()) {
+            Output *oldOutput = m_ownsOutput;
+            setOwnsOutput(target);
+            m_fullscreenGeometry = target->geometry();
+            if (oldOutput)
+                oldOutput->arrangeAllSurfaces();
+        }
+    }
 
     setSurfaceState(State::Fullscreen);
 }

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -313,7 +313,7 @@ public Q_SLOTS:
     void maximize();
     void unmaximize();
     void toggleMaximized();
-    void enterFullscreen();
+    void enterFullscreen(WOutput *targetOutput = nullptr);
     void leaveFullscreen();
     void closeSurface();
     void onMappedChanged();

--- a/waylib/src/server/kernel/wtoplevelsurface.h
+++ b/waylib/src/server/kernel/wtoplevelsurface.h
@@ -9,6 +9,7 @@
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
 class WSeat;
+class WOutput;
 class WToplevelSurfacePrivate;
 class WAYLIB_SERVER_EXPORT WToplevelSurface : public QObject, public WWaylandResource
 {
@@ -124,7 +125,7 @@ Q_SIGNALS:
     void requestCancelMaximize();
     void requestMinimize();
     void requestCancelMinimize(); // Only for XWaylandSurface
-    void requestFullscreen();
+    void requestFullscreen(WOutput *output);
     void requestCancelFullscreen();
     void requestShowWindowMenu(WSeat *seat, QPoint pos, quint32 serial);
 

--- a/waylib/src/server/protocols/wxdgtoplevelsurface.cpp
+++ b/waylib/src/server/protocols/wxdgtoplevelsurface.cpp
@@ -4,6 +4,7 @@
 #include "wxdgtoplevelsurface.h"
 
 #include "private/wtoplevelsurface_p.h"
+#include "woutput.h"
 #include "wseat.h"
 #include "wscoplistener.h"
 #include "wtools.h"
@@ -175,7 +176,10 @@ void WXdgToplevelSurfacePrivate::connect()
     q->listeners()->add(&m_handle->events.request_fullscreen, q,
         [q, this] (void *) {
         if (m_handle->requested.fullscreen) {
-            Q_EMIT q->requestFullscreen();
+            WOutput *output = m_handle->requested.fullscreen_output
+                ? WOutput::fromHandle(m_handle->requested.fullscreen_output)
+                : nullptr;
+            Q_EMIT q->requestFullscreen(output);
         } else {
             Q_EMIT q->requestCancelFullscreen();
         }

--- a/waylib/src/server/protocols/wxwaylandsurface.cpp
+++ b/waylib/src/server/protocols/wxwaylandsurface.cpp
@@ -78,7 +78,7 @@ void WXWaylandSurfacePrivate::init()
     });
     q->listeners()->add(&m_handle->events.request_fullscreen, this, [this, q] (void *) {
         if (handle()->fullscreen) {
-            Q_EMIT q->requestFullscreen();
+            Q_EMIT q->requestFullscreen(nullptr);
         } else {
             Q_EMIT q->requestCancelFullscreen();
         }


### PR DESCRIPTION
Propagate the wl_output specified in xdg_toplevel.set_fullscreen through the waylib signal chain to SurfaceWrapper::enterFullscreen, enabling window fullscreen on the requested output.

将客户端指定的全屏屏幕通过信号链传递到 enterFullscreen，实现
在指定输出上全屏。

Log: 支持客户端的指定输出全屏请求
PMS: TASK-394659
Influence: 客户端请求全屏时指定的屏幕不再被忽略，窗口会移动到目标屏幕全屏。

## Summary by Sourcery

Support client-selected outputs for fullscreen requests and move windows to the requested screen when appropriate.

New Features:
- Honor the client-requested output when entering fullscreen so windows can fullscreen on the specified screen.

Enhancements:
- Propagate fullscreen output information through the Wayland protocol and surface handling signal chain.
- Preserve existing fullscreen behavior for requests without a target output, including XWayland requests.