### PR TITLE
fix(greeter): don't enter greeter when --lockscreen is absent

### DIFF
--- a/src/greeter/greeterproxy.cpp
+++ b/src/greeter/greeterproxy.cpp
@@ -9,6 +9,7 @@
 #include "seat/helper.h"
 #include "session/session.h"
 #include "common/treelandlogging.h"
+#include "utils/cmdline.h"
 #include "core/lockscreen.h"
 
 // DDM
@@ -133,7 +134,10 @@ GreeterProxy::GreeterProxy(QObject *parent)
             lock();
         }
     });
-    m_undecidedTimer->start();
+    m_undecided = CmdLine::ref().useLockScreen();
+    if (m_undecided) {
+        m_undecidedTimer->start();
+    }
 
     conn.connect(Logind::serviceName(),
                  Logind::managerPath(),


### PR DESCRIPTION
Only enable the undecided state and its 5s fallback timer in the --lockscreen

仅在 --lockscreen 锁屏模式下启用 undecided 待决状态及 5 秒兜底定时器

Log: 修复未加 --lockscreen 时误进入 greeter 的问题
PMS: BUG-390751
Influence: 未加 --lockscreen 启动 treeland 时不再误显示登录界面。

## Summary by Sourcery

Only enable greeter fallback behavior when lockscreen mode is requested.

Bug Fixes:
- Prevent the greeter from being displayed when Treeland starts without the --lockscreen option.
- Restrict the undecided state and its fallback timer to lockscreen mode.