### PR TITLE
feat: support wp_single_pixel_buffer_manager_v1 protocol

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2069,6 +2069,8 @@ void Helper::init(Treeland::Treeland *treeland)
 
     if (!wlr_viewporter_create(m_server->handle()))
         qCCritical(lcTlCore) << "Failed to create viewporter";
+    if (!wlr_single_pixel_buffer_manager_v1_create(m_server->handle()))
+        qCCritical(lcTlCore) << "Failed to create single pixel buffer manager";
     m_renderWindow->init(m_renderer, m_allocator);
 
     m_xwaylandOutputManager =

--- a/waylib/src/server/kernel/wlr_all.h
+++ b/waylib/src/server/kernel/wlr_all.h
@@ -111,6 +111,7 @@ extern "C" {
 #include <wlr/types/wlr_screencopy_v1.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/types/wlr_session_lock_v1.h>
+#include <wlr/types/wlr_single_pixel_buffer_v1.h>
 #include <wlr/types/wlr_subcompositor.h>
 #include <wlr/types/wlr_tablet_pad.h>
 #include <wlr/types/wlr_text_input_v3.h>

--- a/waylib/src/server/kernel/wlr_fwd.h
+++ b/waylib/src/server/kernel/wlr_fwd.h
@@ -137,7 +137,7 @@ struct wlr_session_lock_v1;
 struct wlr_shm;
 struct wlr_shm_attributes;
 struct wlr_single_pixel_buffer_v1;
-struct wlr_single_pixel_buffer_v1_manager;
+struct wlr_single_pixel_buffer_manager_v1;
 struct wlr_subcompositor;
 struct wlr_subsurface;
 struct wlr_surface;


### PR DESCRIPTION
## 支持 wp_single_pixel_buffer_manager_v1 协议

### 改动内容

1. **`src/seat/helper.cpp`** — 在 viewporter 创建后紧邻处创建 single-pixel-buffer manager global：
   ```cpp
   if (!wlr_single_pixel_buffer_manager_v1_create(m_server->handle()))
       qCCritical(lcTlCore) << "Failed to create single pixel buffer manager";
   ```
   与 viewporter 同模式，manager 无事件，无需 waylib 包装类。

2. **`waylib/src/server/kernel/wlr_all.h`** — 补 include `wlr/types/wlr_single_pixel_buffer_v1.h`（按字母序插在 `wlr_session_lock_v1.h` 之后）。

3. **`waylib/src/server/kernel/wlr_fwd.h`** — 修正前向声明笔误 `wlr_single_pixel_buffer_v1_manager` → `wlr_single_pixel_buffer_manager_v1`（与实际 wlroots 类型名一致）。

### 编译验证

远程机器上 `cmake --preset=default && cmake --build build -j100`，全部目标编译链接通过。

### 关联 Issue

[WM-324](https://agent-dev.uniontech.com/wm/issues/WM-324)

## Summary by Sourcery

Enable support for the wp_single_pixel_buffer_manager_v1 protocol in the compositor.

New Features:
- Add the wlroots single-pixel-buffer-manager-v1 global to the compositor.

Bug Fixes:
- Correct the single-pixel buffer manager forward declaration to match the wlroots type name.

Chores:
- Expose the single-pixel-buffer protocol header through the aggregated wlroots includes.