### PR TITLE
fix(capture): release mask surface before CaptureSourceSelector destruction

### DIFF
--- a/src/modules/capture/capture.h
+++ b/src/modules/capture/capture.h
@@ -402,6 +402,7 @@ public:
     void doneSelection();
     void cancelSelection();
     void selectSurface(WSurfaceItemContent *surfaceItemContent);
+    void releaseMaskSurface();
 
 Q_SIGNALS:
     void hoveredItemChanged();
@@ -429,7 +430,6 @@ private:
     void handleItemSelectorSelectionRegionChanged();
     WOutputRenderWindow *renderWindow() const;
     void createImage();
-    void releaseMaskSurface();
 
     void updateItemSelectorItemTypes();
     void updateCursorShape();

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1949,6 +1949,7 @@ void Helper::init(Treeland::Treeland *treeland)
                 m_captureSelector = qobject_cast<CaptureSourceSelector *>(
                     qmlEngine()->createCaptureSelector(m_rootSurfaceContainer, captureManagerV1));
             } else if (m_captureSelector) {
+                m_captureSelector->releaseMaskSurface();
                 m_captureSelector->deleteLater();
             }
         });


### PR DESCRIPTION
Call releaseMaskSurface() before deleteLater() so the mask SurfaceWrapper is reparented back to its saved container while the selector is still intact. QQmlElement uses CRTP: its destructor recursively tears down the declarative data of child items (including the mask surface) before ~CaptureSourceSelector runs, so reparenting in the destructor would touch an already-incomplete object. Make releaseMaskSurface() idempotent by clearing m_savedContainer after release.

issue-key: WM-10

Log: 修复CaptureSourceSelector销毁时的mask surface生命周期问题
Influence: 修复了maskSurface被错误销毁导致的潜在崩溃风险

## Summary by Sourcery

Release the capture mask surface before scheduling CaptureSourceSelector destruction to preserve its ownership lifecycle.

Bug Fixes:
- Prevent mask surfaces from being destroyed prematurely when CaptureSourceSelector is torn down, reducing the risk of crashes.

Enhancements:
- Make mask-surface release safe to invoke before selector destruction.