### PR TITLE
fix(surface): avoid null shell surface on XWayland teardown

### DIFF
--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -508,6 +508,8 @@ WXWayland *ShellHandler::createXWayland(WServer *server,
     m_xwaylands.append(xwayland);
     xwayland->setSeat(seat);
     connect(xwayland, &WXWayland::surfaceAdded, this, &ShellHandler::onXWaylandSurfaceAdded);
+    // aboutToDissociate never fires when the XWayland instance is torn down.
+    connect(xwayland, &WXWayland::surfaceRemoved, this, &ShellHandler::onXWaylandSurfaceRemoved);
     connect(xwayland, &WXWayland::ready, xwayland, [this, xwayland] {
         auto atomPid = xwayland->atom("_NET_WM_PID");
         xwayland->setAtomSupported(atomPid, true);
@@ -571,6 +573,17 @@ void ShellHandler::onXdgToplevelSurfaceAdded(WXdgToplevelSurface *surface)
     }
     // Async resolve not started or failed -> directly match or create
     ensureXdgWrapper(surface, QString());
+}
+
+void ShellHandler::onXWaylandSurfaceRemoved(WXWaylandSurface *surface)
+{
+    auto *wrapper = m_rootSurfaceContainer->getSurface(surface);
+    if (!wrapper || wrapper->isAboutToRemove())
+        return;
+    if (auto *xwayland = surface->xwayland())
+        xwayland->cancelAsyncProperties(surface->handle()->window_id);
+    Q_EMIT surfaceWrapperAboutToRemove(wrapper);
+    m_rootSurfaceContainer->destroyForSurface(wrapper);
 }
 
 void ShellHandler::ensureXdgWrapper(WXdgToplevelSurface *surface, const QString &targetAppId)

--- a/src/core/shellhandler.h
+++ b/src/core/shellhandler.h
@@ -108,6 +108,7 @@ private Q_SLOTS:
     void onXdgPopupSurfaceRemoved(WAYLIB_SERVER_NAMESPACE::WXdgPopupSurface *surface);
 
     void onXWaylandSurfaceAdded(WAYLIB_SERVER_NAMESPACE::WXWaylandSurface *surface);
+    void onXWaylandSurfaceRemoved(WAYLIB_SERVER_NAMESPACE::WXWaylandSurface *surface);
 
     void onLayerSurfaceAdded(WAYLIB_SERVER_NAMESPACE::WLayerSurface *surface);
     void onLayerSurfaceRemoved(WAYLIB_SERVER_NAMESPACE::WLayerSurface *surface);

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -287,7 +287,6 @@ void SurfaceWrapper::setup()
                 &WSurfaceItem::bufferScaleChanged,
                 this,
                 &SurfaceWrapper::updateSurfaceSizeRatio);
-        updateSurfaceSizeRatio();
         break;
     }
     case Type::InputPopup:
@@ -303,9 +302,11 @@ void SurfaceWrapper::setup()
     }
 
     QQmlEngine::setContextForObject(m_surfaceItem, m_engine->rootContext());
-    m_surfaceItem->setDelegate(m_engine->surfaceContentComponent());
     m_surfaceItem->setResizeMode(WSurfaceItem::ManualResize);
+    // Must set the shell surface before instantiating the QML delegate.
     m_surfaceItem->setShellSurface(m_shellSurface);
+    updateSurfaceSizeRatio();
+    m_surfaceItem->setDelegate(m_engine->surfaceContentComponent());
     // Initialize focus policy even if focus capability state never toggles later.
     m_surfaceItem->setFocusPolicy(hasFocusCapability() ? Qt::StrongFocus : Qt::NoFocus);
 
@@ -1237,6 +1238,11 @@ void SurfaceWrapper::destroy()
     if (!isWindowAnimationRunning())
         deleteLater();
     // else delete this in Animation(for window close animation) finish
+}
+
+bool SurfaceWrapper::isAboutToRemove() const
+{
+    return m_wrapperAboutToRemove;
 }
 
 bool SurfaceWrapper::acceptKeyboardFocus() const
@@ -2440,6 +2446,7 @@ bool SurfaceWrapper::socketEnabled() const
 void SurfaceWrapper::updateSurfaceSizeRatio()
 {
     if (m_type == Type::XWayland && m_surfaceItem && window()) {
+        Q_ASSERT(shellSurface());
         const qreal targetScale = window()->effectiveDevicePixelRatio();
         if (m_surfaceItem->bufferScale() < targetScale)
             m_surfaceItem->setSurfaceSizeRatio(targetScale / m_surfaceItem->bufferScale());

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -309,6 +309,7 @@ public:
     void setHideByLockScreen(bool hide);
 
     void destroy();
+    bool isAboutToRemove() const;
 
     bool acceptKeyboardFocus() const; // set by treeland-dde-shell
     void setAcceptKeyboardFocus(bool accept);

--- a/waylib/src/server/qtquick/wxwaylandsurfaceitem.cpp
+++ b/waylib/src/server/qtquick/wxwaylandsurfaceitem.cpp
@@ -184,6 +184,7 @@ QPointF WXWaylandSurfaceItem::implicitPosition() const
     const Q_D(WXWaylandSurfaceItem);
 
     auto xwaylandSurface = qobject_cast<WXWaylandSurface *>(d->shellSurface);
+    Q_ASSERT(xwaylandSurface);
 
     const QPoint epos = xwaylandSurface->requestConfigureGeometry().topLeft();
     const qreal ssr = d->surfaceSizeRatio;
@@ -246,6 +247,7 @@ void WXWaylandSurfaceItem::surfaceSizeRatioChange()
 
     W_DC(WXWaylandSurfaceItem);
 
+    Q_ASSERT(d->shellSurface);
     if (d->positionConfigured) {
         updatePosition();
     } else {


### PR DESCRIPTION
## Summary by Sourcery

Fix a crash on XWayland teardown caused by a null shell surface by properly cleaning up surface wrappers when XWayland surfaces are removed.

Bug Fixes:
- Handle XWayland surface removal explicitly since aboutToDissociate does not fire when the XWayland instance is torn down, preventing use of a null shell surface.
- Ensure the shell surface is set before the QML delegate is instantiated to avoid null shell surface access during setup.

Enhancements:
- Add assertions to catch null shell surface references earlier in XWayland surface item code.