### PR TITLE
fix(xwayland): keep modal dialogs above parent windows

### DIFF
--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -220,6 +220,9 @@ void ShellHandler::updateWrapperContainer(SurfaceWrapper *wrapper, WSurface *par
     auto oldContainer = wrapper->container();
     if (parentSurface) {
         auto parentWrapper = m_rootSurfaceContainer->getSurface(parentSurface);
+        if (!parentWrapper)
+            return;
+
         auto parentContainer = qobject_cast<SurfaceContainer *>(parentWrapper->container());
         parentWrapper->addSubSurface(wrapper);
         if (oldContainer != parentContainer) {
@@ -942,12 +945,19 @@ void ShellHandler::ensureXwaylandWrapper(WXWaylandSurface *surface, const QStrin
     }
 
     // Initialize wrapper
-    auto updateSurfaceWithParentContainer = [this, wrapper, surface] {
-        updateWrapperContainer(wrapper, surface->parentSurface());
+    wrapper->setModal(surface->isModal());
+    auto surfaceGuard = QPointer<WXWaylandSurface>(surface);
+    auto wrapperGuard = QPointer<SurfaceWrapper>(wrapper);
+    auto updateSurfaceWithParentContainer = [this, surfaceGuard, wrapperGuard] {
+        if (!surfaceGuard || !wrapperGuard || wrapperGuard->shellSurface() != surfaceGuard)
+            return;
+
+        updateWrapperContainer(wrapperGuard, surfaceGuard->parentSurface());
     };
-    QObject::connect(surface, &WXWaylandSurface::parentSurfaceChanged,
-                         this,
-                         updateSurfaceWithParentContainer);
+    QObject::connect(surface,
+                     &WXWaylandSurface::parentSurfaceChanged,
+                     wrapper,
+                     updateSurfaceWithParentContainer);
     updateSurfaceWithParentContainer();
     Q_ASSERT(wrapper->parentItem());
     const auto initialState = surface->handle()->fullscreen

--- a/waylib/src/server/protocols/private/wxwaylandsurface_p.h
+++ b/waylib/src/server/protocols/private/wxwaylandsurface_p.h
@@ -58,6 +58,7 @@ public:
 
     QList<WXWaylandSurface*> children;
     QPointer<WXWaylandSurface> parent;
+    QMetaObject::Connection parentSurfaceConnection;
     QRect lastRequestConfigureGeometry;
     WXWaylandSurface::ConfigureFlags lastRequestConfigureFlags = {0};
     WXWaylandSurface::WindowTypes windowTypes = {0};

--- a/waylib/src/server/protocols/wxwaylandsurface.cpp
+++ b/waylib/src/server/protocols/wxwaylandsurface.cpp
@@ -172,20 +172,27 @@ void WXWaylandSurfacePrivate::updateChildren()
 
 void WXWaylandSurfacePrivate::updateParent()
 {
+    W_Q(WXWaylandSurface);
+
     auto newParent = WXWaylandSurface::fromHandle(handle()->parent);
     if (parent == newParent)
         return;
 
     const bool hasParentChanged = (parent == nullptr) != (newParent == nullptr);
+    QObject::disconnect(parentSurfaceConnection);
     if (parent)
         parent->d_func()->updateChildren();
     parent = newParent;
-    if (parent)
+    if (parent) {
         parent->d_func()->updateChildren();
-
-    W_Q(WXWaylandSurface);
+        parentSurfaceConnection = QObject::connect(parent,
+                                                   &WToplevelSurface::surfaceChanged,
+                                                   q,
+                                                   &WToplevelSurface::parentSurfaceChanged);
+    }
 
     Q_EMIT q->parentXWaylandSurfaceChanged();
+    Q_EMIT q->parentSurfaceChanged();
 
     if (hasParentChanged)
         Q_EMIT q->isToplevelChanged();
@@ -285,6 +292,12 @@ WSurface *WXWaylandSurface::surface() const
     return d->surface;
 }
 
+WSurface *WXWaylandSurface::parentSurface() const
+{
+    W_DC(WXWaylandSurface);
+    return d->parent ? d->parent->surface() : nullptr;
+}
+
 wlr_xwayland_surface *WXWaylandSurface::handle() const
 {
     W_DC(WXWaylandSurface);
@@ -314,8 +327,10 @@ void WXWaylandSurfacePrivate::handleParentDestroyed(WXWaylandSurface *parent)
     // Mirrors what updateParent() would do once the native set_parent event
     // arrives (native parent is already NULL): the wrapper of the dying
     // parent is still alive here, so the QPointer comparison can proceed.
+    QObject::disconnect(parentSurfaceConnection);
     this->parent = nullptr;
     Q_EMIT q->parentXWaylandSurfaceChanged();
+    Q_EMIT q->parentSurfaceChanged();
     Q_EMIT q->isToplevelChanged();
 }
 
@@ -484,6 +499,12 @@ bool WXWaylandSurface::isBypassManager() const
 {
     W_DC(WXWaylandSurface);
     return d->handle()->override_redirect;
+}
+
+bool WXWaylandSurface::isModal() const
+{
+    W_DC(WXWaylandSurface);
+    return d->handle()->modal;
 }
 
 WXWaylandSurface::WindowTypes WXWaylandSurface::windowTypes() const

--- a/waylib/src/server/protocols/wxwaylandsurface.h
+++ b/waylib/src/server/protocols/wxwaylandsurface.h
@@ -79,6 +79,7 @@ public:
     static WXWaylandSurface *fromSurface(WSurface *surface);
 
     WSurface *surface() const override;
+    WSurface *parentSurface() const override;
     wlr_xwayland_surface *handle() const;
     WXWaylandSurface *parentXWaylandSurface() const;
     WXWayland *xwayland() const;
@@ -108,6 +109,7 @@ public:
     ConfigureFlags requestConfigureFlags() const;
 
     bool isBypassManager() const;
+    bool isModal() const;
     WindowTypes windowTypes() const;
     DecorationsFlags decorationsFlags() const;
 


### PR DESCRIPTION
Expose the native XWayland transient parent through parentSurface() and retry wrapper association when the parent wrapper is created asynchronously. Initialize the modal state so activating a parent keeps its modal dialog above it.

Log: fix XWayland modal dialogs falling behind parent windows
PMS: BUG-371095
Influence: XWayland transient window parenting and modal stacking

## Summary by Sourcery

Preserve correct modal stacking for XWayland dialogs by tracking transient parents and retrying wrapper association after asynchronous parent creation.

Bug Fixes:
- Keep XWayland modal dialogs above their parent windows, including when parent wrappers are created asynchronously.

Enhancements:
- Expose native XWayland transient parent surfaces and modal state, and update wrapper associations when parent surfaces change.