### PR TITLE
fix(show-desktop): cancel show-desktop when opening interactive layer-shell windows

### DIFF
--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -1135,8 +1135,10 @@ void ShellHandler::setupSurfaceActiveWatcher(SurfaceWrapper *wrapper)
                  */
                 if (layerSurface->layer() >= WLayerSurface::LayerType::Top
                     || layerSurface->keyboardInteractivity()
-                        == WLayerSurface::KeyboardInteractivity::Exclusive)
+                        == WLayerSurface::KeyboardInteractivity::Exclusive) {
+                    Helper::instance()->cancelShowDesktop();
                     Helper::instance()->requestKeyboardFocus(wrapper);
+                }
             } else {
                 onSurfaceInactivationRequested(wrapper);
             }


### PR DESCRIPTION

1. Opening an interactive layer-shell window (e.g. the notification center
   opened by Super+M) while show-desktop is active now cancels the
   show-desktop state and resets it to Normal.
2. This matches the behavior of normal windows
   (setActivatedSurface -> cancelShowDesktop); previously layer-shell
   windows were exempt and could not be dismissed with a single Super+D.
3. Popup windows keep their existing behavior (grab/exposure changes only).

Log: Cancel show-desktop when opening interactive layer-shell windows so one Super+D dismisses them.

Influence:
1. With show-desktop active, open the notification center (Super+M), press Super+D once - it closes on the first press.
2. With show-desktop active, open a popup (e.g. desktop context menu) - verify it does NOT cancel show-desktop.
3. Verify normal windows still exit show-desktop on activation.

fix(show-desktop): 打开可交互的 layer-shell 窗口时取消显示桌面状态

1. 显示桌面状态下打开可交互的 layer-shell 窗口（如按 Super+M 唤出的通知
   中心）时，取消显示桌面状态并重置为 Normal。
2. 与普通窗口既有行为（setActivatedSurface -> cancelShowDesktop）保持一致；
   此前 layer-shell 窗口属于例外，无法用一次 Super+D 关闭。
3. popup 窗口保持原有行为（仅受 grab/焦点机制影响，不取消显示桌面）。

Log: 打开可交互的 layer-shell 窗口时取消显示桌面状态，一次 Super+D 即可关闭。

Influence:
1. 显示桌面状态下打开通知中心（Super+M），按一次 Super+D 应直接关闭。
2. 显示桌面状态下打开右键菜单（popup），验证其不会取消显示桌面。
3. 确认普通窗口激活时仍能正常退出显示桌面状态。

PMS: BUG-372393