### PR TITLE
refactor(test): unify struct create/destroy pattern in protocol tests

### DIFF
--- a/tests/protocols/treeland-app-id-resolver-v1/treeland-app-id-resolver-v1.c
+++ b/tests/protocols/treeland-app-id-resolver-v1/treeland-app-id-resolver-v1.c
@@ -30,18 +30,31 @@ struct test_case {
     int (*run)(struct test_ctx *ctx);
 };
 
-void test_init(struct test_ctx *ctx)
+struct test_ctx *test_ctx_create(void)
 {
-    memset(ctx, 0, sizeof(*ctx));
+    struct test_ctx *ctx = calloc(1, sizeof(*ctx));
+    if (ctx == NULL) {
+        fprintf(stderr, "failed to allocate memory for test context\n");
+        return NULL;
+    }
     ctx->identify_pidfd = -1;
     ctx->result_cap = 32;
     ctx->results = calloc(ctx->result_cap, sizeof(*ctx->results));
+    if (ctx->results == NULL) {
+        fprintf(stderr, "failed to allocate memory for test results\n");
+        free(ctx);
+        return NULL;
+    }
+    return ctx;
 }
 
 void test_destroy(struct test_ctx *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
     free(ctx->results);
-    memset(ctx, 0, sizeof(*ctx));
+    free(ctx);
 }
 
 int test_add(struct test_ctx *ctx, const char *name)
@@ -248,27 +261,29 @@ void test_cleanup(struct test_ctx *ctx)
 
 int protocol_test_run(const char *socket_name)
 {
-    struct test_ctx ctx;
-    test_init(&ctx);
-    if (!connect_client(&ctx, socket_name)) {
+    struct test_ctx *ctx = test_ctx_create();
+    if (ctx == NULL) {
+        return 1;
+    }
+    if (!connect_client(ctx, socket_name)) {
         fprintf(stderr, "failed to connect to or bind treeland_app_id_resolver_manager_v1\n");
-        test_cleanup(&ctx);
-        test_destroy(&ctx);
+        test_cleanup(ctx);
+        test_destroy(ctx);
         return 1;
     }
 
     for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
-        const int result = test_add(&ctx, cases[i].name);
-        if (!cases[i].run(&ctx))
-            test_fail(&ctx, result, "assertion failed");
-        if (ctx.display_errored)
+        const int result = test_add(ctx, cases[i].name);
+        if (!cases[i].run(ctx))
+            test_fail(ctx, result, "assertion failed");
+        if (ctx->display_errored)
             continue;
-        if (wl_display_roundtrip(ctx.display) < 0)
-            test_fail(&ctx, result, "Wayland connection failed");
+        if (wl_display_roundtrip(ctx->display) < 0)
+            test_fail(ctx, result, "Wayland connection failed");
     }
 
-    test_cleanup(&ctx);
-    const int success = test_print_results(&ctx);
-    test_destroy(&ctx);
+    test_cleanup(ctx);
+    const int success = test_print_results(ctx);
+    test_destroy(ctx);
     return success ? 0 : 1;
 }

--- a/tests/protocols/treeland-app-id-resolver-v1/treeland-app-id-resolver-v1.h
+++ b/tests/protocols/treeland-app-id-resolver-v1/treeland-app-id-resolver-v1.h
@@ -38,7 +38,7 @@ struct test_ctx {
     int                 result_cap;
 };
 
-void test_init(struct test_ctx *ctx);
+struct test_ctx *test_ctx_create(void);
 void test_destroy(struct test_ctx *ctx);
 int  test_add(struct test_ctx *ctx, const char *name);
 void test_fail(struct test_ctx *ctx, int idx, const char *fmt, ...);

--- a/tests/protocols/treeland-capture-unstable-v1/treeland-capture-unstable-v1.c
+++ b/tests/protocols/treeland-capture-unstable-v1/treeland-capture-unstable-v1.c
@@ -13,17 +13,30 @@ struct test_case {
     int (*run)(struct test_ctx *ctx);
 };
 
-void test_init(struct test_ctx *ctx)
+struct test_ctx *test_ctx_create(void)
 {
-    memset(ctx, 0, sizeof(*ctx));
+    struct test_ctx *ctx = calloc(1, sizeof(*ctx));
+    if (ctx == NULL) {
+        fprintf(stderr, "failed to allocate memory for test context\n");
+        return NULL;
+    }
     ctx->result_cap = 32;
     ctx->results = calloc(ctx->result_cap, sizeof(*ctx->results));
+    if (ctx->results == NULL) {
+        fprintf(stderr, "failed to allocate memory for test results\n");
+        free(ctx);
+        return NULL;
+    }
+    return ctx;
 }
 
 void test_destroy(struct test_ctx *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
     free(ctx->results);
-    memset(ctx, 0, sizeof(*ctx));
+    free(ctx);
 }
 
 int test_add(struct test_ctx *ctx, const char *name)
@@ -268,26 +281,28 @@ void test_cleanup(struct test_ctx *ctx)
 
 int protocol_test_run(const char *socket_name)
 {
-    struct test_ctx ctx;
-    test_init(&ctx);
-    ctx.socket_name = socket_name;
-    if (!connect_client(&ctx, socket_name)) {
+    struct test_ctx *ctx = test_ctx_create();
+    if (ctx == NULL) {
+        return 1;
+    }
+    ctx->socket_name = socket_name;
+    if (!connect_client(ctx, socket_name)) {
         fprintf(stderr, "failed to connect to or bind treeland_capture_manager_v1\n");
-        test_cleanup(&ctx);
-        test_destroy(&ctx);
+        test_cleanup(ctx);
+        test_destroy(ctx);
         return 1;
     }
 
     for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
-        const int result = test_add(&ctx, cases[i].name);
-        if (!cases[i].run(&ctx))
-            test_fail(&ctx, result, "assertion failed");
-        if (wl_display_roundtrip(ctx.display) < 0)
-            test_fail(&ctx, result, "Wayland connection failed");
+        const int result = test_add(ctx, cases[i].name);
+        if (!cases[i].run(ctx))
+            test_fail(ctx, result, "assertion failed");
+        if (wl_display_roundtrip(ctx->display) < 0)
+            test_fail(ctx, result, "Wayland connection failed");
     }
 
-    test_cleanup(&ctx);
-    const int success = test_print_results(&ctx);
-    test_destroy(&ctx);
+    test_cleanup(ctx);
+    const int success = test_print_results(ctx);
+    test_destroy(ctx);
     return success ? 0 : 1;
 }

--- a/tests/protocols/treeland-capture-unstable-v1/treeland-capture-unstable-v1.h
+++ b/tests/protocols/treeland-capture-unstable-v1/treeland-capture-unstable-v1.h
@@ -40,7 +40,7 @@ struct test_ctx {
     int                 result_cap;
 };
 
-void test_init(struct test_ctx *ctx);
+struct test_ctx *test_ctx_create(void);
 void test_destroy(struct test_ctx *ctx);
 int  test_add(struct test_ctx *ctx, const char *name);
 void test_fail(struct test_ctx *ctx, int idx, const char *fmt, ...);

--- a/tests/protocols/treeland-dde-shell-v1/treeland-dde-shell-v1.c
+++ b/tests/protocols/treeland-dde-shell-v1/treeland-dde-shell-v1.c
@@ -16,17 +16,30 @@ struct test_case {
     int (*run)(struct test_ctx *ctx);
 };
 
-void test_init(struct test_ctx *ctx)
+struct test_ctx *test_ctx_create(void)
 {
-    memset(ctx, 0, sizeof(*ctx));
+    struct test_ctx *ctx = calloc(1, sizeof(*ctx));
+    if (ctx == NULL) {
+        fprintf(stderr, "failed to allocate memory for test context\n");
+        return NULL;
+    }
     ctx->result_cap = 32;
     ctx->results = calloc(ctx->result_cap, sizeof(*ctx->results));
+    if (ctx->results == NULL) {
+        fprintf(stderr, "failed to allocate memory for test results\n");
+        free(ctx);
+        return NULL;
+    }
+    return ctx;
 }
 
 void test_destroy(struct test_ctx *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
     free(ctx->results);
-    memset(ctx, 0, sizeof(*ctx));
+    free(ctx);
 }
 
 int test_add(struct test_ctx *ctx, const char *name)
@@ -351,25 +364,27 @@ void test_cleanup(struct test_ctx *ctx)
 
 int protocol_test_run(const char *socket_name)
 {
-    struct test_ctx ctx;
-    test_init(&ctx);
-    if (!connect_client(&ctx, socket_name)) {
+    struct test_ctx *ctx = test_ctx_create();
+    if (ctx == NULL) {
+        return 1;
+    }
+    if (!connect_client(ctx, socket_name)) {
         fprintf(stderr, "failed to connect to or bind treeland_dde_shell_manager_v1\n");
-        test_cleanup(&ctx);
-        test_destroy(&ctx);
+        test_cleanup(ctx);
+        test_destroy(ctx);
         return 1;
     }
 
     for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
-        const int result = test_add(&ctx, cases[i].name);
-        if (!cases[i].run(&ctx))
-            test_fail(&ctx, result, "assertion failed");
-        if (wl_display_roundtrip(ctx.display) < 0)
-            test_fail(&ctx, result, "Wayland connection failed");
+        const int result = test_add(ctx, cases[i].name);
+        if (!cases[i].run(ctx))
+            test_fail(ctx, result, "assertion failed");
+        if (wl_display_roundtrip(ctx->display) < 0)
+            test_fail(ctx, result, "Wayland connection failed");
     }
 
-    test_cleanup(&ctx);
-    const int success = test_print_results(&ctx);
-    test_destroy(&ctx);
+    test_cleanup(ctx);
+    const int success = test_print_results(ctx);
+    test_destroy(ctx);
     return success ? 0 : 1;
 }

--- a/tests/protocols/treeland-dde-shell-v1/treeland-dde-shell-v1.h
+++ b/tests/protocols/treeland-dde-shell-v1/treeland-dde-shell-v1.h
@@ -61,7 +61,7 @@ struct test_ctx {
     int                 result_cap;
 };
 
-void test_init(struct test_ctx *ctx);
+struct test_ctx *test_ctx_create(void);
 void test_destroy(struct test_ctx *ctx);
 int  test_add(struct test_ctx *ctx, const char *name);
 void test_fail(struct test_ctx *ctx, int idx, const char *fmt, ...);

--- a/tests/protocols/treeland-ddm-v1/treeland-ddm-v1.c
+++ b/tests/protocols/treeland-ddm-v1/treeland-ddm-v1.c
@@ -16,17 +16,30 @@ struct test_case {
     int (*run)(struct test_ctx *ctx);
 };
 
-void test_init(struct test_ctx *ctx)
+struct test_ctx *test_ctx_create(void)
 {
-    memset(ctx, 0, sizeof(*ctx));
+    struct test_ctx *ctx = calloc(1, sizeof(*ctx));
+    if (ctx == NULL) {
+        fprintf(stderr, "failed to allocate memory for test context\n");
+        return NULL;
+    }
     ctx->result_cap = 32;
     ctx->results = calloc(ctx->result_cap, sizeof(*ctx->results));
+    if (ctx->results == NULL) {
+        fprintf(stderr, "failed to allocate memory for test results\n");
+        free(ctx);
+        return NULL;
+    }
+    return ctx;
 }
 
 void test_destroy(struct test_ctx *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
     free(ctx->results);
-    memset(ctx, 0, sizeof(*ctx));
+    free(ctx);
 }
 
 int test_add(struct test_ctx *ctx, const char *name)
@@ -213,26 +226,28 @@ void test_cleanup(struct test_ctx *ctx)
 
 int protocol_test_run(const char *socket_name)
 {
-    struct test_ctx ctx;
-    test_init(&ctx);
-    if (!connect_client(&ctx, socket_name)) {
+    struct test_ctx *ctx = test_ctx_create();
+    if (ctx == NULL) {
+        return 1;
+    }
+    if (!connect_client(ctx, socket_name)) {
         fprintf(stderr, "failed to connect to treeland_ddm_v1 test server\n");
-        test_cleanup(&ctx);
-        test_destroy(&ctx);
+        test_cleanup(ctx);
+        test_destroy(ctx);
         return 1;
     }
 
     for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
-        const int result = test_add(&ctx, cases[i].name);
-        if (!cases[i].run(&ctx))
-            test_fail(&ctx, result, "assertion failed");
+        const int result = test_add(ctx, cases[i].name);
+        if (!cases[i].run(ctx))
+            test_fail(ctx, result, "assertion failed");
 
-        if (ctx.display && wl_display_roundtrip(ctx.display) < 0)
-            test_fail(&ctx, result, "Wayland connection failed");
+        if (ctx->display && wl_display_roundtrip(ctx->display) < 0)
+            test_fail(ctx, result, "Wayland connection failed");
     }
 
-    test_cleanup(&ctx);
-    const int success = test_print_results(&ctx);
-    test_destroy(&ctx);
+    test_cleanup(ctx);
+    const int success = test_print_results(ctx);
+    test_destroy(ctx);
     return success ? 0 : 1;
 }

--- a/tests/protocols/treeland-ddm-v1/treeland-ddm-v1.h
+++ b/tests/protocols/treeland-ddm-v1/treeland-ddm-v1.h
@@ -40,7 +40,7 @@ struct test_ctx {
     int                 result_cap;
 };
 
-void test_init(struct test_ctx *ctx);
+struct test_ctx *test_ctx_create(void);
 void test_destroy(struct test_ctx *ctx);
 int  test_add(struct test_ctx *ctx, const char *name);
 void test_fail(struct test_ctx *ctx, int idx, const char *fmt, ...);

--- a/tests/protocols/treeland-foreign-toplevel-manager-v1/treeland-foreign-toplevel-manager-v1.c
+++ b/tests/protocols/treeland-foreign-toplevel-manager-v1/treeland-foreign-toplevel-manager-v1.c
@@ -17,17 +17,30 @@ struct test_case {
     int (*run)(struct test_ctx *ctx);
 };
 
-void test_init(struct test_ctx *ctx)
+struct test_ctx *test_ctx_create(void)
 {
-    memset(ctx, 0, sizeof(*ctx));
+    struct test_ctx *ctx = calloc(1, sizeof(*ctx));
+    if (ctx == NULL) {
+        fprintf(stderr, "failed to allocate memory for test context\n");
+        return NULL;
+    }
     ctx->result_cap = 32;
     ctx->results = calloc(ctx->result_cap, sizeof(*ctx->results));
+    if (ctx->results == NULL) {
+        fprintf(stderr, "failed to allocate memory for test results\n");
+        free(ctx);
+        return NULL;
+    }
+    return ctx;
 }
 
 void test_destroy(struct test_ctx *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
     free(ctx->results);
-    memset(ctx, 0, sizeof(*ctx));
+    free(ctx);
 }
 
 int test_add(struct test_ctx *ctx, const char *name)
@@ -492,25 +505,27 @@ void test_cleanup(struct test_ctx *ctx)
 
 int protocol_test_run(const char *socket_name)
 {
-    struct test_ctx ctx;
-    test_init(&ctx);
-    if (!connect_client(&ctx, socket_name)) {
+    struct test_ctx *ctx = test_ctx_create();
+    if (ctx == NULL) {
+        return 1;
+    }
+    if (!connect_client(ctx, socket_name)) {
         fprintf(stderr, "failed to connect to or bind treeland_foreign_toplevel_manager_v1\n");
-        test_cleanup(&ctx);
-        test_destroy(&ctx);
+        test_cleanup(ctx);
+        test_destroy(ctx);
         return 1;
     }
 
     for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
-        const int result = test_add(&ctx, cases[i].name);
-        if (!cases[i].run(&ctx))
-            test_fail(&ctx, result, "assertion failed");
-        if (wl_display_roundtrip(ctx.display) < 0)
-            test_fail(&ctx, result, "Wayland connection failed");
+        const int result = test_add(ctx, cases[i].name);
+        if (!cases[i].run(ctx))
+            test_fail(ctx, result, "assertion failed");
+        if (wl_display_roundtrip(ctx->display) < 0)
+            test_fail(ctx, result, "Wayland connection failed");
     }
 
-    test_cleanup(&ctx);
-    const int success = test_print_results(&ctx);
-    test_destroy(&ctx);
+    test_cleanup(ctx);
+    const int success = test_print_results(ctx);
+    test_destroy(ctx);
     return success ? 0 : 1;
 }

--- a/tests/protocols/treeland-foreign-toplevel-manager-v1/treeland-foreign-toplevel-manager-v1.h
+++ b/tests/protocols/treeland-foreign-toplevel-manager-v1/treeland-foreign-toplevel-manager-v1.h
@@ -72,7 +72,7 @@ struct test_ctx {
     int                 result_cap;
 };
 
-void test_init(struct test_ctx *ctx);
+struct test_ctx *test_ctx_create(void);
 void test_destroy(struct test_ctx *ctx);
 int  test_add(struct test_ctx *ctx, const char *name);
 void test_fail(struct test_ctx *ctx, int idx, const char *fmt, ...);

--- a/tests/protocols/treeland-output-manager-v1/treeland-output-manager-v1.c
+++ b/tests/protocols/treeland-output-manager-v1/treeland-output-manager-v1.c
@@ -13,17 +13,30 @@ struct test_case {
     int (*run)(struct test_ctx *ctx);
 };
 
-void test_init(struct test_ctx *ctx)
+struct test_ctx *test_ctx_create(void)
 {
-    memset(ctx, 0, sizeof(*ctx));
+    struct test_ctx *ctx = calloc(1, sizeof(*ctx));
+    if (ctx == NULL) {
+        fprintf(stderr, "failed to allocate memory for test context\n");
+        return NULL;
+    }
     ctx->result_cap = 32;
     ctx->results = calloc(ctx->result_cap, sizeof(*ctx->results));
+    if (ctx->results == NULL) {
+        fprintf(stderr, "failed to allocate memory for test results\n");
+        free(ctx);
+        return NULL;
+    }
+    return ctx;
 }
 
 void test_destroy(struct test_ctx *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
     free(ctx->results);
-    memset(ctx, 0, sizeof(*ctx));
+    free(ctx);
 }
 
 int test_add(struct test_ctx *ctx, const char *name)
@@ -155,25 +168,27 @@ void test_cleanup(struct test_ctx *ctx)
 
 int protocol_test_run(const char *socket_name)
 {
-    struct test_ctx ctx;
-    test_init(&ctx);
-    if (!connect_client(&ctx, socket_name)) {
+    struct test_ctx *ctx = test_ctx_create();
+    if (ctx == NULL) {
+        return 1;
+    }
+    if (!connect_client(ctx, socket_name)) {
         fprintf(stderr, "failed to connect to or bind treeland_output_manager_v1\n");
-        test_cleanup(&ctx);
-        test_destroy(&ctx);
+        test_cleanup(ctx);
+        test_destroy(ctx);
         return 1;
     }
 
     for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
-        const int result = test_add(&ctx, cases[i].name);
-        if (!cases[i].run(&ctx))
-            test_fail(&ctx, result, "assertion failed");
-        if (wl_display_roundtrip(ctx.display) < 0)
-            test_fail(&ctx, result, "Wayland connection failed");
+        const int result = test_add(ctx, cases[i].name);
+        if (!cases[i].run(ctx))
+            test_fail(ctx, result, "assertion failed");
+        if (wl_display_roundtrip(ctx->display) < 0)
+            test_fail(ctx, result, "Wayland connection failed");
     }
 
-    test_cleanup(&ctx);
-    const int success = test_print_results(&ctx);
-    test_destroy(&ctx);
+    test_cleanup(ctx);
+    const int success = test_print_results(ctx);
+    test_destroy(ctx);
     return success ? 0 : 1;
 }

--- a/tests/protocols/treeland-output-manager-v1/treeland-output-manager-v1.h
+++ b/tests/protocols/treeland-output-manager-v1/treeland-output-manager-v1.h
@@ -39,7 +39,7 @@ struct test_ctx {
     int                 result_cap;
 };
 
-void test_init(struct test_ctx *ctx);
+struct test_ctx *test_ctx_create(void);
 void test_destroy(struct test_ctx *ctx);
 int  test_add(struct test_ctx *ctx, const char *name);
 void test_fail(struct test_ctx *ctx, int idx, const char *fmt, ...);

--- a/tests/protocols/treeland-personalization-manager-v1/treeland-personalization-manager-v1.c
+++ b/tests/protocols/treeland-personalization-manager-v1/treeland-personalization-manager-v1.c
@@ -14,17 +14,30 @@ struct test_case {
     int (*run)(struct test_ctx *ctx);
 };
 
-void test_init(struct test_ctx *ctx)
+struct test_ctx *test_ctx_create(void)
 {
-    memset(ctx, 0, sizeof(*ctx));
+    struct test_ctx *ctx = calloc(1, sizeof(*ctx));
+    if (ctx == NULL) {
+        fprintf(stderr, "failed to allocate memory for test context\n");
+        return NULL;
+    }
     ctx->result_cap = 32;
     ctx->results = calloc(ctx->result_cap, sizeof(*ctx->results));
+    if (ctx->results == NULL) {
+        fprintf(stderr, "failed to allocate memory for test results\n");
+        free(ctx);
+        return NULL;
+    }
+    return ctx;
 }
 
 void test_destroy(struct test_ctx *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
     free(ctx->results);
-    memset(ctx, 0, sizeof(*ctx));
+    free(ctx);
 }
 
 int test_add(struct test_ctx *ctx, const char *name)
@@ -699,12 +712,14 @@ void test_cleanup(struct test_ctx *ctx)
 
 int protocol_test_run(const char *socket_name)
 {
-    struct test_ctx ctx;
-    test_init(&ctx);
-    if (!connect_client(&ctx, socket_name)) {
+    struct test_ctx *ctx = test_ctx_create();
+    if (ctx == NULL) {
+        return 1;
+    }
+    if (!connect_client(ctx, socket_name)) {
         fprintf(stderr, "failed to connect to or bind treeland_personalization_manager_v1\n");
-        test_cleanup(&ctx);
-        test_destroy(&ctx);
+        test_cleanup(ctx);
+        test_destroy(ctx);
         return 1;
     }
 
@@ -712,21 +727,21 @@ int protocol_test_run(const char *socket_name)
     if (!invoke_on_server_thread(personalization_snapshot_config, &snapshot_valid)
         || !snapshot_valid) {
         fprintf(stderr, "failed to snapshot personalization configuration\n");
-        test_cleanup(&ctx);
-        test_destroy(&ctx);
+        test_cleanup(ctx);
+        test_destroy(ctx);
         return 1;
     }
 
     for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
-        const int result = test_add(&ctx, cases[i].name);
-        if (!cases[i].run(&ctx))
-            test_fail(&ctx, result, "assertion failed");
-        if (wl_display_roundtrip(ctx.display) < 0)
-            test_fail(&ctx, result, "Wayland connection failed");
+        const int result = test_add(ctx, cases[i].name);
+        if (!cases[i].run(ctx))
+            test_fail(ctx, result, "assertion failed");
+        if (wl_display_roundtrip(ctx->display) < 0)
+            test_fail(ctx, result, "Wayland connection failed");
     }
 
-    test_cleanup(&ctx);
-    const int success = test_print_results(&ctx);
-    test_destroy(&ctx);
+    test_cleanup(ctx);
+    const int success = test_print_results(ctx);
+    test_destroy(ctx);
     return success ? 0 : 1;
 }

--- a/tests/protocols/treeland-personalization-manager-v1/treeland-personalization-manager-v1.h
+++ b/tests/protocols/treeland-personalization-manager-v1/treeland-personalization-manager-v1.h
@@ -92,7 +92,7 @@ struct test_ctx {
     int                 result_cap;
 };
 
-void test_init(struct test_ctx *ctx);
+struct test_ctx *test_ctx_create(void);
 void test_destroy(struct test_ctx *ctx);
 int  test_add(struct test_ctx *ctx, const char *name);
 void test_fail(struct test_ctx *ctx, int idx, const char *fmt, ...);

--- a/tests/protocols/treeland-prelaunch-splash-v2/treeland-prelaunch-splash-v2.c
+++ b/tests/protocols/treeland-prelaunch-splash-v2/treeland-prelaunch-splash-v2.c
@@ -20,17 +20,30 @@ struct test_case {
     int (*run)(struct test_ctx *ctx);
 };
 
-void test_init(struct test_ctx *ctx)
+struct test_ctx *test_ctx_create(void)
 {
-    memset(ctx, 0, sizeof(*ctx));
+    struct test_ctx *ctx = calloc(1, sizeof(*ctx));
+    if (ctx == NULL) {
+        fprintf(stderr, "failed to allocate memory for test context\n");
+        return NULL;
+    }
     ctx->result_cap = 32;
     ctx->results = calloc(ctx->result_cap, sizeof(*ctx->results));
+    if (ctx->results == NULL) {
+        fprintf(stderr, "failed to allocate memory for test results\n");
+        free(ctx);
+        return NULL;
+    }
+    return ctx;
 }
 
 void test_destroy(struct test_ctx *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
     free(ctx->results);
-    memset(ctx, 0, sizeof(*ctx));
+    free(ctx);
 }
 
 int test_add(struct test_ctx *ctx, const char *name)
@@ -223,25 +236,27 @@ void test_cleanup(struct test_ctx *ctx)
 
 int protocol_test_run(const char *socket_name)
 {
-    struct test_ctx ctx;
-    test_init(&ctx);
-    if (!connect_client(&ctx, socket_name)) {
+    struct test_ctx *ctx = test_ctx_create();
+    if (ctx == NULL) {
+        return 1;
+    }
+    if (!connect_client(ctx, socket_name)) {
         fprintf(stderr, "failed to connect to or bind treeland_prelaunch_splash_manager_v2\n");
-        test_cleanup(&ctx);
-        test_destroy(&ctx);
+        test_cleanup(ctx);
+        test_destroy(ctx);
         return 1;
     }
 
     for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
-        const int result = test_add(&ctx, cases[i].name);
-        if (!cases[i].run(&ctx))
-            test_fail(&ctx, result, "assertion failed");
-        if (wl_display_roundtrip(ctx.display) < 0)
-            test_fail(&ctx, result, "Wayland connection failed");
+        const int result = test_add(ctx, cases[i].name);
+        if (!cases[i].run(ctx))
+            test_fail(ctx, result, "assertion failed");
+        if (wl_display_roundtrip(ctx->display) < 0)
+            test_fail(ctx, result, "Wayland connection failed");
     }
 
-    test_cleanup(&ctx);
-    const int success = test_print_results(&ctx);
-    test_destroy(&ctx);
+    test_cleanup(ctx);
+    const int success = test_print_results(ctx);
+    test_destroy(ctx);
     return success ? 0 : 1;
 }

--- a/tests/protocols/treeland-prelaunch-splash-v2/treeland-prelaunch-splash-v2.h
+++ b/tests/protocols/treeland-prelaunch-splash-v2/treeland-prelaunch-splash-v2.h
@@ -52,7 +52,7 @@ struct test_ctx {
     int                 result_cap;
 };
 
-void test_init(struct test_ctx *ctx);
+struct test_ctx *test_ctx_create(void);
 void test_destroy(struct test_ctx *ctx);
 int  test_add(struct test_ctx *ctx, const char *name);
 void test_fail(struct test_ctx *ctx, int idx, const char *fmt, ...);

--- a/tests/protocols/treeland-screensaver-v1/treeland-screensaver-v1.c
+++ b/tests/protocols/treeland-screensaver-v1/treeland-screensaver-v1.c
@@ -17,17 +17,30 @@ struct test_case {
     int (*run)(struct test_ctx *ctx);
 };
 
-void test_init(struct test_ctx *ctx)
+struct test_ctx *test_ctx_create(void)
 {
-    memset(ctx, 0, sizeof(*ctx));
+    struct test_ctx *ctx = calloc(1, sizeof(*ctx));
+    if (ctx == NULL) {
+        fprintf(stderr, "failed to allocate memory for test context\n");
+        return NULL;
+    }
     ctx->result_cap = 16;
     ctx->results = calloc(ctx->result_cap, sizeof(*ctx->results));
+    if (ctx->results == NULL) {
+        fprintf(stderr, "failed to allocate memory for test results\n");
+        free(ctx);
+        return NULL;
+    }
+    return ctx;
 }
 
 void test_destroy(struct test_ctx *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
     free(ctx->results);
-    memset(ctx, 0, sizeof(*ctx));
+    free(ctx);
 }
 
 int test_add(struct test_ctx *ctx, const char *name)
@@ -175,28 +188,30 @@ void test_cleanup(struct test_ctx *ctx)
 
 int protocol_test_run(const char *socket_name)
 {
-    struct test_ctx ctx;
-    test_init(&ctx);
-    if (!connect_client(&ctx, socket_name)) {
+    struct test_ctx *ctx = test_ctx_create();
+    if (ctx == NULL) {
+        return 1;
+    }
+    if (!connect_client(ctx, socket_name)) {
         fprintf(stderr, "failed to connect to or bind treeland_screensaver_v1\n");
-        test_cleanup(&ctx);
-        test_destroy(&ctx);
+        test_cleanup(ctx);
+        test_destroy(ctx);
         return 1;
     }
 
     const size_t case_count = sizeof(cases) / sizeof(cases[0]);
     for (size_t i = 0; i < case_count; ++i) {
-        const int result = test_add(&ctx, cases[i].name);
-        if (!cases[i].run(&ctx))
-            test_fail(&ctx, result, "assertion failed");
+        const int result = test_add(ctx, cases[i].name);
+        if (!cases[i].run(ctx))
+            test_fail(ctx, result, "assertion failed");
 
-        if (!ctx.roundtripped && wl_display_roundtrip(ctx.display) < 0)
-            test_fail(&ctx, result, "Wayland connection failed");
-        ctx.roundtripped = 0;
+        if (!ctx->roundtripped && wl_display_roundtrip(ctx->display) < 0)
+            test_fail(ctx, result, "Wayland connection failed");
+        ctx->roundtripped = 0;
     }
 
-    test_cleanup(&ctx);
-    const int success = test_print_results(&ctx);
-    test_destroy(&ctx);
+    test_cleanup(ctx);
+    const int success = test_print_results(ctx);
+    test_destroy(ctx);
     return success ? 0 : 1;
 }

--- a/tests/protocols/treeland-screensaver-v1/treeland-screensaver-v1.h
+++ b/tests/protocols/treeland-screensaver-v1/treeland-screensaver-v1.h
@@ -35,7 +35,7 @@ struct test_ctx {
     int                 result_cap;
 };
 
-void test_init(struct test_ctx *ctx);
+struct test_ctx *test_ctx_create(void);
 void test_destroy(struct test_ctx *ctx);
 int  test_add(struct test_ctx *ctx, const char *name);
 void test_fail(struct test_ctx *ctx, int idx, const char *fmt, ...);

--- a/tests/protocols/treeland-shortcut-manager-v2/treeland-shortcut-manager-v2.c
+++ b/tests/protocols/treeland-shortcut-manager-v2/treeland-shortcut-manager-v2.c
@@ -13,17 +13,30 @@ struct test_case {
     int (*run)(struct test_ctx *ctx);
 };
 
-void test_init(struct test_ctx *ctx)
+struct test_ctx *test_ctx_create(void)
 {
-    memset(ctx, 0, sizeof(*ctx));
+    struct test_ctx *ctx = calloc(1, sizeof(*ctx));
+    if (ctx == NULL) {
+        fprintf(stderr, "failed to allocate memory for test context\n");
+        return NULL;
+    }
     ctx->result_cap = 32;
     ctx->results = calloc(ctx->result_cap, sizeof(*ctx->results));
+    if (ctx->results == NULL) {
+        fprintf(stderr, "failed to allocate memory for test results\n");
+        free(ctx);
+        return NULL;
+    }
+    return ctx;
 }
 
 void test_destroy(struct test_ctx *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
     free(ctx->results);
-    memset(ctx, 0, sizeof(*ctx));
+    free(ctx);
 }
 
 int test_add(struct test_ctx *ctx, const char *name)
@@ -220,25 +233,27 @@ void test_cleanup(struct test_ctx *ctx)
 
 int protocol_test_run(const char *socket_name)
 {
-    struct test_ctx ctx;
-    test_init(&ctx);
-    if (!connect_client(&ctx, socket_name)) {
+    struct test_ctx *ctx = test_ctx_create();
+    if (ctx == NULL) {
+        return 1;
+    }
+    if (!connect_client(ctx, socket_name)) {
         fprintf(stderr, "failed to connect to or bind treeland_shortcut_manager_v2\n");
-        test_cleanup(&ctx);
-        test_destroy(&ctx);
+        test_cleanup(ctx);
+        test_destroy(ctx);
         return 1;
     }
 
     for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
-        const int result = test_add(&ctx, cases[i].name);
-        if (!cases[i].run(&ctx))
-            test_fail(&ctx, result, "assertion failed");
-        if (wl_display_roundtrip(ctx.display) < 0)
-            test_fail(&ctx, result, "Wayland connection failed");
+        const int result = test_add(ctx, cases[i].name);
+        if (!cases[i].run(ctx))
+            test_fail(ctx, result, "assertion failed");
+        if (wl_display_roundtrip(ctx->display) < 0)
+            test_fail(ctx, result, "Wayland connection failed");
     }
 
-    test_cleanup(&ctx);
-    const int success = test_print_results(&ctx);
-    test_destroy(&ctx);
+    test_cleanup(ctx);
+    const int success = test_print_results(ctx);
+    test_destroy(ctx);
     return success ? 0 : 1;
 }

--- a/tests/protocols/treeland-shortcut-manager-v2/treeland-shortcut-manager-v2.h
+++ b/tests/protocols/treeland-shortcut-manager-v2/treeland-shortcut-manager-v2.h
@@ -43,7 +43,7 @@ struct test_ctx {
     int                 result_cap;
 };
 
-void test_init(struct test_ctx *ctx);
+struct test_ctx *test_ctx_create(void);
 void test_destroy(struct test_ctx *ctx);
 int  test_add(struct test_ctx *ctx, const char *name);
 void test_fail(struct test_ctx *ctx, int idx, const char *fmt, ...);

--- a/tests/protocols/treeland-virtual-output-manager-v1/treeland-virtual-output-manager-v1.c
+++ b/tests/protocols/treeland-virtual-output-manager-v1/treeland-virtual-output-manager-v1.c
@@ -17,17 +17,30 @@ struct test_case {
     int (*run)(struct test_ctx *ctx);
 };
 
-void test_init(struct test_ctx *ctx)
+struct test_ctx *test_ctx_create(void)
 {
-    memset(ctx, 0, sizeof(*ctx));
+    struct test_ctx *ctx = calloc(1, sizeof(*ctx));
+    if (ctx == NULL) {
+        fprintf(stderr, "failed to allocate memory for test context\n");
+        return NULL;
+    }
     ctx->result_cap = 32;
     ctx->results = calloc(ctx->result_cap, sizeof(*ctx->results));
+    if (ctx->results == NULL) {
+        fprintf(stderr, "failed to allocate memory for test results\n");
+        free(ctx);
+        return NULL;
+    }
+    return ctx;
 }
 
 void test_destroy(struct test_ctx *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
     free(ctx->results);
-    memset(ctx, 0, sizeof(*ctx));
+    free(ctx);
 }
 
 int test_add(struct test_ctx *ctx, const char *name)
@@ -349,25 +362,27 @@ void test_cleanup(struct test_ctx *ctx)
 
 int protocol_test_run(const char *socket_name)
 {
-    struct test_ctx ctx;
-    test_init(&ctx);
-    if (!connect_client(&ctx, socket_name)) {
+    struct test_ctx *ctx = test_ctx_create();
+    if (ctx == NULL) {
+        return 1;
+    }
+    if (!connect_client(ctx, socket_name)) {
         fprintf(stderr, "failed to connect to or bind treeland_virtual_output_manager_v1\n");
-        test_cleanup(&ctx);
-        test_destroy(&ctx);
+        test_cleanup(ctx);
+        test_destroy(ctx);
         return 1;
     }
 
     for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
-        const int result = test_add(&ctx, cases[i].name);
-        if (!cases[i].run(&ctx))
-            test_fail(&ctx, result, "assertion failed");
-        if (wl_display_roundtrip(ctx.display) < 0)
-            test_fail(&ctx, result, "Wayland connection failed");
+        const int result = test_add(ctx, cases[i].name);
+        if (!cases[i].run(ctx))
+            test_fail(ctx, result, "assertion failed");
+        if (wl_display_roundtrip(ctx->display) < 0)
+            test_fail(ctx, result, "Wayland connection failed");
     }
 
-    test_cleanup(&ctx);
-    const int success = test_print_results(&ctx);
-    test_destroy(&ctx);
+    test_cleanup(ctx);
+    const int success = test_print_results(ctx);
+    test_destroy(ctx);
     return success ? 0 : 1;
 }

--- a/tests/protocols/treeland-virtual-output-manager-v1/treeland-virtual-output-manager-v1.h
+++ b/tests/protocols/treeland-virtual-output-manager-v1/treeland-virtual-output-manager-v1.h
@@ -54,7 +54,7 @@ struct test_ctx {
     int                 result_cap;
 };
 
-void test_init(struct test_ctx *ctx);
+struct test_ctx *test_ctx_create(void);
 void test_destroy(struct test_ctx *ctx);
 int  test_add(struct test_ctx *ctx, const char *name);
 void test_fail(struct test_ctx *ctx, int idx, const char *fmt, ...);

--- a/tests/protocols/treeland-wallpaper-color-v1/treeland-wallpaper-color-v1.c
+++ b/tests/protocols/treeland-wallpaper-color-v1/treeland-wallpaper-color-v1.c
@@ -21,17 +21,30 @@ struct test_case {
     int (*run)(struct test_ctx *ctx);
 };
 
-void test_init(struct test_ctx *ctx)
+struct test_ctx *test_ctx_create(void)
 {
-    memset(ctx, 0, sizeof(*ctx));
+    struct test_ctx *ctx = calloc(1, sizeof(*ctx));
+    if (ctx == NULL) {
+        fprintf(stderr, "failed to allocate memory for test context\n");
+        return NULL;
+    }
     ctx->result_cap = 32;
     ctx->results = calloc(ctx->result_cap, sizeof(*ctx->results));
+    if (ctx->results == NULL) {
+        fprintf(stderr, "failed to allocate memory for test results\n");
+        free(ctx);
+        return NULL;
+    }
+    return ctx;
 }
 
 void test_destroy(struct test_ctx *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
     free(ctx->results);
-    memset(ctx, 0, sizeof(*ctx));
+    free(ctx);
 }
 
 int test_add(struct test_ctx *ctx, const char *name)
@@ -170,25 +183,27 @@ void test_cleanup(struct test_ctx *ctx)
 
 int protocol_test_run(const char *socket_name)
 {
-    struct test_ctx ctx;
-    test_init(&ctx);
-    if (!connect_client(&ctx, socket_name)) {
+    struct test_ctx *ctx = test_ctx_create();
+    if (ctx == NULL) {
+        return 1;
+    }
+    if (!connect_client(ctx, socket_name)) {
         fprintf(stderr, "failed to connect to or bind treeland_wallpaper_color_manager_v1\n");
-        test_cleanup(&ctx);
-        test_destroy(&ctx);
+        test_cleanup(ctx);
+        test_destroy(ctx);
         return 1;
     }
 
     for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
-        const int result = test_add(&ctx, cases[i].name);
-        if (!cases[i].run(&ctx))
-            test_fail(&ctx, result, "assertion failed");
-        if (wl_display_roundtrip(ctx.display) < 0)
-            test_fail(&ctx, result, "Wayland connection failed");
+        const int result = test_add(ctx, cases[i].name);
+        if (!cases[i].run(ctx))
+            test_fail(ctx, result, "assertion failed");
+        if (wl_display_roundtrip(ctx->display) < 0)
+            test_fail(ctx, result, "Wayland connection failed");
     }
 
-    test_cleanup(&ctx);
-    const int success = test_print_results(&ctx);
-    test_destroy(&ctx);
+    test_cleanup(ctx);
+    const int success = test_print_results(ctx);
+    test_destroy(ctx);
     return success ? 0 : 1;
 }

--- a/tests/protocols/treeland-wallpaper-color-v1/treeland-wallpaper-color-v1.h
+++ b/tests/protocols/treeland-wallpaper-color-v1/treeland-wallpaper-color-v1.h
@@ -34,7 +34,7 @@ struct test_ctx {
     int                 result_cap;
 };
 
-void test_init(struct test_ctx *ctx);
+struct test_ctx *test_ctx_create(void);
 void test_destroy(struct test_ctx *ctx);
 int  test_add(struct test_ctx *ctx, const char *name);
 void test_fail(struct test_ctx *ctx, int idx, const char *fmt, ...);

--- a/tests/protocols/treeland-wallpaper-manager-unstable-v1/treeland-wallpaper-manager-unstable-v1.c
+++ b/tests/protocols/treeland-wallpaper-manager-unstable-v1/treeland-wallpaper-manager-unstable-v1.c
@@ -18,17 +18,30 @@ struct test_case {
     int (*run)(struct test_ctx *ctx);
 };
 
-void test_init(struct test_ctx *ctx)
+struct test_ctx *test_ctx_create(void)
 {
-    memset(ctx, 0, sizeof(*ctx));
+    struct test_ctx *ctx = calloc(1, sizeof(*ctx));
+    if (ctx == NULL) {
+        fprintf(stderr, "failed to allocate memory for test context\n");
+        return NULL;
+    }
     ctx->result_cap = 32;
     ctx->results = calloc(ctx->result_cap, sizeof(*ctx->results));
+    if (ctx->results == NULL) {
+        fprintf(stderr, "failed to allocate memory for test results\n");
+        free(ctx);
+        return NULL;
+    }
+    return ctx;
 }
 
 void test_destroy(struct test_ctx *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
     free(ctx->results);
-    memset(ctx, 0, sizeof(*ctx));
+    free(ctx);
 }
 
 int test_add(struct test_ctx *ctx, const char *name)
@@ -187,26 +200,28 @@ void test_cleanup(struct test_ctx *ctx)
 
 int protocol_test_run(const char *socket_name)
 {
-    struct test_ctx ctx;
-    test_init(&ctx);
-    if (!connect_client(&ctx, socket_name)) {
+    struct test_ctx *ctx = test_ctx_create();
+    if (ctx == NULL) {
+        return 1;
+    }
+    if (!connect_client(ctx, socket_name)) {
         fprintf(stderr, "failed to connect or bind treeland_wallpaper_manager_v1 "
                         "(need wl_compositor, wl_output and the manager global)\n");
-        test_cleanup(&ctx);
-        test_destroy(&ctx);
+        test_cleanup(ctx);
+        test_destroy(ctx);
         return 1;
     }
 
     for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
-        const int result = test_add(&ctx, cases[i].name);
-        if (!cases[i].run(&ctx))
-            test_fail(&ctx, result, "assertion failed");
-        if (wl_display_roundtrip(ctx.display) < 0)
-            test_fail(&ctx, result, "Wayland connection failed");
+        const int result = test_add(ctx, cases[i].name);
+        if (!cases[i].run(ctx))
+            test_fail(ctx, result, "assertion failed");
+        if (wl_display_roundtrip(ctx->display) < 0)
+            test_fail(ctx, result, "Wayland connection failed");
     }
 
-    test_cleanup(&ctx);
-    const int success = test_print_results(&ctx);
-    test_destroy(&ctx);
+    test_cleanup(ctx);
+    const int success = test_print_results(ctx);
+    test_destroy(ctx);
     return success ? 0 : 1;
 }

--- a/tests/protocols/treeland-wallpaper-manager-unstable-v1/treeland-wallpaper-manager-unstable-v1.h
+++ b/tests/protocols/treeland-wallpaper-manager-unstable-v1/treeland-wallpaper-manager-unstable-v1.h
@@ -52,7 +52,7 @@ struct test_ctx {
     int                 result_cap;
 };
 
-void test_init(struct test_ctx *ctx);
+struct test_ctx *test_ctx_create(void);
 void test_destroy(struct test_ctx *ctx);
 int  test_add(struct test_ctx *ctx, const char *name);
 void test_fail(struct test_ctx *ctx, int idx, const char *fmt, ...);

--- a/tests/protocols/treeland-wallpaper-shell-unstable-v1/treeland-wallpaper-shell-unstable-v1.c
+++ b/tests/protocols/treeland-wallpaper-shell-unstable-v1/treeland-wallpaper-shell-unstable-v1.c
@@ -25,17 +25,30 @@ struct test_case {
     int (*run)(struct test_ctx *ctx);
 };
 
-void test_init(struct test_ctx *ctx)
+struct test_ctx *test_ctx_create(void)
 {
-    memset(ctx, 0, sizeof(*ctx));
+    struct test_ctx *ctx = calloc(1, sizeof(*ctx));
+    if (ctx == NULL) {
+        fprintf(stderr, "failed to allocate memory for test context\n");
+        return NULL;
+    }
     ctx->result_cap = 32;
     ctx->results = calloc(ctx->result_cap, sizeof(*ctx->results));
+    if (ctx->results == NULL) {
+        fprintf(stderr, "failed to allocate memory for test results\n");
+        free(ctx);
+        return NULL;
+    }
+    return ctx;
 }
 
 void test_destroy(struct test_ctx *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
     free(ctx->results);
-    memset(ctx, 0, sizeof(*ctx));
+    free(ctx);
 }
 
 int test_add(struct test_ctx *ctx, const char *name)
@@ -272,25 +285,27 @@ void test_cleanup(struct test_ctx *ctx)
 
 int protocol_test_run(const char *socket_name)
 {
-    struct test_ctx ctx;
-    test_init(&ctx);
-    if (!connect_client(&ctx, socket_name)) {
+    struct test_ctx *ctx = test_ctx_create();
+    if (ctx == NULL) {
+        return 1;
+    }
+    if (!connect_client(ctx, socket_name)) {
         fprintf(stderr, "failed to connect to or bind treeland_wallpaper_shell_v1\n");
-        test_cleanup(&ctx);
-        test_destroy(&ctx);
+        test_cleanup(ctx);
+        test_destroy(ctx);
         return 1;
     }
 
     for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
-        const int result = test_add(&ctx, cases[i].name);
-        if (!cases[i].run(&ctx))
-            test_fail(&ctx, result, "assertion failed");
-        if (wl_display_roundtrip(ctx.display) < 0)
-            test_fail(&ctx, result, "Wayland connection failed");
+        const int result = test_add(ctx, cases[i].name);
+        if (!cases[i].run(ctx))
+            test_fail(ctx, result, "assertion failed");
+        if (wl_display_roundtrip(ctx->display) < 0)
+            test_fail(ctx, result, "Wayland connection failed");
     }
 
-    test_cleanup(&ctx);
-    const int success = test_print_results(&ctx);
-    test_destroy(&ctx);
+    test_cleanup(ctx);
+    const int success = test_print_results(ctx);
+    test_destroy(ctx);
     return success ? 0 : 1;
 }

--- a/tests/protocols/treeland-wallpaper-shell-unstable-v1/treeland-wallpaper-shell-unstable-v1.h
+++ b/tests/protocols/treeland-wallpaper-shell-unstable-v1/treeland-wallpaper-shell-unstable-v1.h
@@ -45,7 +45,7 @@ struct test_ctx {
     int                 result_cap;
 };
 
-void test_init(struct test_ctx *ctx);
+struct test_ctx *test_ctx_create(void);
 void test_destroy(struct test_ctx *ctx);
 int  test_add(struct test_ctx *ctx, const char *name);
 void test_fail(struct test_ctx *ctx, int idx, const char *fmt, ...);

--- a/tests/protocols/treeland-window-management-v1/treeland-window-management-v1.c
+++ b/tests/protocols/treeland-window-management-v1/treeland-window-management-v1.c
@@ -18,17 +18,30 @@ struct test_case {
     int (*run)(struct test_ctx *ctx);
 };
 
-void test_init(struct test_ctx *ctx)
+struct test_ctx *test_ctx_create(void)
 {
-    memset(ctx, 0, sizeof(*ctx));
+    struct test_ctx *ctx = calloc(1, sizeof(*ctx));
+    if (ctx == NULL) {
+        fprintf(stderr, "failed to allocate memory for test context\n");
+        return NULL;
+    }
     ctx->result_cap = 32;
     ctx->results = calloc(ctx->result_cap, sizeof(*ctx->results));
+    if (ctx->results == NULL) {
+        fprintf(stderr, "failed to allocate memory for test results\n");
+        free(ctx);
+        return NULL;
+    }
+    return ctx;
 }
 
 void test_destroy(struct test_ctx *ctx)
 {
+    if (ctx == NULL) {
+        return;
+    }
     free(ctx->results);
-    memset(ctx, 0, sizeof(*ctx));
+    free(ctx);
 }
 
 int test_add(struct test_ctx *ctx, const char *name)
@@ -192,25 +205,27 @@ void test_cleanup(struct test_ctx *ctx)
 
 int protocol_test_run(const char *socket_name)
 {
-    struct test_ctx ctx;
-    test_init(&ctx);
-    if (!connect_client(&ctx, socket_name)) {
+    struct test_ctx *ctx = test_ctx_create();
+    if (ctx == NULL) {
+        return 1;
+    }
+    if (!connect_client(ctx, socket_name)) {
         fprintf(stderr, "failed to connect to or bind treeland_window_management_v1\n");
-        test_cleanup(&ctx);
-        test_destroy(&ctx);
+        test_cleanup(ctx);
+        test_destroy(ctx);
         return 1;
     }
 
     for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
-        const int result = test_add(&ctx, cases[i].name);
-        if (!cases[i].run(&ctx))
-            test_fail(&ctx, result, "assertion failed");
-        if (wl_display_roundtrip(ctx.display) < 0)
-            test_fail(&ctx, result, "Wayland connection failed");
+        const int result = test_add(ctx, cases[i].name);
+        if (!cases[i].run(ctx))
+            test_fail(ctx, result, "assertion failed");
+        if (wl_display_roundtrip(ctx->display) < 0)
+            test_fail(ctx, result, "Wayland connection failed");
     }
 
-    test_cleanup(&ctx);
-    const int success = test_print_results(&ctx);
-    test_destroy(&ctx);
+    test_cleanup(ctx);
+    const int success = test_print_results(ctx);
+    test_destroy(ctx);
     return success ? 0 : 1;
 }

--- a/tests/protocols/treeland-window-management-v1/treeland-window-management-v1.h
+++ b/tests/protocols/treeland-window-management-v1/treeland-window-management-v1.h
@@ -36,7 +36,7 @@ struct test_ctx {
     int                 result_cap;
 };
 
-void test_init(struct test_ctx *ctx);
+struct test_ctx *test_ctx_create(void);
 void test_destroy(struct test_ctx *ctx);
 int  test_add(struct test_ctx *ctx, const char *name);
 void test_fail(struct test_ctx *ctx, int idx, const char *fmt, ...);


### PR DESCRIPTION
## 概述

将 `tests/protocols/` 目录下 15 个 treeland-protocol 基础测试文件的 struct 创建/销毁方式从栈分配 `test_init(ctx)` / `test_destroy(ctx)` 统一重构为堆分配 `test_ctx_create()` / `test_destroy(ctx)` 模式。

## 改动内容

- **`test_ctx_create`**：使用 `calloc(1, sizeof(*ctx))` 堆分配，分配失败时打印日志并返回 NULL；子资源（results 数组）分配失败时先 `free(ctx)` 再返回 NULL。
- **`test_destroy`**：增加 NULL 守卫，依次释放内部资源（`ctx->results`）与自身（`ctx`）。
- **`protocol_test_run`**：`struct test_ctx ctx` → `struct test_ctx *ctx`，`&ctx` → `ctx`，`ctx.` → `ctx->`，create 后增加 NULL 检查。
- **`.h` 声明同步更新**：`void test_init(struct test_ctx *)` → `struct test_ctx *test_ctx_create(void)`。

## 改动范围

30 个文件（15 `.c` + 15 `.h`），+485 / -260，全部位于 `tests/protocols/`。

## 验证

- 全部 15 个文件编译链接通过
- 12 项测试通过
- Code Review 审核通过 ✅

## 关联 Issue

[WM-329](https://agent-dev.uniontech.com/wm/issues/WM-329)

## Summary by Sourcery

Unify protocol test context lifecycle management across the protocol test suite.

Enhancements:
- Standardize the 15 protocol tests on heap-allocated test contexts with consistent creation, cleanup, and destruction semantics.
- Improve test-context allocation failure handling and make destruction safe for null contexts.