### PR TITLE
fix: avoid QGuiApplication static destruction crash

### DIFF
--- a/src/core/treelandinit.cpp
+++ b/src/core/treelandinit.cpp
@@ -6,7 +6,6 @@
 #include <QGuiApplication>
 #include <QPalette>
 #include <QQuickStyle>
-#include <memory>
 #include <wrenderhelper.h>
 #include <wlogging.h>
 #include <wbackend.h>
@@ -28,8 +27,6 @@ DCORE_USE_NAMESPACE
 namespace Treeland {
 
 namespace {
-std::unique_ptr<QGuiApplication> application;
-
 class QDeepinTheme : public QGenericUnixTheme
 {
 public:
@@ -44,7 +41,7 @@ public:
 };
 }
 
-void preInit(int &argc, char *argv[])
+std::unique_ptr<QGuiApplication> preInit(int &argc, char *argv[])
 {
     WLog::init();
     DTK_GUI_NAMESPACE::DGuiApplicationHelper::setAttribute(
@@ -57,9 +54,10 @@ void preInit(int &argc, char *argv[])
     QGuiApplication::setQuitOnLastWindowClosed(false);
     QQuickStyle::setStyle("Chameleon");
 
-    application = std::make_unique<QGuiApplication>(argc, argv);
+    auto application = std::make_unique<QGuiApplication>(argc, argv);
     application->setOrganizationName("deepin");
     application->setApplicationName("treeland");
+    return application;
 }
 
 void initTestServer(WServer *server)

--- a/src/core/treelandinit.h
+++ b/src/core/treelandinit.h
@@ -4,12 +4,16 @@
 #pragma once
 #include <wglobal.h>
 
+#include <memory>
+
+class QGuiApplication;
+
 WAYLIB_SERVER_BEGIN_NAMESPACE
 class WServer;
 WAYLIB_SERVER_END_NAMESPACE
 
 namespace Treeland {
-void preInit(int &argc, char *argv[]);
+std::unique_ptr<QGuiApplication> preInit(int &argc, char *argv[]);
 void postInit();
 void initTestServer(WAYLIB_SERVER_NAMESPACE::WServer *server);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,7 +14,7 @@
 
 int main(int argc, char *argv[])
 {
-    Treeland::preInit(argc, argv);
+    auto application = Treeland::preInit(argc, argv);
 
 #ifdef QT_DEBUG
     DLogManager::registerConsoleAppender();

--- a/tests/protocols/framework/protocol-test-entry.cpp
+++ b/tests/protocols/framework/protocol-test-entry.cpp
@@ -163,7 +163,7 @@ int main(int argc, char *argv[])
         dconfigService.stop();
         return 1;
     }
-    Treeland::preInit(argc, argv);
+    auto application = Treeland::preInit(argc, argv);
     Treeland::postInit();
     if (!dconfigService.waitForService()) {
         dconfigService.stop();


### PR DESCRIPTION
修复的问题: deepin-wine11-stable纯Wayland下运行命令与征服:心灵终结时, 遭遇战选择心灵军团阵营进游戏直接导致treeland崩溃, 排查出来修复方案如下:

将 QGuiApplication 的所有权从 libtreeland.so 内部静态 unique_ptr 移交给主程序和协议测试入口。确保 Treeland 及其 Wayland/渲染对象先销毁，再显式销毁 QGuiApplication，避免 Qt 全局数据析构顺序导致 QCoreApplication 清理 app_libpaths 时访问无效状态。