### PR TITLE
fix(waylib): update subsurface manager class name to match protocol rename

### DIFF
--- a/waylib/src/server/protocols/wremotesubsurfacemanagerv1.cpp
+++ b/waylib/src/server/protocols/wremotesubsurfacemanagerv1.cpp
@@ -194,14 +194,14 @@ static inline QStringView shortToken(const QString &token)
 
 class WRemoteSubsurfaceManagerV1Private
     : public WObjectPrivate
-    , public QtWaylandServer::treeland_subsurface_manager_v1
+    , public QtWaylandServer::treeland_remote_subsurface_manager_v1
 {
     Q_DECLARE_PUBLIC(WRemoteSubsurfaceManagerV1)
 
 public:
     explicit WRemoteSubsurfaceManagerV1Private(WRemoteSubsurfaceManagerV1 *q)
         : WObjectPrivate(q)
-        , QtWaylandServer::treeland_subsurface_manager_v1()
+        , QtWaylandServer::treeland_remote_subsurface_manager_v1()
     {
     }
 
@@ -764,7 +764,7 @@ wl_global *WRemoteSubsurfaceManagerV1::global() const
 
 QByteArrayView WRemoteSubsurfaceManagerV1::interfaceName() const
 {
-    return QtWaylandServer::treeland_subsurface_manager_v1::interfaceName();
+    return QtWaylandServer::treeland_remote_subsurface_manager_v1::interfaceName();
 }
 
 WAYLIB_SERVER_END_NAMESPACE


### PR DESCRIPTION
## Problem

treeland-protocols commit ffbc937 renamed the Wayland interface from `treeland_subsurface_manager_v1` to `treeland_remote_subsurface_manager_v1`, but the C++ implementation in `wremotesubsurfacemanagerv1.cpp` was not updated accordingly, causing compilation failures on CI.

## Root Cause

The protocol XML interface was renamed in treeland-protocols:
```
-    <interface name="treeland_subsurface_manager_v1" version="1">
+    <interface name="treeland_remote_subsurface_manager_v1" version="1">
```

But 3 references in `waylib/src/server/protocols/wremotesubsurfacemanagerv1.cpp` still used the old name `treeland_subsurface_manager_v1`, causing:
- `expected class-name before '{' token`
- `m_global was not declared in this scope`
- `Resource has not been declared`
- `destroy(int*) marked override, but does not override`
- `export_surface(...) marked override, but does not override`
- `QtWaylandServer::treeland_subsurface_manager_v1 has not been declared`

## Fix

Updated all 3 occurrences of `treeland_subsurface_manager_v1` → `treeland_remote_subsurface_manager_v1` to match the renamed protocol interface.

## Summary by Sourcery

Bug Fixes:
- Update the Waylib remote subsurface manager implementation to use the renamed protocol interface, restoring compatibility with the generated protocol bindings and fixing CI compilation failures.