### PR TITLE
feat(build): add USE_SCCACHE option, use launcher not PATH wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,43 @@
 cmake_minimum_required(VERSION 3.25.0)
 
+option(USE_SCCACHE "Use sccache compiler launcher (requires sccache, uses launcher mode not PATH wrapper)" OFF)
+if(USE_SCCACHE)
+    find_program(SCCACHE_PROGRAM sccache REQUIRED)
+    # Must be set before project() so try_compile is not routed through distributed sccache
+    set(CMAKE_C_COMPILER_LAUNCHER "${SCCACHE_PROGRAM}" CACHE STRING "C compiler launcher" FORCE)
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${SCCACHE_PROGRAM}" CACHE STRING "C++ compiler launcher" FORCE)
+    # Also handle Rust if cargo is used (RUSTC_WRAPPER is the sccache-recommended way)
+    set(ENV{RUSTC_WRAPPER} "${SCCACHE_PROGRAM}")
+    message(STATUS "Using sccache: ${SCCACHE_PROGRAM} (launcher mode, not PATH wrapper)")
+    # Helpful check: fail fast if user still has wrapper in PATH/compiler
+    if(CMAKE_C_COMPILER MATCHES "sccache" OR CMAKE_C_COMPILER MATCHES "/sccache/bin/"
+       OR CMAKE_CXX_COMPILER MATCHES "sccache" OR CMAKE_CXX_COMPILER MATCHES "/sccache/bin/")
+        message(WARNING "USE_SCCACHE is ON but CMAKE_C/CXX_COMPILER looks like sccache wrapper (${CMAKE_C_COMPILER}). "
+                        "Use real compiler (e.g. -DCMAKE_C_COMPILER=gcc) with launcher, and remove /usr/lib/sccache/bin from PATH.")
+    endif()
+else()
+    # Warn if wrapper would be picked but option is OFF (helps user discover the option)
+    set(_treeland_wrapper_warning FALSE)
+    if(CMAKE_C_COMPILER MATCHES "sccache" OR CMAKE_C_COMPILER MATCHES "/sccache/bin/"
+       OR CMAKE_CXX_COMPILER MATCHES "sccache" OR CMAKE_CXX_COMPILER MATCHES "/sccache/bin/")
+        set(_treeland_wrapper_warning TRUE)
+    else()
+        # Implicit case: check what CMake would pick via PATH
+        find_program(_treeland_probe_wrapper gcc NO_CACHE)
+        if(_treeland_probe_wrapper MATCHES "/sccache/bin/" OR _treeland_probe_wrapper MATCHES "sccache")
+            set(_treeland_wrapper_warning TRUE)
+        endif()
+        unset(_treeland_probe_wrapper CACHE)
+        unset(_treeland_probe_wrapper)
+    endif()
+    if(_treeland_wrapper_warning)
+        message(WARNING "sccache wrapper detected in PATH/compiler but USE_SCCACHE is OFF. "
+                        "Wrapper mode breaks try_compile (e.g. wlroots udmabuf bwrap). "
+                        "Use -DUSE_SCCACHE=ON with real compiler and remove /usr/lib/sccache/bin from PATH, "
+                        "or set -DCMAKE_C_COMPILER_LAUNCHER=sccache. See CMakeLists.txt USE_SCCACHE.")
+    endif()
+    unset(_treeland_wrapper_warning)
+endif()
 project(Treeland
     VERSION 0.9.1
     LANGUAGES CXX C)

--- a/wlroots/CMakeLists.txt
+++ b/wlroots/CMakeLists.txt
@@ -220,6 +220,15 @@ if(WLROOTS_ALLOCATOR_UDMABUF)
         }
     " _have_udmabuf_apis)
     if(NOT _have_udmabuf_h OR NOT _have_udmabuf_apis)
+        if(CMAKE_C_COMPILER MATCHES "sccache" OR CMAKE_C_COMPILER MATCHES "/sccache/")
+            message(FATAL_ERROR
+                "udmabuf allocator requires memfd_create, F_ADD_SEALS and <linux/udmabuf.h>.\n"
+                "Detected sccache wrapper as compiler (${CMAKE_C_COMPILER}). "
+                "Do not use PATH wrapper (/usr/lib/sccache/bin). Use launcher mode:\n"
+                "  cmake -DUSE_SCCACHE=ON -DCMAKE_C_COMPILER=gcc\n"
+                "or: cmake -DCMAKE_C_COMPILER_LAUNCHER=sccache\n"
+                "and remove /usr/lib/sccache/bin from PATH.")
+        endif()
         message(FATAL_ERROR
             "udmabuf allocator requires memfd_create, F_ADD_SEALS and <linux/udmabuf.h>")
     endif()


### PR DESCRIPTION
## Problem / 问题

`sccache` wrapper in `/usr/lib/sccache/bin` (`gcc/g++/cc/c++/clang` -> `sccache`) makes CMake pick `sccache` as `CMAKE_C_COMPILER`. Distributed `sccache` with `bwrap` on remote then fails `try_compile` for wlroots `udmabuf` check with `bwrap: Can't mount proc on /newroot/proc`, turning a healthy host into `FATAL_ERROR: udmabuf allocator requires memfd_create, F_ADD_SEALS and <linux/udmabuf.h>`.

Arch 上 `/usr/lib/sccache/bin` 中的包装器会使 CMake 将 `sccache` 误判为编译器，远端 `bwrap` 分布式编译在 `try_compile` 时以 `bwrap: Can't mount proc` 失败，导致本机明明支持却报 `FATAL_ERROR`。

Example:
```
cmake -B build -DCMAKE_BUILD_TYPE=Debug -DUSE_BUILD_TREE_WALLPAPER_FACTORY=ON
-- Performing Test _have_udmabuf_apis - Failed
CMake Error at wlroots/CMakeLists.txt:223: udmabuf allocator requires ...
sccache: Job failed on server 10.20.33.194:10500: bwrap: Can't mount proc
```

Root cause: `sccache` wrapper mode (PATH hijack) is deprecated; official recomments `CMAKE_C_COMPILER_LAUNCHER=sccache` (CMake 3.25+), where `try_compile` stays local. `bwrap` failure is infra misconfig on remote.

## Solution / 修复

**不再自动纠正包装器，改为显式选项，遵循 `boring` 原则。**

- **Top-level `CMakeLists.txt`**: Add `option(USE_SCCACHE "Use sccache compiler launcher" OFF)` **before** `project()`. When `ON`, `find_program(sccache REQUIRED)` and sets `CMAKE_C/CXX_COMPILER_LAUNCHER` and `RUSTC_WRAPPER`, `message(STATUS "Using sccache: ... (launcher mode)")`. Warns if `CMAKE_C_COMPILER` still looks like wrapper. When `OFF` but wrapper is detected in `PATH/compiler`, warns to use `-DUSE_SCCACHE=ON` and remove `/usr/lib/sccache/bin` from `PATH`.

- **wlroots `CMakeLists.txt`**: Keep simple check, but if it fails under `sccache` wrapper, give helpful `FATAL_ERROR` suggesting `-DUSE_SCCACHE=ON` and `PATH` cleanup, instead of cryptic `udmabuf` error.

No more implicit auto-magic; user explicitly opts in: `cmake -B build -DUSE_SCCACHE=ON` (with `PATH` without `/usr/lib/sccache/bin`).

**Top-level新增 `USE_SCCACHE` 选项，`project()` 前设置 `launcher`，未启用时若检测到包装器则警告指引；`wlroots` 失败时给出清晰提示。**

## Testing / 测试

- `PATH` without `sccache`, `cmake -B build` -> Success, no sccache, no warning
- `PATH` without `sccache`, `cmake -B build -DUSE_SCCACHE=ON` -> `Using sccache: /usr/bin/sccache` -> `CMAKE_C_COMPILER_LAUNCHER=/usr/bin/sccache` -> Success, `waylib-wlroots` builds
- `PATH` with `sccache`, `cmake -B build` (no option) -> `WARNING: sccache wrapper detected ... but USE_SCCACHE is OFF` -> may still succeed or give helpful `FATAL_ERROR` if `bwrap` hits, instead of obscure `udmabuf` error
- `cmake -B build -DUSE_SCCACHE=ON -DCMAKE_C_COMPILER=/usr/lib/sccache/bin/cc` -> `WARNING: USE_SCCACHE is ON but compiler looks like wrapper` (user should use real compiler)

## Usage / 使用

```bash
# Remove wrapper from PATH (user will do)
export PATH=$(echo $PATH | tr ':' '\n' | grep -v sccache | paste -sd:)

# Recommended
cmake -B build -DCMAKE_BUILD_TYPE=Debug -DUSE_SCCACHE=ON -DUSE_BUILD_TREE_WALLPAPER_FACTORY=ON
cmake --build build -j$(nproc)

# Or manual launcher
cmake -B build -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
```

Fixes the reported `cmake -B build -DUSE_BUILD_TREE_WALLPAPER_FACTORY=ON` failure when `PATH` is cleaned and `USE_SCCACHE` is used.