### PR TITLE
fix: avoid invalid pointer constraint warp

### DIFF
--- a/waylib/src/server/kernel/wcursor.cpp
+++ b/waylib/src/server/kernel/wcursor.cpp
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include <QDebug>
+
 #include "wscoplistener.h"
 #include <QCursor>
 #include <memory>
+#include <cmath>
 #include "private/wprivateaccessor_p.h"
 
 #include "wcursor.h"
@@ -799,7 +801,7 @@ void WCursor::warpToActiveConstraintHint()
         return;
 
     wlr_seat *wlrSeat = d->seat ? d->seat->handle() : nullptr;
-    if (!wlrSeat)
+    if (!wlrSeat || wlrSeat->pointer_state.focused_surface != constraint->surface)
         return;
 
     if (!constraint->current.cursor_hint.enabled)
@@ -807,14 +809,20 @@ void WCursor::warpToActiveConstraintHint()
 
     // Convert the surface-local cursor_hint to global coordinates by
     // computing the offset from the current surface-local pointer position
-    // and applying it on top of the current cursor position. This matches
-    // the same geometry used in updateLockedWarpTarget() and follows
+    // and applying it on top of the current cursor position. This matches the
+    // same geometry used in updateLockedWarpTarget() and follows
     // Sway's warp_to_constraint_cursor_hint().
     const double sx = wlrSeat->pointer_state.sx;
     const double sy = wlrSeat->pointer_state.sy;
-    const QPointF globalPos = position()
-        + QPointF(constraint->current.cursor_hint.x - sx,
-                  constraint->current.cursor_hint.y - sy);
+    const double hintX = constraint->current.cursor_hint.x;
+    const double hintY = constraint->current.cursor_hint.y;
+    if (!std::isfinite(sx) || !std::isfinite(sy) || !std::isfinite(hintX) || !std::isfinite(hintY))
+        return;
+
+    const QPointF globalPos = position() + QPointF(hintX - sx, hintY - sy);
+    if (!std::isfinite(globalPos.x()) || !std::isfinite(globalPos.y()))
+        return;
+
     setPosition(nullptr, globalPos);
     wlr_seat_pointer_warp(wlrSeat,
                           constraint->current.cursor_hint.x,

--- a/waylib/src/server/kernel/wcursor.cpp
+++ b/waylib/src/server/kernel/wcursor.cpp
@@ -799,7 +799,9 @@ void WCursor::warpToActiveConstraintHint()
         return;
 
     wlr_seat *wlrSeat = d->seat ? d->seat->handle() : nullptr;
-    if (!wlrSeat)
+    // Focus already left this surface (cleared or moved elsewhere) —
+    // the surface-local -> global conversion is meaningless.
+    if (!wlrSeat || wlrSeat->pointer_state.focused_surface != constraint->surface)
         return;
 
     if (!constraint->current.cursor_hint.enabled)
@@ -815,6 +817,11 @@ void WCursor::warpToActiveConstraintHint()
     const QPointF globalPos = position()
         + QPointF(constraint->current.cursor_hint.x - sx,
                   constraint->current.cursor_hint.y - sy);
+    if (!qIsFinite(globalPos.x()) || !qIsFinite(globalPos.y())) {
+        qCWarning(lcWlCursor) << "warpToActiveConstraintHint: computed position is"
+                             << "not finite (" << globalPos << "), skipping warp";
+        return;
+    }
     setPosition(nullptr, globalPos);
     wlr_seat_pointer_warp(wlrSeat,
                           constraint->current.cursor_hint.x,


### PR DESCRIPTION
在使用deepin-wine11-stable跑命令与征服:心灵终结时,在游戏结束后退出时有高概率引起treeland崩溃, 问题如下:

在 pointer-constraints 释放光标约束时，只有当约束 surface 仍保持 pointer focus 且 seat 坐标、cursor hint 和目标坐标均为有限值时才执行恢复光标位置。客户端被强制终止或 surface 失焦后跳过 warp，避免 wlroots 将 NaN 坐标传入 wlr_cursor_warp_closest() 并触发断言导致 Treeland 崩溃。

## Summary by Sourcery

Bug Fixes:
- Prevent crashes when releasing pointer constraints after focus is lost or invalid coordinates are produced by skipping unsafe cursor warps.