### PR TITLE
treeland-debug: rename dconfig option debugSource to remoteDebug

### DIFF
--- a/.agents/skills/treeland-debug/SKILL.md
+++ b/.agents/skills/treeland-debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treeland-debug
-description: Use this skill whenever a task asks you to debug, diagnose, reproduce, or analyze a problem in the running treeland compositor — window/workspace/input/output/rendering issues, crashes, hangs, focus problems, or requests to inspect live state. Trigger on `treeland-debug`, `debugSource`, `WindowTree` Remote Object, `QT_LOGGING_RULES`, treeland logging categories, `journalctl` for treeland, `org.deepin.Compositor1`, window tree inspection, input event injection, or screenshot capture from a live compositor. Pair with the systematic-debugging approach — reproduce, isolate, then fix at the root cause.
+description: Use this skill whenever a task asks you to debug, diagnose, reproduce, or analyze a problem in the running treeland compositor — window/workspace/input/output/rendering issues, crashes, hangs, focus problems, or requests to inspect live state. Trigger on `treeland-debug`, `remoteDebug`, `WindowTree` Remote Object, `QT_LOGGING_RULES`, treeland logging categories, `journalctl` for treeland, `org.deepin.Compositor1`, window tree inspection, input event injection, or screenshot capture from a live compositor. Pair with the systematic-debugging approach — reproduce, isolate, then fix at the root cause.
 ---
 
 # Treeland Debug
@@ -55,7 +55,7 @@ WLR_BACKENDS=x11 ./build/src/treeland.sh
 
 `treeland.sh` wraps `treeland` (adding the pixman software-rendering fallback on `dri2` failure, same as the service). Debugging this instance:
 
-- **Debug source is already on**: in Debug builds (`TREELAND_DEBUG_BUILD`) the debug Remote Object is enabled **by default** (`ALWAYS_ENABLE_TREELAND_DEBUG` is defined for the Debug config; pass `-DTREELAND_DEBUG_SOURCE=OFF` to CMake to keep it off) — skip the DConfig step below. Only release builds need `debugSource` set.
+- **Debug source is already on**: in Debug builds (`TREELAND_DEBUG_BUILD`) the debug Remote Object is enabled **by default** (`ALWAYS_ENABLE_TREELAND_DEBUG` is defined for the Debug config; pass `-DTREELAND_DEBUG_SOURCE=OFF` to CMake to keep it off) — skip the DConfig step below. Only release builds need `remoteDebug` set.
 - **No `sudo -u dde`**: run `treeland-debug` as the **current user**, same session as the instance. Because the socket is owner-only, this attaches to your own instance by default.
 - **Logs go to the terminal**, not journalctl: treeland's stdout/stderr (Qt categories) land where you launched it. Set `QT_LOGGING_RULES` in that process's environment, and pass `--console-log` to force console logging on a release build (debug builds always log to console).
 - **No socket conflict with the global service**: a debug build uses the distinct `-dev` socket name and auto-suffixes for concurrent instances (see Debug socket naming above), so the nested dev instance coexists with the global `treeland.service` — no need to stop it. A debug-built `treeland-debug` prefers your dev instance by default.
@@ -67,11 +67,11 @@ The `WindowTree` debug Remote Object is **off by default in release builds** (De
 sudo -u dde -- dde-dconfig set \
   -a org.deepin.dde.treeland \
   -r org.deepin.dde.treeland \
-  -k debugSource \
+  -k remoteDebug \
   -v true
 ```
 
-Toggling `debugSource` takes effect **immediately** — the remote source is created or destroyed on the fly, no restart needed (the compositor watches `debugSourceChanged` at runtime). `treeland-debug` connects to the build-specific debug socket (see Debug socket naming above), remote object `WindowTree`.
+Toggling `remoteDebug` takes effect **immediately** — the remote source is created or destroyed on the fly, no restart needed (the compositor watches `remoteDebugChanged` at runtime). `treeland-debug` connects to the build-specific debug socket (see Debug socket naming above), remote object `WindowTree`.
 
 ## treeland-debug CLI
 `treeland-debug` is an adb-style inspector/controller. Two modes: one-shot `treeland-debug <cmd> [args]` and REPL `treeland-debug shell`. Run every command as `dde`. `--json` gives machine-readable output for `tree`/`cursor`/`windows`/`clients`.
@@ -105,7 +105,7 @@ Every window has a stable numeric `id` (and an `appId`); either is accepted by a
 ### Quick start
 ```bash
 # enable once (takes effect immediately, no restart) — only for release builds; Debug builds are on by default
-sudo -u dde -- dde-dconfig set -a org.deepin.dde.treeland -r org.deepin.dde.treeland -k debugSource -v true
+sudo -u dde -- dde-dconfig set -a org.deepin.dde.treeland -r org.deepin.dde.treeland -k remoteDebug -v true
 
 # inspect (drop the `sudo -u dde` prefix when debugging a nested dev instance)
 sudo -u dde -- treeland-debug tree

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ endif()
 
 # Enable the treeland-debug remote source by default in Debug builds so the
 # adb-style debug tool works out of the box without toggling the DConfig key.
-# Release builds stay gated by the debugSource DConfig key (default false), so
+# Release builds stay gated by the remoteDebug DConfig key (default false), so
 # the source is not created unless explicitly enabled. Pass
 # -DTREELAND_DEBUG_SOURCE=OFF to also keep it off in Debug builds.
 option(TREELAND_DEBUG_SOURCE "Enable treeland-debug remote source by default in Debug builds" ON)

--- a/README.md
+++ b/README.md
@@ -72,16 +72,16 @@ sudo cmake --install build --component treeland-debug
 
 The debug Remote Object is opt-in: it is enabled by default in **Debug** builds
 (so `treeland-debug` works out of the box without extra config), and in
-**Release** builds it is off until you enable the `debugSource` DConfig option
+**Release** builds it is off until you enable the `remoteDebug` DConfig option
 as the `dde` user (Treeland runs as `dde` in global mode and its local socket is
-owner-only). Toggling `debugSource` in Release builds takes effect immediately
+owner-only). Toggling `remoteDebug` in Release builds takes effect immediately
 -- the remote source is created or destroyed on the fly, no restart needed:
 
 ```bash
 sudo -u dde -- dde-dconfig set \
   -a org.deepin.dde.treeland \
   -r org.deepin.dde.treeland \
-  -k debugSource \
+  -k remoteDebug \
   -v true
 ```
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -68,15 +68,15 @@ sudo cmake --install build --component treeland-debug
 
 调试 Remote Object 默认为可选项：**Debug** 编译版本默认开启（无需额外配置，
 `treeland-debug` 开箱即用），**Release** 版本默认关闭，需以 `dde` 用户开启
-`debugSource` DConfig 选项（Treeland 在 global 模式下以 `dde` 身份运行，其本地
-socket 仅属主可访问）。Release 版本下切换 `debugSource` 即时生效——远程源会
+`remoteDebug` DConfig 选项（Treeland 在 global 模式下以 `dde` 身份运行，其本地
+socket 仅属主可访问）。Release 版本下切换 `remoteDebug` 即时生效——远程源会
 动态创建或销毁，无需重启 Treeland：
 
 ```bash
 sudo -u dde -- dde-dconfig set \
   -a org.deepin.dde.treeland \
   -r org.deepin.dde.treeland \
-  -k debugSource \
+  -k remoteDebug \
   -v true
 ```
 

--- a/misc/dconfig/org.deepin.dde.treeland.json
+++ b/misc/dconfig/org.deepin.dde.treeland.json
@@ -46,7 +46,7 @@
             "permissions": "readwrite",
             "visibility": "public"
         },
-        "debugSource": {
+        "remoteDebug": {
             "value": false,
             "serial": 0,
             "flags": [],
@@ -55,7 +55,7 @@
             "description": "Enable the Qt Remote Object remote source for window tree debugging tools. Performance impact when enabled.",
             "description[zh_CN]": "启用窗口树调试工具的Qt Remote Object远程数据源。开启后会有性能影响。",
             "permissions": "readwrite",
-            "visibility": "public"
+            "visibility": "private"
         },
         "showOtherUserOption": {
             "value": false,

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -285,11 +285,11 @@ Helper::Helper(QObject *parent)
             &WallpaperManager::syncAddWorkspace);
     tryInitRemoteSource();
 #ifndef ALWAYS_ENABLE_TREELAND_DEBUG
-    // Release builds: react to runtime changes of the debugSource DConfig key,
+    // Release builds: react to runtime changes of the remoteDebug DConfig key,
     // creating or destroying the remote source on the fly instead of only at
     // startup.
     connect(m_globalConfig.get(),
-            &TreelandConfig::debugSourceChanged,
+            &TreelandConfig::remoteDebugChanged,
             this,
             &Helper::tryInitRemoteSource);
 #endif
@@ -419,15 +419,15 @@ void Helper::tryInitRemoteSource()
     m_treelandRemoteSource = new TreelandRemoteSource(this);
     return;
 #else
-    // Release builds: follow the debugSource DConfig key (default false) and
+    // Release builds: follow the remoteDebug DConfig key (default false) and
     // react to its runtime changes -- toggling the key creates or destroys the
     // remote source without restarting the compositor.
     if (m_treelandRemoteSource) {
-        if (!m_globalConfig->debugSource()) {
+        if (!m_globalConfig->remoteDebug()) {
             delete m_treelandRemoteSource;
             m_treelandRemoteSource = nullptr;
         }
-    } else if (m_globalConfig->debugSource()) {
+    } else if (m_globalConfig->remoteDebug()) {
         m_treelandRemoteSource = new TreelandRemoteSource(this);
     }
 #endif

--- a/tools/treeland-debug/README.md
+++ b/tools/treeland-debug/README.md
@@ -32,14 +32,14 @@ Set `CMAKE_INSTALL_PREFIX` during configuration to use another prefix.
 Treeland runs as the `dde` user in global mode. Its Qt Remote Object server uses
 owner-only local socket access, so run this client as `dde`.
 
-Before starting Treeland, enable the `debugSource` DConfig option as the `dde`
+Before starting Treeland, enable the `remoteDebug` DConfig option as the `dde`
 user; otherwise the `WindowTree` Remote Object source is absent:
 
 ```bash
 sudo -u dde -- dde-dconfig set \
   -a org.deepin.dde.treeland \
   -r org.deepin.dde.treeland \
-  -k debugSource \
+  -k remoteDebug \
   -v true
 ```
 


### PR DESCRIPTION
将 DConfig 选项 `debugSource` 重命名为 `remoteDebug`，原名称 `debug-source` 语义不清晰，`remoteDebug` 更准确地描述其用途（启用 Qt Remote Object 调试远程源）。

改动内容：
- `misc/dconfig/org.deepin.dde.treeland.json`: DConfig key `debugSource` → `remoteDebug`
- `src/seat/helper.cpp`: 更新 `debugSource()` / `debugSourceChanged` → `remoteDebug()` / `remoteDebugChanged`
- `CMakeLists.txt`, `README.md`, `README.zh_CN.md`, `tools/treeland-debug/README.md`: 更新文档引用

## Summary by Sourcery

Rename the DConfig option `debugSource` to `remoteDebug` for clearer semantics.

Enhancements:
- Rename the `debugSource`/`debugSourceChanged` DConfig API to `remoteDebug`/`remoteDebugChanged`.

Documentation:
- Update README and treeland-debug documentation to reference the renamed `remoteDebug` DConfig option.