### PR TITLE
refactor: extract set_region lambda to member function

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,8 @@ ctest --preset ci
 
 ## Project Rules
 - Use C++20 and Qt6 only.
+- Prefer member function pointers over lambdas for `connect()` and signal listeners when the lambda only forwards to a single member function.
+- Avoid complex lambdas; if a lambda body grows beyond a few lines, extract it into a named member function.
 - Keep diffs minimal: touch only task-related files and symbols.
 - Avoid broad refactors, unrelated renames, and unrelated reformatting.
 - New source files must include an SPDX line consistent with this repo, typically `SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only`.

--- a/src/seat/pointerconstraintsmanager.cpp
+++ b/src/seat/pointerconstraintsmanager.cpp
@@ -28,9 +28,7 @@ PointerConstraintsManager::PointerConstraintsManager(WPointerConstraintsV1 *cons
             &PointerConstraintsManager::onNewConstraint);
 
     // active-window change triggers constraint re-evaluation.
-    connect(Helper::instance(), &Helper::activatedSurfaceChanged, this, [this]() {
-        onActiveWindowChanged();
-    });
+    connect(Helper::instance(), &Helper::activatedSurfaceChanged, this, &PointerConstraintsManager::onActiveWindowChanged);
 
     auto *helper = Helper::instance();
     auto *seatManager = helper->seatManager();
@@ -56,35 +54,7 @@ void PointerConstraintsManager::onNewConstraint(wlr_pointer_constraint_v1 *const
     auto *constraintOwner = new WListenerOwner();
     constraint->data = constraintOwner;
     constraintOwner->listeners()->add(&constraint->events.set_region, this, [this, constraint]() {
-        if (!m_active.contains(constraint)) {
-            // Not yet active: try to activate now that
-            // wlroots has updated the effective region.
-            tryActivateConstraint(constraint);
-            return;
-        }
-
-        // LOCKED: region changes do not affect a frozen cursor.
-        if (constraint->type == WLR_POINTER_CONSTRAINT_V1_LOCKED)
-            return;
-
-        // CONFINED: unconfine if the pointer leaves the new region.
-        wlr_seat *wlrSeat = constraint->seat;
-        if (!wlrSeat)
-            return;
-        const double sx = wlrSeat->pointer_state.sx;
-        const double sy = wlrSeat->pointer_state.sy;
-        if (pixman_region32_contains_point(&constraint->region, floor(sx), floor(sy), NULL))
-            return;
-        // Deferred: synchronous send_deactivated inside
-        // wlr_signal_emit_mutable would assert-fail on the
-        // still-iterated listener.
-        QMetaObject::invokeMethod(
-            this,
-            [this, constraint]() {
-                if (m_constraints.contains(constraint))
-                    deactivateConstraint(constraint);
-            },
-            Qt::QueuedConnection);
+        onConstraintRegionChanged(constraint);
     });
     constraintOwner->listeners()->add(&constraint->events.destroy, this, [this, constraint]() {
         onConstraintDestroyed(constraint);
@@ -175,6 +145,39 @@ void PointerConstraintsManager::deactivateConstraint(wlr_pointer_constraint_v1 *
     // not touch the constraint object after this call (the destroy listener
     // above will fire and clean up the owner).
     wlr_pointer_constraint_v1_send_deactivated(constraint);
+}
+
+void PointerConstraintsManager::onConstraintRegionChanged(wlr_pointer_constraint_v1 *constraint)
+{
+    if (!m_active.contains(constraint)) {
+        // Not yet active: try to activate now that
+        // wlroots has updated the effective region.
+        tryActivateConstraint(constraint);
+        return;
+    }
+
+    // LOCKED: region changes do not affect a frozen cursor.
+    if (constraint->type == WLR_POINTER_CONSTRAINT_V1_LOCKED)
+        return;
+
+    // CONFINED: unconfine if the pointer leaves the new region.
+    wlr_seat *wlrSeat = constraint->seat;
+    if (!wlrSeat)
+        return;
+    const double sx = wlrSeat->pointer_state.sx;
+    const double sy = wlrSeat->pointer_state.sy;
+    if (pixman_region32_contains_point(&constraint->region, floor(sx), floor(sy), NULL))
+        return;
+    // Deferred: synchronous send_deactivated inside
+    // wlr_signal_emit_mutable would assert-fail on the
+    // still-iterated listener.
+    QMetaObject::invokeMethod(
+        this,
+        [this, constraint]() {
+            if (m_constraints.contains(constraint))
+                deactivateConstraint(constraint);
+        },
+        Qt::QueuedConnection);
 }
 
 void PointerConstraintsManager::onConstraintDestroyed(wlr_pointer_constraint_v1 *constraint)

--- a/src/seat/pointerconstraintsmanager.h
+++ b/src/seat/pointerconstraintsmanager.h
@@ -39,6 +39,7 @@ private:
     bool canActivate(wlr_pointer_constraint_v1 *constraint) const;
     void tryActivateConstraint(wlr_pointer_constraint_v1 *constraint);
     void deactivateConstraint(wlr_pointer_constraint_v1 *constraint);
+    void onConstraintRegionChanged(wlr_pointer_constraint_v1 *constraint);
     void onConstraintDestroyed(wlr_pointer_constraint_v1 *constraint);
     void releaseConstraintCursor(wlr_pointer_constraint_v1 *constraint);
     void onActiveWindowChanged();


### PR DESCRIPTION
1. Replace trivial forwarding lambda in activatedSurfaceChanged connect() with a direct member function pointer.
2. Extract the 20-line set_region listener lambda into the named member function onConstraintRegionChanged().
3. Add lambda usage guidelines to AGENTS.md Project Rules.

refactor: 将 set_region lambda 提取为成员函数

1. 将 activatedSurfaceChanged 连接中的简单转发 lambda 替换为直接的成员函数指针。
2. 将 set_region 监听器的 20 行 lambda 提取为命名 成员函数 onConstraintRegionChanged()。
3. 在 AGENTS.md 项目规则中添加 lambda 使用指南。

Log: 无用户可见变化

PMS: TASK-390751

## Summary by Sourcery

Refactor pointer constraint signal handling to use named member functions and establish clearer lambda usage guidelines.

Enhancements:
- Replace forwarding and complex signal-listener lambdas with direct member-function connections and named handlers for pointer constraint updates.

Documentation:
- Document project guidelines for preferring member-function pointers and extracting complex lambdas.