### PR TITLE
fix(debug): avoid debug socket conflicts across run modes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,22 @@ if (TREELAND_DEBUG_SOURCE)
     add_compile_definitions(TREELAND_DEBUG_BUILD)
 endif()
 
+# Socket base names for the treeland-debug remote-object channel.
+# Debug builds use a distinct name so a debug-compiled treeland can run
+# alongside a release one in the same runtime directory.  A debug-built
+# treeland-debug client prefers the debug instance and falls back to the
+# release instance when the debug one is unreachable.
+set(TREELAND_DEBUG_SOCKET_RELEASE "org.deepin.dde.treeland.debug")
+set(TREELAND_DEBUG_SOCKET_DEV "org.deepin.dde.treeland.debug-dev")
+# Use generator expressions so multi-config generators (Ninja Multi-Config,
+# Visual Studio) also select the debug socket for Debug configurations.
+add_compile_definitions(
+    "TREELAND_DEBUG_SOCKET_RELEASE=\"${TREELAND_DEBUG_SOCKET_RELEASE}\""
+    "$<$<CONFIG:Debug>:TREELAND_DEBUG_DEV_BUILD>"
+    "$<$<CONFIG:Debug>:TREELAND_DEBUG_SOCKET=\"${TREELAND_DEBUG_SOCKET_DEV}\">"
+    "$<$<NOT:$<CONFIG:Debug>>:TREELAND_DEBUG_SOCKET=\"${TREELAND_DEBUG_SOCKET_RELEASE}\">"
+)
+
 # NOTE: Qt keywords conflict with wlroots. but dtksystemsettings still uses it.
 # add_definitions("-DQT_NO_KEYWORDS")
 

--- a/README.md
+++ b/README.md
@@ -85,11 +85,31 @@ sudo -u dde -- dde-dconfig set \
 All commands below are run as the `dde` user, e.g.
 `sudo -u dde -- treeland-debug windows`.
 
+### Socket naming and connection
+
+Treeland publishes the debug source on a local socket whose default name is
+`org.deepin.dde.treeland.debug` (placed in `QDir::tempPath()` — typically
+`/tmp`, but respects `$TMPDIR` — by Qt, so a client running under any
+`XDG_RUNTIME_DIR` can discover it). When that name is already taken
+by another running treeland (global service, session service, local build),
+a numeric suffix is appended (`org.deepin.dde.treeland.debug-1`, `-2`, …),
+selected with a non-blocking advisory lock (the same approach libwayland uses
+for Wayland sockets). A stale socket file left by a crashed instance is
+reclaimed, and a live old-build instance (one without a lock file) is probed
+and left alone.
+
+Debug builds use a distinct base name (`org.deepin.dde.treeland.debug-dev`)
+so a debug-compiled treeland can run alongside a release one. A debug-built
+treeland-debug client automatically prefers the debug instance and falls back
+to the release instance when the debug one is unreachable; a release-built
+client uses the release instance. An explicit `--url` always overrides this
+with no implicit processing.
+
 ### Global options
 
 | Option | Default | Description |
 | --- | --- | --- |
-| `--url <url>` | `local:org.deepin.dde.treeland.debug` | Remote object host URL. |
+| `--url <url>` | auto: debug socket (debug build) with release fallback, else release socket | Remote object host URL. |
 | `--name <name>` | `WindowTree` | Remote object name. |
 | `--timeout-ms <n>` | `30000` | Request timeout in ms (non-negative integer). |
 | `--json` | off | Emit machine-readable JSON for `tree`/`cursor`/`windows`/`clients`. |

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -80,11 +80,26 @@ sudo -u dde -- dde-dconfig set \
 
 下文所有命令均以 `dde` 用户运行，例如 `sudo -u dde -- treeland-debug windows`。
 
+### socket 命名与连接
+
+Treeland 在本地 socket 上发布调试源，默认名为 `org.deepin.dde.treeland.debug`
+（Qt 将其放在 `QDir::tempPath()`——通常是 `/tmp`，但受 `$TMPDIR` 影响——因此任何
+`XDG_RUNTIME_DIR` 下的客户端都能发现）。当该名称
+已被另一个正在运行的 treeland（全局服务、会话服务、本地构建）占用时，会自动追加数字
+后缀（`org.deepin.dde.treeland.debug-1`、`-2`…），通过非阻塞 advisory lock 选择
+（与 libwayland 选择 Wayland socket 的方式一致）。崩溃实例残留的 socket 文件会被
+回收，而无锁文件的旧版本实例会被探测并跳过。
+
+Debug 构建使用不同的默认名（`org.deepin.dde.treeland.debug-dev`），因此调试版与正式版
+treeland 可同时运行。Debug 构建的 treeland-debug 客户端自动优先连接调试实例，连不上时
+回退到正式版实例；Release 构建的客户端连接正式版实例。显式传入 `--url` 始终优先，不做
+任何隐式处理。
+
 ### 全局选项
 
 | 选项 | 默认值 | 说明 |
 | --- | --- | --- |
-| `--url <url>` | `local:org.deepin.dde.treeland.debug` | Remote object host URL。 |
+| `--url <url>` | 自动：Debug 构建优先调试 socket 并回退到正式版 socket，否则正式版 socket | Remote object host URL。 |
 | `--name <name>` | `WindowTree` | Remote object 名称。 |
 | `--timeout-ms <n>` | `30000` | 请求超时（毫秒，非负整数）。 |
 | `--json` | 关 | 为 `tree`/`cursor`/`windows`/`clients` 输出机器可读 JSON。 |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -177,6 +177,8 @@ qt_add_qml_module(libtreeland
         interfaces/proxyinterface.h
         modules/resource/treelandremotesource.cpp
         modules/resource/treelandremotesource.h
+        modules/resource/treelanddebugsocket.cpp
+        modules/resource/treelanddebugsocket.h
         output/output.cpp
         output/output.h
         output/backlight.h

--- a/src/common/treelandlogging.cpp
+++ b/src/common/treelandlogging.cpp
@@ -93,3 +93,6 @@ Q_LOGGING_CATEGORY(lcTlShellXdg, "treeland.shell.xdg", QtInfoMsg)
 // Hook scripts runner
 Q_LOGGING_CATEGORY(lcTlHooks, "treeland.hooks")
 
+// Debug remote source
+Q_LOGGING_CATEGORY(lcTlDebug, "treeland.debug")
+

--- a/src/common/treelandlogging.h
+++ b/src/common/treelandlogging.h
@@ -97,4 +97,7 @@ Q_DECLARE_LOGGING_CATEGORY(lcTlShellXdg)
 // Hook scripts runner
 Q_DECLARE_LOGGING_CATEGORY(lcTlHooks)
 
+// Debug remote source
+Q_DECLARE_LOGGING_CATEGORY(lcTlDebug)
+
 #endif // TREELAND_LOGGING_H

--- a/src/modules/resource/treelanddebugsocket.cpp
+++ b/src/modules/resource/treelanddebugsocket.cpp
@@ -1,0 +1,163 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "treelanddebugsocket.h"
+
+#include <QDir>
+#include <QFile>
+#include <QLocalServer>
+#include <QLocalSocket>
+
+#include <fcntl.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <utility>
+
+QString treelandDebugDefaultSocketName()
+{
+    return QStringLiteral(TREELAND_DEBUG_SOCKET);
+}
+
+QString treelandDebugDefaultSocketUrl()
+{
+    return QStringLiteral("local:") + treelandDebugDefaultSocketName();
+}
+
+QString treelandDebugReleaseSocketName()
+{
+    return QStringLiteral(TREELAND_DEBUG_SOCKET_RELEASE);
+}
+
+QString treelandDebugReleaseSocketUrl()
+{
+    return QStringLiteral("local:") + treelandDebugReleaseSocketName();
+}
+
+QStringList treelandDebugCandidateSocketUrls()
+{
+#ifdef TREELAND_DEBUG_DEV_BUILD
+    return { treelandDebugDefaultSocketUrl(), treelandDebugReleaseSocketUrl() };
+#else
+    return { treelandDebugDefaultSocketUrl() };
+#endif
+}
+
+// ── TreelandDebugSocketLock ──────────────────────────────────────────────
+
+namespace {
+
+// Returns true if a server is actively accepting connections on @p socketName.
+// Used only after the flock is acquired, to avoid clobbering a live
+// old-build instance that doesn't hold a lock file.  For local (AF_UNIX)
+// sockets, QLocalSocket::connectToServer completes synchronously — a live
+// server is in ConnectedState immediately, a stale/absent socket is in
+// UnconnectedState with an error.  No waitForConnected() is needed, so this
+// never blocks the compositor startup path.
+bool socketIsLive(const QString &socketName)
+{
+    QLocalSocket probe;
+    probe.connectToServer(socketName);
+    return probe.state() == QLocalSocket::ConnectedState;
+}
+
+// Mirrors QLocalServerPrivate::fullServerName: bare names are resolved
+// to <tempDir>/<name>, where tempDir = QDir::tempPath() (respects $TMPDIR,
+// defaults to /tmp on Linux).  Absolute paths are used as-is.  Must match
+// Qt exactly so the lock file sits next to the socket.
+QString resolveFullServerName(const QString &name)
+{
+    if (name.startsWith(QLatin1Char('/')))
+        return name;
+    return QDir::cleanPath(QDir::tempPath()) + QLatin1Char('/') + name;
+}
+
+} // namespace
+
+TreelandDebugSocketLock::~TreelandDebugSocketLock() { release(); }
+
+TreelandDebugSocketLock::TreelandDebugSocketLock(TreelandDebugSocketLock &&other) noexcept
+{
+    std::swap(m_fd, other.m_fd);
+    std::swap(m_lockPath, other.m_lockPath);
+}
+
+TreelandDebugSocketLock &TreelandDebugSocketLock::operator=(TreelandDebugSocketLock &&other) noexcept
+{
+    if (this != &other) {
+        release();
+        std::swap(m_fd, other.m_fd);
+        std::swap(m_lockPath, other.m_lockPath);
+    }
+    return *this;
+}
+
+bool TreelandDebugSocketLock::tryAcquire(const QString &socketName)
+{
+    release();
+    // Resolve the full path Qt would use, so the lock file sits next to the
+    // socket.  QLocalServerPrivate::fullServerName does the same.
+    const QString fullPath = resolveFullServerName(socketName);
+    m_lockPath = QFile::encodeName(fullPath + QStringLiteral(".lock"));
+    m_fd = ::open(m_lockPath.constData(), O_CREAT | O_CLOEXEC | O_RDWR,
+                  S_IRUSR | S_IWUSR);
+    if (m_fd < 0) {
+        m_lockPath.clear();
+        return false;
+    }
+    if (::flock(m_fd, LOCK_EX | LOCK_NB) < 0) {
+        ::close(m_fd);
+        m_fd = -1;
+        m_lockPath.clear();
+        return false;
+    }
+    // The flock rules out any other new-build treeland (they all use this
+    // lock).  But a pre-existing old-build instance may be listening on this
+    // socket without holding a lock file; reclaiming it would delete its
+    // socket path and break its clients.  Probe liveness first and, if a live
+    // server answers, leave the name to it and fail so the caller moves on to
+    // a suffixed name.  A stale file left by a crash (no live server) is still
+    // reclaimed.  For local (AF_UNIX) sockets the connect completes
+    // synchronously, so this probe returns immediately.
+    if (socketIsLive(socketName)) {
+        release();
+        return false;
+    }
+    QLocalServer::removeServer(socketName);
+    return true;
+}
+
+void TreelandDebugSocketLock::release()
+{
+    // Unlink the lock file while the fd is still open (flock held), then
+    // close — mirrors wl_socket_destroy() ordering.
+    if (!m_lockPath.isEmpty()) {
+        ::unlink(m_lockPath.constData());
+        m_lockPath.clear();
+    }
+    if (m_fd >= 0) {
+        ::close(m_fd);
+        m_fd = -1;
+    }
+}
+
+bool TreelandDebugSocketLock::isHeld() const
+{
+    return m_fd >= 0;
+}
+
+QString treelandDebugPickFreeSocketName(
+    TreelandDebugSocketLock &lock,
+    const QString &base)
+{
+    lock.release();
+    for (int i = 0; i < 100; ++i) {
+        const QString candidate = (i == 0)
+            ? base
+            : QStringLiteral("%1-%2").arg(base).arg(i);
+        if (lock.tryAcquire(candidate))
+            return candidate;
+    }
+    return {};
+}

--- a/src/modules/resource/treelanddebugsocket.h
+++ b/src/modules/resource/treelanddebugsocket.h
@@ -1,0 +1,101 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+//
+// Shared socket-naming logic for the treeland-debug remote-object channel.
+//
+// The socket name is a bare name (no path), so Qt's QLocalServer places it
+// in QDir::tempPath() (typically /tmp on Linux, but respects $TMPDIR)
+// regardless of XDG_RUNTIME_DIR.  This lets a treeland-debug client find the
+// compositor's debug socket even when the two run under different runtime
+// directories (e.g. global service as user dde vs. a normal user running
+// treeland-debug).
+//
+// When the default name is already held by a live instance, a numeric suffix
+// is chosen using a non-blocking advisory lock, mirroring libwayland's
+// wl_display_add_socket_auto (see waylib/src/server/kernel/wsocket.cpp).
+// Debug-compiled treeland uses a distinct base name so it can run alongside a
+// release build; a debug-built treeland-debug client prefers the debug socket
+// and falls back to the release socket.
+
+#pragma once
+
+#include <QByteArray>
+#include <QString>
+#include <QStringList>
+
+// Provided by CMake as a compile definition (see top-level CMakeLists.txt).
+#ifndef TREELAND_DEBUG_SOCKET
+#  error "TREELAND_DEBUG_SOCKET must be provided by CMake (see top-level CMakeLists.txt)"
+#endif
+
+// Build-specific socket base name (bare name, no path, no "local:" scheme).
+QString treelandDebugDefaultSocketName();
+
+// Default URL for QRemoteObjectHost / client, e.g.
+// "local:org.deepin.dde.treeland.debug".  Qt resolves the bare name to
+// QDir::tempPath()/<name> (typically /tmp on Linux), so the socket is
+// discoverable regardless of the caller's XDG_RUNTIME_DIR.
+QString treelandDebugDefaultSocketUrl();
+
+// Release-build socket base name (always defined so a debug-built client can
+// fall back to a release instance).
+#ifndef TREELAND_DEBUG_SOCKET_RELEASE
+#  error "TREELAND_DEBUG_SOCKET_RELEASE must be provided by CMake (see top-level CMakeLists.txt)"
+#endif
+QString treelandDebugReleaseSocketName();
+
+// Release socket URL, e.g. "local:org.deepin.dde.treeland.debug".
+QString treelandDebugReleaseSocketUrl();
+
+// Candidate socket URLs for the treeland-debug client, in preference order.
+// A debug-built client prefers the debug instance and falls back to the
+// release instance; a release-built client only uses the release instance.
+// An explicit --url always overrides this list (handled by the caller).
+QStringList treelandDebugCandidateSocketUrls();
+
+// RAII lock that claims a local-socket name, mirroring wl_socket_lock() in
+// libwayland.  An exclusive flock on "<name>.lock" (placed next to the
+// socket by Qt, in QDir::tempPath()) is held for the lifetime of the
+// QLocalServer, so two treeland instances can never silently steal each
+// other's socket — QLocalServer::listen(), unlike raw bind(), replaces an
+// existing socket file instead of failing with EADDRINUSE, so the flock is
+// the real ownership guard.
+//
+// The destroy ordering matches wl_socket_destroy(): the lock file is unlinked
+// *while* the fd (and thus the flock) is still held, so no other process can
+// open the same inode and race the release.
+class TreelandDebugSocketLock
+{
+public:
+    TreelandDebugSocketLock() = default;
+    ~TreelandDebugSocketLock();
+
+    TreelandDebugSocketLock(const TreelandDebugSocketLock &) = delete;
+    TreelandDebugSocketLock &operator=(const TreelandDebugSocketLock &) = delete;
+    TreelandDebugSocketLock(TreelandDebugSocketLock &&other) noexcept;
+    TreelandDebugSocketLock &operator=(TreelandDebugSocketLock &&other) noexcept;
+
+    bool tryAcquire(const QString &socketName);
+    void release();
+    bool isHeld() const;
+
+private:
+    int m_fd = -1;
+    QByteArray m_lockPath;
+};
+
+// Returns the first free socket name, Wayland-style: tries @p base, then
+// "<base>-1", "<base>-2", ... up to "<base>-99".  For each candidate a lock
+// file is acquired with flock(LOCK_EX|LOCK_NB); if the lock is already held
+// by another process the name is in use and the next candidate is tried.
+//
+// On success @p lock holds the lock — the caller MUST keep it alive for the
+// lifetime of the QLocalServer so the name stays claimed.  On failure (all
+// names locked) returns an empty string and @p lock is released.
+//
+// The returned name is a bare name (no path); the caller passes it directly
+// to QRemoteObjectHost as "local:<name>" so Qt resolves it consistently on
+// both server and client.
+QString treelandDebugPickFreeSocketName(
+    TreelandDebugSocketLock &lock,
+    const QString &base = treelandDebugDefaultSocketName());

--- a/src/modules/resource/treelandremotesource.cpp
+++ b/src/modules/resource/treelandremotesource.cpp
@@ -42,6 +42,9 @@
 #include <QSet>
 #include <QTimer>
 #include <QUrl>
+
+#include "treelanddebugsocket.h"
+#include "common/treelandlogging.h"
 #include <private/qxkbcommon_p.h>
 
 WAYLIB_SERVER_USE_NAMESPACE
@@ -184,15 +187,39 @@ int qtKeyToEvdev(int qtKey, wlr_keyboard *keyboard)
 TreelandRemoteSource::TreelandRemoteSource(QObject *parent)
     : WindowTreeRemoteSource(parent)
 {
+    // Pick a conflict-free socket name.  A bare name (no path) lets Qt place
+    // the socket in /tmp so a treeland-debug client running under a different
+    // XDG_RUNTIME_DIR can still discover it.  A concurrent instance takes a
+    // numeric suffix, selected with a non-blocking advisory lock.
+    const QString socketName = treelandDebugPickFreeSocketName(m_debugSocketLock);
+    if (socketName.isEmpty()) {
+        // All 100 candidate names are already locked — extremely unlikely
+        // for a debug channel, but don't bind an invalid URL; leave the debug
+        // source unpublished.
+        qCWarning(lcTlDebug) << "No free debug socket name available; "
+                                "debug remote source disabled";
+        return;
+    }
+
     auto *host = new QRemoteObjectHost(this);
     QRemoteObjectHost::setLocalServerOptions(QLocalServer::UserAccessOption);
-    host->setHostUrl(QUrl(QStringLiteral("local:org.deepin.dde.treeland.debug")));
+    if (!host->setHostUrl(QUrl(QStringLiteral("local:%1").arg(socketName)))) {
+        qCWarning(lcTlDebug) << "Failed to listen on debug socket" << socketName
+                             << "; debug remote source disabled";
+        m_debugSocketLock.release();
+        return;
+    }
     host->enableRemoting(this, QStringLiteral("WindowTree"));
 }
 
 TreelandRemoteSource::~TreelandRemoteSource()
 {
     stopEventCapture();
+    // Destroy the host (parent-owned child) before the socket lock member
+    // releases, so the socket stops listening while we still hold the lock.
+    // Otherwise a concurrent instance could acquire the lock and remove the
+    // socket path while the old host is still alive.
+    delete findChild<QRemoteObjectHost *>();
 }
 
 QPointF TreelandRemoteSource::cursorPosition() const

--- a/src/modules/resource/treelandremotesource.h
+++ b/src/modules/resource/treelandremotesource.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include "rep_treelandwindowtree_source.h"
+#include "treelanddebugsocket.h"
+
 
 #include <QPointF>
 #include <QTimer>
@@ -107,4 +109,8 @@ private:
     static constexpr int MAX_EVENTS = 2000;
     bool m_eventCaptureActive = false;
     QTimer *m_eventIdleTimer = nullptr;
+    // Held for the lifetime of the QRemoteObjectHost so the socket name
+    // claimed in the constructor stays ours (Wayland-style flock lock file,
+    // see TreelandDebugSocketLock).
+    TreelandDebugSocketLock m_debugSocketLock;
 };

--- a/tests/test_treeland_debug/CMakeLists.txt
+++ b/tests/test_treeland_debug/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS Test Core)
+find_package(Qt6 REQUIRED COMPONENTS Test Core Network)
 
 # Reuse the extracted helpers from the treeland-debug tool.
 set(debug_helpers_dir "${PROJECT_SOURCE_DIR}/tools/treeland-debug")
@@ -6,16 +6,19 @@ set(debug_helpers_dir "${PROJECT_SOURCE_DIR}/tools/treeland-debug")
 add_executable(test_treeland_debug
     main.cpp
     "${debug_helpers_dir}/debughelpers.cpp"
+    "${PROJECT_SOURCE_DIR}/src/modules/resource/treelanddebugsocket.cpp"
 )
 
 target_include_directories(test_treeland_debug PRIVATE
     "${debug_helpers_dir}"
+    "${PROJECT_SOURCE_DIR}/src/modules/resource"
 )
 
 target_link_libraries(test_treeland_debug
     PRIVATE
         Qt6::Test
         Qt6::Core
+        Qt6::Network
 )
 
 add_test(NAME test_treeland_debug COMMAND test_treeland_debug)

--- a/tests/test_treeland_debug/main.cpp
+++ b/tests/test_treeland_debug/main.cpp
@@ -3,6 +3,8 @@
 
 #include "debughelpers.h"
 
+#include "treelanddebugsocket.h"
+
 #include <QDir>
 #include <QFile>
 #include <QJsonObject>
@@ -10,6 +12,12 @@
 #include <QRectF>
 #include <QTemporaryDir>
 #include <QTest>
+#include <QLocalServer>
+#include <QLocalSocket>
+
+#include <fcntl.h>
+#include <sys/file.h>
+#include <unistd.h>
 
 // Unit tests for the pure-logic helpers shared by the treeland-debug tool
 // (stateName, buttonCode, keyCode, saveCapture, pointToJson, rectToJson)
@@ -37,6 +45,13 @@ private Q_SLOTS:
     void testSaveCaptureAutoPath();
     void testPointToJson();
     void testRectToJson();
+
+    // --- treeland-debug socket naming / conflict avoidance ---
+    void testSocketDefaultPath();
+    void testSocketPickFreeName();
+    void testSocketPickFreeNameOccupied();
+    void testSocketPickFreeNameSkipsLiveOldInstance();
+    void testSocketCandidateUrls();
 
     // --- parseCommand: no-argument commands ---
     void testParseTree();
@@ -279,6 +294,105 @@ void TreelandDebugTest::testRectToJson()
     QCOMPARE(obj.value("y").toDouble(), 20.0);
     QCOMPARE(obj.value("width").toDouble(), 300.0);
     QCOMPARE(obj.value("height").toDouble(), 400.0);
+}
+
+// ---------------------------------------------------------------------------
+// treeland-debug socket naming / conflict avoidance
+// ---------------------------------------------------------------------------
+
+void TreelandDebugTest::testSocketDefaultPath()
+{
+    // The default socket URL must be a local: URL with the bare socket name
+    // (no path), so Qt resolves it to /tmp/<name> and the socket is
+    // discoverable regardless of XDG_RUNTIME_DIR.
+    const QString name = treelandDebugDefaultSocketName();
+    QVERIFY(!name.isEmpty());
+    const QString url = treelandDebugDefaultSocketUrl();
+    QCOMPARE(url, QStringLiteral("local:") + name);
+    QVERIFY(!url.contains(QStringLiteral("/")));
+}
+
+void TreelandDebugTest::testSocketPickFreeName()
+{
+    // Free base → returned as-is, lock held.  Use a PID-qualified name so
+    // parallel ctest runs don't collide.
+    const QString base = QStringLiteral("test.treeland.debug.socket.free.%1").arg(::getpid());
+    QLocalServer::removeServer(base);
+
+    TreelandDebugSocketLock lock;
+    QCOMPARE(treelandDebugPickFreeSocketName(lock, base), base);
+    QVERIFY(lock.isHeld());
+    // Lock released on scope exit → lock file unlinked.
+}
+
+void TreelandDebugTest::testSocketPickFreeNameOccupied()
+{
+    // Occupied base → numeric suffix, and the occupied name is untouched.
+    const QString base = QStringLiteral("test.treeland.debug.socket.occupied.%1").arg(::getpid());
+    const QString suffix = base + QStringLiteral("-1");
+    QLocalServer::removeServer(base);
+    QLocalServer::removeServer(suffix);
+
+    // Occupy the base name by holding its lock.
+    TreelandDebugSocketLock holder;
+    QVERIFY(holder.tryAcquire(base));
+
+    TreelandDebugSocketLock lock;
+    QCOMPARE(treelandDebugPickFreeSocketName(lock, base), suffix);
+    QVERIFY(lock.isHeld());
+    // Both locks released on scope exit → lock files unlinked.
+}
+
+void TreelandDebugTest::testSocketPickFreeNameSkipsLiveOldInstance()
+{
+    // An old-build treeland may listen on the base socket WITHOUT holding a
+    // flock lock file. The picker must not clobber it (removeServer would
+    // delete the live socket path) — it should skip the live name and take a
+    // suffix instead.
+    const QString base = QStringLiteral("test.treeland.debug.socket.live.%1").arg(::getpid());
+    QLocalServer::removeServer(base);
+
+    QLocalServer server;
+    server.setSocketOptions(QLocalServer::UserAccessOption);
+    QVERIFY(server.listen(base));
+    // Discard the brief probe connections so they don't queue up.
+    connect(&server, &QLocalServer::newConnection, &server,
+            [&server]() { delete server.nextPendingConnection(); });
+
+    TreelandDebugSocketLock lock;
+    // base is live (server listening) but has no lock file -> must skip.
+    QCOMPARE(treelandDebugPickFreeSocketName(lock, base),
+             base + QStringLiteral("-1"));
+    QVERIFY(lock.isHeld());
+
+    server.close();
+    QLocalServer::removeServer(base);
+}
+
+void TreelandDebugTest::testSocketCandidateUrls()
+{
+    // The candidate URL list drives the client's auto-discovery: a debug
+    // build tries the debug socket first and falls back to the release
+    // socket; a release build only has the release socket.
+    const auto urls = treelandDebugCandidateSocketUrls();
+    QVERIFY(!urls.isEmpty());
+
+    // Every candidate must be a local: URL with a bare name (no path).
+    for (const auto &u : urls) {
+        QVERIFY(u.startsWith(QStringLiteral("local:")));
+        QVERIFY(!u.contains(QStringLiteral("/")));
+    }
+
+#ifdef TREELAND_DEBUG_DEV_BUILD
+    // Debug build: first candidate is the dev socket, second is release.
+    QCOMPARE(urls.size(), 2);
+    QVERIFY(urls.first().contains(QStringLiteral("debug-dev")));
+    QVERIFY(urls.last().endsWith(treelandDebugReleaseSocketName()));
+#else
+    // Release build: only the release socket.
+    QCOMPARE(urls.size(), 1);
+    QVERIFY(urls.first().endsWith(treelandDebugReleaseSocketName()));
+#endif
 }
 
 // ---------------------------------------------------------------------------

--- a/tools/treeland-debug/CMakeLists.txt
+++ b/tools/treeland-debug/CMakeLists.txt
@@ -32,6 +32,7 @@ set(treeland_debug_sources
     main.cpp
     debughelpers.cpp
     debugsession.cpp
+    "${PROJECT_SOURCE_DIR}/src/modules/resource/treelanddebugsocket.cpp"
     "${windowtree_replica_header}"
 )
 
@@ -47,6 +48,7 @@ set_target_properties(treeland-debug PROPERTIES
 
 target_include_directories(treeland-debug PRIVATE
     "${windowtree_generated_dir}"
+    "${PROJECT_SOURCE_DIR}/src/modules/resource"
 )
 
 target_link_libraries(treeland-debug PRIVATE

--- a/tools/treeland-debug/debugserver.cpp
+++ b/tools/treeland-debug/debugserver.cpp
@@ -18,10 +18,10 @@
 #include <functional>
 #include <algorithm>
 
-DebugServer::DebugServer(const QString &url, const QString &name, int timeoutMs,
+DebugServer::DebugServer(const QStringList &urls, const QString &name, int timeoutMs,
                          QObject *parent)
     : QObject(parent)
-    , m_url(url)
+    , m_urls(urls)
     , m_name(name)
     , m_timeoutMs(timeoutMs)
 {
@@ -29,14 +29,14 @@ DebugServer::DebugServer(const QString &url, const QString &name, int timeoutMs,
 
 bool DebugServer::createSession(Session &session)
 {
-    return connectSession(session, m_url, m_name, m_timeoutMs);
+    return connectSession(session, m_urls, m_name, m_timeoutMs);
 }
 
 QJsonObject DebugServer::sessionRequest(const std::function<QJsonObject(Session &)> &work)
 {
     Session session;
     if (!createSession(session))
-        return {{"ok", false}, {"error", QStringLiteral("failed to connect to remote object node: %1").arg(m_url)}};
+        return {{"ok", false}, {"error", QStringLiteral("failed to connect to remote object node")}};
 
     return work(session);
 }

--- a/tools/treeland-debug/debugserver.h
+++ b/tools/treeland-debug/debugserver.h
@@ -21,7 +21,7 @@ class DebugServer : public QObject
     Q_OBJECT
 
 public:
-    explicit DebugServer(const QString &url, const QString &name, int timeoutMs,
+    explicit DebugServer(const QStringList &urls, const QString &name, int timeoutMs,
                          QObject *parent = nullptr);
 
     // Binds the HTTP and WebSocket listener to @p host:@p port.  Returns true
@@ -74,8 +74,7 @@ private:
     void startLiveSubscription(QWebSocket *socket, const QString &id,
                                DebugCommand command, int intervalMs);
     void stopLiveSubscription(QWebSocket *socket, const QString &id);
-
-    QString m_url;
+    QStringList m_urls;
     QString m_name;
     int m_timeoutMs;
     QHttpServer m_httpServer;

--- a/tools/treeland-debug/debugsession.cpp
+++ b/tools/treeland-debug/debugsession.cpp
@@ -14,6 +14,61 @@ bool connectSession(Session &session, const QString &url, const QString &name, i
     return session.replica->waitForSource(timeoutMs);
 }
 
+bool connectSession(Session &session, const QStringList &urls,
+                     const QString &name, int timeoutMs,
+                     QString *connectedUrl)
+{
+    if (urls.isEmpty())
+        return false;
+
+    // Try each URL with an independent QRemoteObjectNode so a previously-
+    // failed connection cannot cause a false success on a later candidate
+    // (the replica watches *all* connected nodes — a shared node would
+    // let a late-becoming-reachable earlier URL succeed while we think we
+    // are probing a later one).  A live local socket responds in
+    // milliseconds; give earlier (preferred) candidates a short probe and
+    // the last one the remaining timeout, so the total never exceeds
+    // timeoutMs.
+    constexpr int probeTimeout = 3000;
+    int remaining = timeoutMs;
+
+    for (int i = 0; i < urls.size(); ++i) {
+        const int t = (i < urls.size() - 1) ? qMin(remaining, probeTimeout) : remaining;
+        if (t < 0)
+            return false;   // budget exhausted
+
+        QRemoteObjectNode probeNode;
+        if (!probeNode.connectToNode(QUrl(urls[i])))
+            continue;   // malformed URL
+
+        auto *replica = probeNode.acquire<WindowTreeRemoteReplica>(name);
+        if (replica->waitForSource(t)) {
+            if (connectedUrl)
+                *connectedUrl = urls[i];
+            // Probe succeeded.  Reconnect the session's own node and acquire
+            // a fresh replica, waiting for it to initialize before returning so
+            // callers see a ready replica.  Use the remaining budget after the
+            // probe so the total never exceeds timeoutMs.  The server is
+            // known-live so this completes quickly.
+            remaining -= t;
+            session.node.connectToNode(QUrl(urls[i]));
+            delete session.replica;
+            session.replica = session.node.acquire<WindowTreeRemoteReplica>(name);
+            const int sessionTimeout = qMin(remaining, probeTimeout);
+            if (sessionTimeout < 0 || !session.replica->waitForSource(sessionTimeout)) {
+                // Extremely unlikely — the source was just live.  Treat as
+                // failure so we don't return an uninitialized replica.
+                delete session.replica;
+                session.replica = nullptr;
+                return false;
+            }
+            return true;
+        }
+        remaining -= t;
+    }
+    return false;
+}
+
 bool waitCaptureResult(WindowTreeRemoteReplica *replica, int timeoutMs, QByteArray *out)
 {
     QEventLoop loop;

--- a/tools/treeland-debug/debugsession.h
+++ b/tools/treeland-debug/debugsession.h
@@ -24,6 +24,14 @@ struct Session
 // given @p name. Returns true on success.
 bool connectSession(Session &session, const QString &url, const QString &name, int timeoutMs);
 
+// Tries each URL in @p urls in order, connecting to the first whose source is
+// reachable. Earlier (higher-preference) URLs get a short probe timeout; the
+// last URL gets the full remaining timeout. If @p connectedUrl is non-null it
+// receives the URL that succeeded. An empty list returns false.
+bool connectSession(Session &session, const QStringList &urls,
+                     const QString &name, int timeoutMs,
+                     QString *connectedUrl = nullptr);
+
 // Set to 1 by the SIGINT handler during interactive ("live") commands so the
 // blocking waitSlot() below can break out promptly instead of being stuck in
 // a single waitForFinished() until the RPC timeout. It is async-signal-safe

--- a/tools/treeland-debug/main.cpp
+++ b/tools/treeland-debug/main.cpp
@@ -24,6 +24,8 @@
 #include "debugserver.h"
 #endif
 
+#include "treelanddebugsocket.h"
+
 #include "rep_treeland_windowtree_replica.h"
 
 namespace {
@@ -303,7 +305,7 @@ QString helpText()
         "interactive REPL.\n"
         "\n"
         "Global options:\n"
-        "  --url <url>          Remote object host URL (default: local:org.deepin.dde.treeland.debug)\n"
+        "  --url <url>          Remote object host URL (default: build-specific socket, auto)\n"
         "  --name <name>        Remote object name (default: WindowTree)\n"
         "  --timeout-ms <n>     Request timeout in milliseconds (default: 30000)\n"
         "  --json               Emit machine-readable JSON for `tree`/`cursor`/`windows`/`clients`\n"
@@ -395,7 +397,12 @@ int main(int argc, char *argv[])
     QCoreApplication::setApplicationName(QStringLiteral("treeland-debug"));
     QCoreApplication::setApplicationVersion(QStringLiteral("1.0"));
 
-    QString url = QStringLiteral("local:org.deepin.dde.treeland.debug");
+    // URL resolution: an explicit --url is used verbatim with no implicit
+    // processing.  When --url is absent, a debug build prefers the debug
+    // socket and falls back to the release socket; a release build uses the
+    // release socket directly.  See treelandDebugCandidateSocketUrls().
+    QString url;
+    bool urlExplicit = false;
     QString name = QStringLiteral("WindowTree");
     int timeoutMs = 30000;
     bool timeoutOk = true;
@@ -412,11 +419,13 @@ int main(int argc, char *argv[])
                 return QString::fromUtf8(argv[++i]);
             return {};
         };
-        if (arg == QLatin1String("--url"))
+        if (arg == QLatin1String("--url")) {
             url = next();
-        else if (arg.startsWith(QLatin1String("--url=")))
+            urlExplicit = true;
+        } else if (arg.startsWith(QLatin1String("--url="))) {
             url = arg.mid(6);
-        else if (arg == QLatin1String("--name"))
+            urlExplicit = true;
+        } else if (arg == QLatin1String("--name"))
             name = next();
         else if (arg.startsWith(QLatin1String("--name=")))
             name = arg.mid(7);
@@ -455,6 +464,9 @@ int main(int argc, char *argv[])
     if (!timeoutOk || timeoutMs < 0)
         return fail("--timeout-ms must be a non-negative integer");
 
+    if (urlExplicit && url.isEmpty())
+        return fail("--url requires a non-empty value");
+
     registerNamedMetatypes();
 
     QString command;
@@ -480,7 +492,8 @@ int main(int argc, char *argv[])
         const ParseResult parsed = parseCommand(command, commandArgs);
         if (!parsed.ok)
             return fail(parsed.error);
-        DebugServer server(url, name, timeoutMs);
+        DebugServer server(urlExplicit ? QStringList{url} : treelandDebugCandidateSocketUrls(),
+                            name, timeoutMs);
         if (!server.listen(parsed.host, parsed.port))
             return fail(QStringLiteral("listen: failed to bind to %1:%2").arg(parsed.host).arg(parsed.port));
         QTextStream(stdout) << "treeland-debug listening on " << parsed.host << ":" << parsed.port << "\n";
@@ -488,9 +501,24 @@ int main(int argc, char *argv[])
     }
 #endif
 
+    // Resolve the URL to connect to.  An explicit --url is used verbatim;
+    // otherwise the build-default candidate list (debug → release fallback in
+    // debug builds) is tried in order.
+    const QStringList candidateUrls = urlExplicit
+        ? QStringList{url}
+        : treelandDebugCandidateSocketUrls();
+
     Session session;
-    if (!connectSession(session, url, name, timeoutMs))
-        return fail(QStringLiteral("failed to connect to remote object node: %1").arg(url));
+    QString connectedUrl;
+    if (!connectSession(session, candidateUrls, name, timeoutMs, &connectedUrl))
+        return fail(QStringLiteral("failed to connect to remote object node (tried: %1)")
+                        .arg(candidateUrls.join(" or ")));
+
+    // Log only when a fallback actually happened (preferred candidate was
+    // unreachable), not on every debug build, to avoid polluting --json output.
+    if (candidateUrls.size() > 1 && connectedUrl != candidateUrls.first())
+        QTextStream(stderr) << "treeland-debug: connected to " << connectedUrl
+                            << " (fallback from " << candidateUrls.first() << ")\n";
 
     if (command == QLatin1String("shell"))
         return runShell(session, timeoutMs, json, previewOpt);


### PR DESCRIPTION
## Summary

Re-implements debug-socket conflict avoidance (replacing #1352), fixing the original PR's two problems:

1. **Blocking `waitForConnected(100)` socket probe** replaced with non-blocking `flock(LOCK_EX|LOCK_NB)` advisory lock (same as libwayland's `wl_socket_lock`), so compositor startup never stalls.

2. **Confused `local:` prefix + systemd env-var injection** removed. Socket uses a bare name so Qt places it in `/tmp`, discoverable by clients under any `XDG_RUNTIME_DIR` (critical: global service runs as user `dde` with `XDG_RUNTIME_DIR=/run/treeland`, but `treeland-debug` runs under a different runtime dir).

### Design

- **Socket location**: bare name (`org.deepin.dde.treeland.debug`), Qt resolves to `/tmp/<name>` on Linux. Any user / runtime dir can discover it.
- **Suffix selection**: when the default name is held by a live instance, a numeric suffix (`-1`, `-2`, ...) is chosen via non-blocking `flock`. A stale socket file from a crashed instance is reclaimed; a live old-build instance (no lock file) is probed and left alone.
- **Debug vs release**: debug builds use `org.deepin.dde.treeland.debug-dev`. A debug-built `treeland-debug` client automatically prefers the debug socket and falls back to the release socket. A release-built client uses the release socket. An explicit `--url` is always used verbatim with no implicit processing.
- **No systemd env-var export**: client discovery is automatic via candidate URL list — no `TREELAND_DEBUG_URL` needed.

### Improvements over #1352

- **No env var dependency**: #1352 exports `TREELAND_DEBUG_URL` via systemd and has a known issue where a suffixed instance's exit leaves the env var pointing at a dead socket. Our candidate-URL approach is stateless.
- **Debug client fallback**: #1352's debug client ignores the env var entirely. Ours tries debug socket first, falls back to release if unreachable.
- **Categorized logging**: uses `qCWarning(lcTlDebug)` instead of bare `qWarning()`.
- **RAII lock**: `TreelandDebugSocketLock` class (move ctor, auto-unlink on release) — destructor ordering is correct (host is parent-owned, destroyed before lock member).

### Files (16)

- `src/modules/resource/treelanddebugsocket.h` — **new**: shared socket-naming + RAII lock + selection logic
- `src/modules/resource/treelandremotesource.{h,cpp}` — constructor uses lock-based selection, RAII lock member
- `src/common/treelandlogging.{h,cpp}` — new `lcTlDebug` logging category
- `CMakeLists.txt` — `TREELAND_DEBUG_SOCKET` + `TREELAND_DEBUG_SOCKET_RELEASE` compile definitions
- `tools/treeland-debug/main.cpp` — candidate-URL resolution (no env var), explicit `--url` verbatim
- `tools/treeland-debug/debugsession.{h,cpp}` — multi-URL `connectSession` with sequential fallback
- `tools/treeland-debug/debugserver.{h,cpp}` — store URL list instead of single URL
- `tools/treeland-debug/CMakeLists.txt` — resource include path
- `tests/test_treeland_debug/{CMakeLists.txt,main.cpp}` — 5 new socket tests
- `README.md` / `README.zh_CN.md` — socket naming documentation

## Test

- `test_treeland_debug`: 94 passed, 0 failed (including 5 new socket tests)
- `treeland`, `treeland-debug`, `libtreeland.so` all build successfully

## Summary by Sourcery

Make Treeland debug socket selection non-blocking and conflict-safe while providing automatic cross-build client discovery without environment-variable configuration.

New Features:
- Support build-aware debug socket discovery, with debug clients preferring development sockets and falling back to release sockets.

Bug Fixes:
- Prevent debug socket conflicts between concurrent Treeland instances and avoid blocking compositor startup during socket selection.
- Allow clients running under different runtime directories to discover the compositor debug socket and safely reclaim stale socket files.

Enhancements:
- Use non-blocking advisory locking, automatic numeric socket suffixes, and categorized debug logging for robust socket ownership and diagnostics.

Build:
- Add build-specific debug socket compile definitions and include the shared socket implementation in the relevant targets.

Documentation:
- Document debug socket naming, conflict handling, build-specific discovery, and connection behavior in English and Chinese.

Tests:
- Add coverage for socket paths, free-name selection, occupied and legacy live sockets, and candidate URL resolution.