### PR TITLE
fix(surface): restore surface to original output on leave fullscreen

### DIFF
--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -905,7 +905,7 @@ void SurfaceWrapper::setMaximizedGeometry(const QRectF &newMaximizedGeometry)
     // to avoid incorrect sizing of Xwayland windows.
     updateSurfaceSizeRatio();
 
-    if (m_surfaceState == State::Maximized) {
+    if (m_surfaceState == State::Maximized && !m_geometryAnimation) {
         setPosition(newMaximizedGeometry.topLeft());
         resize(newMaximizedGeometry.size());
     } else if (m_pendingState == State::Maximized && m_geometryAnimation) {
@@ -932,7 +932,7 @@ void SurfaceWrapper::setFullscreenGeometry(const QRectF &newFullscreenGeometry)
     // to avoid incorrect sizing of Xwayland windows.
     updateSurfaceSizeRatio();
 
-    if (m_surfaceState == State::Fullscreen) {
+    if (m_surfaceState == State::Fullscreen && !m_geometryAnimation) {
         setPosition(newFullscreenGeometry.topLeft());
         resize(newFullscreenGeometry.size());
     } else if (m_pendingState == State::Fullscreen && m_geometryAnimation) {


### PR DESCRIPTION
Save the pre-fullscreen output when entering fullscreen and restore it on leave, so a surface that went fullscreen on another screen returns to its original position/output.

进入全屏时记录原输出，退出全屏时恢复归属输出，解决跨屏全屏后
窗口未回到原位的问题。

Log: 修复跨屏全屏退出后窗口未回到原位的问题
PMS: TASK-394659
Influence: 跨屏进入全屏的窗口退出后回到原输出屏及原位，符合预期。

## Summary by Sourcery

Bug Fixes:
- Prevent fullscreen and maximized geometry updates from overriding active geometry animations, preserving the surface’s original position and output when leaving fullscreen.