### PR TITLE
fix(xwayland): skip restacking override-redirect windows

### DIFF
--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -967,8 +967,10 @@ void ShellHandler::ensureXwaylandWrapper(WXWaylandSurface *surface, const QStrin
 
         updateWrapperContainer(wrapperGuard, surfaceGuard->parentSurface());
 
-        if (auto *parent = surfaceGuard->parentXWaylandSurface())
-            surfaceGuard->restack(parent, WXWaylandSurface::XCB_STACK_MODE_ABOVE);
+        if (!surfaceGuard->isBypassManager()) {
+            if (auto *parent = surfaceGuard->parentXWaylandSurface())
+                surfaceGuard->restack(parent, WXWaylandSurface::XCB_STACK_MODE_ABOVE);
+        }
     };
     QObject::connect(surface,
                      &WXWaylandSurface::parentSurfaceChanged,


### PR DESCRIPTION
Avoid calling the managed XWayland restack API when associating an override-redirect transient window with its parent.

Override-redirect windows manage their own stacking and are rejected by wlr_xwayland_surface_restack(), causing Treeland to abort on its assertion.

Log: fix crash when creating XWayland override-redirect transient windows
PMS: BUG-375823、371095
Influence: XWayland transient window association and stacking

## Summary by Sourcery

Bug Fixes:
- Prevent crashes when associating override-redirect XWayland transient windows with their parents by skipping unsupported restacking operations.