### PR TITLE
refactor: rename qwBuffer to wlrBuffer for naming consistency

### DIFF
--- a/src/modules/capture/capture.cpp
+++ b/src/modules/capture/capture.cpp
@@ -1014,7 +1014,7 @@ wlr_buffer *CaptureSourceOutput::internalBuffer()
 {
     Q_ASSERT(m_sourceList.size() == 1);
     if (m_sourceList.first().first && m_outputViewport->wTextureProvider())
-        return m_outputViewport->wTextureProvider()->qwBuffer();
+        return m_outputViewport->wTextureProvider()->wlrBuffer();
     else
         return nullptr;
 }
@@ -1047,7 +1047,7 @@ wlr_buffer *CaptureSourceRegion::internalBuffer()
 {
     if (m_sourceList.size() == 1 && m_sourceList.first().first
         && m_sourceList.first().second->wTextureProvider()) {
-        return m_sourceList.first().second->wTextureProvider()->qwBuffer();
+        return m_sourceList.first().second->wTextureProvider()->wlrBuffer();
     } else {
         return nullptr;
     }

--- a/src/modules/capture/impl/capturev1impl.cpp
+++ b/src/modules/capture/impl/capturev1impl.cpp
@@ -301,12 +301,12 @@ void handle_treeland_capture_frame_v1_copy(wl_client *client,
 {
     treeland_capture_frame_v1 *frame = capture_frame_from_resource(resource);
     Q_ASSERT(frame);
-    wlr_buffer *qwBuffer = wlr_buffer_try_from_resource(buffer);
-    if (!qwBuffer) {
+    wlr_buffer *wlrBuffer = wlr_buffer_try_from_resource(buffer);
+    if (!wlrBuffer) {
         wl_client_post_implementation_error(client, "Buffer not created!");
         return;
     }
-    Q_EMIT frame->copy(qwBuffer);
+    Q_EMIT frame->copy(wlrBuffer);
 }
 
 void treeland_capture_session_v1::sendProduceMoreCancel()

--- a/waylib/src/server/qtquick/private/wbufferrenderer.cpp
+++ b/waylib/src/server/qtquick/private/wbufferrenderer.cpp
@@ -679,7 +679,7 @@ void WBufferRenderer::updateTextureProvider()
         return;
 
     if (shouldCacheBuffer()) {
-        const bool hasCachedBuffer = m_textureProvider->qwBuffer();
+        const bool hasCachedBuffer = m_textureProvider->wlrBuffer();
         // Ensure only update the buffer when the "shouldCacheBuffer" state is changed.
         // If the state is not changed, the buffer is update in the WBufferRenderer::render.
         if (!hasCachedBuffer && m_lastBuffer)

--- a/waylib/src/server/qtquick/wquickcursor.cpp
+++ b/waylib/src/server/qtquick/wquickcursor.cpp
@@ -80,10 +80,10 @@ public:
             return proxy->qwTexture();
         return WSGTextureProvider::qwTexture();
     }
-    wlr_buffer *qwBuffer() const override {
+    wlr_buffer *wlrBuffer() const override {
         if (proxy)
-            return proxy->qwBuffer();
-        return WSGTextureProvider::qwBuffer();
+            return proxy->wlrBuffer();
+        return WSGTextureProvider::wlrBuffer();
     }
 
     WBufferDropPtr buffer;
@@ -572,7 +572,7 @@ QSGNode *WQuickCursor::updatePaintNode(QSGNode *node, UpdatePaintNodeData *)
         tp->setImage(d->cursorImage->image());
     }
 
-    // Ignore the tp->proxy, Don't use tp->qwBuffer()
+    // Ignore the tp->proxy, Don't use tp->wlrBuffer()
     if (!tp->buffer) {
         delete node;
         return nullptr;

--- a/waylib/src/server/qtquick/wsgtextureprovider.cpp
+++ b/waylib/src/server/qtquick/wsgtextureprovider.cpp
@@ -189,7 +189,7 @@ wlr_texture *WSGTextureProvider::qwTexture() const
     return d->texture;
 }
 
-wlr_buffer *WSGTextureProvider::qwBuffer() const
+wlr_buffer *WSGTextureProvider::wlrBuffer() const
 {
     W_DC(WSGTextureProvider);
     return d->buffer;

--- a/waylib/src/server/qtquick/wsgtextureprovider.h
+++ b/waylib/src/server/qtquick/wsgtextureprovider.h
@@ -29,7 +29,7 @@ public:
 
     QSGTexture *texture() const override;
     virtual wlr_texture *qwTexture() const;
-    virtual wlr_buffer *qwBuffer() const;
+    virtual wlr_buffer *wlrBuffer() const;
 
     bool smooth() const;
     void setSmooth(bool newSmooth);

--- a/waylib/src/server/utils/wextimagecapturesourcev1impl.cpp
+++ b/waylib/src/server/utils/wextimagecapturesourcev1impl.cpp
@@ -341,7 +341,7 @@ void WExtImageCaptureSourceV1Impl::copy_frame(wlr_ext_image_copy_capture_frame_v
         return;
     }
 
-    auto buffer = textureProvider->qwBuffer();
+    auto buffer = textureProvider->wlrBuffer();
     if (!buffer) {
         qCWarning(lcWlImageCapture) << "No internal buffer available";
         wlr_ext_image_copy_capture_frame_v1_fail(dst_frame, EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);


### PR DESCRIPTION
## 变更说明

将类型为 `wlr_buffer` 的变量/方法从 `qwBuffer` 重命名为 `wlrBuffer`，使命名与 wlroots C API 类型一致。

`qw` 前缀是已移除的 `qwlroots` 封装库的历史遗留（见提交 `9582881dd: feat: remove qwlroots dependency, use wlroots C API directly`），现在直接使用 wlroots C API，应统一命名。

### 变更范围（7 个文件，13 处修改）

| 文件 | 修改点 |
|------|--------|
| `waylib/src/server/qtquick/wsgtextureprovider.h` | 方法声明 |
| `waylib/src/server/qtquick/wsgtextureprovider.cpp` | 方法定义 |
| `waylib/src/server/qtquick/wquickcursor.cpp` | override、调用及注释 |
| `waylib/src/server/qtquick/private/wbufferrenderer.cpp` | 调用处 |
| `waylib/src/server/utils/wextimagecapturesourcev1impl.cpp` | 调用处 |
| `src/modules/capture/capture.cpp` | 2 处调用 |
| `src/modules/capture/impl/capturev1impl.cpp` | 局部变量及使用 |

### 注意

- 作用域限定为 `wlr_buffer` 类型，`qwTexture()`（返回 `wlr_texture*`）保持不变。
- 所有调用者均在 treeland 仓库内，无外部消费者受影响。

关联 issue: WM-386

## Summary by Sourcery

Enhancements:
- Rename the wlr_buffer accessor, overrides, local variables, and call sites from qwBuffer to wlrBuffer for consistent wlroots API naming while retaining the existing qwTexture name.