### PR TITLE
fix: extract protocol interface versions into static constexpr Interf…

### DIFF
--- a/waylib/src/server/protocols/private/wtextinputv1.cpp
+++ b/waylib/src/server/protocols/private/wtextinputv1.cpp
@@ -430,7 +430,7 @@ void WTextInputManagerV1::create(WServer *server)
 {
     m_global = wl_global_create(server->handle(),
                                 &zwp_text_input_manager_v1_interface,
-                                1,
+                                InterfaceVersion,
                                 this,
                                 text_input_manager_bind);
     Q_ASSERT(m_global);

--- a/waylib/src/server/protocols/private/wtextinputv1_p.h
+++ b/waylib/src/server/protocols/private/wtextinputv1_p.h
@@ -150,6 +150,7 @@ public:
 
     QByteArrayView interfaceName() const override;
 
+    static constexpr int InterfaceVersion = 1;
 Q_SIGNALS:
     void newTextInput(WTextInputV1 *textInput);
 

--- a/waylib/src/server/protocols/private/wtextinputv2.cpp
+++ b/waylib/src/server/protocols/private/wtextinputv2.cpp
@@ -313,7 +313,11 @@ QByteArrayView WTextInputManagerV2::interfaceName() const
 
 void WTextInputManagerV2::create(WServer *server)
 {
-    m_global = wl_global_create(server->handle(), &zwp_text_input_manager_v2_interface, 1, this, text_input_manager_bind);
+    m_global = wl_global_create(server->handle(),
+                                &zwp_text_input_manager_v2_interface,
+                                InterfaceVersion,
+                                this,
+                                text_input_manager_bind);
     Q_ASSERT(m_global);
     m_handle = this;
 }

--- a/waylib/src/server/protocols/private/wtextinputv2_p.h
+++ b/waylib/src/server/protocols/private/wtextinputv2_p.h
@@ -131,6 +131,7 @@ public:
 
     QByteArrayView interfaceName() const override;
 
+    static constexpr int InterfaceVersion = 1;
 Q_SIGNALS:
     void newTextInput(WTextInputV2 *textInput);
 

--- a/waylib/src/server/protocols/wcursorshapemanagerv1.cpp
+++ b/waylib/src/server/protocols/wcursorshapemanagerv1.cpp
@@ -9,9 +9,6 @@
 
 #include <wlr_all.h>
 
-// TODO: set to 2 after wlroots 0.20
-#define CURSOR_SHAPE_MANAGER_V1_VERSION 1
-
 WAYLIB_SERVER_BEGIN_NAMESPACE
 
 class Q_DECL_HIDDEN WCursorShapeManagerV1Private : public WObjectPrivate
@@ -128,7 +125,7 @@ void WCursorShapeManagerV1::create(WServer *server)
 {
     W_D(WCursorShapeManagerV1);
     if (!m_handle) {
-        m_handle = wlr_cursor_shape_manager_v1_create(server->handle(), CURSOR_SHAPE_MANAGER_V1_VERSION);
+        m_handle = wlr_cursor_shape_manager_v1_create(server->handle(), InterfaceVersion);
         listeners()->add(&handle()->events.request_set_shape, this, []
                          (wlr_cursor_shape_manager_v1_request_set_shape_event *event) {
             if (auto *seat = WSeat::fromHandle(event->seat_client->seat)) {

--- a/waylib/src/server/protocols/wcursorshapemanagerv1.h
+++ b/waylib/src/server/protocols/wcursorshapemanagerv1.h
@@ -24,6 +24,7 @@ public:
     wlr_cursor_shape_manager_v1 *handle() const;
 
     QByteArrayView interfaceName() const override;
+    static constexpr int InterfaceVersion = 2;
 
 protected:
     void create(WServer *server) override;

--- a/waylib/src/server/protocols/wextforeigntoplevellistv1.cpp
+++ b/waylib/src/server/protocols/wextforeigntoplevellistv1.cpp
@@ -12,8 +12,6 @@
 
 #include <map>
 
-#define EXT_FOREIGN_TOPLEVEL_LIST_V1_VERSION 1
-
 WAYLIB_SERVER_BEGIN_NAMESPACE
 class Q_DECL_HIDDEN WExtForeignToplevelListV1Private : public WObjectPrivate
 {
@@ -143,7 +141,7 @@ wlr_ext_foreign_toplevel_list_v1 *WExtForeignToplevelListV1::handle() const
 
 void WExtForeignToplevelListV1::create(WServer *server)
 {
-    m_handle = wlr_ext_foreign_toplevel_list_v1_create(server->handle(), EXT_FOREIGN_TOPLEVEL_LIST_V1_VERSION);
+    m_handle = wlr_ext_foreign_toplevel_list_v1_create(server->handle(), InterfaceVersion);
 }
 
 void WExtForeignToplevelListV1::destroy([[maybe_unused]] WServer *server)

--- a/waylib/src/server/protocols/wextforeigntoplevellistv1.h
+++ b/waylib/src/server/protocols/wextforeigntoplevellistv1.h
@@ -33,6 +33,7 @@ public:
     QByteArrayView interfaceName() const override;
     wlr_ext_foreign_toplevel_list_v1 *handle() const;
 
+    static constexpr int InterfaceVersion = 1;
 private:
     void create(WServer *server) override;
     void destroy(WServer *server) override;

--- a/waylib/src/server/protocols/wlayershell.cpp
+++ b/waylib/src/server/protocols/wlayershell.cpp
@@ -98,7 +98,7 @@ void WLayerShell::create(WServer *server)
 {
     W_D(WLayerShell);
 
-    auto *layer_shell = wlr_layer_shell_v1_create(server->handle(), 4);
+    auto *layer_shell = wlr_layer_shell_v1_create(server->handle(), InterfaceVersion);
     Q_ASSERT(layer_shell);
     listeners()->add(&layer_shell->events.new_surface, d,
         &WLayerShellPrivate::onNewSurface);

--- a/waylib/src/server/protocols/wlayershell.h
+++ b/waylib/src/server/protocols/wlayershell.h
@@ -29,6 +29,7 @@ public:
     QVector<WLayerSurface*> surfaceList() const;
     QByteArrayView interfaceName() const override;
 
+    static constexpr int InterfaceVersion = 4;
 Q_SIGNALS:
     void surfaceAdded(WLayerSurface *surface);
     void surfaceRemoved(WLayerSurface *surface);

--- a/waylib/src/server/protocols/wxdgdialogmanagerv1.cpp
+++ b/waylib/src/server/protocols/wxdgdialogmanagerv1.cpp
@@ -129,7 +129,7 @@ wlr_xdg_wm_dialog_v1 *WXdgDialogManagerV1::handle() const
 
 void WXdgDialogManagerV1::create(WServer *server)
 {
-    auto *wm = wlr_xdg_wm_dialog_v1_create(server->handle(), 1);
+    auto *wm = wlr_xdg_wm_dialog_v1_create(server->handle(), InterfaceVersion);
     m_handle = wm;
 
     W_D(WXdgDialogManagerV1);

--- a/waylib/src/server/protocols/wxdgdialogmanagerv1.h
+++ b/waylib/src/server/protocols/wxdgdialogmanagerv1.h
@@ -29,6 +29,7 @@ public:
     QByteArrayView interfaceName() const override;
     wlr_xdg_wm_dialog_v1 *handle() const;
 
+    static constexpr int InterfaceVersion = 1;
 Q_SIGNALS:
     void surfaceModalChanged(WAYLIB_SERVER_NAMESPACE::WXdgToplevelSurface *surface, bool modal);
 

--- a/waylib/src/server/protocols/wxdgtopleveltagmanager.cpp
+++ b/waylib/src/server/protocols/wxdgtopleveltagmanager.cpp
@@ -64,7 +64,7 @@ void WXdgToplevelTagManagerV1::create([[maybe_unused]] WServer *wserver)
 {
     W_D(WXdgToplevelTagManagerV1);
 
-    d->manager = wlr_xdg_toplevel_tag_manager_v1_create(server()->handle(), 1);
+    d->manager = wlr_xdg_toplevel_tag_manager_v1_create(server()->handle(), InterfaceVersion);
     m_handle = d->manager;
 
     if (d->manager) {

--- a/waylib/src/server/protocols/wxdgtopleveltagmanager.h
+++ b/waylib/src/server/protocols/wxdgtopleveltagmanager.h
@@ -24,6 +24,7 @@ public:
     explicit WXdgToplevelTagManagerV1();
     QByteArrayView interfaceName() const override;
 
+    static constexpr int InterfaceVersion = 1;
 protected:
     void create(WServer *wserver) override;
     void destroy(WServer *server) override;


### PR DESCRIPTION
…aceVersion

Replace hardcoded version literals in wl_global_create() and wlr_*_create() calls with a per-class static constexpr InterfaceVersion member. This centralizes the version in each class header, making overrides and future bumps single-point edits and improving readability at call sites.

Log: refactor protocol version constants
PMS: TASK-393657
Influence: waylib protocol wrappers use consistent InterfaceVersion pattern

## Summary by Sourcery

Centralize protocol interface version declarations in wrapper classes to simplify maintenance and keep protocol creation calls consistent.

Enhancements:
- Centralize protocol interface versions as per-class static constexpr values and use them when creating Wayland and wlroots protocol objects.
- Update the cursor shape manager wrapper to advertise interface version 2.