### PR TITLE
fix(xwayland): synchronize transient window stacking

### DIFF
--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -966,6 +966,9 @@ void ShellHandler::ensureXwaylandWrapper(WXWaylandSurface *surface, const QStrin
             return;
 
         updateWrapperContainer(wrapperGuard, surfaceGuard->parentSurface());
+
+        if (auto *parent = surfaceGuard->parentXWaylandSurface())
+            surfaceGuard->restack(parent, WXWaylandSurface::XCB_STACK_MODE_ABOVE);
     };
     QObject::connect(surface,
                      &WXWaylandSurface::parentSurfaceChanged,


### PR DESCRIPTION
Keep the native X11 window stack synchronized with the QtQuick scene stack when associating an XWayland transient window with its parent.

Restack the transient above its parent so Xwayland pointer hit testing targets the visible dialog instead of the underlying parent window.

Log: fix mouse input for XWayland transient dialogs
PMS: BUG-375823、371095
Influence: XWayland transient window stacking and pointer input

## Summary by Sourcery

Bug Fixes:
- Keep XWayland transient windows stacked above their parent so pointer input reaches visible dialogs instead of the underlying window.