### PR TITLE
refactor(surface): drop redundant fullscreen re-arrangement

### DIFF
--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -1919,14 +1919,8 @@ void SurfaceWrapper::enterFullscreen(WOutput *targetOutput)
     if (targetOutput) {
         auto *helper = Helper::instance();
         auto *target = helper ? helper->getOutput(targetOutput) : nullptr;
-        if (target && target != m_ownsOutput
-            && target->isSource()) {
-            Output *oldOutput = m_ownsOutput;
+        if (target && target != m_ownsOutput && target->isSource()) 
             setOwnsOutput(target);
-            m_fullscreenGeometry = target->geometry();
-            if (oldOutput)
-                oldOutput->arrangeAllSurfaces();
-        }
     }
 
     setSurfaceState(State::Fullscreen);


### PR DESCRIPTION
Remove old output variable and geometry copy in enterFullscreen; the old output is updated automatically and needs no arrangeAllSurfaces.

移除 enterFullscreen 中的冗余代码：旧输出与全屏几何自动更新，
已移除的屏幕无需重排。

Log: 移除全屏切换中的冗余代码
PMS: TASK-394659
Influence: 行为不变，仅清理冗余逻辑；全屏/退出全屏路径不受影响。

## Summary by Sourcery

Enhancements:
- Remove redundant fullscreen transition logic while preserving existing fullscreen and exit-fullscreen behavior.