### PR TITLE
fix(treeland-debug): use m_urls.join for screenshot errors

### DIFF
--- a/tools/treeland-debug/debugserver.cpp
+++ b/tools/treeland-debug/debugserver.cpp
@@ -593,7 +593,7 @@ DebugServer::ScreenshotBytes DebugServer::captureOutputBytes(const QString &outp
     ScreenshotBytes result;
     Session session;
     if (!createSession(session)) {
-        result.error = QStringLiteral("failed to connect to compositor: %1").arg(m_url);
+        result.error = QStringLiteral("failed to connect to compositor: %1").arg(m_urls.join(QStringLiteral(", ")));
         return result;
     }
     QByteArray data;
@@ -616,7 +616,7 @@ DebugServer::ScreenshotBytes DebugServer::captureWindowBytes(const QString &targ
     }
     Session session;
     if (!createSession(session)) {
-        result.error = QStringLiteral("failed to connect to compositor: %1").arg(m_url);
+        result.error = QStringLiteral("failed to connect to compositor: %1").arg(m_urls.join(QStringLiteral(", ")));
         return result;
     }
     bool ok = false;


### PR DESCRIPTION
### Summary
- DebugServer member renamed from `m_url` to `m_urls` (`QStringList`) but `captureOutputBytes` and `captureWindowBytes` still referenced `m_url`, breaking build (sccache error at `debugserver.cpp:596,619`).
- Replace with `m_urls.join(", ")` to report all attempted URLs in the error message.

Build verified: `cmake --build build --target treeland-debug` succeeds.

### Change
`tools/treeland-debug/debugserver.cpp`: 2 lines changed, `m_url` → `m_urls.join(QStringLiteral(", "))` in both screenshot byte helpers.

### Testing
1. Build `treeland-debug` target
2. Force compositor connection failure and verify error contains joined URLs
3. Exercise `captureOutput`/`captureWindow` failure paths

Fixes build break introduced alongside multi-URL support.

## Summary by Sourcery

Bug Fixes:
- Fix compositor connection error reporting for screenshot capture failures after the debug server switched to supporting multiple URLs.