### PR TITLE
refactor: replace hardcoded etc path with CMake variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,8 @@ GNUInstallDirs_get_absolute_install_dir(
     DATADIR
 )
 
+set(TREELAND_SYSCONFDIR "${CMAKE_INSTALL_FULL_SYSCONFDIR}/treeland" CACHE PATH "treeland system config directory")
+
 add_compile_definitions("TREELAND_DATA_DIR=\"${TREELAND_FULL_DATA_DIR}\"")
 # NOTE:: remove force assert before stable version
 add_compile_definitions("QT_FORCE_ASSERTS")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -283,6 +283,7 @@ qt_add_repc_sources(libtreeland
 target_compile_definitions(libtreeland
     PRIVATE
     WLR_USE_UNSTABLE
+    "TREELAND_SYSCONFDIR=\"${TREELAND_SYSCONFDIR}\""
 )
 
 if (USE_BUILD_TREE_WALLPAPER_FACTORY)

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1981,7 +1981,7 @@ void Helper::init(Treeland::Treeland *treeland)
 
     // Initialize seats from configuration
     m_primarySeat =
-        m_seatManager->initializeFromConfig("/etc/deepin/treeland/seats.json", m_server);
+        m_seatManager->initializeFromConfig(QStringLiteral(TREELAND_SYSCONFDIR "/seats.json"), m_server);
     if (!m_primarySeat) {
         qCCritical(lcTlCore) << "Failed to initialize seats!";
         return;


### PR DESCRIPTION
1. Introduce TREELAND_SYSCONFDIR as a CACHE PATH variable
2. Replace /etc/deepin/treeland/seats.json with compile-time macro
3. Consistent with existing TREELAND_DATA_DIR pattern in project

Log: No user-facing changes

Influence:
1. Verify seats.json is loaded from CMAKE_INSTALL_FULL_SYSCONFDIR/treeland/
2. Verify cmake configure succeeds with default and custom SYSCONFDIR
3. Verify multi-seat initialization still falls back to default seat

refactor: 用 CMake 变量替换硬编码的 etc 路径

1. 通过 CACHE PATH 引入 TREELAND_SYSCONFDIR 变量
2. 将 /etc/deepin/treeland/seats.json 替换为编译期宏
3. 与项目中已有的 TREELAND_DATA_DIR 模式保持一致

Log: 无用户可见变化

Influence:
1. 验证 seats.json 从 CMAKE_INSTALL_FULL_SYSCONFDIR/treeland/ 加载
2. 验证 cmake configure 在默认和自定义 SYSCONFDIR 下均成功
3. 验证多座位初始化仍能正确回退到默认座位

PMS: TASK-390751

## Summary by Sourcery

Replace the hardcoded seats configuration path with a configurable CMake system configuration directory.

Enhancements:
- Make the Treeland system configuration directory configurable through CMake and use it when loading the seats configuration.

Build:
- Add the TREELAND_SYSCONFDIR CMake cache path and expose it as a compile-time definition.