### PR TITLE
fix(xwayland): preserve compositor-controlled resize geometry

### DIFF
--- a/waylib/src/server/qtquick/wxwaylandsurfaceitem.cpp
+++ b/waylib/src/server/qtquick/wxwaylandsurfaceitem.cpp
@@ -42,15 +42,14 @@ QSize WXWaylandSurfaceItemPrivate::expectSurfaceSize() const
     const Q_Q(WXWaylandSurfaceItem);
     using enum WXWaylandSurfaceItem::ResizeMode;
 
-    const auto resizeMode = q->resizeMode();
-    const bool useRequestSize = resizeMode != SizeToSurface
-        && !q->xwaylandSurface()->isBypassManager()
+    if (q->resizeMode() == SizeFromSurface) {
+        const bool useRequestSize = !q->xwaylandSurface()->isBypassManager()
         && q->xwaylandSurface()->requestConfigureFlags()
-               .testAnyFlags(WXWaylandSurface::XCB_CONFIG_WINDOW_SIZE);
-    if (useRequestSize)
-        return q->xwaylandSurface()->requestConfigureGeometry().size();
-
-    if (resizeMode == SizeToSurface) {
+              .testAnyFlags(WXWaylandSurface::XCB_CONFIG_WINDOW_SIZE);
+        return useRequestSize
+            ? q->xwaylandSurface()->requestConfigureGeometry().size()
+            : q->xwaylandSurface()->geometry().size();
+    } else if (q->resizeMode() == SizeToSurface) {
         const auto s = (q->size() - paddingsSize()) * surfaceSizeRatio;
         return s.toSize();
     }


### PR DESCRIPTION
Only use client-requested XWayland sizes in SizeFromSurface mode.

In ManualResize mode, the surface wrapper owns the geometry and applies the requested size after updating the anchored position, so XCB applications can resize correctly from the left and top edges.

Log: fix left and top edge resizing for XWayland windows
PMS: BUG-371235
Influence: XWayland window resize behavior

https://github.com/linuxdeepin/treeland/pull/1340这个提交多修改了代码导致x11窗口左边resiz的时候出现问题

## Summary by Sourcery

Bug Fixes:
- Preserve compositor-controlled geometry in ManualResize mode while allowing XWayland client-requested sizes only in SizeFromSurface mode, fixing resizing from the left and top edges.