### PR TITLE
fix(xwayland): handle size hint updates

### DIFF
--- a/waylib/src/server/protocols/wxwaylandsurface.cpp
+++ b/waylib/src/server/protocols/wxwaylandsurface.cpp
@@ -107,7 +107,7 @@ void WXWaylandSurfacePrivate::init()
     });
     q->listeners()->add(&m_handle->events.set_override_redirect, q, &WXWaylandSurface::bypassManagerChanged);
     q->listeners()->add(&m_handle->events.set_geometry, q, &WXWaylandSurface::geometryChanged);
-    q->listeners()->add(&m_handle->events.set_hints, this, &WXWaylandSurfacePrivate::updateSizeHints);
+    q->listeners()->add(&m_handle->events.set_size_hints, this, &WXWaylandSurfacePrivate::updateSizeHints);
     q->listeners()->add(&m_handle->events.set_window_type, this, &WXWaylandSurfacePrivate::updateWindowTypes);
     q->listeners()->add(&m_handle->events.set_decorations, q, &WXWaylandSurface::decorationsFlagsChanged);
     q->listeners()->add(&m_handle->events.set_title, q, &WXWaylandSurface::titleChanged);

--- a/waylib/tests/unit_tests/test_native_handles/main.cpp
+++ b/waylib/tests/unit_tests/test_native_handles/main.cpp
@@ -165,7 +165,7 @@ class NativeHandlesTest : public QObject
                  &surface->events.request_resize,
                  &surface->events.set_override_redirect,
                  &surface->events.set_geometry,
-                 &surface->events.set_hints,
+                 &surface->events.set_size_hints,
                  &surface->events.set_window_type,
                  &surface->events.set_decorations,
                  &surface->events.set_title,


### PR DESCRIPTION
Listen to the XWayland set_size_hints event so minimum and maximum window sizes are updated when clients change their size constraints.

Log: fix XWayland window size hint updates
PMS: BUG-371235
Influence: XWayland window size constraints

## Summary by Sourcery

Handle XWayland size-hint updates so window minimum and maximum sizes remain current.

Bug Fixes:
- Update XWayland window size constraints when clients change their size hints.

Tests:
- Update native-handle event coverage to use the XWayland size-hints event.