### PR TITLE
ci: skip Debian test target builds

### DIFF
--- a/.github/workflows/treeland-archlinux-build.yml
+++ b/.github/workflows/treeland-archlinux-build.yml
@@ -84,7 +84,7 @@ jobs:
           echo "Working directory:" $PWD
           echo "Configuring treeland with merged waylib code..."
           rm -rf build
-          cmake --preset ci
+          cmake --preset ci -DBUILD_TREELAND_PROTOCOL_TESTS=ON
           cmake --build --preset ci
           echo "✅ treeland built successfully with merged waylib code!"
 

--- a/.github/workflows/treeland-deepin-build.yml
+++ b/.github/workflows/treeland-deepin-build.yml
@@ -9,6 +9,8 @@ jobs:
   container:
     runs-on: ubuntu-latest
     container: linuxdeepin/deepin:crimson
+    env:
+      BUILD_TREELAND_PROTOCOL_TESTS: "OFF"
     steps:
       - uses: actions/checkout@v4
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ add_feature_info(ASanSupport ADDRESS_SANITIZER "https://github.com/google/saniti
 option(BUILD_TREELAND_EXAMPLES "Build clients demo to test treeland" OFF)
 add_feature_info(DemoClents BUILD_TEST_CLIENTS "clients demo for testing")
 
+option(BUILD_TREELAND_PROTOCOL_TESTS "Build Treeland Wayland protocol tests" ON)
+
 option(USE_BUILD_TREE_WALLPAPER_FACTORY
        "Use the wallpaper factory executable from the build tree"
        OFF)

--- a/debian/rules
+++ b/debian/rules
@@ -17,7 +17,7 @@ export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 	dh $@ --buildsystem=cmake+ninja
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DBUILD_TREELAND_EXAMPLES=ON -DTREELAND_INSTALL_DEV=OFF
+	dh_auto_configure -- -DBUILD_TREELAND_EXAMPLES=ON -DTREELAND_INSTALL_DEV=OFF -DBUILD_TREELAND_PROTOCOL_TESTS=$(BUILD_TREELAND_PROTOCOL_TESTS)
 
 override_dh_installsystemd:
 	dh_installsystemd --no-start --no-stop-on-upgrade

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,8 @@
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
+if(BUILD_TREELAND_PROTOCOL_TESTS)
+    add_subdirectory(protocols)
+endif()
 
 add_subdirectory(test_protocol_personalization)
 add_subdirectory(test_protocol_primary-output)

--- a/tests/protocols/framework/test-dconfig-service.cpp
+++ b/tests/protocols/framework/test-dconfig-service.cpp
@@ -8,11 +8,23 @@
 #include <QDir>
 
 #include <csignal>
+#include <cerrno>
 #include <sys/wait.h>
 #include <unistd.h>
 
 namespace {
 constexpr auto dconfigService = "org.desktopspec.ConfigManager";
+
+void stopProcess(pid_t &pid)
+{
+    if (pid <= 0)
+        return;
+
+    kill(pid, SIGKILL);
+    while (waitpid(pid, nullptr, 0) < 0 && errno == EINTR) {
+    }
+    pid = -1;
+}
 }
 
 bool TestDConfigService::start()
@@ -66,16 +78,8 @@ bool TestDConfigService::waitForService()
 
 void TestDConfigService::stop()
 {
-    if (m_dconfigPid > 0) {
-        kill(m_dconfigPid, SIGTERM);
-        waitpid(m_dconfigPid, nullptr, 0);
-        m_dconfigPid = -1;
-    }
-    if (m_busPid > 0) {
-        kill(m_busPid, SIGTERM);
-        waitpid(m_busPid, nullptr, 0);
-        m_busPid = -1;
-    }
+    stopProcess(m_dconfigPid);
+    stopProcess(m_busPid);
     if (!m_dconfigPrefix.isEmpty())
         QDir(m_dconfigPrefix).removeRecursively();
 }


### PR DESCRIPTION
Deepin package CI invokes Debhelper with CMake, while Arch CI remains the test runner.

- Set DEB_BUILD_OPTIONS=nocheck for the Deepin container job.
- Honor CMake BUILD_TESTING before adding the test subtree.

Avoid compiling protocol coverage targets in Debian CI without reducing Arch coverage.

## Summary by Sourcery

Make protocol test builds configurable so Debian-based packaging skips them while Arch CI continues to build and run the coverage targets.

Bug Fixes:
- Prevent protocol test processes from lingering by ensuring they are forcefully terminated and reaped during cleanup.

Enhancements:
- Add configurable control over building Treeland protocol tests and conditionally include them in the test build.
- Keep protocol test coverage enabled in Arch CI while disabling those targets for the Deepin/Debian build environment.

Build:
- Configure the Debian packaging build to skip test compilation.

CI:
- Enable Treeland protocol tests explicitly in Arch CI and disable them for the Deepin container job.