### PR TITLE
fix: send frame done to remote subsurfaces

### DIFF
--- a/waylib/src/server/kernel/wsurface.cpp
+++ b/waylib/src/server/kernel/wsurface.cpp
@@ -219,6 +219,10 @@ WSubsurface *WSurfacePrivate::addRemoteSubsurface(wlr_surface *childHandle)
         [this, subsurface](void *) {
             releaseSubsurface(subsurface);
         });
+    // Propagate parent outputs to the remote child surface so that
+    // framePacingOutput is set and frame-done callbacks are delivered.
+    for (auto *output : std::as_const(outputs))
+        childSurface->enterOutput(output);
     rebuildTotalSubsurfaces();
     Q_EMIT q->subsurfaceAdded(subsurface);
     return subsurface;
@@ -476,6 +480,16 @@ void WSurface::enterOutput(WOutput *output)
         d->ensureSubsurface(subsurface)->surface()->enterOutput(output);
     }
 
+    // for remote subsurfaces
+    for (auto *sub : std::as_const(d->remoteBelow)) {
+        if (auto *childSurface = sub->surface())
+            childSurface->enterOutput(output);
+    }
+    for (auto *sub : std::as_const(d->remoteAbove)) {
+        if (auto *childSurface = sub->surface())
+            childSurface->enterOutput(output);
+    }
+
     Q_EMIT outputEntered(output);
 }
 
@@ -498,6 +512,16 @@ void WSurface::leaveOutput(WOutput *output)
 
     wl_list_for_each(subsurface, &surface->current.subsurfaces_above, current.link) {
         d->ensureSubsurface(subsurface)->surface()->leaveOutput(output);
+    }
+
+    // for remote subsurfaces
+    for (auto *sub : std::as_const(d->remoteBelow)) {
+        if (auto *childSurface = sub->surface())
+            childSurface->leaveOutput(output);
+    }
+    for (auto *sub : std::as_const(d->remoteAbove)) {
+        if (auto *childSurface = sub->surface())
+            childSurface->leaveOutput(output);
     }
 
     Q_EMIT outputLeave(output);

--- a/waylib/src/server/protocols/wremotesubsurfacemanagerv1.cpp
+++ b/waylib/src/server/protocols/wremotesubsurfacemanagerv1.cpp
@@ -12,7 +12,7 @@
 #include "wsurface.h"
 
 extern "C" {
-#include <wlr_all.h>
+#include <wlr/types/wlr_compositor.h>
 }
 
 #include <QHash>
@@ -505,6 +505,8 @@ void ExportedSurfaceContext::handleSurfaceDestroy()
             return;
         }
     }
+    if (m_manager)
+        m_manager->cleanupExportedContext(this);
     delete this;
 }
 

--- a/waylib/src/server/protocols/wremotesubsurfacemanagerv1.cpp
+++ b/waylib/src/server/protocols/wremotesubsurfacemanagerv1.cpp
@@ -7,11 +7,12 @@
 #include "qwayland-server-treeland-remote-subsurface-unstable-v1.h"
 #include "wayliblogging.h"
 #include "wserver.h"
+#include "wscoplistener.h"
 #include "wsubsurface.h"
 #include "wsurface.h"
 
 extern "C" {
-#include <wlr/types/wlr_compositor.h>
+#include <wlr_all.h>
 }
 
 #include <QHash>
@@ -66,6 +67,11 @@ public:
         , m_surface(surface)
         , m_token(token)
     {
+        // WSurface follows a surface role and may be destroyed with an
+        // xdg_toplevel while the underlying wl_surface remains valid.
+        m_surfaceDestroyListener.init(&m_surface->events.destroy,
+                                      this,
+                                      &ExportedSurfaceContext::handleSurfaceDestroy);
     }
 
     ~ExportedSurfaceContext() override = default;
@@ -101,9 +107,12 @@ protected:
                                   const QString &parent_token) override;
 
 private:
+    void handleSurfaceDestroy();
+
     WRemoteSubsurfaceManagerV1Private *m_manager;
     wlr_surface *m_surface = nullptr;
     QString m_token;
+    WScopedListener m_surfaceDestroyListener;
 };
 
 // ---------------------------------------------------------------------------
@@ -399,19 +408,6 @@ public:
         delete remote;
     }
 
-    static void safeDestroyExported(ExportedSurfaceContext *ctx)
-    {
-        if (!ctx)
-            return;
-        if (auto *res = ctx->resource()) {
-            if (res->handle) {
-                wl_resource_destroy(res->handle);
-                return;
-            }
-        }
-        delete ctx;
-    }
-
     // Cleanup
     void cleanupExportedContext(ExportedSurfaceContext *ctx)
     {
@@ -488,17 +484,6 @@ protected:
 
         registerExported(context);
         context->send_surface_token(token);
-
-        auto *ws = WSurface::fromHandle(wlrSurface);
-        if (ws) {
-            QObject::connect(ws,
-                             &WSurface::beforeDestroy,
-                             context,
-                             [this, context]() {
-                                 if (m_tokens.contains(context->token()))
-                                     safeDestroyExported(context);
-                             });
-        }
     }
 
 private:
@@ -508,6 +493,20 @@ private:
 // ---------------------------------------------------------------------------
 // ExportedSurfaceContext implementation
 // ---------------------------------------------------------------------------
+
+void ExportedSurfaceContext::handleSurfaceDestroy()
+{
+    if (!m_manager || m_manager->findExportedByToken(m_token) != this)
+        return;
+
+    if (auto *res = resource()) {
+        if (res->handle) {
+            wl_resource_destroy(res->handle);
+            return;
+        }
+    }
+    delete this;
+}
 
 void ExportedSurfaceContext::destroy_resource(Resource *)
 {


### PR DESCRIPTION
1. Remote subsurfaces were not included in enterOutput/leaveOutput recursion, so their wlr_surface never received output enter events
2. This caused framePacingOutput to remain null, preventing notifyFrameDone from being called after rendering
3. Mesa/EGL clients (e.g. Flutter in Wine) stalled waiting for wl_callback.done that was never sent

Log: Fix remote subsurface rendering freeze caused by missing frame callback

Influence:
1. Open a Wine app with Flutter/OpenGL child window embedded via remote subsurface and verify it renders without freezing
2. Drag the window across multiple outputs and verify remote subsurface content follows without visual glitches
3. Verify standard subsurfaces still work correctly after the change

fix: 修复 remote subsurface 缺少 frame 回调导致渲染卡死

1. remote subsurface 未参与 enterOutput/leaveOutput 递归， 其 wlr_surface 从未收到 output enter 事件
2. 导致 framePacingOutput 始终为空，渲染完成后无法触发 notifyFrameDone 发送 wl_callback.done
3. Mesa/EGL 客户端（如 Wine 中的 Flutter 窗口）因等待 永不返回的 frame callback 而卡死

Log: 修复 remote subsurface 因缺少 frame 回调导致的渲染卡死问题

Influence:
1. 打开 Wine 下使用 Flutter/OpenGL 子窗口的应用，验证 remote subsurface 内容能正常渲染不卡死
2. 拖动窗口跨越多个输出，验证 remote subsurface 内容 跟随移动且无画面异常
3. 验证普通 subsurface 在修改后仍正常工作

PMS: TASK-393795

## Summary by Sourcery

Ensure remote subsurfaces receive output lifecycle events and are safely cleaned up when their source surfaces are destroyed.

Bug Fixes:
- Propagate output enter and leave events to remote subsurfaces so frame pacing and frame-done callbacks work correctly.
- Clean up exported remote-subsurface contexts when their underlying surfaces are destroyed.