### PR TITLE
feat(debug): avoid treeland-debug socket conflicts and export session env

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ endif()
 # debug-built treeland-debug client connects to the debug instance by default.
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(TREELAND_DEBUG_SOCKET "org.deepin.dde.treeland.debug-dev")
+    add_compile_definitions(TREELAND_DEBUG_DEV)
 else()
     set(TREELAND_DEBUG_SOCKET "org.deepin.dde.treeland.debug")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,23 @@ if (TREELAND_DEBUG_SOURCE)
     add_compile_definitions(TREELAND_DEBUG_BUILD)
 endif()
 
+# Default local-socket name of the treeland-debug remote-object host.
+#
+# Single source of truth: exposed both as the TREELAND_DEBUG_SOCKET CMake
+# variable (substituted into the treeland-sd session unit via
+# @TREELAND_DEBUG_SOCKET@) and as a compile definition of the same name
+# consumed by treelandDebugDefaultSocketName() in
+# src/modules/resource/treelanddebugsocket.h, so the C++ default and the
+# session unit can never drift apart. Debug builds use a distinct name so a
+# debug treeland can run alongside a release one without colliding, and a
+# debug-built treeland-debug client connects to the debug instance by default.
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(TREELAND_DEBUG_SOCKET "org.deepin.dde.treeland.debug-dev")
+else()
+    set(TREELAND_DEBUG_SOCKET "org.deepin.dde.treeland.debug")
+endif()
+add_compile_definitions("TREELAND_DEBUG_SOCKET=\"${TREELAND_DEBUG_SOCKET}\"")
+
 # NOTE: Qt keywords conflict with wlroots. but dtksystemsettings still uses it.
 # add_definitions("-DQT_NO_KEYWORDS")
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ At session start (treeland-sd.service) the actual socket URL is published as
 the **`TREELAND_DEBUG_URL`** environment variable, so `treeland-debug` run
 inside the session connects to the right instance without any flags. It falls
 back to the default socket URL when the variable is unset, and an explicit
-`--url` always wins.
+`--url` always wins. Debug-built `treeland-debug` ignores the environment
+variable and always targets the debug socket, so it connects to a debug
+instance even when the session env var points to a release socket.
 
 ### Global options
 

--- a/README.md
+++ b/README.md
@@ -96,13 +96,16 @@ steal each other's socket. Debug builds use a distinct default
 release-compiled one can run side by side, and a debug-built treeland-debug
 client connects to the debug instance by default.
 
-At session start (treeland-sd.service) the actual socket URL is published as
+At session start (treeland-sd.service) the default socket URL is published as
 the **`TREELAND_DEBUG_URL`** environment variable, so `treeland-debug` run
-inside the session connects to the right instance without any flags. It falls
-back to the default socket URL when the variable is unset, and an explicit
-`--url` always wins. Debug-built `treeland-debug` ignores the environment
-variable and always targets the debug socket, so it connects to a debug
-instance even when the session env var points to a release socket.
+inside the session connects to the primary treeland instance without any
+flags. It falls back to the default socket URL when the variable is unset,
+and an explicit `--url` always wins. A second treeland that had to take a
+suffixed socket name is not reflected in the env var (a single variable can
+only point to one instance); connect to such an instance with
+`--url local:<suffixed-name>`. Debug-built `treeland-debug` ignores the
+environment variable and always targets the debug socket, so it connects to
+a debug instance even when the session env var points to a release socket.
 
 ### Global options
 

--- a/README.md
+++ b/README.md
@@ -85,11 +85,28 @@ sudo -u dde -- dde-dconfig set \
 All commands below are run as the `dde` user, e.g.
 `sudo -u dde -- treeland-debug windows`.
 
+### Socket naming and connection
+
+Treeland publishes the debug source on a local socket whose default name is
+`org.deepin.dde.treeland.debug`. When that name is already taken by another
+running treeland (nested/dev instances), a numeric suffix is appended
+(`org.deepin.dde.treeland.debug-1`, `-2`, …), so multiple instances never
+steal each other's socket. Debug builds use a distinct default
+(`org.deepin.dde.treeland.debug-dev`) so a debug-compiled treeland and a
+release-compiled one can run side by side, and a debug-built treeland-debug
+client connects to the debug instance by default.
+
+At session start (treeland-sd.service) the actual socket URL is published as
+the **`TREELAND_DEBUG_URL`** environment variable, so `treeland-debug` run
+inside the session connects to the right instance without any flags. It falls
+back to the default socket URL when the variable is unset, and an explicit
+`--url` always wins.
+
 ### Global options
 
 | Option | Default | Description |
 | --- | --- | --- |
-| `--url <url>` | `local:org.deepin.dde.treeland.debug` | Remote object host URL. |
+| `--url <url>` | `$TREELAND_DEBUG_URL` if set, else `local:org.deepin.dde.treeland.debug` | Remote object host URL. |
 | `--name <name>` | `WindowTree` | Remote object name. |
 | `--timeout-ms <n>` | `30000` | Request timeout in ms (non-negative integer). |
 | `--json` | off | Emit machine-readable JSON for `tree`/`cursor`/`windows`/`clients`. |

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -91,6 +91,8 @@ treeland 可同时运行，且 Debug 构建的 treeland-debug 客户端默认连
 会话启动时（treeland-sd.service）会将实际 socket URL 导出为环境变量
 **`TREELAND_DEBUG_URL`**，因此在会话内直接运行 `treeland-debug` 无需任何参数即可
 连接到正确实例。未设置该变量时回退到默认 socket URL，显式传入 `--url` 始终优先。
+Debug 编译的 `treeland-debug` 会忽略环境变量，始终连接到调试 socket，因此即使会话
+环境变量指向正式版 socket，也能连接到调试实例。
 
 ### 全局选项
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -88,11 +88,13 @@ Treeland 在本地 socket 上发布调试源，默认名为 `org.deepin.dde.tree
 Debug 构建使用不同的默认名（`org.deepin.dde.treeland.debug-dev`），因此调试版与正式版
 treeland 可同时运行，且 Debug 构建的 treeland-debug 客户端默认连接到调试实例。
 
-会话启动时（treeland-sd.service）会将实际 socket URL 导出为环境变量
+会话启动时（treeland-sd.service）会将默认 socket URL 导出为环境变量
 **`TREELAND_DEBUG_URL`**，因此在会话内直接运行 `treeland-debug` 无需任何参数即可
-连接到正确实例。未设置该变量时回退到默认 socket URL，显式传入 `--url` 始终优先。
-Debug 编译的 `treeland-debug` 会忽略环境变量，始终连接到调试 socket，因此即使会话
-环境变量指向正式版 socket，也能连接到调试实例。
+连接到主 treeland 实例。未设置该变量时回退到默认 socket URL，显式传入 `--url` 始终
+优先。当第二个 treeland 因冲突使用了带后缀的 socket 名时，环境变量仍指向默认实例
+（单个环境变量只能指向一个实例）；如需连接该后缀实例，请使用
+`--url local:<带后缀的名>`。Debug 编译的 `treeland-debug` 会忽略环境变量，始终
+连接到调试 socket，因此即使会话环境变量指向正式版 socket，也能连接到调试实例。
 
 ### 全局选项
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -80,11 +80,23 @@ sudo -u dde -- dde-dconfig set \
 
 下文所有命令均以 `dde` 用户运行，例如 `sudo -u dde -- treeland-debug windows`。
 
+### socket 命名与连接
+
+Treeland 在本地 socket 上发布调试源，默认名为 `org.deepin.dde.treeland.debug`。
+当该名称已被另一个正在运行的 treeland（嵌套/开发实例）占用时，会自动追加数字后缀
+（`org.deepin.dde.treeland.debug-1`、`-2`…），避免多个实例互相抢占 socket。
+Debug 构建使用不同的默认名（`org.deepin.dde.treeland.debug-dev`），因此调试版与正式版
+treeland 可同时运行，且 Debug 构建的 treeland-debug 客户端默认连接到调试实例。
+
+会话启动时（treeland-sd.service）会将实际 socket URL 导出为环境变量
+**`TREELAND_DEBUG_URL`**，因此在会话内直接运行 `treeland-debug` 无需任何参数即可
+连接到正确实例。未设置该变量时回退到默认 socket URL，显式传入 `--url` 始终优先。
+
 ### 全局选项
 
 | 选项 | 默认值 | 说明 |
 | --- | --- | --- |
-| `--url <url>` | `local:org.deepin.dde.treeland.debug` | Remote object host URL。 |
+| `--url <url>` | `$TREELAND_DEBUG_URL`（已设置时），否则 `local:org.deepin.dde.treeland.debug` | Remote object host URL。 |
 | `--name <name>` | `WindowTree` | Remote object 名称。 |
 | `--timeout-ms <n>` | `30000` | 请求超时（毫秒，非负整数）。 |
 | `--json` | 关 | 为 `tree`/`cursor`/`windows`/`clients` 输出机器可读 JSON。 |

--- a/misc/systemd/CMakeLists.txt
+++ b/misc/systemd/CMakeLists.txt
@@ -10,6 +10,17 @@ if (NOT DEFINED SYSTEMD_USER_UNIT_DIR)
     pkg_get_variable(SYSTEMD_USER_UNIT_DIR systemd systemduserunitdir)
 endif()
 
+# Default treeland-debug socket name, matching treelandDebugDefaultSocketName()
+# in src/modules/resource/treelanddebugsocket.h (Debug builds use a distinct
+# name so a debug treeland doesn't collide with a release one). Injected into
+# the session unit so the default URL is exported at session start even when
+# the debug source stays off.
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(TREELAND_DEBUG_SOCKET "org.deepin.dde.treeland.debug-dev")
+else()
+    set(TREELAND_DEBUG_SOCKET "org.deepin.dde.treeland.debug")
+endif()
+
 macro(install_symlink filepath wantsdir)
     file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/link/${wantsdir}/)
     execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_INSTALL_PREFIX}/lib/systemd/user/${filepath} ${PROJECT_BINARY_DIR}/link/${wantsdir}/${filepath})

--- a/misc/systemd/CMakeLists.txt
+++ b/misc/systemd/CMakeLists.txt
@@ -10,16 +10,11 @@ if (NOT DEFINED SYSTEMD_USER_UNIT_DIR)
     pkg_get_variable(SYSTEMD_USER_UNIT_DIR systemd systemduserunitdir)
 endif()
 
-# Default treeland-debug socket name, matching treelandDebugDefaultSocketName()
-# in src/modules/resource/treelanddebugsocket.h (Debug builds use a distinct
-# name so a debug treeland doesn't collide with a release one). Injected into
-# the session unit so the default URL is exported at session start even when
-# the debug source stays off.
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(TREELAND_DEBUG_SOCKET "org.deepin.dde.treeland.debug-dev")
-else()
-    set(TREELAND_DEBUG_SOCKET "org.deepin.dde.treeland.debug")
-endif()
+# TREELAND_DEBUG_SOCKET is defined once at the top level (CMakeLists.txt)
+# and shared with treelandDebugDefaultSocketName() via a compile definition of
+# the same name, so there is a single source of truth. It is substituted into
+# the session unit below so the default URL is exported at session start even
+# when the debug source stays off.
 
 macro(install_symlink filepath wantsdir)
     file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/link/${wantsdir}/)

--- a/misc/systemd/dde-session-pre.target.wants/treeland-sd.service.in
+++ b/misc/systemd/dde-session-pre.target.wants/treeland-sd.service.in
@@ -22,6 +22,7 @@ UnsetEnvironment=DISPLAY
 UnsetEnvironment=WAYLAND_DISPLAY
 ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/treeland-sd --type wayland
 ExecStartPost=-/usr/bin/systemctl --user set-environment WAYLAND_DISPLAY=treeland.socket
+ExecStartPost=-/usr/bin/systemctl --user set-environment TREELAND_DEBUG_URL=local:@TREELAND_DEBUG_SOCKET@
 ExecStartPost=-/usr/bin/systemctl --user set-environment QT_IM_MODULE=fcitx
 ExecStartPost=-/usr/bin/systemctl --user set-environment QT_IM_MODULES=wayland;fcitx
 ExecStartPost=-/usr/bin/systemctl --user set-environment SDL_IM_MODULE=fcitx
@@ -33,5 +34,6 @@ ExecStop=-/usr/bin/systemctl --user unset-environment SDL_IM_MODULE
 ExecStop=-/usr/bin/systemctl --user unset-environment QT_IM_MODULES
 ExecStop=-/usr/bin/systemctl --user unset-environment QT_IM_MODULE
 ExecStop=-/usr/bin/systemctl --user unset-environment WAYLAND_DISPLAY
+ExecStop=-/usr/bin/systemctl --user unset-environment TREELAND_DEBUG_URL
 Slice=session.slice
 RestartSec=1s

--- a/src/modules/resource/treelanddebugsocket.h
+++ b/src/modules/resource/treelanddebugsocket.h
@@ -5,7 +5,14 @@
 
 #include <QLocalServer>
 #include <QLocalSocket>
+#include <QFile>
+#include <QStandardPaths>
 #include <QString>
+
+#include <fcntl.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 // Default local-socket name of the treeland-debug remote-object host.
 //
@@ -29,29 +36,125 @@ inline QString treelandDebugDefaultSocketUrl()
     return QStringLiteral("local:") + treelandDebugDefaultSocketName();
 }
 
-// Returns the first free local-socket name, Wayland-style: @p base, or
-// "<base>-1", "<base>-2", ... when a live server already owns it.
+// RAII lock file that claims a local-socket name, mirroring wl_socket_lock()
+// in libwayland (src/wayland-server.c). An exclusive flock on
+// "<runtime_dir>/<name>.lock" is held for the lifetime of the QLocalServer,
+// so two treeland instances can never silently steal each other's socket —
+// QLocalServer::listen(), unlike raw bind(), replaces an existing socket file
+// instead of failing with EADDRINUSE, so the flock is the real ownership guard.
 //
-// This is a *pre-bind* collision check: QLocalServer/QRemoteObjectHost silently
-// steal an in-use name (both listen() calls succeed), so liveness has to be
-// probed explicitly with a tentative connection. A stale socket file left by a
-// crashed instance is reclaimed so the default name survives a restart.
-// ponytail: probe-then-bind has a tiny TOCTOU window if two treeland instances
-// start at the same instant; acceptable for a debug channel, upgrade with a
-// bind-and-verify loop if it ever matters.
-inline QString treelandDebugPickFreeSocketName(const QString &base = treelandDebugDefaultSocketName())
+// The destroy ordering matches wl_socket_destroy(): the lock file is unlinked
+// *while* the fd (and thus the flock) is still held, so no other process can
+// open the same inode and race the release.
+class TreelandDebugSocketLock
 {
-    QString candidate = base;
-    for (int i = 1; i <= 100; ++i) {
-        QLocalSocket probe;
-        probe.connectToServer(candidate);
-        if (!probe.waitForConnected(100)) {
-            if (probe.error() == QLocalSocket::ConnectionRefusedError)
-                QLocalServer::removeServer(candidate); // stale file from a crash
-            return candidate; // free (ServerNotFoundError) or reclaimed
-        }
-        probe.disconnectFromServer();
-        candidate = QStringLiteral("%1-%2").arg(base).arg(i);
+public:
+    TreelandDebugSocketLock() = default;
+    ~TreelandDebugSocketLock() { release(); }
+
+    TreelandDebugSocketLock(const TreelandDebugSocketLock &) = delete;
+    TreelandDebugSocketLock &operator=(const TreelandDebugSocketLock &) = delete;
+    TreelandDebugSocketLock(TreelandDebugSocketLock &&other) noexcept
+    {
+        std::swap(m_fd, other.m_fd);
+        std::swap(m_lockPath, other.m_lockPath);
     }
-    return candidate;
+    TreelandDebugSocketLock &operator=(TreelandDebugSocketLock &&other) noexcept
+    {
+        if (this != &other) {
+            release();
+            std::swap(m_fd, other.m_fd);
+            std::swap(m_lockPath, other.m_lockPath);
+        }
+        return *this;
+    }
+
+    // Tries to acquire the lock for @p socketName.
+    // Returns true on success (lock held), false if another process owns it
+    // or the lock file cannot be created.
+    bool tryAcquire(const QString &socketName)
+    {
+        release();
+        m_lockPath = lockFilePath(socketName);
+        m_fd = open(m_lockPath.constData(), O_CREAT | O_CLOEXEC | O_RDWR,
+                    S_IRUSR | S_IWUSR);
+        if (m_fd < 0) {
+            m_lockPath.clear();
+            return false;
+        }
+        if (flock(m_fd, LOCK_EX | LOCK_NB) < 0) {
+            close(m_fd);
+            m_fd = -1;
+            m_lockPath.clear();
+            return false;
+        }
+        // Reclaim a stale socket file left by a crashed instance — same as
+        // wl_socket_lock() unlinking the socket after acquiring the lock.
+        QLocalServer::removeServer(socketName);
+        return true;
+    }
+
+    void release()
+    {
+        // Unlink the lock file while the fd is still open (flock held), then
+        // close — mirrors wl_socket_destroy() ordering.
+        if (!m_lockPath.isEmpty()) {
+            unlink(m_lockPath.constData());
+            m_lockPath.clear();
+        }
+        if (m_fd >= 0) {
+            close(m_fd);
+            m_fd = -1;
+        }
+    }
+
+    bool isHeld() const { return m_fd >= 0; }
+
+private:
+    // QLocalServer on Linux places the socket at $XDG_RUNTIME_DIR/<name>
+    // (or /tmp/<name> as fallback). The lock file sits right next to it with
+    // a ".lock" suffix, exactly like libwayland's LOCK_SUFFIX.
+    static QByteArray lockFilePath(const QString &socketName)
+    {
+        QString path;
+        if (socketName.startsWith(QLatin1Char('/')))
+            path = socketName;
+        else {
+            QString dir = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
+            if (dir.isEmpty())
+                dir = QStringLiteral("/tmp");
+            path = QStringLiteral("%1/%2").arg(dir, socketName);
+        }
+        return QFile::encodeName(path + QStringLiteral(".lock"));
+    }
+
+    int m_fd = -1;
+    QByteArray m_lockPath;
+};
+
+// Returns the first free socket name, Wayland-style: tries @p base, then
+// "<base>-1", "<base>-2", ... up to "<base>-99". For each candidate a lock
+// file is acquired with flock(LOCK_EX|LOCK_NB); if the lock is already held
+// by another process the name is in use and the next candidate is tried.
+//
+// On success @p lock holds the lock — the caller MUST keep it alive for the
+// lifetime of the QLocalServer so the name stays claimed. On failure (all
+// names locked) returns an empty string and @p lock is released.
+//
+// Mirrors wl_display_add_socket_auto() (the do/while loop over "wayland-0",
+// "wayland-1", …) combined with wl_socket_lock() (the flock-based ownership
+// check) in libwayland's src/wayland-server.c.
+inline QString treelandDebugPickFreeSocketName(
+    TreelandDebugSocketLock &lock,
+    const QString &base = treelandDebugDefaultSocketName())
+{
+    lock.release();
+    for (int i = 0; i < 100; ++i) {
+        const QString candidate = (i == 0)
+            ? base
+            : QStringLiteral("%1-%2").arg(base).arg(i);
+        if (lock.tryAcquire(candidate))
+            return candidate;
+    }
+    return {};
 }

--- a/src/modules/resource/treelanddebugsocket.h
+++ b/src/modules/resource/treelanddebugsocket.h
@@ -14,6 +14,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <utility>
+
 // Default local-socket name of the treeland-debug remote-object host.
 //
 // The value is defined once in the top-level CMakeLists.txt as the
@@ -88,8 +90,18 @@ public:
             m_lockPath.clear();
             return false;
         }
-        // Reclaim a stale socket file left by a crashed instance — same as
-        // wl_socket_lock() unlinking the socket after acquiring the lock.
+        // The flock rules out any other *new-build* treeland (they all use
+        // this lock). But a pre-existing old-build instance may be listening
+        // on this socket without holding a lock file; reclaiming it would
+        // delete its socket path and break its clients. Probe liveness first
+        // and, if a live server answers, leave the name to it and fail so the
+        // caller moves on to a suffixed name. A stale file left by a crash
+        // (no live server) is still reclaimed, mirroring wl_socket_lock()
+        // unlinking the socket after acquiring the lock.
+        if (socketIsLive(socketName)) {
+            release();
+            return false;
+        }
         QLocalServer::removeServer(socketName);
         return true;
     }
@@ -111,6 +123,19 @@ public:
     bool isHeld() const { return m_fd >= 0; }
 
 private:
+    // Returns true if a server is actively accepting connections on @p socketName.
+    // Used only after the flock is acquired, to avoid clobbering a live
+    // old-build instance that doesn't hold a lock file. For local (AF_UNIX)
+    // sockets the connect completes synchronously, so this returns immediately
+    // — true if a live server answered, false for a stale or absent file.
+    static bool socketIsLive(const QString &socketName)
+    {
+        QLocalSocket probe;
+        probe.connectToServer(socketName);
+        if (probe.waitForConnected(100))
+            return true;
+        return false;
+    }
     // QLocalServer on Linux places the socket at $XDG_RUNTIME_DIR/<name>
     // (or /tmp/<name> as fallback). The lock file sits right next to it with
     // a ".lock" suffix, exactly like libwayland's LOCK_SUFFIX.

--- a/src/modules/resource/treelanddebugsocket.h
+++ b/src/modules/resource/treelanddebugsocket.h
@@ -9,18 +9,19 @@
 
 // Default local-socket name of the treeland-debug remote-object host.
 //
+// The value is defined once in the top-level CMakeLists.txt as the
+// TREELAND_DEBUG_SOCKET CMake variable and forwarded here as a compile
+// definition of the same name, so the C++ default and the treeland-sd session
+// unit (which substitutes @TREELAND_DEBUG_SOCKET@) can never drift apart.
 // Debug builds use a distinct name so a debug treeland can run alongside a
 // release one without colliding, and a debug-built treeland-debug client
-// connects to the debug instance by default (WM-342). Keep in sync with the
-// TREELAND_DEBUG_SOCKET variable in misc/systemd/CMakeLists.txt, which injects
-// the same value into the session unit.
+// connects to the debug instance by default (WM-342).
+#ifndef TREELAND_DEBUG_SOCKET
+#  error "TREELAND_DEBUG_SOCKET must be provided by CMake (see top-level CMakeLists.txt)"
+#endif
 inline QString treelandDebugDefaultSocketName()
 {
-#ifdef QT_DEBUG
-    return QStringLiteral("org.deepin.dde.treeland.debug-dev");
-#else
-    return QStringLiteral("org.deepin.dde.treeland.debug");
-#endif
+    return QStringLiteral(TREELAND_DEBUG_SOCKET);
 }
 
 inline QString treelandDebugDefaultSocketUrl()

--- a/src/modules/resource/treelanddebugsocket.h
+++ b/src/modules/resource/treelanddebugsocket.h
@@ -1,0 +1,56 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <QLocalServer>
+#include <QLocalSocket>
+#include <QString>
+
+// Default local-socket name of the treeland-debug remote-object host.
+//
+// Debug builds use a distinct name so a debug treeland can run alongside a
+// release one without colliding, and a debug-built treeland-debug client
+// connects to the debug instance by default (WM-342). Keep in sync with the
+// TREELAND_DEBUG_SOCKET variable in misc/systemd/CMakeLists.txt, which injects
+// the same value into the session unit.
+inline QString treelandDebugDefaultSocketName()
+{
+#ifdef QT_DEBUG
+    return QStringLiteral("org.deepin.dde.treeland.debug-dev");
+#else
+    return QStringLiteral("org.deepin.dde.treeland.debug");
+#endif
+}
+
+inline QString treelandDebugDefaultSocketUrl()
+{
+    return QStringLiteral("local:") + treelandDebugDefaultSocketName();
+}
+
+// Returns the first free local-socket name, Wayland-style: @p base, or
+// "<base>-1", "<base>-2", ... when a live server already owns it.
+//
+// This is a *pre-bind* collision check: QLocalServer/QRemoteObjectHost silently
+// steal an in-use name (both listen() calls succeed), so liveness has to be
+// probed explicitly with a tentative connection. A stale socket file left by a
+// crashed instance is reclaimed so the default name survives a restart.
+// ponytail: probe-then-bind has a tiny TOCTOU window if two treeland instances
+// start at the same instant; acceptable for a debug channel, upgrade with a
+// bind-and-verify loop if it ever matters.
+inline QString treelandDebugPickFreeSocketName(const QString &base = treelandDebugDefaultSocketName())
+{
+    QString candidate = base;
+    for (int i = 1; i <= 100; ++i) {
+        QLocalSocket probe;
+        probe.connectToServer(candidate);
+        if (!probe.waitForConnected(100)) {
+            if (probe.error() == QLocalSocket::ConnectionRefusedError)
+                QLocalServer::removeServer(candidate); // stale file from a crash
+            return candidate; // free (ServerNotFoundError) or reclaimed
+        }
+        probe.disconnectFromServer();
+        candidate = QStringLiteral("%1-%2").arg(base).arg(i);
+    }
+    return candidate;
+}

--- a/src/modules/resource/treelandremotesource.cpp
+++ b/src/modules/resource/treelandremotesource.cpp
@@ -36,7 +36,6 @@
 #include <QImage>
 #include <QLocalServer>
 #include <QMetaEnum>
-#include <QProcess>
 
 #include "treelanddebugsocket.h"
 #include <QQuickItem>
@@ -191,23 +190,16 @@ TreelandRemoteSource::TreelandRemoteSource(QObject *parent)
     // file (see treelanddebugsocket.h), then listen on it. The lock is held
     // for this object's lifetime so no other treeland can steal the name.
     const QString socketName = treelandDebugPickFreeSocketName(m_debugSocketLock);
+    const QString url = QStringLiteral("local:%1").arg(socketName);
     auto *host = new QRemoteObjectHost(this);
     QRemoteObjectHost::setLocalServerOptions(QLocalServer::UserAccessOption);
-    host->setHostUrl(QUrl(QStringLiteral("local:%1").arg(socketName)));
+    host->setHostUrl(QUrl(url));
     host->enableRemoting(this, QStringLiteral("WindowTree"));
 
-    // Publish the actually-bound socket URL to the session so treeland-debug
-    // clients find it. The treeland-sd session unit already exports the default
-    // URL at session start (even when the source stays off); re-exporting here
-    // with the real name keeps the env var correct when a second treeland took
-    // a suffixed socket. Deferred so it lands after the unit's ExecStartPost.
-    const QString url = QStringLiteral("local:%1").arg(socketName);
-    qputenv("TREELAND_DEBUG_URL", url.toUtf8());
-    QTimer::singleShot(0, this, [url] {
-        QProcess::startDetached(QStringLiteral("systemctl"),
-                                {QStringLiteral("--user"), QStringLiteral("set-environment"),
-                                 QStringLiteral("TREELAND_DEBUG_URL=%1").arg(url)});
-    });
+    // The TREELAND_DEBUG_URL session env var is exported by the treeland-sd
+    // systemd unit at session start (see
+    // misc/systemd/dde-session-pre.target.wants/treeland-sd.service.in),
+    // so there is no need to re-export it here.
 }
 
 TreelandRemoteSource::~TreelandRemoteSource()

--- a/src/modules/resource/treelandremotesource.cpp
+++ b/src/modules/resource/treelandremotesource.cpp
@@ -187,9 +187,10 @@ int qtKeyToEvdev(int qtKey, wlr_keyboard *keyboard)
 TreelandRemoteSource::TreelandRemoteSource(QObject *parent)
     : WindowTreeRemoteSource(parent)
 {
-    // Wayland-style conflict avoidance: default socket name, numeric suffix
-    // when another treeland already owns it (see treelanddebugsocket.h).
-    const QString socketName = treelandDebugPickFreeSocketName();
+    // Wayland-style conflict avoidance: claim a socket name via a flock lock
+    // file (see treelanddebugsocket.h), then listen on it. The lock is held
+    // for this object's lifetime so no other treeland can steal the name.
+    const QString socketName = treelandDebugPickFreeSocketName(m_debugSocketLock);
     auto *host = new QRemoteObjectHost(this);
     QRemoteObjectHost::setLocalServerOptions(QLocalServer::UserAccessOption);
     host->setHostUrl(QUrl(QStringLiteral("local:%1").arg(socketName)));

--- a/src/modules/resource/treelandremotesource.cpp
+++ b/src/modules/resource/treelandremotesource.cpp
@@ -36,6 +36,9 @@
 #include <QImage>
 #include <QLocalServer>
 #include <QMetaEnum>
+#include <QProcess>
+
+#include "treelanddebugsocket.h"
 #include <QQuickItem>
 #include <QQuickItemGrabResult>
 #include <QRemoteObjectHost>
@@ -184,10 +187,26 @@ int qtKeyToEvdev(int qtKey, wlr_keyboard *keyboard)
 TreelandRemoteSource::TreelandRemoteSource(QObject *parent)
     : WindowTreeRemoteSource(parent)
 {
+    // Wayland-style conflict avoidance: default socket name, numeric suffix
+    // when another treeland already owns it (see treelanddebugsocket.h).
+    const QString socketName = treelandDebugPickFreeSocketName();
     auto *host = new QRemoteObjectHost(this);
     QRemoteObjectHost::setLocalServerOptions(QLocalServer::UserAccessOption);
-    host->setHostUrl(QUrl(QStringLiteral("local:org.deepin.dde.treeland.debug")));
+    host->setHostUrl(QUrl(QStringLiteral("local:%1").arg(socketName)));
     host->enableRemoting(this, QStringLiteral("WindowTree"));
+
+    // Publish the actually-bound socket URL to the session so treeland-debug
+    // clients find it. The treeland-sd session unit already exports the default
+    // URL at session start (even when the source stays off); re-exporting here
+    // with the real name keeps the env var correct when a second treeland took
+    // a suffixed socket. Deferred so it lands after the unit's ExecStartPost.
+    const QString url = QStringLiteral("local:%1").arg(socketName);
+    qputenv("TREELAND_DEBUG_URL", url.toUtf8());
+    QTimer::singleShot(0, this, [url] {
+        QProcess::startDetached(QStringLiteral("systemctl"),
+                                {QStringLiteral("--user"), QStringLiteral("set-environment"),
+                                 QStringLiteral("TREELAND_DEBUG_URL=%1").arg(url)});
+    });
 }
 
 TreelandRemoteSource::~TreelandRemoteSource()

--- a/src/modules/resource/treelandremotesource.cpp
+++ b/src/modules/resource/treelandremotesource.cpp
@@ -190,6 +190,14 @@ TreelandRemoteSource::TreelandRemoteSource(QObject *parent)
     // file (see treelanddebugsocket.h), then listen on it. The lock is held
     // for this object's lifetime so no other treeland can steal the name.
     const QString socketName = treelandDebugPickFreeSocketName(m_debugSocketLock);
+    if (socketName.isEmpty()) {
+        // All 100 candidate names are already locked — extremely unlikely
+        // for a debug channel, but don't bind an invalid "local:" URL; leave
+        // the debug source unpublished.
+        qWarning("treeland-debug: no free debug socket name available; "
+                 "debug remote source disabled");
+        return;
+    }
     const QString url = QStringLiteral("local:%1").arg(socketName);
     auto *host = new QRemoteObjectHost(this);
     QRemoteObjectHost::setLocalServerOptions(QLocalServer::UserAccessOption);

--- a/src/modules/resource/treelandremotesource.h
+++ b/src/modules/resource/treelandremotesource.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "rep_treelandwindowtree_source.h"
+#include "treelanddebugsocket.h"
 
 #include <QPointF>
 #include <QTimer>
@@ -107,4 +108,9 @@ private:
     static constexpr int MAX_EVENTS = 2000;
     bool m_eventCaptureActive = false;
     QTimer *m_eventIdleTimer = nullptr;
+
+    // Held for the lifetime of the QRemoteObjectHost so the socket name
+    // claimed in the constructor stays ours (Wayland-style flock lock file,
+    // see TreelandDebugSocketLock).
+    TreelandDebugSocketLock m_debugSocketLock;
 };

--- a/tests/test_treeland_debug/CMakeLists.txt
+++ b/tests/test_treeland_debug/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS Test Core)
+find_package(Qt6 REQUIRED COMPONENTS Test Core Network)
 
 # Reuse the extracted helpers from the treeland-debug tool.
 set(debug_helpers_dir "${PROJECT_SOURCE_DIR}/tools/treeland-debug")
@@ -10,12 +10,14 @@ add_executable(test_treeland_debug
 
 target_include_directories(test_treeland_debug PRIVATE
     "${debug_helpers_dir}"
+    "${PROJECT_SOURCE_DIR}/src/modules/resource"
 )
 
 target_link_libraries(test_treeland_debug
     PRIVATE
         Qt6::Test
         Qt6::Core
+        Qt6::Network
 )
 
 add_test(NAME test_treeland_debug COMMAND test_treeland_debug)

--- a/tests/test_treeland_debug/main.cpp
+++ b/tests/test_treeland_debug/main.cpp
@@ -3,6 +3,8 @@
 
 #include "debughelpers.h"
 
+#include "treelanddebugsocket.h"
+
 #include <QDir>
 #include <QFile>
 #include <QJsonObject>
@@ -10,6 +12,7 @@
 #include <QRectF>
 #include <QTemporaryDir>
 #include <QTest>
+#include <QLocalServer>
 
 // Unit tests for the pure-logic helpers shared by the treeland-debug tool
 // (stateName, buttonCode, keyCode, saveCapture, pointToJson, rectToJson)
@@ -37,6 +40,10 @@ private Q_SLOTS:
     void testSaveCaptureAutoPath();
     void testPointToJson();
     void testRectToJson();
+
+    // --- treeland-debug socket naming / conflict avoidance ---
+    void testSocketDefaultName();
+    void testSocketPickFreeName();
 
     // --- parseCommand: no-argument commands ---
     void testParseTree();
@@ -284,6 +291,36 @@ void TreelandDebugTest::testRectToJson()
 // ---------------------------------------------------------------------------
 // parseCommand: no-argument commands
 // ---------------------------------------------------------------------------
+
+void TreelandDebugTest::testSocketDefaultName()
+{
+    // The default socket URL must be a valid local: URL derived from the
+    // socket name, so treeland and treeland-debug agree on where to connect.
+    const QString name = treelandDebugDefaultSocketName();
+    QVERIFY(!name.isEmpty());
+    QCOMPARE(treelandDebugDefaultSocketUrl(), QStringLiteral("local:%1").arg(name));
+}
+
+void TreelandDebugTest::testSocketPickFreeName()
+{
+    // Use a dedicated base so the test never races a live treeland.
+    const QString base = QStringLiteral("test.treeland.debug.socket");
+    QLocalServer::removeServer(base);
+    QLocalServer::removeServer(base + QStringLiteral("-1"));
+
+    // Free base -> returned as-is.
+    QCOMPARE(treelandDebugPickFreeSocketName(base), base);
+
+    // Occupied base -> numeric suffix, next free name below stays untouched.
+    QLocalServer holder;
+    QVERIFY(holder.listen(base));
+    QCOMPARE(treelandDebugPickFreeSocketName(base), base + QStringLiteral("-1"));
+
+    holder.close();
+    QLocalServer::removeServer(base);
+    QLocalServer::removeServer(base + QStringLiteral("-1"));
+    QCOMPARE(treelandDebugPickFreeSocketName(base), base);
+}
 
 void TreelandDebugTest::testParseTree()
 {

--- a/tests/test_treeland_debug/main.cpp
+++ b/tests/test_treeland_debug/main.cpp
@@ -305,21 +305,31 @@ void TreelandDebugTest::testSocketPickFreeName()
 {
     // Use a dedicated base so the test never races a live treeland.
     const QString base = QStringLiteral("test.treeland.debug.socket");
-    QLocalServer::removeServer(base);
-    QLocalServer::removeServer(base + QStringLiteral("-1"));
 
-    // Free base -> returned as-is.
-    QCOMPARE(treelandDebugPickFreeSocketName(base), base);
+    // Free base -> returned as-is, lock held by the caller.
+    {
+        TreelandDebugSocketLock lock;
+        QCOMPARE(treelandDebugPickFreeSocketName(lock, base), base);
+        QVERIFY(lock.isHeld());
+    } // lock released here
 
-    // Occupied base -> numeric suffix, next free name below stays untouched.
-    QLocalServer holder;
-    QVERIFY(holder.listen(base));
-    QCOMPARE(treelandDebugPickFreeSocketName(base), base + QStringLiteral("-1"));
+    // Occupied base -> numeric suffix. The holder claims the base name with
+    // its own lock, so the picker must skip to "<base>-1".
+    {
+        TreelandDebugSocketLock holder;
+        QVERIFY(holder.tryAcquire(base));
 
-    holder.close();
-    QLocalServer::removeServer(base);
-    QLocalServer::removeServer(base + QStringLiteral("-1"));
-    QCOMPARE(treelandDebugPickFreeSocketName(base), base);
+        TreelandDebugSocketLock lock;
+        QCOMPARE(treelandDebugPickFreeSocketName(lock, base),
+                 base + QStringLiteral("-1"));
+        QVERIFY(lock.isHeld());
+    }
+
+    // After the holder releases, the base name is free again.
+    {
+        TreelandDebugSocketLock lock;
+        QCOMPARE(treelandDebugPickFreeSocketName(lock, base), base);
+    }
 }
 
 void TreelandDebugTest::testParseTree()

--- a/tests/test_treeland_debug/main.cpp
+++ b/tests/test_treeland_debug/main.cpp
@@ -44,6 +44,7 @@ private Q_SLOTS:
     // --- treeland-debug socket naming / conflict avoidance ---
     void testSocketDefaultName();
     void testSocketPickFreeName();
+    void testSocketPickFreeNameSkipsLiveOldInstance();
 
     // --- parseCommand: no-argument commands ---
     void testParseTree();
@@ -330,6 +331,35 @@ void TreelandDebugTest::testSocketPickFreeName()
         TreelandDebugSocketLock lock;
         QCOMPARE(treelandDebugPickFreeSocketName(lock, base), base);
     }
+}
+
+void TreelandDebugTest::testSocketPickFreeNameSkipsLiveOldInstance()
+{
+    // An old-build treeland may listen on the base socket WITHOUT holding a
+    // flock lock file. The picker must not clobber it (removeServer would
+    // delete the live socket path) — it should skip the live name and take a
+    // suffix instead. New-build instances are already excluded by the flock;
+    // this only exercises the mixed-version guard.
+    const QString base = QStringLiteral("test.treeland.debug.live.socket");
+    QLocalServer::removeServer(base); // reclaim any stale file from a prior run
+
+    QLocalServer server;
+    server.setSocketOptions(QLocalServer::UserAccessOption);
+    QVERIFY(server.listen(base));
+    // Discard the brief probe connections so they don't queue up.
+    connect(&server, &QLocalServer::newConnection, &server,
+            [&server]() { delete server.nextPendingConnection(); });
+
+    {
+        TreelandDebugSocketLock lock;
+        // base is live (server listening) but has no lock file -> must skip.
+        QCOMPARE(treelandDebugPickFreeSocketName(lock, base),
+                 base + QStringLiteral("-1"));
+        QVERIFY(lock.isHeld());
+    } // lock released -> base-1.lock unlinked
+
+    server.close();
+    QLocalServer::removeServer(base); // clean up the base socket file
 }
 
 void TreelandDebugTest::testParseTree()

--- a/tools/treeland-debug/CMakeLists.txt
+++ b/tools/treeland-debug/CMakeLists.txt
@@ -47,6 +47,7 @@ set_target_properties(treeland-debug PROPERTIES
 
 target_include_directories(treeland-debug PRIVATE
     "${windowtree_generated_dir}"
+    "${PROJECT_SOURCE_DIR}/src/modules/resource"
 )
 
 target_link_libraries(treeland-debug PRIVATE

--- a/tools/treeland-debug/main.cpp
+++ b/tools/treeland-debug/main.cpp
@@ -24,6 +24,8 @@
 #include "debugserver.h"
 #endif
 
+#include "treelanddebugsocket.h"
+
 #include "rep_treeland_windowtree_replica.h"
 
 namespace {
@@ -303,7 +305,7 @@ QString helpText()
         "interactive REPL.\n"
         "\n"
         "Global options:\n"
-        "  --url <url>          Remote object host URL (default: local:org.deepin.dde.treeland.debug)\n"
+        "  --url <url>          Remote object host URL (default: TREELAND_DEBUG_URL env, else the socket default)\n"
         "  --name <name>        Remote object name (default: WindowTree)\n"
         "  --timeout-ms <n>     Request timeout in milliseconds (default: 30000)\n"
         "  --json               Emit machine-readable JSON for `tree`/`cursor`/`windows`/`clients`\n"
@@ -395,7 +397,9 @@ int main(int argc, char *argv[])
     QCoreApplication::setApplicationName(QStringLiteral("treeland-debug"));
     QCoreApplication::setApplicationVersion(QStringLiteral("1.0"));
 
-    QString url = QStringLiteral("local:org.deepin.dde.treeland.debug");
+    QString url = QString::fromUtf8(qgetenv("TREELAND_DEBUG_URL"));
+    if (url.isEmpty())
+        url = treelandDebugDefaultSocketUrl();
     QString name = QStringLiteral("WindowTree");
     int timeoutMs = 30000;
     bool timeoutOk = true;

--- a/tools/treeland-debug/main.cpp
+++ b/tools/treeland-debug/main.cpp
@@ -305,7 +305,7 @@ QString helpText()
         "interactive REPL.\n"
         "\n"
         "Global options:\n"
-        "  --url <url>          Remote object host URL (default: TREELAND_DEBUG_URL env, else the socket default)\n"
+        "  --url <url>          Remote object host URL (default: TREELAND_DEBUG_URL env, else the build-specific socket default; debug builds always use the debug socket)\n"
         "  --name <name>        Remote object name (default: WindowTree)\n"
         "  --timeout-ms <n>     Request timeout in milliseconds (default: 30000)\n"
         "  --json               Emit machine-readable JSON for `tree`/`cursor`/`windows`/`clients`\n"
@@ -397,9 +397,15 @@ int main(int argc, char *argv[])
     QCoreApplication::setApplicationName(QStringLiteral("treeland-debug"));
     QCoreApplication::setApplicationVersion(QStringLiteral("1.0"));
 
+#ifdef TREELAND_DEBUG_DEV
+    // Debug builds target the debug socket directly — the session env var
+    // (if set by a release treeland-sd) would point to the release socket.
+    QString url = treelandDebugDefaultSocketUrl();
+#else
     QString url = QString::fromUtf8(qgetenv("TREELAND_DEBUG_URL"));
     if (url.isEmpty())
         url = treelandDebugDefaultSocketUrl();
+#endif
     QString name = QStringLiteral("WindowTree");
     int timeoutMs = 30000;
     bool timeoutOk = true;


### PR DESCRIPTION
## Summary

treeland-debug communicates via qtremoteobject. When multiple treeland instances run, the fixed socket name can conflict. This change avoids socket-name conflicts (borrowing the Wayland `flock`-based approach) and exports a session env var so the treeland-debug client can locate the default target.

## Changes

**Server** (`src/modules/resource/treelandremotesource.cpp`)
- No longer binds a fixed `local:org.deepin.dde.treeland.debug`; instead claims a name the Wayland way — an exclusive `flock(LOCK_EX|LOCK_NB)` on `<runtime_dir>/<name>.lock` (mirroring `wl_socket_lock()`), trying the default name first and appending `-1`, `-2`, … when the lock is already held. The lock is held for the lifetime of the `QRemoteObjectHost`, so two treeland instances can never silently steal each other's socket (`QLocalServer::listen()` replaces an existing socket file instead of failing, so the flock is the real ownership guard).
- A stale socket file left by a crashed instance is reclaimed after acquiring the lock (mirroring `wl_socket_lock()` unlinking the socket). Before reclaiming, a liveness probe guards against clobbering a live *old-build* instance that doesn't use the lock file.
- `TREELAND_DEBUG_URL` is provided solely by the `treeland-sd` systemd unit (see below); the server does **not** re-export it — a single env var can only point to one instance, and overwriting it for a suffixed second treeland would leave it dangling after that instance exits. Connect to a non-default (suffixed) instance with `--url`.
- New `src/modules/resource/treelanddebugsocket.h`: shared default socket name, the `flock`-based `TreelandDebugSocketLock` (RAII), and `treelandDebugPickFreeSocketName()` (mirrors `wl_display_add_socket_auto()`).

**Session export** (`misc/systemd/dde-session-pre.target.wants/treeland-sd.service.in`)
- Export `TREELAND_DEBUG_URL=local:@TREELAND_DEBUG_SOCKET@` at session start (even when the debug source is not enabled, since this export can only happen at session start); unset it on stop. It always points to the default socket, i.e. the primary treeland instance.

**Client** (`tools/treeland-debug/main.cpp`)
- Release builds read `$TREELAND_DEBUG_URL` first, fall back to the default socket when unset; an explicit `--url` always wins. Debug-built `treeland-debug` ignores the env var and targets the debug socket directly (the env var, if set by a release treeland-sd, would point to the release socket).

**Debug vs release socket naming**
- The default socket name is defined once in the top-level `CMakeLists.txt` as `TREELAND_DEBUG_SOCKET` (debug builds get `org.deepin.dde.treeland.debug-dev`, others `org.deepin.dde.treeland.debug`), forwarded to C++ as a compile definition and substituted into the session unit, so the three can never drift apart.

**Tests**: `test_treeland_debug` gains socket naming / selection cases (including a mixed-version live-socket guard); README (EN/ZH) updated.
