### PR TITLE
fix(tests): remove unused protocols subdirectory build

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,5 @@
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
-add_subdirectory(protocols)
 
 add_subdirectory(test_protocol_personalization)
 add_subdirectory(test_protocol_primary-output)


### PR DESCRIPTION
test

Log: test
PMS: BUG-374965
Influence:

## Summary by Sourcery

Build:
- Stop including the protocols test subdirectory in the test build configuration.