### PR TITLE
fix(treeland-debug): silence unused noEscalate warning in dev builds

### DIFF
--- a/tools/treeland-debug/main.cpp
+++ b/tools/treeland-debug/main.cpp
@@ -413,7 +413,7 @@ int main(int argc, char *argv[])
     bool previewOpt = 0; // 0=auto-detect, 1=force on, 2=force off
     bool compatTree = false;
     bool compatCursor = false;
-    bool noEscalate = false;
+    [[maybe_unused]] bool noEscalate = false;
     QStringList rest;
 
     for (int i = 1; i < argc; ++i) {


### PR DESCRIPTION
noEscalate is only read under #ifndef TREELAND_DEBUG_DEV_BUILD, so dev builds write it via --no-escalate without ever reading it, triggering a -Wunused-but-set-variable warning. Mark it [[maybe_unused]].

noEscalate 仅在非开发构建分支中被读取，开发构建中 --no-escalate 会赋值
但从不使用，触发 -Wunused-but-set-variable 告警，故标记 [[maybe_unused]]。

Log: 消除开发构建中未使用变量的编译告警
Influence: 仅消除编译告警，无行为变化。

## Summary by Sourcery

Enhancements:
- Suppress the unused-variable warning for the development-only `noEscalate` option without changing runtime behavior.