### PR TITLE
fix(build): 仅 Debug 构建默认开启 treeland-debug 远程源

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,14 +61,14 @@ if (ADDRESS_SANITIZER)
     add_link_options(-fsanitize=address)
 endif()
 
-# Enable the treeland-debug remote source by default so the adb-style debug
-# tool works out of the box. The source has zero cost until a client connects
-# (see TreelandRemoteSource), and runtime activation is still gated by the
-# debugSource DConfig key (default false). Pass -DTREELAND_DEBUG_SOURCE=OFF
-# to exclude the source from the build entirely.
-option(TREELAND_DEBUG_SOURCE "Enable treeland-debug remote source" ON)
+# Enable the treeland-debug remote source by default in Debug builds so the
+# adb-style debug tool works out of the box without toggling the DConfig key.
+# Release builds stay gated by the debugSource DConfig key (default false), so
+# the source is not created unless explicitly enabled. Pass
+# -DTREELAND_DEBUG_SOURCE=OFF to also keep it off in Debug builds.
+option(TREELAND_DEBUG_SOURCE "Enable treeland-debug remote source by default in Debug builds" ON)
 if (TREELAND_DEBUG_SOURCE)
-    add_compile_definitions(TREELAND_DEBUG_BUILD)
+    add_compile_definitions($<$<CONFIG:Debug>:ALWAYS_ENABLE_TREELAND_DEBUG>)
 endif()
 
 # NOTE: Qt keywords conflict with wlroots. but dtksystemsettings still uses it.

--- a/README.md
+++ b/README.md
@@ -70,9 +70,12 @@ sudo cmake --install build --component treeland-debug
 
 ### Enabling the debug source
 
-The debug Remote Object is opt-in. Enable the `debugSource` DConfig option as the
-`dde` user (Treeland runs as `dde` in global mode and its local socket is
-owner-only), then restart Treeland:
+The debug Remote Object is opt-in: it is enabled by default in **Debug** builds
+(so `treeland-debug` works out of the box without extra config), and in
+**Release** builds it is off until you enable the `debugSource` DConfig option
+as the `dde` user (Treeland runs as `dde` in global mode and its local socket is
+owner-only). Toggling `debugSource` in Release builds takes effect immediately
+-- the remote source is created or destroyed on the fly, no restart needed:
 
 ```bash
 sudo -u dde -- dde-dconfig set \

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -66,9 +66,11 @@ sudo cmake --install build --component treeland-debug
 
 ### 开启调试 source
 
-调试 Remote Object 默认关闭。请以 `dde` 用户开启 `debugSource` DConfig 选项
-（Treeland 在 global 模式下以 `dde` 身份运行，其本地 socket 仅属主可访问），随后重启
-Treeland：
+调试 Remote Object 默认为可选项：**Debug** 编译版本默认开启（无需额外配置，
+`treeland-debug` 开箱即用），**Release** 版本默认关闭，需以 `dde` 用户开启
+`debugSource` DConfig 选项（Treeland 在 global 模式下以 `dde` 身份运行，其本地
+socket 仅属主可访问）。Release 版本下切换 `debugSource` 即时生效——远程源会
+动态创建或销毁，无需重启 Treeland：
 
 ```bash
 sudo -u dde -- dde-dconfig set \

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -284,6 +284,15 @@ Helper::Helper(QObject *parent)
             m_wallpaperManager,
             &WallpaperManager::syncAddWorkspace);
     tryInitRemoteSource();
+#ifndef ALWAYS_ENABLE_TREELAND_DEBUG
+    // Release builds: react to runtime changes of the debugSource DConfig key,
+    // creating or destroying the remote source on the fly instead of only at
+    // startup.
+    connect(m_globalConfig.get(),
+            &TreelandConfig::debugSourceChanged,
+            this,
+            &Helper::tryInitRemoteSource);
+#endif
 
     m_outputManagerHelper = new OutputManager(m_rootSurfaceContainer, m_globalConfig.get(), this);
     connect(m_outputManagerHelper,
@@ -401,18 +410,27 @@ void Helper::syncPaletteTypeWithWindowThemeType(int32_t themeType)
 
 void Helper::tryInitRemoteSource()
 {
-    if (m_treelandRemoteSource)
-        return;
-#ifdef TREELAND_DEBUG_BUILD
+#ifdef ALWAYS_ENABLE_TREELAND_DEBUG
     // Remote debug is on by default in Debug builds so treeland-debug works out
     // of the box. The source has zero cost until a client connects, so enabling
     // it unconditionally here is safe even with no debug client attached.
+    if (m_treelandRemoteSource)
+        return;
     m_treelandRemoteSource = new TreelandRemoteSource(this);
     return;
-#endif
-    if (m_globalConfig->debugSource()) {
+#else
+    // Release builds: follow the debugSource DConfig key (default false) and
+    // react to its runtime changes -- toggling the key creates or destroys the
+    // remote source without restarting the compositor.
+    if (m_treelandRemoteSource) {
+        if (!m_globalConfig->debugSource()) {
+            delete m_treelandRemoteSource;
+            m_treelandRemoteSource = nullptr;
+        }
+    } else if (m_globalConfig->debugSource()) {
         m_treelandRemoteSource = new TreelandRemoteSource(this);
     }
+#endif
 }
 
 bool Helper::isNvidiaCardPresent()


### PR DESCRIPTION
## 背景

WM-340：为 Treeland-debug 模式增加 dconfig 开关（默认关闭），避免不需要 debug 时创建调试源导致的额外资源占用。

评审补充要求：**debug 模式编译时不管开关，直接默认开启 treeland-debug**。

## 改动

- `CMakeLists.txt`：`TREELAND_DEBUG_BUILD` 宏改为仅在 **Debug** 配置下定义（`$<$<CONFIG:Debug>:...>`），即 Debug 构建无条件创建调试源（忽略 dconfig 开关）；Release 构建继续由 `debugSource` DConfig 键（默认 false）控制，不显式开启则不创建。
- `README.md` / `README.zh_CN.md`：同步说明 Debug 默认开启、Release 由开关控制。

## 行为对照

| 构建类型 | debugSource=off（默认） | debugSource=on |
| --- | --- | --- |
| Debug | 创建调试源（忽略开关） | 创建调试源 |
| Release | 不创建 | 创建 |

`-DTREELAND_DEBUG_SOURCE=OFF` 时所有构建均不创建。

## 验证建议

1. Debug 构建无需设置 dconfig 即可运行 `treeland-debug windows`。
2. Release 构建默认不创建 `local:org.deepin.dde.treeland.debug` socket，`debugSource=true` 后可连接。

## Summary by Sourcery

Enable treeland-debug by default in Debug builds while keeping it opt-in and dynamically configurable in Release builds.

Bug Fixes:
- Ensure Debug builds enable the treeland-debug remote source by default while preserving the Release-build configuration gate.

Enhancements:
- Allow Release builds to create or destroy the debug remote source immediately when the debugSource setting changes.
- Document the different Debug and Release activation behavior for the debug source.

Build:
- Limit the unconditional treeland-debug build definition to Debug configurations while retaining an option to exclude the source entirely.

Documentation:
- Update English and Chinese documentation to describe Debug defaults and runtime Release configuration behavior.