### PR TITLE
fix(xwayland): acknowledge client configure requests

### DIFF
--- a/.github/workflows/treeland-deepin-build.yml
+++ b/.github/workflows/treeland-deepin-build.yml
@@ -17,11 +17,8 @@ jobs:
           set -euxo pipefail
 
           echo "deb [trusted=yes] http://mirrors.kernel.org/deepin/beige/ crimson main commercial community" > /etc/apt/sources.list
-          echo "deb-src [trusted=yes] http://mirrors.kernel.org/deepin/beige/ crimson main commercial community" >> /etc/apt/sources.list
           echo "deb [trusted=yes] https://ci.deepin.com/repo/deepin/deepin-community/stable/ crimson main commercial community" >> /etc/apt/sources.list
-          echo "deb-src [trusted=yes] https://ci.deepin.com/repo/deepin/deepin-community/stable/ crimson main commercial community" >> /etc/apt/sources.list
           echo "deb [trusted=yes] https://ci.deepin.com/repo/deepin/deepin-community/testing/ unstable/crimson main commercial community" >> /etc/apt/sources.list
-          echo "deb-src [trusted=yes] https://ci.deepin.com/repo/deepin/deepin-community/testing/ unstable/crimson main commercial community" >> /etc/apt/sources.list
           rm -rf /etc/apt/sources.list.d
 
           apt-get update

--- a/examples/test_color_control/CMakeLists.txt
+++ b/examples/test_color_control/CMakeLists.txt
@@ -9,7 +9,7 @@ qt_add_executable(${BIN_NAME}
 
 qt_generate_wayland_protocol_client_sources(${BIN_NAME}
     FILES
-        ${TREELAND_PROTOCOLS_DATA_DIR}treeland-output-manager-v1.xml
+        ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-output-manager-v1.xml
 )
 
 target_link_libraries(${BIN_NAME}

--- a/examples/test_primary_output/CMakeLists.txt
+++ b/examples/test_primary_output/CMakeLists.txt
@@ -9,7 +9,7 @@ qt_add_executable(${BIN_NAME}
 
 qt_generate_wayland_protocol_client_sources(${BIN_NAME}
     FILES
-        ${TREELAND_PROTOCOLS_DATA_DIR}treeland-output-manager-v1.xml
+        ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-output-manager-v1.xml
 )
 
 target_link_libraries(${BIN_NAME}

--- a/waylib/src/server/qtquick/wxwaylandsurfaceitem.cpp
+++ b/waylib/src/server/qtquick/wxwaylandsurfaceitem.cpp
@@ -85,6 +85,8 @@ WXWaylandSurface *WXWaylandSurfaceItem::xwaylandSurface() const
 
 bool WXWaylandSurfaceItem::setShellSurface(WToplevelSurface *surface)
 {
+    Q_D(WXWaylandSurfaceItem);
+
     if (!WSurfaceItem::setShellSurface(surface))
         return false;
 
@@ -107,11 +109,15 @@ bool WXWaylandSurfaceItem::setShellSurface(WToplevelSurface *surface)
                 resize(rm);
             }
         };
-        QObject::connect(xwaylandSurface(), &WXWaylandSurface::requestConfigure, this, [this] {
+        QObject::connect(xwaylandSurface(), &WXWaylandSurface::requestConfigure, this, [this, d] {
             if (xwaylandSurface()->requestConfigureFlags().testAnyFlags(
                     WXWaylandSurface::ConfigureFlag::XCB_CONFIG_WINDOW_POSITION)) {
                 Q_EMIT implicitPositionChanged();
             }
+
+            // send back a ConfigureNotify event with the computed geometry.
+            d->configureSurface(QRect(d->explicitSurfacePosition(),
+                                      d->expectSurfaceSize()));
         });
         QObject::connect(xwaylandSurface(), &WXWaylandSurface::geometryChanged, this, updateGeometry);
         connect(this, &WXWaylandSurfaceItem::topPaddingChanged,


### PR DESCRIPTION
Configure XWayland surfaces with the geometry accepted by the compositor after handling client configure requests to prevent 360 EMApp windows from jittering during move operations.

Log: fix 360 EMApp window jitter during move
PMS: BUG-374965
Influence:

## Summary by Sourcery

Bug Fixes:
- Acknowledge XWayland client configure requests using the geometry accepted by the compositor, preventing window jitter during move operations.

## Summary by Sourcery

Ensure XWayland surfaces receive configure acknowledgements using the geometry accepted by the compositor, preventing window jitter during move operations.

Bug Fixes:
- Acknowledge XWayland client configure requests with the compositor-accepted geometry to prevent application windows from jittering during moves.

Build:
- Remove source package repositories from the Deepin build workflow and correct protocol file paths in color-control and primary-output example builds.