### PR TITLE
feat(splash): auto-disable prelaunch splash after consecutive mismatches

### DIFF
--- a/misc/dconfig/org.deepin.dde.treeland.app.json
+++ b/misc/dconfig/org.deepin.dde.treeland.app.json
@@ -67,6 +67,17 @@
             "description[zh_CN]": "闪屏使用亮色主题时的背景色",
             "permissions": "readwrite",
             "visibility": "public"
+        },
+        "splashMismatchCount": {
+            "value": 0,
+            "serial": 0,
+            "flags": [],
+            "name": "Splash Mismatch Count",
+            "name[zh_CN]": "闪屏不匹配次数",
+            "description": "Consecutive splash match failure count; reset to 0 on success",
+            "description[zh_CN]": "连续闪屏匹配失败次数，匹配成功后重置为0",
+            "permissions": "readwrite",
+            "visibility": "public"
         }
     }
 }

--- a/misc/dconfig/org.deepin.dde.treeland.json
+++ b/misc/dconfig/org.deepin.dde.treeland.json
@@ -133,6 +133,17 @@
             "description[zh_CN]": "复制模式输出 ID 的 JSON 字符串数组。第一个元素是被复制屏，后续元素镜像它。",
             "permissions": "readwrite",
             "visibility": "public"
+        },
+        "prelaunchSplashMaxMismatchCount": {
+            "value": 4,
+            "serial": 0,
+            "flags": [],
+            "name": "Prelaunch Splash Max Mismatch Count",
+            "name[zh_CN]": "预启动闪屏最大不匹配次数",
+            "description": "Maximum consecutive splash match failures before disabling splash for an app. 0 means never auto-disable.",
+            "description[zh_CN]": "连续闪屏匹配失败达到此次数后禁用该应用的闪屏功能。0 表示永不自动禁用。",
+            "permissions": "readwrite",
+            "visibility": "public"
         }
     }
 }

--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -349,6 +349,13 @@ void ShellHandler::createPrelaunchSplash(const QString &appId,
 
         // Destroy the splash wrapper
         m_rootSurfaceContainer->destroyForSurface(wrapper);
+
+        // Splash closed without matching a real window — record mismatch
+        if (m_windowConfigStore) {
+            const int maxMismatch = static_cast<int>(
+                Helper::instance()->globalConfig()->prelaunchSplashMaxMismatchCount());
+            m_windowConfigStore->recordSplashMismatch(appId, maxMismatch);
+        }
     });
 
     if (timeoutMs > 0) {
@@ -366,7 +373,13 @@ void ShellHandler::createPrelaunchSplash(const QString &appId,
                                    << "Prelaunch splash timeout, destroy wrapper appId="
                                    << wrapper->appId();
                                m_prelaunchWrappers.removeAt(idx);
+                               const QString mismatchAppId = wrapper->appId();
                                m_rootSurfaceContainer->destroyForSurface(wrapper);
+                               if (m_windowConfigStore) {
+                                   const int maxMismatch = static_cast<int>(
+                                       Helper::instance()->globalConfig()->prelaunchSplashMaxMismatchCount());
+                                   m_windowConfigStore->recordSplashMismatch(mismatchAppId, maxMismatch);
+                               }
                            });
     }
 }
@@ -386,6 +399,11 @@ void ShellHandler::handlePrelaunchSplashClosed(const QString &appId, const QStri
                 << "Client requested close_splash, destroy wrapper appId=" << appId;
             m_prelaunchWrappers.removeAt(i);
             m_rootSurfaceContainer->destroyForSurface(wrapper);
+            if (m_windowConfigStore) {
+                const int maxMismatch = static_cast<int>(
+                    Helper::instance()->globalConfig()->prelaunchSplashMaxMismatchCount());
+                m_windowConfigStore->recordSplashMismatch(appId, maxMismatch);
+            }
             return;
         }
     }
@@ -594,6 +612,9 @@ void ShellHandler::ensureXdgWrapper(WXdgToplevelSurface *surface, const QString 
                 candidate->convertToNormalSurface(surface, SurfaceWrapper::Type::XdgToplevel);
                 wrapper = candidate;
                 isNewWrapper = false; // matched from prelaunch, not newly created
+                if (m_windowConfigStore) {
+                    m_windowConfigStore->resetSplashMismatchCount(targetAppId);
+                }
                 break;
             }
         }
@@ -912,6 +933,9 @@ void ShellHandler::ensureXwaylandWrapper(WXWaylandSurface *surface, const QStrin
                 candidate->convertToNormalSurface(surface, SurfaceWrapper::Type::XWayland);
                 wrapper = candidate;
                 isNewWrapper = false; // matched from prelaunch, not newly created
+                if (m_windowConfigStore) {
+                    m_windowConfigStore->resetSplashMismatchCount(targetAppId);
+                }
                 break;
             }
         }

--- a/src/core/windowconfigstore.cpp
+++ b/src/core/windowconfigstore.cpp
@@ -133,3 +133,43 @@ void WindowConfigStore::withSplashConfigFor(const QString &appId,
         },
         Qt::SingleShotConnection);
 }
+
+void WindowConfigStore::recordSplashMismatch(const QString &appId, int maxMismatchCount)
+{
+    if (appId.isEmpty() || maxMismatchCount <= 0) {
+        return;
+    }
+
+    auto *config = configForApp(appId);
+    if (!config) {
+        return;
+    }
+
+    int count = static_cast<int>(config->splashMismatchCount()) + 1;
+    config->setSplashMismatchCount(count);
+    qCInfo(lcTlCore) << "WindowConfigStore: splash mismatch count for" << appId << "is now"
+                         << count;
+    if (count >= maxMismatchCount) {
+        config->setEnablePrelaunchSplash(false);
+        config->setSplashMismatchCount(0);
+        qCInfo(lcTlCore) << "WindowConfigStore: auto-disabled prelaunch splash for" << appId
+                             << "after" << count << "consecutive mismatches";
+    }
+}
+
+void WindowConfigStore::resetSplashMismatchCount(const QString &appId)
+{
+    if (appId.isEmpty()) {
+        return;
+    }
+
+    auto *config = configForApp(appId);
+    if (!config) {
+        return;
+    }
+
+    if (config->splashMismatchCount() != 0) {
+        config->setSplashMismatchCount(0);
+        qCDebug(lcTlCore) << "WindowConfigStore: reset splash mismatch count for" << appId;
+    }
+}

--- a/src/core/windowconfigstore.h
+++ b/src/core/windowconfigstore.h
@@ -29,6 +29,9 @@ public:
                            qlonglong splashThemeType)> callback,
         std::function<void()> skipCallback) const;
 
+    void recordSplashMismatch(const QString &appId, int maxMismatchCount);
+    void resetSplashMismatchCount(const QString &appId);
+
 private:
     AppConfig *configForApp(const QString &appId) const;
 


### PR DESCRIPTION
## 概述

实现 splash 匹配失败自动禁用功能。当应用的预启动闪屏连续匹配失败达到阈值次数后，自动禁用该应用的 splash 功能，避免无效闪屏干扰。

关联 issue: [WM-309](https://agent-dev.uniontech.com/wm/issues/WM-309)

## 改动内容

- **`misc/dconfig/org.deepin.dde.treeland.json`**：新增全局配置项 `prelaunchSplashMaxMismatchCount`（默认 4，0 表示永不自动禁用）
- **`misc/dconfig/org.deepin.dde.treeland.app.json`**：新增 per-app 配置项 `splashMismatchCount`（默认 0）
- **`src/core/windowconfigstore.h/.cpp`**：新增 `recordSplashMismatch()`（累计失败次数，达到阈值则置 `enablePrelaunchSplash=false` 并重置计数）和 `resetSplashMismatchCount()`（匹配成功时重置计数）
- **`src/core/shellhandler.cpp`**：在 3 个失败路径（splashCloseRequested、超时、handlePrelaunchSplashClosed）调用 `recordSplashMismatch`；在 2 个成功路径（ensureXdgWrapper、ensureXwaylandWrapper）调用 `resetSplashMismatchCount`

## 审核状态

Code Review 审核已通过。

## Summary by Sourcery

Automatically disable prelaunch splash screens after repeated mismatches while preserving configurable per-application recovery behavior.

New Features:
- Add configurable automatic disabling of per-application prelaunch splash screens after consecutive matching failures.

Enhancements:
- Track splash mismatches per application and reset the count when a prelaunch splash successfully matches its window.