### PR TITLE
style(tests): remove consecutive blank lines in tests directory

### DIFF
--- a/tests/protocols/framework/README.md
+++ b/tests/protocols/framework/README.md
@@ -129,7 +129,6 @@ screensaver 的 ext-idle inhibit 用例。若没有可观察的生产 signal/eve
 完全复用 `Treeland` 的正常插件发现和初始化流程：plugin output 目录可访问时使用该目录，
 否则回退安装目录。测试框架不再维护独立的插件加载路径或代理实现。
 
-
 ## 代码组织
 
 ```text

--- a/tests/protocols/treeland-app-id-resolver-v1/setup.cpp
+++ b/tests/protocols/treeland-app-id-resolver-v1/setup.cpp
@@ -18,7 +18,6 @@ AppIdResolverManager *g_manager = nullptr;
 
 extern "C" {
 
-
 struct app_id_resolver_test_state {
     int resolve_started;
     int resolve_matched;
@@ -27,7 +26,6 @@ struct app_id_resolver_test_state {
 
 struct app_id_resolver_test_state g_app_id_resolver_state;
 struct app_id_resolver_test_state g_app_id_resolver_snapshot;
-
 
 void server_start_resolve(void *)
 {

--- a/tests/protocols/treeland-app-id-resolver-v1/treeland-app-id-resolver-v1.c
+++ b/tests/protocols/treeland-app-id-resolver-v1/treeland-app-id-resolver-v1.c
@@ -15,7 +15,6 @@
 #define EXPECTED_APP_ID "org.deepin.dde.test-app"
 #define EXPECTED_SANDBOX "test-sandbox"
 
-
 struct app_id_resolver_test_state {
     int resolve_started;
     int resolve_matched;
@@ -110,7 +109,6 @@ static int connect_client(struct test_ctx *ctx, const char *socket_name)
     return ctx->manager != NULL;
 }
 
-
 static int pidfd_refers_to_self(int pidfd)
 {
     char path[64];
@@ -128,7 +126,6 @@ static int pidfd_refers_to_self(int pidfd)
     return target_pid == (int)getpid();
 }
 
-
 static int resolve_without_resolver_fails(struct test_ctx *ctx)
 {
     (void)ctx;
@@ -139,7 +136,6 @@ static int resolve_without_resolver_fails(struct test_ctx *ctx)
     return g_app_id_resolver_snapshot.resolve_started == 0;
 }
 
-
 static int get_resolver_creates_object(struct test_ctx *ctx)
 {
     ctx->resolver = treeland_app_id_resolver_manager_v1_get_resolver(ctx->manager);
@@ -147,7 +143,6 @@ static int get_resolver_creates_object(struct test_ctx *ctx)
         return 0;
     return treeland_app_id_resolver_v1_add_listener(ctx->resolver, &resolver_listener, ctx) == 0;
 }
-
 
 static int resolve_roundtrip(struct test_ctx *ctx)
 {
@@ -180,7 +175,6 @@ static int resolve_roundtrip(struct test_ctx *ctx)
         && g_app_id_resolver_snapshot.resolve_matched == 1;
 }
 
-
 static int second_resolve_empty_response(struct test_ctx *ctx)
 {
     ctx->identify_received = 0;
@@ -211,14 +205,12 @@ static int second_resolve_empty_response(struct test_ctx *ctx)
         && g_app_id_resolver_snapshot.resolve_empty == 1;
 }
 
-
 static int duplicate_get_resolver_errors(struct test_ctx *ctx)
 {
 
     ctx->display_errored = 1;
 
     (void)treeland_app_id_resolver_manager_v1_get_resolver(ctx->manager);
-
 
     if (wl_display_roundtrip(ctx->display) >= 0)
         return 0;

--- a/tests/protocols/treeland-app-id-resolver-v1/treeland-app-id-resolver-v1.h
+++ b/tests/protocols/treeland-app-id-resolver-v1/treeland-app-id-resolver-v1.h
@@ -23,20 +23,15 @@ struct test_ctx {
     struct client_connection connection;
     struct wl_display    *display;
 
-
     struct treeland_app_id_resolver_manager_v1 *manager;
 
-
     struct treeland_app_id_resolver_v1 *resolver;
-
 
     int identify_received;
     uint32_t identify_request_id;
     int identify_pidfd;
 
-
     int display_errored;
-
 
     struct test_result *results;
     int                 result_count;

--- a/tests/protocols/treeland-capture-unstable-v1/treeland-capture-unstable-v1.h
+++ b/tests/protocols/treeland-capture-unstable-v1/treeland-capture-unstable-v1.h
@@ -24,20 +24,16 @@ struct test_ctx {
     struct wl_display    *display;
     const char           *socket_name;
 
-
     struct treeland_capture_manager_v1 *manager;
-
 
     struct treeland_capture_context_v1 *context_a;
     struct treeland_capture_context_v1 *context_b;
     struct treeland_capture_context_v1 *context_c;
 
-
     int      a_source_failed_received;
     int      b_source_failed_received;
     uint32_t b_source_failed_reason;
     int      c_source_failed_received;
-
 
     struct test_result *results;
     int                 result_count;

--- a/tests/protocols/treeland-dde-shell-v1/treeland-dde-shell-v1.h
+++ b/tests/protocols/treeland-dde-shell-v1/treeland-dde-shell-v1.h
@@ -34,11 +34,9 @@ struct test_ctx {
     struct client_connection connection;
     struct wl_display    *display;
 
-
     struct wl_compositor *compositor;
     struct wl_seat       *seat;
     struct wl_output     *output;
-
 
     struct treeland_dde_shell_manager_v1  *manager;
     struct treeland_window_overlap_checker *checker;
@@ -49,7 +47,6 @@ struct test_ctx {
     struct treeland_lockscreen_v1         *lockscreen;
     struct wl_surface                     *test_surface;
 
-
     int checker_enter_received;
     int checker_leave_received;
     int active_in_received;
@@ -58,7 +55,6 @@ struct test_ctx {
     int drop_received;
     int picker_window_received;
     int picker_pid;
-
 
     struct test_result *results;
     int                 result_count;

--- a/tests/protocols/treeland-ddm-v1/treeland-ddm-v1.c
+++ b/tests/protocols/treeland-ddm-v1/treeland-ddm-v1.c
@@ -183,7 +183,6 @@ static int is_connected_false_after_all_clients_gone(struct test_ctx *ctx)
     ctx->display = NULL;
     client_disconnect(&ctx->aux);
 
-
     if (!client_connect(&ctx->checker, ctx->socket_name))
         return 0;
     const int connected = check_is_connected(ctx);

--- a/tests/protocols/treeland-ddm-v1/treeland-ddm-v1.h
+++ b/tests/protocols/treeland-ddm-v1/treeland-ddm-v1.h
@@ -23,23 +23,17 @@ struct test_ctx {
     struct client_connection connection;
     struct wl_display    *display;
 
-
     const char *socket_name;
-
 
     struct client_connection aux;
 
-
     struct client_connection checker;
-
 
     struct treeland_ddm_v1 *ddm;
     int bound_version;
 
-
     int switch_to_vt_received;
     int acquire_vt_received;
-
 
     struct test_result *results;
     int                 result_count;

--- a/tests/protocols/treeland-foreign-toplevel-manager-v1/treeland-foreign-toplevel-manager-v1.h
+++ b/tests/protocols/treeland-foreign-toplevel-manager-v1/treeland-foreign-toplevel-manager-v1.h
@@ -20,7 +20,6 @@ struct test_result {
     char        message[TEST_MSG_MAX];
 };
 
-
 struct ftm_server_state {
     int      output_ready;
     int      wrapper_created;
@@ -55,13 +54,11 @@ struct test_ctx {
     struct client_connection connection;
     struct wl_display    *display;
 
-
     struct treeland_foreign_toplevel_manager_v1  *manager;
     struct treeland_dock_preview_context_v1      *context;
     struct treeland_foreign_toplevel_handle_v1   *handle;
     struct wl_seat                                *seat;
     struct xdg_toplevel_client             xdg_toplevel;
-
 
     int context_enter_received;
     int context_leave_received;
@@ -69,7 +66,6 @@ struct test_ctx {
     int handle_count;
     int handle_closed_count;
     uint32_t handle_identifier;
-
 
     struct test_result *results;
     int                 result_count;

--- a/tests/protocols/treeland-keyboard-state-notify-unstable-v1/treeland-keyboard-state-notify-unstable-v1.c
+++ b/tests/protocols/treeland-keyboard-state-notify-unstable-v1/treeland-keyboard-state-notify-unstable-v1.c
@@ -5,8 +5,6 @@
 
 #include <stdio.h>
 
-
-
 struct watcher_state {
     int current_state_count;
     int state_changed_count;
@@ -49,14 +47,11 @@ static const struct treeland_keyboard_state_watcher_v1_listener watcher_listener
     .state_changed = handle_state_changed,
 };
 
-
-
 int protocol_test_run(const char *socket_name)
 {
     struct client_connection connection;
     if (!client_connect(&connection, socket_name))
         return 1;
-
 
     struct wl_seat *seat = client_bind(&connection, "wl_seat",
                                                &wl_seat_interface, 1);
@@ -67,7 +62,6 @@ int protocol_test_run(const char *socket_name)
         fprintf(stderr, "keyboard-state-notify: failed to bind globals\n");
         goto failed;
     }
-
 
     {
         struct watcher_state ws = {0};
@@ -81,7 +75,6 @@ int protocol_test_run(const char *socket_name)
 
         treeland_keyboard_state_watcher_v1_add_listener(watcher, &watcher_listener, &ws);
 
-
         treeland_keyboard_state_watcher_v1_set_modifiers(watcher,
             TREELAND_KEYBOARD_STATE_WATCHER_V1_MODIFIER_CAPS_LOCK);
         treeland_keyboard_state_watcher_v1_set_flags(watcher,
@@ -89,7 +82,6 @@ int protocol_test_run(const char *socket_name)
             TREELAND_KEYBOARD_STATE_WATCHER_V1_WATCH_FLAG_UNLOCKED);
         treeland_keyboard_state_watcher_v1_apply(watcher);
         wl_display_roundtrip(connection.display);
-
 
         if (ws.current_state_count > 0) {
 
@@ -123,7 +115,6 @@ int protocol_test_run(const char *socket_name)
         treeland_keyboard_state_watcher_v1_destroy(watcher);
     }
 
-
     {
         struct watcher_state ws = {0};
 
@@ -135,7 +126,6 @@ int protocol_test_run(const char *socket_name)
         }
 
         treeland_keyboard_state_watcher_v1_add_listener(watcher, &watcher_listener, &ws);
-
 
         treeland_keyboard_state_watcher_v1_apply(watcher);
         wl_display_roundtrip(connection.display);
@@ -151,7 +141,6 @@ int protocol_test_run(const char *socket_name)
 
         treeland_keyboard_state_watcher_v1_destroy(watcher);
     }
-
 
     treeland_keyboard_state_notify_manager_v1_destroy(manager);
     wl_seat_destroy(seat);

--- a/tests/protocols/treeland-output-manager-v1/treeland-output-manager-v1.c
+++ b/tests/protocols/treeland-output-manager-v1/treeland-output-manager-v1.c
@@ -107,14 +107,12 @@ static int output_bound(struct test_ctx *ctx)
     return ctx->output != NULL;
 }
 
-
 static int primary_output_event_received(struct test_ctx *ctx)
 {
     wl_display_roundtrip(ctx->display);
     return ctx->primary_output_received && ctx->primary_output_count == 1
         && ctx->primary_output_name[0] != '\0';
 }
-
 
 static int set_primary_output_unknown(struct test_ctx *ctx)
 {
@@ -124,7 +122,6 @@ static int set_primary_output_unknown(struct test_ctx *ctx)
         return 0;
     return ctx->primary_output_count == before;
 }
-
 
 static int get_color_control_valid_output(struct test_ctx *ctx)
 {

--- a/tests/protocols/treeland-output-manager-v1/treeland-output-manager-v1.h
+++ b/tests/protocols/treeland-output-manager-v1/treeland-output-manager-v1.h
@@ -23,21 +23,16 @@ struct test_ctx {
     struct client_connection connection;
     struct wl_display    *display;
 
-
     struct wl_output *output;
-
 
     struct treeland_output_manager_v1        *manager;
     struct treeland_output_color_control_v1  *color_control;
 
-
     const char *socket_name;
-
 
     int         primary_output_received;
     int         primary_output_count;
     char        primary_output_name[128];
-
 
     struct test_result *results;
     int                 result_count;

--- a/tests/protocols/treeland-personalization-manager-v1/treeland-personalization-manager-v1.c
+++ b/tests/protocols/treeland-personalization-manager-v1/treeland-personalization-manager-v1.c
@@ -68,8 +68,6 @@ int test_print_results(struct test_ctx *ctx)
     return failed == 0;
 }
 
-
-
 static void cursor_verfity(void *data, struct treeland_personalization_cursor_context_v1 *cursor,
                            int32_t success)
 {
@@ -109,8 +107,6 @@ static const struct treeland_personalization_cursor_context_v1_listener cursor_l
     .size = cursor_size,
 };
 
-
-
 static void font_event(void *data, struct treeland_personalization_font_context_v1 *font,
                        const char *font_name)
 {
@@ -145,8 +141,6 @@ static const struct treeland_personalization_font_context_v1_listener font_liste
     .monospace_font = monospace_font_event,
     .font_size = font_size_event,
 };
-
-
 
 static void round_corner_radius_event(void *data, struct treeland_personalization_appearance_context_v1 *appearance,
                                       int32_t radius)
@@ -213,8 +207,6 @@ static const struct treeland_personalization_appearance_context_v1_listener appe
     .window_titlebar_height = window_titlebar_height_event,
 };
 
-
-
 static int connect_client(struct test_ctx *ctx, const char *socket_name)
 {
     if (!client_connect(&ctx->connection, socket_name))
@@ -267,8 +259,6 @@ static int create_appearance_context(struct test_ctx *ctx)
         treeland_personalization_appearance_context_v1_add_listener(ctx->appearance_context, &appearance_listener, ctx);
     return ctx->appearance_context != NULL;
 }
-
-
 
 static int set_blend_mode(struct test_ctx *ctx)
 {
@@ -366,8 +356,6 @@ static int verify_titlebar_enabled(struct test_ctx *ctx)
     return state.no_titlebar == 0;
 }
 
-
-
 static int cursor_set_theme(struct test_ctx *ctx)
 {
     treeland_personalization_cursor_context_v1_set_theme(ctx->cursor_context, "test-theme");
@@ -413,7 +401,6 @@ static int cursor_verfity_received(struct test_ctx *ctx)
     return ctx->cursor_verfity_count == 1 && ctx->cursor_verfity == 1;
 }
 
-
 static int invalid_cursor_commit(struct test_ctx *ctx)
 {
     treeland_personalization_cursor_context_v1_set_theme(ctx->invalid_cursor_context, "");
@@ -425,8 +412,6 @@ static int invalid_cursor_verfity_received(struct test_ctx *ctx)
 {
     return ctx->invalid_cursor_verfity_count >= 1 && ctx->invalid_cursor_verfity_first == 0;
 }
-
-
 
 static int font_set_size(struct test_ctx *ctx)
 {
@@ -493,8 +478,6 @@ static int monospace_font_received(struct test_ctx *ctx)
 {
     return ctx->monospace_font_count >= 2 && strcmp(ctx->monospace_font, "TestMonoFont") == 0;
 }
-
-
 
 static int appearance_set_radius(struct test_ctx *ctx)
 {
@@ -630,8 +613,6 @@ static int appearance_titlebar_height_echo_received(struct test_ctx *ctx)
 {
     return ctx->window_titlebar_height_count >= 3 && ctx->window_titlebar_height == 36;
 }
-
-
 
 static const struct test_case cases[] = {
     { "manager.get_window_context", create_window_context },

--- a/tests/protocols/treeland-personalization-manager-v1/treeland-personalization-manager-v1.h
+++ b/tests/protocols/treeland-personalization-manager-v1/treeland-personalization-manager-v1.h
@@ -11,7 +11,6 @@ extern "C" {
 
 int protocol_test_run(const char *socket_name);
 
-
 struct window_context_state {
     int32_t background_type;
     int32_t corner_radius;
@@ -29,7 +28,6 @@ struct window_context_state {
     int32_t border_alpha;
     int32_t no_titlebar;
 };
-
 
 void personalization_window_state(void *data);
 void personalization_snapshot_config(void *data);
@@ -49,9 +47,7 @@ struct test_ctx {
     struct client_connection connection;
     struct wl_display    *display;
 
-
     struct wl_compositor *compositor;
-
 
     struct treeland_personalization_manager_v1 *manager;
     struct treeland_personalization_window_context_v1 *window_context;
@@ -60,7 +56,6 @@ struct test_ctx {
     struct treeland_personalization_font_context_v1 *font_context;
     struct treeland_personalization_appearance_context_v1 *appearance_context;
     struct wl_surface *surface;
-
 
     char     cursor_theme[128];
     int      cursor_theme_count;
@@ -72,14 +67,12 @@ struct test_ctx {
     int32_t invalid_cursor_verfity_first;
     int     invalid_cursor_verfity_count;
 
-
     char     font[128];
     int      font_count;
     char     monospace_font[128];
     int      monospace_font_count;
     uint32_t font_size;
     int      font_size_count;
-
 
     int32_t  round_corner_radius;
     int      round_corner_radius_count;
@@ -93,7 +86,6 @@ struct test_ctx {
     int      window_theme_type_count;
     uint32_t window_titlebar_height;
     int      window_titlebar_height_count;
-
 
     struct test_result *results;
     int                 result_count;

--- a/tests/protocols/treeland-prelaunch-splash-v2/treeland-prelaunch-splash-v2.h
+++ b/tests/protocols/treeland-prelaunch-splash-v2/treeland-prelaunch-splash-v2.h
@@ -21,7 +21,6 @@ struct test_result {
     char        message[TEST_MSG_MAX];
 };
 
-
 struct splash_server_state {
     int request_count;
     int close_count;
@@ -38,19 +37,15 @@ struct test_ctx {
     struct client_connection connection;
     struct wl_display *display;
 
-
     struct treeland_prelaunch_splash_manager_v2 *manager;
     struct wl_shm *shm;
-
 
     struct treeland_prelaunch_splash_v2 *splash1;
     struct treeland_prelaunch_splash_v2 *splash2;
     struct treeland_prelaunch_splash_v2 *splash3;
     struct wl_buffer *icon_buffer;
 
-
     struct splash_server_state server;
-
 
     struct test_result *results;
     int                 result_count;

--- a/tests/protocols/treeland-screensaver-v1/setup.cpp
+++ b/tests/protocols/treeland-screensaver-v1/setup.cpp
@@ -20,7 +20,6 @@ void protocol_test_setup(Helper *helper)
     Q_ASSERT(g_screensaver);
 }
 
-
 extern "C" void screensaver_query_inhibited(void *data)
 {
     int *inhibited = static_cast<int *>(data);

--- a/tests/protocols/treeland-screensaver-v1/treeland-screensaver-v1.c
+++ b/tests/protocols/treeland-screensaver-v1/treeland-screensaver-v1.c
@@ -119,7 +119,6 @@ static int server_inhibited_after_uninhibit(struct test_ctx *ctx)
     return inhibited == 0;
 }
 
-
 static int expect_protocol_error(struct test_ctx *ctx, struct wl_display *display,
                                  uint32_t expected_code)
 {

--- a/tests/protocols/treeland-screensaver-v1/treeland-screensaver-v1.h
+++ b/tests/protocols/treeland-screensaver-v1/treeland-screensaver-v1.h
@@ -25,13 +25,10 @@ struct test_ctx {
     struct wl_display    *display;
     char                  socket_name[256];
 
-
     struct treeland_screensaver_v1 *screensaver;
     struct treeland_screensaver_v1 *error_screensaver;
 
-
     int roundtripped;
-
 
     struct test_result *results;
     int                 result_count;

--- a/tests/protocols/treeland-shortcut-manager-v2/treeland-shortcut-manager-v2.h
+++ b/tests/protocols/treeland-shortcut-manager-v2/treeland-shortcut-manager-v2.h
@@ -23,14 +23,11 @@ struct test_ctx {
     struct client_connection connection;
     struct wl_display    *display;
 
-
     struct wl_compositor *compositor;
-
 
     struct treeland_shortcut_manager_v2 *manager;
     struct treeland_shortcut_capture_v1 *capture;
     struct wl_surface                   *test_surface;
-
 
     int      commit_success_received;
     int      commit_failure_received;
@@ -40,7 +37,6 @@ struct test_ctx {
     char     capture_captured_key[64];
     int      capture_failed_received;
     uint32_t capture_failed_reason;
-
 
     struct test_result *results;
     int                 result_count;

--- a/tests/protocols/treeland-virtual-output-manager-v1/setup.cpp
+++ b/tests/protocols/treeland-virtual-output-manager-v1/setup.cpp
@@ -20,13 +20,11 @@ void protocol_test_setup(Helper *helper)
                      [](VirtualOutputInterfaceV1 *interface) { g_virtual_output = interface; });
 }
 
-
 extern "C" void virtual_output_emit_outputs(void *)
 {
     if (g_virtual_output)
         g_virtual_output->sendOutputs(QStringLiteral("group1"), QByteArray("DP-1\0VGA-1", 10));
 }
-
 
 extern "C" void virtual_output_emit_error(void *)
 {

--- a/tests/protocols/treeland-virtual-output-manager-v1/treeland-virtual-output-manager-v1.c
+++ b/tests/protocols/treeland-virtual-output-manager-v1/treeland-virtual-output-manager-v1.c
@@ -71,8 +71,6 @@ int test_print_results(struct test_ctx *ctx)
     return failed == 0;
 }
 
-
-
 static struct virtual_output_state *state_for_object(struct test_ctx *ctx,
                                                      struct treeland_virtual_output_v1 *obj)
 {
@@ -160,8 +158,6 @@ static const struct treeland_virtual_output_manager_v1_listener manager_listener
     .virtual_output_list = manager_list_event,
 };
 
-
-
 static int connect_client(struct test_ctx *ctx, const char *socket_name)
 {
     if (!client_connect(&ctx->connection, socket_name))
@@ -188,8 +184,6 @@ static int fill_string_array(struct wl_array *array, const char *const *strings,
     }
     return 1;
 }
-
-
 
 static int create_valid(struct test_ctx *ctx)
 {
@@ -260,8 +254,6 @@ static int get_existing(struct test_ctx *ctx)
     return ctx->fetched != NULL;
 }
 
-
-
 static int emit_outputs(struct test_ctx *ctx)
 {
     (void)ctx;
@@ -273,8 +265,6 @@ static int emit_error(struct test_ctx *ctx)
     (void)ctx;
     return invoke_on_server_thread(virtual_output_emit_error, NULL);
 }
-
-
 
 static int outputs_created_received(struct test_ctx *ctx)
 {

--- a/tests/protocols/treeland-virtual-output-manager-v1/treeland-virtual-output-manager-v1.h
+++ b/tests/protocols/treeland-virtual-output-manager-v1/treeland-virtual-output-manager-v1.h
@@ -19,7 +19,6 @@ struct test_result {
     char        message[TEST_MSG_MAX];
 };
 
-
 struct virtual_output_state {
     int      outputs_count;
     char     outputs_name[64];
@@ -33,9 +32,7 @@ struct test_ctx {
     struct client_connection connection;
     struct wl_display *display;
 
-
     struct treeland_virtual_output_manager_v1 *manager;
-
 
     struct treeland_virtual_output_v1 *virtual_output;
     struct treeland_virtual_output_v1 *err_empty;
@@ -43,17 +40,14 @@ struct test_ctx {
     struct treeland_virtual_output_v1 *err_dup;
     struct treeland_virtual_output_v1 *fetched;
 
-
     struct virtual_output_state created;
     struct virtual_output_state empty;
     struct virtual_output_state single;
     struct virtual_output_state dup;
     struct virtual_output_state fetched_state;
 
-
     int  list_event_count;
     char list_event_names[256];
-
 
     struct test_result *results;
     int                 result_count;

--- a/tests/protocols/treeland-wallpaper-color-v1/setup.cpp
+++ b/tests/protocols/treeland-wallpaper-color-v1/setup.cpp
@@ -18,7 +18,6 @@ void protocol_test_setup(Helper *helper)
     g_manager = find_server_interface<WallpaperColorInterfaceV1>(helper);
 }
 
-
 extern "C" void wallpaper_color_set_color(const char *output, int is_dark)
 {
     if (!g_manager)

--- a/tests/protocols/treeland-wallpaper-color-v1/treeland-wallpaper-color-v1.h
+++ b/tests/protocols/treeland-wallpaper-color-v1/treeland-wallpaper-color-v1.h
@@ -23,14 +23,11 @@ struct test_ctx {
     struct client_connection connection;
     struct wl_display    *display;
 
-
     struct treeland_wallpaper_color_manager_v1 *manager;
-
 
     int  output_color_count;
     int  output_color_isdark;
     char output_color_name[128];
-
 
     struct test_result *results;
     int                 result_count;

--- a/tests/protocols/treeland-wallpaper-manager-unstable-v1/treeland-wallpaper-manager-unstable-v1.c
+++ b/tests/protocols/treeland-wallpaper-manager-unstable-v1/treeland-wallpaper-manager-unstable-v1.c
@@ -9,7 +9,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-
 extern void wm_query_server_state(void *data);
 extern void wm_emit_failed(void *data);
 extern void wm_emit_changed(void *data);

--- a/tests/protocols/treeland-wallpaper-manager-unstable-v1/treeland-wallpaper-manager-unstable-v1.h
+++ b/tests/protocols/treeland-wallpaper-manager-unstable-v1/treeland-wallpaper-manager-unstable-v1.h
@@ -14,7 +14,6 @@ int protocol_test_run(const char *socket_name);
 #define TEST_MSG_MAX 256
 #define WM_TEST_SOURCE "/usr/share/wallpapers/deepin-wallpapers/test-wallpaper.jpg"
 
-
 struct wm_server_state {
     int wallpaper_created;
     int second_created;
@@ -32,16 +31,13 @@ struct test_ctx {
     struct client_connection connection;
     struct wl_display    *display;
 
-
     struct wl_compositor *compositor;
     struct wl_output     *output;
-
 
     struct treeland_wallpaper_manager_v1 *manager;
     struct treeland_wallpaper_v1         *wallpaper;
     struct treeland_wallpaper_v1         *wallpaper2;
     struct wl_surface                    *test_surface;
-
 
     int  failed_received;
     int  failed_error;
@@ -50,7 +46,6 @@ struct test_ctx {
     int  changed_role;
     int  changed_type;
     char changed_source[TEST_MSG_MAX];
-
 
     struct test_result *results;
     int                 result_count;

--- a/tests/protocols/treeland-wallpaper-shell-unstable-v1/setup.cpp
+++ b/tests/protocols/treeland-wallpaper-shell-unstable-v1/setup.cpp
@@ -41,7 +41,6 @@ void protocol_test_setup(Helper *helper)
                      });
 }
 
-
 extern "C" {
 
 void wallpaper_emit_play(void *)

--- a/tests/protocols/treeland-wallpaper-shell-unstable-v1/treeland-wallpaper-shell-unstable-v1.h
+++ b/tests/protocols/treeland-wallpaper-shell-unstable-v1/treeland-wallpaper-shell-unstable-v1.h
@@ -23,15 +23,12 @@ struct test_ctx {
     struct client_connection connection;
     struct wl_display    *display;
 
-
     struct wl_compositor *compositor;
     struct treeland_wallpaper_notifier_v1 *notifier;
-
 
     struct treeland_wallpaper_shell_v1   *shell;
     struct treeland_wallpaper_surface_v1 *wallpaper_surface;
     struct wl_surface                    *test_surface;
-
 
     int      play_received;
     int      pause_received;
@@ -42,7 +39,6 @@ struct test_ctx {
     uint32_t notifier_add_type;
     char     notifier_add_source[TEST_MSG_MAX];
     char     notifier_remove_source[TEST_MSG_MAX];
-
 
     struct test_result *results;
     int                 result_count;

--- a/tests/protocols/treeland-window-management-v1/setup.cpp
+++ b/tests/protocols/treeland-window-management-v1/setup.cpp
@@ -18,9 +18,6 @@ void protocol_test_setup(Helper *helper)
     g_windowManagement = find_server_interface<WindowManagementInterfaceV1>(helper);
 }
 
-
-
-
 extern "C" void window_management_get_desktop_state(void *data)
 {
     uint32_t *out = static_cast<uint32_t *>(data);
@@ -28,7 +25,6 @@ extern "C" void window_management_get_desktop_state(void *data)
                ? static_cast<uint32_t>(g_windowManagement->desktopState())
                : UINT32_MAX;
 }
-
 
 extern "C" void window_management_set_desktop_state(void *data)
 {

--- a/tests/protocols/treeland-window-management-v1/treeland-window-management-v1.c
+++ b/tests/protocols/treeland-window-management-v1/treeland-window-management-v1.c
@@ -147,7 +147,6 @@ static int desktop_state_preview(struct test_ctx *ctx)
     return desktop_state_is(ctx, TREELAND_WINDOW_MANAGEMENT_V1_DESKTOP_STATE_PREVIEW_SHOW);
 }
 
-
 static int server_set_desktop_state(struct test_ctx *ctx)
 {
     (void)ctx;

--- a/tests/protocols/treeland-window-management-v1/treeland-window-management-v1.h
+++ b/tests/protocols/treeland-window-management-v1/treeland-window-management-v1.h
@@ -25,14 +25,11 @@ struct test_ctx {
     struct client_connection connection;
     struct wl_display    *display;
 
-
     struct treeland_window_management_v1 *manager;
-
 
     int      show_desktop_received;
     uint32_t show_desktop_last_state;
     int      show_desktop_count;
-
 
     struct test_result *results;
     int                 result_count;

--- a/tests/protocols/treeland-wine-window-management-unstable-v1/treeland-wine-window-management-unstable-v1.c
+++ b/tests/protocols/treeland-wine-window-management-unstable-v1/treeland-wine-window-management-unstable-v1.c
@@ -71,17 +71,14 @@ int protocol_test_run(const char *socket_name)
     struct wine_wm_state state = {0};
     int stage = 0;
 
-
     if (!client_connect(&connection, socket_name))
         return 1;
     if (!xdg_toplevel_client_create(&connection, &toplevel))
         goto failed;
     stage = 1;
 
-
     if (!read_state(&state) || !state.wrapper_created)
         goto failed;
-
 
     manager = client_bind(&connection,
                                  "treeland_wine_window_manager_v1",
@@ -90,7 +87,6 @@ int protocol_test_run(const char *socket_name)
     if (!manager)
         goto failed;
     stage = 2;
-
 
     control = treeland_wine_window_manager_v1_get_window_control(manager, toplevel.toplevel);
     treeland_wine_window_control_v1_add_listener(control, &control_listener, NULL);
@@ -104,7 +100,6 @@ int protocol_test_run(const char *socket_name)
     if (configure_stacking_count < 1 || last_topmost != 0)
         goto failed;
 
-
     if (!read_state(&state) || !state.wrapper_created)
         goto failed;
     if (state.z != 0 || state.effective_always_on_top != 0)
@@ -112,7 +107,6 @@ int protocol_test_run(const char *socket_name)
     if (state.parent_item_count < 1)
         goto failed;
     stage = 4;
-
 
     treeland_wine_window_control_v1_set_position(control, 100, 200, 1);
     if (wl_display_roundtrip(connection.display) < 0)
@@ -124,7 +118,6 @@ int protocol_test_run(const char *socket_name)
     if (!read_state(&state) || state.x != 100 || state.y != 200)
         goto failed;
     stage = 5;
-
 
     treeland_wine_window_control_v1_set_z_order(control,
                                                   TREELAND_WINE_WINDOW_CONTROL_V1_Z_ORDER_OP_HWND_TOPMOST,
@@ -139,7 +132,6 @@ int protocol_test_run(const char *socket_name)
         goto failed;
     stage = 6;
 
-
     treeland_wine_window_control_v1_set_z_order(control,
                                                   TREELAND_WINE_WINDOW_CONTROL_V1_Z_ORDER_OP_HWND_NOTOPMOST,
                                                   0);
@@ -151,7 +143,6 @@ int protocol_test_run(const char *socket_name)
 
     if (!read_state(&state) || state.z != 0 || state.effective_always_on_top != 0)
         goto failed;
-
 
     treeland_wine_window_control_v1_destroy(control);
     treeland_wine_window_manager_v1_destroy(manager);

--- a/tests/protocols/treeland-wine-window-management-unstable-v1/treeland-wine-window-management-unstable-v1.h
+++ b/tests/protocols/treeland-wine-window-management-unstable-v1/treeland-wine-window-management-unstable-v1.h
@@ -10,7 +10,6 @@ extern "C" {
 #include "client-connection.h"
 #include "xdg-toplevel-client.h"
 
-
 struct wine_wm_state {
     int wrapper_created;
     int x;

--- a/tests/protocols/treeland-wine-window-state-unstable-v1/treeland-wine-window-state-unstable-v1.c
+++ b/tests/protocols/treeland-wine-window-state-unstable-v1/treeland-wine-window-state-unstable-v1.c
@@ -58,7 +58,6 @@ int protocol_test_run(const char *socket_name)
     struct wine_ws_state state = { 0 };
     int stage = 0;
 
-
     if (!client_connect(&connection, socket_name))
         return 1;
     stage = 1;
@@ -73,7 +72,6 @@ int protocol_test_run(const char *socket_name)
         goto failed;
     stage = 3;
 
-
     manager = client_bind(&connection,
                                  "treeland_wine_window_state_manager_v1",
                                  &treeland_wine_window_state_manager_v1_interface,
@@ -81,7 +79,6 @@ int protocol_test_run(const char *socket_name)
     if (!manager)
         goto failed;
     stage = 4;
-
 
     client.state_events = 0;
     client.last_state = 0;
@@ -92,11 +89,9 @@ int protocol_test_run(const char *socket_name)
     if (client.state_events < 1 || client.last_state != 0)
         goto failed;
 
-
     if (!read_state(&state) || !state.visible)
         goto failed;
     stage = 5;
-
 
     client.state_events = 0;
     client.last_state = 0;
@@ -111,7 +106,6 @@ int protocol_test_run(const char *socket_name)
         goto failed;
     stage = 6;
 
-
     client.state_events = 0;
     client.last_state = 0;
     treeland_wine_window_state_v1_set_attention(ws, 0, 0);
@@ -125,7 +119,6 @@ int protocol_test_run(const char *socket_name)
         goto failed;
     stage = 7;
 
-
     client.state_events = 0;
     client.last_state = 0;
     treeland_wine_window_state_v1_clear_attention(ws);
@@ -138,7 +131,6 @@ int protocol_test_run(const char *socket_name)
         goto failed;
     stage = 8;
 
-
     client.state_events = 0;
     client.last_state = 0;
     treeland_wine_window_state_v1_unminimize(ws);
@@ -150,7 +142,6 @@ int protocol_test_run(const char *socket_name)
 
     if (!read_state(&state) || state.minimized != 0 || state.visible != 1)
         goto failed;
-
 
     treeland_wine_window_state_v1_destroy(ws);
     treeland_wine_window_state_manager_v1_destroy(manager);

--- a/tests/test_effect_glass/main.cpp
+++ b/tests/test_effect_glass/main.cpp
@@ -357,7 +357,6 @@ private Q_SLOTS:
         QCOMPARE(m_glass->property("multiEffectEnabled").toBool(), true);
     }
 
-
     void materialKnobsAreRuntimeQmlProperties()
     {
         auto *shader = m_glass->findChild<QObject *>("glassShader");
@@ -638,7 +637,6 @@ private Q_SLOTS:
                                 .arg(seamStep)));
     }
 
-
     void largeBezelWithSmallRadiusKeepsStraightEdgeRefraction()
     {
         setSmallRadiusLargeBezel();
@@ -661,7 +659,6 @@ private Q_SLOTS:
                                 .arg(changed)
                                 .arg(samples)));
     }
-
 
     void contentEdgePullChangesSilhouetteRefraction()
     {
@@ -718,7 +715,6 @@ private Q_SLOTS:
                                 .arg(changed)
                                 .arg(rightEdgeBand.width() * rightEdgeBand.height())));
     }
-
 
     void radiusLargerThanBezelDoesNotIntroduceCornerDiagonalSeam()
     {

--- a/tests/test_protocol_window-management/main.cpp
+++ b/tests/test_protocol_window-management/main.cpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2024 Dingyuan Zhang <lxz@mkacg.com>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
-
 #include "modules/window-management/windowmanagementinterfacev1.h"
 
 #include <wserver.h>


### PR DESCRIPTION
## Description

Collapse multiple consecutive blank lines into single blank lines across 36 files in the `tests/` directory to fix leftover style issues.

- 36 files changed, 160 lines deleted
- Pure whitespace cleanup, no code logic changes
- Does not affect compilation or runtime behavior

## Related Issue

[WM-323](https://agent-dev.uniontech.com/wm/issues/WM-323)

## Summary by Sourcery

Enhancements:
- Normalize excessive consecutive blank lines throughout the tests directory to improve formatting consistency.