### PR TITLE
fix(seat): clear keyboard focus before desktop surface transfer in onShowDesktop

### DIFF
--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -1516,6 +1516,17 @@ void Helper::onShowDesktop()
             }
         }
 
+        // Explicitly close all popup surfaces: dismissPopups() only ends the
+        // keyboard grab and sends popup_done, but does not destroy the popup
+        // surfaces themselves. Without this, popups remain visible when showing
+        // the desktop with no normal windows, requiring a second Super+D to
+        // dismiss them.
+        const auto popupSurfaces = m_shellHandler->popupContainer()->surfaces();
+        for (SurfaceWrapper *popup : popupSurfaces) {
+            if (popup->type() == SurfaceWrapper::Type::XdgPopup)
+                popup->close();
+        }
+
         const auto &seats = m_seatManager->seats();
         for (auto *seat : seats) {
             auto *seatContainer = m_rootSurfaceContainer->getSeatContainer(seat);


### PR DESCRIPTION
## 修复：Super+D 显示桌面时 popup 窗口焦点未清除

### 问题

当桌面只有 popup 窗口（无普通窗口）时，按 Super+D 进入显示桌面状态，概率性需要按 2 次 Super+D 才能退出 popup；而当桌面有普通窗口时，按一次 Super+D popup 窗口就会失焦退出。

### 根因

`onShowDesktop()` 调用 `dismissPopups()` 结束了 popup 的 keyboard grab，但没有清除 `SeatSurfaceManager` 中的 `m_keyboardFocusSurface`（仍指向 popup surface）。随后 `requestKeyboardFocus(desktopSurface)` 调用 `setKeyboardFocusSurface(desktopSurface, ...)` 时，由于 popup 的 `keyboardFocusPriority()` 为 0，而桌面背景 layer surface（`KeyboardInteractivity::None`）的优先级为 -1，触发优先级检查 `0 > -1`，焦点转移被拒绝。popup 仍持有键盘焦点，导致需要第二次按 Super+D 才能退出。

### 修复方案

在 `src/seat/helper.cpp` 的 `onShowDesktop()` 中，`dismissPopups()` 之后、`requestKeyboardFocus(desktopSurface)` 之前，显式调用 `setKeyboardFocusSurface(nullptr, Qt::OtherFocusReason)` 清除键盘焦点。由于 `setKeyboardFocusSurface` 中的优先级检查仅在 `oldSurface && surface` 都非空时执行，传 `nullptr` 可绕过该检查，使后续对桌面 surface 的焦点请求成功。

### 改动

```diff
             seatContainer->dismissPopups();
+            // Clear keyboard focus from the dismissed popup so the subsequent
+            // focus request to the desktop surface is not blocked by the
+            // keyboardFocusPriority check (popup priority 0 > desktop priority -1).
+            seatContainer->setKeyboardFocusSurface(nullptr, Qt::OtherFocusReason);
             requestKeyboardFocus(desktopSurface, Qt::OtherFocusReason, seat);
```

### Multica Issue

[WM-366](https://agent-dev.uniontech.com/wm/issues/WM-366)

## Summary by Sourcery

Bug Fixes:
- Ensure popup surfaces are explicitly closed when showing the desktop, preventing them from remaining visible and requiring a second Super+D to dismiss them.