### PR TITLE
commit(protocols): test(protocols): share protocol test framework build

### DIFF
--- a/.github/workflows/treeland-deepin-build.yml
+++ b/.github/workflows/treeland-deepin-build.yml
@@ -25,7 +25,7 @@ jobs:
           rm -rf /etc/apt/sources.list.d
 
           apt-get update
-          apt-get install -y dde-dconfig-daemon libdtkdata qml6-module-qtquick-window qml6-module-qt5compat-graphicaleffects devscripts equivs git
+          apt-get install -y dde-dconfig-daemon libdtkdata qml6-module-qtquick-window qml6-module-qtquick-controls2-styles-chameleon qml6-module-qt5compat-graphicaleffects devscripts equivs git
 
           # The full desktop fixture follows Treeland's normal global-session
           # path, whose compositor-owned session is the system user "dde".

--- a/tests/protocols/framework/ProtocolTest.cmake
+++ b/tests/protocols/framework/ProtocolTest.cmake
@@ -2,6 +2,63 @@ include_guard(GLOBAL)
 
 set(TREELAND_PROTOCOL_TEST_FRAMEWORK_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
+pkg_get_variable(WAYLAND_PROTOCOLS_DATADIR wayland-protocols pkgdatadir)
+set(TREELAND_PROTOCOL_TEST_FRAMEWORK_BINARY_DIR
+    "${CMAKE_CURRENT_BINARY_DIR}/framework")
+file(MAKE_DIRECTORY "${TREELAND_PROTOCOL_TEST_FRAMEWORK_BINARY_DIR}")
+set(xdg_shell_xml "${WAYLAND_PROTOCOLS_DATADIR}/stable/xdg-shell/xdg-shell.xml")
+set(xdg_shell_header
+    "${TREELAND_PROTOCOL_TEST_FRAMEWORK_BINARY_DIR}/xdg-shell-client-protocol.h")
+set(xdg_shell_code
+    "${TREELAND_PROTOCOL_TEST_FRAMEWORK_BINARY_DIR}/xdg-shell-client-protocol.c")
+add_custom_command(
+    OUTPUT "${xdg_shell_header}"
+    COMMAND wayland-scanner client-header "${xdg_shell_xml}" "${xdg_shell_header}"
+    DEPENDS "${xdg_shell_xml}"
+    VERBATIM
+)
+add_custom_command(
+    OUTPUT "${xdg_shell_code}"
+    COMMAND wayland-scanner private-code "${xdg_shell_xml}" "${xdg_shell_code}"
+    DEPENDS "${xdg_shell_xml}" "${xdg_shell_header}"
+    VERBATIM
+)
+
+add_library(treeland_protocol_test_framework STATIC
+    "${TREELAND_PROTOCOL_TEST_FRAMEWORK_DIR}/protocol-test-entry.cpp"
+    "${TREELAND_PROTOCOL_TEST_FRAMEWORK_DIR}/test-accounts-service.cpp"
+    "${TREELAND_PROTOCOL_TEST_FRAMEWORK_DIR}/test-accounts-service.h"
+    "${TREELAND_PROTOCOL_TEST_FRAMEWORK_DIR}/client-connection.c"
+    "${TREELAND_PROTOCOL_TEST_FRAMEWORK_DIR}/test-dconfig-service.cpp"
+    "${TREELAND_PROTOCOL_TEST_FRAMEWORK_DIR}/test-dconfig-service.h"
+    "${TREELAND_PROTOCOL_TEST_FRAMEWORK_DIR}/server-bridge.cpp"
+    "${TREELAND_PROTOCOL_TEST_FRAMEWORK_DIR}/server-bridge-api.h"
+    "${TREELAND_PROTOCOL_TEST_FRAMEWORK_DIR}/xdg-toplevel-client.c"
+    "${TREELAND_PROTOCOL_TEST_FRAMEWORK_DIR}/xdg-toplevel-client.h"
+    "${xdg_shell_header}"
+    "${xdg_shell_code}"
+)
+target_include_directories(treeland_protocol_test_framework
+    PUBLIC
+        "${TREELAND_PROTOCOL_TEST_FRAMEWORK_DIR}"
+        "${TREELAND_PROTOCOL_TEST_FRAMEWORK_BINARY_DIR}"
+    PRIVATE
+        "${CMAKE_SOURCE_DIR}/src"
+        "${CMAKE_SOURCE_DIR}/waylib/src/server"
+        "${CMAKE_SOURCE_DIR}/waylib/src/server/kernel"
+        "${CMAKE_SOURCE_DIR}/waylib/src/server/utils"
+)
+target_link_libraries(treeland_protocol_test_framework
+    PUBLIC
+        libtreeland
+        PkgConfig::WAYLAND_CLIENT
+        Qt6::Core
+        Qt6::DBus
+        Qt6::Gui
+        Qt6::Test
+)
+set_target_properties(treeland_protocol_test_framework PROPERTIES C_STANDARD 11)
+
 function(treeland_add_protocol_test)
     set(oneValueArgs NAME XML SETUP CLIENT)
     set(multiValueArgs EXTRA_XMLS EXTRA_LIBRARIES)
@@ -11,23 +68,6 @@ function(treeland_add_protocol_test)
             message(FATAL_ERROR "treeland_add_protocol_test requires ${required}")
         endif()
     endforeach()
-
-    pkg_get_variable(WAYLAND_PROTOCOLS_DATADIR wayland-protocols pkgdatadir)
-    set(xdg_shell_xml "${WAYLAND_PROTOCOLS_DATADIR}/stable/xdg-shell/xdg-shell.xml")
-    set(xdg_shell_header "${CMAKE_CURRENT_BINARY_DIR}/xdg-shell-client-protocol.h")
-    set(xdg_shell_code "${CMAKE_CURRENT_BINARY_DIR}/xdg-shell-client-protocol.c")
-    add_custom_command(
-        OUTPUT "${xdg_shell_header}"
-        COMMAND wayland-scanner client-header "${xdg_shell_xml}" "${xdg_shell_header}"
-        DEPENDS "${xdg_shell_xml}"
-        VERBATIM
-    )
-    add_custom_command(
-        OUTPUT "${xdg_shell_code}"
-        COMMAND wayland-scanner private-code "${xdg_shell_xml}" "${xdg_shell_code}"
-        DEPENDS "${xdg_shell_xml}" "${xdg_shell_header}"
-        VERBATIM
-    )
 
     string(REPLACE "-" "_" target_suffix "${ARGS_NAME}")
     set(target "test_${target_suffix}")
@@ -69,20 +109,8 @@ function(treeland_add_protocol_test)
         list(APPEND protocol_client_sources "${extra_protocol_header}" "${extra_protocol_code}")
     endforeach()
     add_executable(${target}
-        "${TREELAND_PROTOCOL_TEST_FRAMEWORK_DIR}/protocol-test-entry.cpp"
-        "${TREELAND_PROTOCOL_TEST_FRAMEWORK_DIR}/test-accounts-service.cpp"
-        "${TREELAND_PROTOCOL_TEST_FRAMEWORK_DIR}/test-accounts-service.h"
-        "${TREELAND_PROTOCOL_TEST_FRAMEWORK_DIR}/client-connection.c"
-        "${TREELAND_PROTOCOL_TEST_FRAMEWORK_DIR}/test-dconfig-service.cpp"
-        "${TREELAND_PROTOCOL_TEST_FRAMEWORK_DIR}/test-dconfig-service.h"
-        "${TREELAND_PROTOCOL_TEST_FRAMEWORK_DIR}/server-bridge.cpp"
-        "${TREELAND_PROTOCOL_TEST_FRAMEWORK_DIR}/server-bridge-api.h"
-        "${TREELAND_PROTOCOL_TEST_FRAMEWORK_DIR}/xdg-toplevel-client.c"
-        "${TREELAND_PROTOCOL_TEST_FRAMEWORK_DIR}/xdg-toplevel-client.h"
         "${ARGS_SETUP}"
         "${ARGS_CLIENT}"
-        "${xdg_shell_header}"
-        "${xdg_shell_code}"
         ${protocol_client_sources}
     )
     target_include_directories(${target} PRIVATE
@@ -95,15 +123,17 @@ function(treeland_add_protocol_test)
         "${CMAKE_SOURCE_DIR}/waylib/src/server/utils"
     )
     target_link_libraries(${target} PRIVATE
-        libtreeland
-        PkgConfig::WAYLAND_CLIENT
-        Qt6::Core
-        Qt6::DBus
-        Qt6::Gui
-        Qt6::Test
+        "$<LINK_LIBRARY:WHOLE_ARCHIVE,treeland_protocol_test_framework>"
         ${ARGS_EXTRA_LIBRARIES}
     )
-    set_target_properties(${target} PROPERTIES C_STANDARD 11)
+    # Q_OBJECT users live in treeland_protocol_test_framework.  Per-protocol
+    # fixtures and C clients do not need an autogen pass of their own.
+    set_target_properties(${target} PROPERTIES
+        AUTOMOC OFF
+        AUTOUIC OFF
+        AUTORCC OFF
+        C_STANDARD 11
+    )
     add_dependencies(${target} lockscreen multitaskview)
     add_test(NAME ${target} COMMAND ${target})
     set_tests_properties(${target} PROPERTIES


### PR DESCRIPTION
The protocol test helper compiled its common runner, server bridge, service fixtures, client helpers, and xdg-shell bindings into every protocol executable.

- Create one static protocol test framework library.
- Link each protocol test against the shared framework.
- Generate xdg-shell client bindings once in the shared framework output directory.

Avoid recompiling common protocol test infrastructure for every protocol target.

## Summary by Sourcery

Share common protocol test infrastructure through one reusable framework library to reduce redundant protocol test builds.

Enhancements:
- Build and share a single static protocol test framework across all protocol test executables, avoiding repeated compilation of common test infrastructure.
- Generate shared xdg-shell client bindings once and disable redundant per-test Qt autogen processing.

Build:
- Add the Chameleon Qt Quick Controls style dependency to the deep-in build environment.