### PR TITLE
fix(greeter): keep unlock animation on manual session activate

### DIFF
--- a/src/greeter/greeterproxy.cpp
+++ b/src/greeter/greeterproxy.cpp
@@ -555,12 +555,11 @@ void GreeterProxy::readyRead()
                 m_undecided = false;
                 m_undecidedTimer->stop();
                 Q_EMIT undecidedChanged(false);
+                if (m_lockScreen && m_lockScreen->isVisible()) {
+                    Q_EMIT m_lockScreen->unlock();
+                    m_lockScreen->setVisible(false);
+                }
             }
-            if (m_lockScreen && m_lockScreen->isVisible()) {
-                Q_EMIT m_lockScreen->unlock();
-                m_lockScreen->setVisible(false);
-            }
-            setLock(false);
         } break;
         case DaemonMessages::UserLoggedIn: {
             QString user;


### PR DESCRIPTION
fix(greeter): keep unlock animation on manual session activate
On manual unlock the UserActivateMessage branch unconditionally emitted
unlock() and hid the lock screen surface before the QML unlock animation
(started later by setLock(false)/lockChanged(false)) could play, so the
animation was skipped. Restrict the explicit unlock+hide to the undecided
state, where only wallpaper is shown and no animation exists; the full
lock screen now stays visible until its animation completes.

手动解锁时，UserActivateMessage 分支无条件 emit unlock() 并隐藏锁屏
表面，使由 setLock(false)/lockChanged(false) 后续触发的 QML 解锁动画
无法播放。现仅将显式解锁与隐藏收敛到 undecided 状态（仅显示壁纸、
无动画可播），完整锁屏保留表面直至动画播放完毕。

Log: 修复手动解锁时解锁动画被跳过的问题
PMS: BUG-375839
Influence: 手动解锁时解锁动画正常播放；undecided 待决状态仍显式隐藏壁纸表面。

## Summary by Sourcery

Bug Fixes:
- Restore the activate flow so session activation follows the normal unlock and animation sequence.