### PR TITLE
fix(lockscreen): make login view global and follow cursor output

### DIFF
--- a/src/core/lockscreen.cpp
+++ b/src/core/lockscreen.cpp
@@ -10,13 +10,15 @@
 #include "common/treelandlogging.h"
 #include "greeter/greeterproxy.h"
 
-#ifdef EXT_SESSION_LOCK_V1
-#include <wsessionlock.h>
-#include <wsessionlocksurface.h>
+#include <woutputitem.h>
 
+#ifdef EXT_SESSION_LOCK_V1
 #include "rootsurfacecontainer.h"
 #include "surfacewrapper.h"
-#include "woutputitem.h"
+
+#include <wcursor.h>
+#include <wsessionlock.h>
+#include <wsessionlocksurface.h>
 #endif
 
 WAYLIB_SERVER_USE_NAMESPACE
@@ -32,6 +34,15 @@ LockScreen::LockScreen(ILockScreen *impl, SurfaceContainer *parent, GreeterProxy
     m_delayTimer->setSingleShot(true);
     // Display desktop animation after lock screen animation with a delay of 300ms
     m_delayTimer->setInterval(300);
+
+    // The global login view is lazily created when this container becomes
+    // visible (locked) and destroyed when it hides (unlocked). Track the
+    // cursor so the login UI follows the output the mouse is on.
+    connect(this, &QQuickItem::visibleChanged, this, &LockScreen::onLoginViewVisibleChanged);
+    connect(rootContainer()->cursor(),
+            &WCursor::positionChanged,
+            this,
+            &LockScreen::onCursorPositionChanged);
 }
 
 void LockScreen::lock()
@@ -87,10 +98,11 @@ void LockScreen::addOutput(Output *output)
     qCDebug(lcTlShell) << "Adding output to lock screen:" << output;
 
     SurfaceContainer::addOutput(output);
-#if EXT_SESSION_LOCK_V1
     auto outputItem = output->outputItem();
-    connect(outputItem, &WOutputItem::geometryChanged, this, &LockScreen::onOutputGeometryChanged);
+    connect(outputItem, &WOutputItem::geometryChanged, this, &LockScreen::repositionLoginView);
 
+#if EXT_SESSION_LOCK_V1
+    connect(outputItem, &WOutputItem::geometryChanged, this, &LockScreen::onOutputGeometryChanged);
     const auto &[_, ok] = m_lockSurfaces.emplace(outputItem, nullptr);
     Q_ASSERT(ok);
 #endif
@@ -100,10 +112,6 @@ void LockScreen::addOutput(Output *output)
     }
 
     auto *item = m_impl->createLockScreen(output, this);
-    item->setProperty("primaryOutputName", m_primaryOutputName);
-
-    connect(item, SIGNAL(animationPlayed()), this, SLOT(onAnimationPlayed()));
-    connect(item, SIGNAL(animationPlayFinished()), this, SLOT(onAnimationPlayFinished()));
 
     m_components.insert(
         { output, std::unique_ptr<QQuickItem, void (*)(QQuickItem *)>(item, [](QQuickItem *item) {
@@ -121,8 +129,10 @@ void LockScreen::removeOutput(Output *output)
     qCDebug(lcTlShell) << "Removing output from lock screen:" << output;
 
     SurfaceContainer::removeOutput(output);
-#if EXT_SESSION_LOCK_V1
     auto outputItem = output->outputItem();
+    disconnect(outputItem, &WOutputItem::geometryChanged, this, &LockScreen::repositionLoginView);
+
+#if EXT_SESSION_LOCK_V1
     disconnect(outputItem,
                &WOutputItem::geometryChanged,
                this,
@@ -135,6 +145,7 @@ void LockScreen::removeOutput(Output *output)
     }
 #endif
     m_components.erase(output);
+    repositionLoginView();
 }
 
 void LockScreen::onAnimationPlayed()
@@ -157,16 +168,80 @@ bool LockScreen::available() const
     return m_impl != nullptr;
 }
 
-void LockScreen::setPrimaryOutputName(const QString &primaryOutputName)
+void LockScreen::onLoginViewVisibleChanged()
 {
-    qCDebug(lcTlShell) << "Setting primary output name for lock screen:" << primaryOutputName;
-
-    m_primaryOutputName = primaryOutputName;
-    for (const auto &[k, v] : std::as_const(m_components)) {
-        v->setProperty("primaryOutputName", primaryOutputName);
+    if (isVisible()) {
+        createLoginView();
+    } else {
+        destroyLoginView();
     }
 }
 
+void LockScreen::createLoginView()
+{
+    if (!m_impl || m_loginView) {
+        return;
+    }
+
+    qCDebug(lcTlShell) << "Creating global login view for lock screen";
+    auto *item = m_impl->createLockView(this);
+    if (!item) {
+        qCWarning(lcTlShell) << "Failed to create global login view";
+        return;
+    }
+
+    connect(item, SIGNAL(animationPlayed()), this, SLOT(onAnimationPlayed()));
+    connect(item, SIGNAL(animationPlayFinished()), this, SLOT(onAnimationPlayFinished()));
+
+    m_loginView = item;
+    repositionLoginView();
+}
+
+void LockScreen::destroyLoginView()
+{
+    if (!m_loginView) {
+        return;
+    }
+    qCDebug(lcTlShell) << "Destroying global login view for lock screen";
+    m_loginView->deleteLater();
+    m_loginView = nullptr;
+}
+
+Output *LockScreen::followerOutput() const
+{
+    auto *root = rootContainer();
+    if (auto *out = root->cursorOutput()) {
+        return out;
+    }
+    return root->primaryOutput();
+}
+
+void LockScreen::repositionLoginView()
+{
+    if (!m_loginView) {
+        return;
+    }
+
+    auto *out = followerOutput();
+    if (!out) {
+        return;
+    }
+
+    const auto pos = out->outputItem()->position();
+    const auto size = out->outputItem()->size();
+
+    m_loginView->setX(pos.x());
+    m_loginView->setY(pos.y());
+    m_loginView->setWidth(size.width());
+    m_loginView->setHeight(size.height());
+}
+
+void LockScreen::onCursorPositionChanged()
+{
+    if (m_loginView) {
+        repositionLoginView();
+    }
+}
 #if EXT_SESSION_LOCK_V1
 // ext_session_lock_v1 capabilities
 

--- a/src/core/lockscreen.h
+++ b/src/core/lockscreen.h
@@ -43,7 +43,6 @@ public:
     void lock();
     void shutdown();
     void switchUser();
-    void setPrimaryOutputName(const QString &primaryOutputName);
 
 Q_SIGNALS:
     void unlock();
@@ -71,6 +70,13 @@ public:
     void removeOutput(Output *output) override;
 
 private:
+    void onLoginViewVisibleChanged();
+    void createLoginView();
+    void destroyLoginView();
+    void repositionLoginView();
+    void onCursorPositionChanged();
+    Output *followerOutput() const;
+
     ILockScreen *m_impl{ nullptr };
     GreeterProxy *m_greeterProxy{ nullptr };
     std::map<Output *, std::unique_ptr<QQuickItem, void (*)(QQuickItem *)>> m_components;
@@ -80,5 +86,5 @@ private:
     std::map<WOutputItem *, std::unique_ptr<QQuickItem, std::function<void(QQuickItem*)>>> m_fallbackItems;
     WSessionLock* m_sessionLock{ nullptr };
 #endif
-    QString m_primaryOutputName;
+    QQuickItem *m_loginView{ nullptr };
 };

--- a/src/interfaces/lockscreeninterface.h
+++ b/src/interfaces/lockscreeninterface.h
@@ -16,6 +16,7 @@ public:
     virtual ~ILockScreen() = default;
 
     virtual QQuickItem *createLockScreen(Output *output, QQuickItem *parent) = 0;
+    virtual QQuickItem *createLockView(QQuickItem *parent) = 0;
 };
 
 Q_DECLARE_INTERFACE(ILockScreen, "org.deepin.treeland.v1.LockScreenInterface")

--- a/src/plugins/lockscreen/CMakeLists.txt
+++ b/src/plugins/lockscreen/CMakeLists.txt
@@ -24,6 +24,7 @@ qt_add_qml_module(lockscreen
         qml/ControlAction.qml
         qml/Greeter.qml
         qml/LockView.qml
+        qml/LoginView.qml
         qml/PowerList.qml
         qml/RoundBlur.qml
         qml/ShutdownButton.qml

--- a/src/plugins/lockscreen/lockscreenplugin.cpp
+++ b/src/plugins/lockscreen/lockscreenplugin.cpp
@@ -12,6 +12,7 @@ void LockScreenPlugin::initialize(TreelandProxyInterface *proxy)
 {
     m_proxy = proxy;
 
+    new (&m_lockViewComponent) QQmlComponent(m_proxy->qmlEngine(), "LockScreen", "LoginView", this);
     new (&m_lockscreenComponent) QQmlComponent(m_proxy->qmlEngine(), "LockScreen", "Greeter", this);
 }
 
@@ -27,4 +28,9 @@ QQuickItem *LockScreenPlugin::createLockScreen(Output *output, QQuickItem *paren
         parent,
         { { "output", QVariant::fromValue(output->output()) },
           { "outputItem", QVariant::fromValue(output->outputItem()) } });
+}
+
+QQuickItem *LockScreenPlugin::createLockView(QQuickItem *parent)
+{
+    return m_proxy->qmlEngine()->createComponent(m_lockViewComponent, parent);
 }

--- a/src/plugins/lockscreen/lockscreenplugin.h
+++ b/src/plugins/lockscreen/lockscreenplugin.h
@@ -36,9 +36,11 @@ public:
         return true;
     }
 
+    QQuickItem *createLockView(QQuickItem *parent) override;
     QQuickItem *createLockScreen(Output *output, QQuickItem *parent) override;
 
 private:
     TreelandProxyInterface *m_proxy;
+    QQmlComponent m_lockViewComponent;
     QQmlComponent m_lockscreenComponent;
 };

--- a/src/plugins/lockscreen/qml/Greeter.qml
+++ b/src/plugins/lockscreen/qml/Greeter.qml
@@ -10,13 +10,8 @@ FocusScope {
     id: root
     clip: true
 
-    signal animationPlayed
-    signal animationPlayFinished
-
     required property QtObject output
     required property QtObject outputItem
-    property string primaryOutputName
-    property bool isPrimaryOutput: primaryOutputName === "" || primaryOutputName === output.name
     visible: true
 
     x: outputItem.x
@@ -120,70 +115,4 @@ FocusScope {
         enabled: true
     }
 
-    Loader {
-        id: lockViewLoader
-        anchors.fill: parent
-        active: isPrimaryOutput
-        sourceComponent: lockViewComponent
-    }
-
-    Component {
-        id: lockViewComponent
-        LockView {
-            id: lockView
-            anchors.fill: parent
-            onAnimationPlayFinished: function () {
-                if (lockView.state === LoginAnimation.Hide) {
-                    root.animationPlayFinished()
-                }
-            }
-        }
-    }
-
-    Loader {
-        id: shutdownViewLoader
-        anchors.fill: parent
-        active: GreeterProxy.showShutdownView && isPrimaryOutput
-        sourceComponent: shutdownViewComponent
-    }
-
-    Component {
-        id: shutdownViewComponent
-        ShutdownView {
-            id: shutdownView
-            anchors.fill: parent
-            onSwitchUser: {
-                root.switchUser()
-            }
-        }
-    }
-
-    /*****************************/
-    /* Functions and Connections */
-    /*****************************/
-
-    function switchUser() {
-        GreeterProxy.lock()
-        lockView.showUserView()
-    }
-
-    Connections {
-        target: GreeterProxy
-
-        function onLockChanged(isLocked) {
-            if (!isLocked)
-                root.animationPlayed()
-        }
-
-        function onShowShutdownViewChanged(show) {
-            if (!show && !GreeterProxy.isLocked) {
-                root.animationPlayed()
-                root.animationPlayFinished()
-            }
-        }
-
-        function onSwitchUser() {
-            root.switchUser()
-        }
-    }
 }

--- a/src/plugins/lockscreen/qml/LoginView.qml
+++ b/src/plugins/lockscreen/qml/LoginView.qml
@@ -1,0 +1,74 @@
+// Copyright (C) 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+import QtQuick
+import Treeland
+import LockScreen
+
+// Global login UI container. Unlike Greeter (created once per output), this
+// component is a single instance owned by the LockScreen container and
+// repositioned to follow the output the cursor is on. It is created when the
+// lock screen becomes visible and destroyed when it hides, so the login UI
+// does not outlive the lock session.
+FocusScope {
+    id: root
+
+    signal animationPlayed
+    signal animationPlayFinished
+
+    LockView {
+        id: lockView
+        anchors.fill: parent
+        onAnimationPlayFinished: function () {
+            if (lockView.state === LoginAnimation.Hide) {
+                root.animationPlayFinished()
+            }
+        }
+    }
+
+    Loader {
+        id: shutdownViewLoader
+        anchors.fill: parent
+        active: GreeterProxy.showShutdownView
+        sourceComponent: shutdownViewComponent
+    }
+
+    Component {
+        id: shutdownViewComponent
+        ShutdownView {
+            id: shutdownView
+            anchors.fill: parent
+            onSwitchUser: {
+                root.switchUser()
+            }
+        }
+    }
+
+    /*****************************/
+    /* Functions and Connections */
+    /*****************************/
+
+    function switchUser() {
+        GreeterProxy.lock()
+        lockView.showUserView()
+    }
+
+    Connections {
+        target: GreeterProxy
+
+        function onLockChanged(isLocked) {
+            if (!isLocked)
+                root.animationPlayed()
+        }
+
+        function onShowShutdownViewChanged(show) {
+            if (!show && !GreeterProxy.isLocked) {
+                root.animationPlayed()
+                root.animationPlayFinished()
+            }
+        }
+
+        function onSwitchUser() {
+            root.switchUser()
+        }
+    }
+}

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2019,14 +2019,6 @@ void Helper::init(Treeland::Treeland *treeland)
             this,
             &Helper::onRestoreCopyOutput);
 
-    connect(m_rootSurfaceContainer, &RootSurfaceContainer::primaryOutputChanged, this, [this]() {
-        if (m_rootSurfaceContainer->primaryOutput()) {
-            if (m_lockScreen) {
-                m_lockScreen->setPrimaryOutputName(m_rootSurfaceContainer->primaryOutput()->output()->name());
-            }
-        }
-    });
-
     qmlRegisterUncreatableType<Personalization>("Treeland.Protocols",
                                                 1,
                                                 0,
@@ -3461,10 +3453,6 @@ void Helper::setLockScreenImpl(ILockScreen *impl)
 
     for (auto *output : std::as_const(m_rootSurfaceContainer->outputs())) {
         m_lockScreen->addOutput(output);
-    }
-
-    if (auto primaryOutput = m_rootSurfaceContainer->primaryOutput()) {
-        m_lockScreen->setPrimaryOutputName(primaryOutput->output()->name());
     }
 
     connect(m_lockScreen, &LockScreen::unlock, this, [this] {


### PR DESCRIPTION
Make the lock screen login UI a single global view that follows the output the cursor is on, instead of one instance per output anchored to the primary screen. The view is lazily created on lock and destroyed on unlock, so the typed password and session state survive output switches. 

将锁屏登录界面从每屏一份、固定在主屏，改为全局唯一并跟随鼠标所在
输出移动。视图在锁定时懒加载、解锁后销毁，切屏不丢失已输入的密码
与会话状态。

Log: 锁屏登录界面全局化并跟随鼠标所在屏
PMS: BUG-371115
Influence: 锁屏/关机界面在多屏环境下跟随鼠标所在屏显示，切屏不销毁
登录状态；

## Summary by Sourcery

Make the lock-screen login interface global and move it to follow the cursor’s current output.

New Features:
- Provide a single global lock-screen login view that follows the output containing the cursor.
- Preserve the login and session state while switching between outputs during a lock session.

Bug Fixes:
- Fix multi-monitor lock-screen and shutdown UI placement so it is no longer fixed to the primary output.

Enhancements:
- Create the global login UI when locking and destroy it after unlocking to align its lifetime with the lock session.