### PR TITLE
fix(shell): keep close animation in place on activation transfer

### DIFF
--- a/src/core/shellhandler.cpp
+++ b/src/core/shellhandler.cpp
@@ -1094,7 +1094,8 @@ void ShellHandler::onSurfaceInactivationRequested(SurfaceWrapper *wrapper)
             if (seat == primarySeat) {
                 helper->activateSurface(m_workspace->current()->latestActiveSurface(),
                                         Qt::OtherFocusReason,
-                                        seat);
+                                        seat,
+                                        false);
             } else {
                 helper->requestKeyboardFocus(nullptr, Qt::OtherFocusReason, seat);
             }

--- a/src/seat/helper.cpp
+++ b/src/seat/helper.cpp
@@ -2378,7 +2378,10 @@ WSeat *Helper::getSeatForEvent(QInputEvent *event) const
     return m_seatManager->getSeatForEvent(event);
 }
 
-void Helper::activateSurface(SurfaceWrapper *wrapper, Qt::FocusReason reason, WSeat *seat)
+void Helper::activateSurface(SurfaceWrapper *wrapper,
+                             Qt::FocusReason reason,
+                             WSeat *seat,
+                             bool raise)
 {
     if (wrapper && wrapper->isIMCandidatePanel())
         return;
@@ -2414,7 +2417,7 @@ void Helper::activateSurface(SurfaceWrapper *wrapper, Qt::FocusReason reason, WS
     }
 
     if (!wrapper || wrapper->hasActiveCapability()) {
-        setActivatedSurface(wrapper, seat);
+        setActivatedSurface(wrapper, seat, raise);
     } else {
         qCCritical(lcTlShell)
             << "Trying to activate a surface which doesn't have ActiveCapability!";
@@ -3000,7 +3003,7 @@ SurfaceWrapper *Helper::activatedSurface() const
     return seatContainer ? seatContainer->activatedSurface() : nullptr;
 }
 
-void Helper::setActivatedSurface(SurfaceWrapper *newActivateSurface, WSeat *seat)
+void Helper::setActivatedSurface(SurfaceWrapper *newActivateSurface, WSeat *seat, bool raise)
 {
     if (!m_rootSurfaceContainer) {
         qCWarning(lcTlCore) << "Cannot set activated surface: root surface container is null";
@@ -3028,12 +3031,14 @@ void Helper::setActivatedSurface(SurfaceWrapper *newActivateSurface, WSeat *seat
 
     if (newActivateSurface) {
         Q_ASSERT(newActivateSurface->showOnWorkspace(workspace()->current()->id()));
-        newActivateSurface->stackToLast();
-        if (newActivateSurface->type() == SurfaceWrapper::Type::XWayland) {
-            auto xwaylandSurface =
-                qobject_cast<WXWaylandSurface *>(newActivateSurface->shellSurface());
-            Q_ASSERT(!xwaylandSurface->isBypassManager());
-            xwaylandSurface->restack(nullptr, WXWaylandSurface::XCB_STACK_MODE_ABOVE);
+        if (raise) {
+            newActivateSurface->stackToLast();
+            if (newActivateSurface->type() == SurfaceWrapper::Type::XWayland) {
+                auto xwaylandSurface =
+                    qobject_cast<WXWaylandSurface *>(newActivateSurface->shellSurface());
+                Q_ASSERT(!xwaylandSurface->isBypassManager());
+                xwaylandSurface->restack(nullptr, WXWaylandSurface::XCB_STACK_MODE_ABOVE);
+            }
         }
     }
 

--- a/src/seat/helper.h
+++ b/src/seat/helper.h
@@ -282,7 +282,8 @@ public:
 public Q_SLOTS:
     void activateSurface(SurfaceWrapper *wrapper,
                          Qt::FocusReason reason = Qt::OtherFocusReason,
-                         WSeat *seat = nullptr);
+                         WSeat *seat = nullptr,
+                         bool raise = true);
     void forceActivateSurface(SurfaceWrapper *wrapper,
                               Qt::FocusReason reason = Qt::OtherFocusReason,
                               WSeat *seat = nullptr);
@@ -349,7 +350,9 @@ private:
 
     SurfaceWrapper *keyboardFocusSurface() const;
     SurfaceWrapper *activatedSurface() const;
-    void setActivatedSurface(SurfaceWrapper *newActivateSurface, WSeat *seat = nullptr);
+    void setActivatedSurface(SurfaceWrapper *newActivateSurface,
+                             WSeat *seat = nullptr,
+                             bool raise = true);
 
     bool beforeDisposeEvent(WSeat *seat, QWindow *window, QInputEvent *event) override;
     bool afterHandleEvent(WSeat *seat, WSurface *watched, QObject *shellObject,

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -1522,6 +1522,9 @@ void SurfaceWrapper::createNewOrClose(uint direction)
     }
 
     if (m_windowAnimation) {
+        if (m_windowAnimation->parentItem() == parentItem()) {
+            m_windowAnimation->stackAfter(this);
+        }
         if (Helper::instance()->noAnimation()) {
             if (direction == OPEN_ANIMATION) {
                 onShowAnimationFinished();


### PR DESCRIPTION
Transfer activation to the next surface without raising it, so the closing window's animation stays visible at its original stacking position.

关闭窗口时将激活转移到下一窗口但不提升，使关闭动画保持原位可见；

Log: 关闭窗口激活转移时不再提升新窗口
Influence: 关闭前置窗口时关闭动画不再被后置窗口盖住

## Summary by Sourcery

Preserve closing animation visibility by transferring activation without raising the next surface.

Bug Fixes:
- Keep closing-window animations visible at their original stacking position when activation transfers to another surface.

Enhancements:
- Allow surface activation to optionally preserve the current stacking order instead of raising the activated surface.