### PR TITLE
fix(xwayland): honor client resize configure requests

### DIFF
--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -438,6 +438,25 @@ void SurfaceWrapper::setup()
                         moveNormalGeometryInOutput(xwaylandSurfaceItem->implicitPosition());
                 });
 
+        connect(xwaylandSurface,
+                &WXWaylandSurface::requestConfigure,
+                this,
+                [this, xwaylandSurface, xwaylandSurfaceItem]() {
+                    const auto flags = xwaylandSurface->requestConfigureFlags();
+                    if (!flags.testAnyFlags(WXWaylandSurface::XCB_CONFIG_WINDOW_SIZE))
+                        return;
+
+                    const qreal ratio = xwaylandSurfaceItem->surfaceSizeRatio();
+                    const QSizeF paddings(xwaylandSurfaceItem->leftPadding()
+                                              + xwaylandSurfaceItem->rightPadding(),
+                                          xwaylandSurfaceItem->topPadding()
+                                              + xwaylandSurfaceItem->bottomPadding());
+                    const QSizeF requestedSize = QSizeF(xwaylandSurface->requestConfigureGeometry().size())
+                        / ratio + paddings;
+
+                    setSize(alignGeometryToPixelGrid(QRectF(position(), requestedSize)).size());
+                });
+
         connect(this, &QQuickItem::xChanged, xwaylandSurface, [this, xwaylandSurfaceItem]() {
             xwaylandSurfaceItem->moveTo(position(), !m_xwaylandPositionFromSurface);
         });

--- a/waylib/src/server/qtquick/wxwaylandsurfaceitem.cpp
+++ b/waylib/src/server/qtquick/wxwaylandsurfaceitem.cpp
@@ -42,14 +42,15 @@ QSize WXWaylandSurfaceItemPrivate::expectSurfaceSize() const
     const Q_Q(WXWaylandSurfaceItem);
     using enum WXWaylandSurfaceItem::ResizeMode;
 
-    if (q->resizeMode() == SizeFromSurface) {
-        const bool useRequestSize = !q->xwaylandSurface()->isBypassManager()
-            && q->xwaylandSurface()->requestConfigureFlags()
-                   .testAnyFlags(WXWaylandSurface::XCB_CONFIG_WINDOW_SIZE);
-        return useRequestSize
-            ? q->xwaylandSurface()->requestConfigureGeometry().size()
-            : q->xwaylandSurface()->geometry().size();
-    } else if (q->resizeMode() == SizeToSurface) {
+    const auto resizeMode = q->resizeMode();
+    const bool useRequestSize = resizeMode != SizeToSurface
+        && !q->xwaylandSurface()->isBypassManager()
+        && q->xwaylandSurface()->requestConfigureFlags()
+               .testAnyFlags(WXWaylandSurface::XCB_CONFIG_WINDOW_SIZE);
+    if (useRequestSize)
+        return q->xwaylandSurface()->requestConfigureGeometry().size();
+
+    if (resizeMode == SizeToSurface) {
         const auto s = (q->size() - paddingsSize()) * surfaceSizeRatio;
         return s.toSize();
     }


### PR DESCRIPTION
Apply client-requested XWayland geometry to the surface item and wrapper so resizing works in all directions and the new size is preserved when the window is moved.

Log: fix XWayland window resize and size restoration issues
PMS: BUG-371235
Influence: XWayland window resize and move behavior

## Summary by Sourcery

Honor XWayland client resize requests to fix window resizing and size restoration during movement.

Bug Fixes:
- Honor XWayland client-requested sizes so window resizing works consistently in all directions and requested sizes are preserved when moving windows.

Enhancements:
- Keep surface item sizing and wrapper geometry synchronized with XWayland configure requests across applicable resize modes.