### PR TITLE
fix(xwayland): honor above and below window states

### DIFF
--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -32,6 +32,7 @@
 #define OPEN_ANIMATION 1
 #define CLOSE_ANIMATION 2
 #define ALWAYSONTOPLAYER 1
+#define ALWAYSONBOTTOMLAYER -1
 
 SurfaceWrapper::SurfaceWrapper(QmlEngine *qmlEngine,
                                WToplevelSurface *shellSurface,
@@ -49,6 +50,7 @@ SurfaceWrapper::SurfaceWrapper(QmlEngine *qmlEngine,
     , m_noTitleBar(true)
     , m_noCornerRadius(false)
     , m_alwaysOnTop(false)
+    , m_alwaysOnBottom(false)
     , m_skipSwitcher(false)
     , m_skipDockPreView(true)
     , m_skipMutiTaskView(false)
@@ -86,6 +88,7 @@ SurfaceWrapper::SurfaceWrapper(SurfaceWrapper *original, QQuickItem *parent)
     , m_noTitleBar(true)
     , m_noCornerRadius(false)
     , m_alwaysOnTop(false)
+    , m_alwaysOnBottom(false)
     , m_skipSwitcher(false)
     , m_skipDockPreView(true)
     , m_skipMutiTaskView(false)
@@ -156,6 +159,7 @@ SurfaceWrapper::SurfaceWrapper(QmlEngine *qmlEngine,
     , m_noTitleBar(true)
     , m_noCornerRadius(false)
     , m_alwaysOnTop(false)
+    , m_alwaysOnBottom(false)
     , m_skipSwitcher(false)
     , m_skipDockPreView(false)
     , m_skipMutiTaskView(false)
@@ -525,7 +529,16 @@ void SurfaceWrapper::setup()
                     updateX11SkipFlags();
                     updateSizeCapabilities();
                 });
+        connect(xwaylandSurface,
+                &WXWaylandSurface::aboveChanged,
+                this,
+                &SurfaceWrapper::updateXWaylandStackingState);
+        connect(xwaylandSurface,
+                &WXWaylandSurface::belowChanged,
+                this,
+                &SurfaceWrapper::updateXWaylandStackingState);
         updateX11SkipFlags();
+        updateXWaylandStackingState();
     }
     // Connect DConfig windowRadius change so QML bindings re-evaluate radius()
     if (m_type == Type::XdgToplevel || m_type == Type::XWayland) {
@@ -2164,7 +2177,7 @@ void SurfaceWrapper::addSubSurface(SurfaceWrapper *surface)
 {
     Q_ASSERT(!surface->m_parentSurface);
     surface->m_parentSurface = this;
-    surface->updateExplicitAlwaysOnTop();
+    surface->updateStackingLayer();
     m_subSurfaces.append(surface);
     surface->ensureAboveParent();
 }
@@ -2173,7 +2186,7 @@ void SurfaceWrapper::removeSubSurface(SurfaceWrapper *surface)
 {
     Q_ASSERT(surface->m_parentSurface == this);
     surface->m_parentSurface = nullptr;
-    surface->updateExplicitAlwaysOnTop();
+    surface->updateStackingLayer();
     m_subSurfaces.removeOne(surface);
 }
 
@@ -2345,9 +2358,18 @@ void SurfaceWrapper::setAlwaysOnTop(bool alwaysOnTop)
     if (m_alwaysOnTop == alwaysOnTop)
         return;
     m_alwaysOnTop = alwaysOnTop;
-    updateExplicitAlwaysOnTop();
+    updateStackingLayer();
 
     Q_EMIT alwaysOnTopChanged();
+}
+
+void SurfaceWrapper::setAlwaysOnBottom(bool alwaysOnBottom)
+{
+    if (m_alwaysOnBottom == alwaysOnBottom)
+        return;
+
+    m_alwaysOnBottom = alwaysOnBottom;
+    updateStackingLayer();
 }
 
 bool SurfaceWrapper::showOnAllWorkspace() const
@@ -2491,19 +2513,46 @@ void SurfaceWrapper::disableWindowAnimation(bool disable)
     m_windowAnimationEnabled = !disable;
 }
 
-void SurfaceWrapper::updateExplicitAlwaysOnTop()
+void SurfaceWrapper::updateStackingLayer()
 {
     int newExplicitAlwaysOnTop = m_alwaysOnTop;
-    if (m_parentSurface)
+    bool newExplicitAlwaysOnBottom = m_alwaysOnBottom;
+    if (m_parentSurface) {
         newExplicitAlwaysOnTop += m_parentSurface->m_explicitAlwaysOnTop;
+        newExplicitAlwaysOnBottom = newExplicitAlwaysOnBottom
+            || m_parentSurface->m_explicitAlwaysOnBottom;
+    }
 
-    if (m_explicitAlwaysOnTop == newExplicitAlwaysOnTop)
+    if (newExplicitAlwaysOnTop)
+        newExplicitAlwaysOnBottom = false;
+
+    if (m_explicitAlwaysOnTop == newExplicitAlwaysOnTop
+        && m_explicitAlwaysOnBottom == newExplicitAlwaysOnBottom)
         return;
 
     m_explicitAlwaysOnTop = newExplicitAlwaysOnTop;
-    setZ(m_explicitAlwaysOnTop ? ALWAYSONTOPLAYER : 0);
+    m_explicitAlwaysOnBottom = newExplicitAlwaysOnBottom;
+    setZ(m_explicitAlwaysOnTop ? ALWAYSONTOPLAYER
+                               : (m_explicitAlwaysOnBottom ? ALWAYSONBOTTOMLAYER : 0));
     for (const auto &sub : std::as_const(m_subSurfaces))
-        sub->updateExplicitAlwaysOnTop();
+        sub->updateStackingLayer();
+}
+
+void SurfaceWrapper::updateXWaylandStackingState()
+{
+    auto *xwaylandSurface = qobject_cast<WXWaylandSurface *>(m_shellSurface.data());
+    if (!xwaylandSurface)
+        return;
+
+    const bool above = xwaylandSurface->isAbove();
+    const bool below = !above && xwaylandSurface->isBelow();
+    setAlwaysOnBottom(below);
+    setAlwaysOnTop(above);
+    if (above) {
+        stackToLast();
+    } else if (below) {
+        stackToFirst();
+    }
 }
 
 void SurfaceWrapper::updateSizeCapabilities()

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -262,6 +262,7 @@ public:
     bool alwaysOnTop() const;
     bool effectiveAlwaysOnTop() const;
     void setAlwaysOnTop(bool alwaysOnTop);
+    void setAlwaysOnBottom(bool alwaysOnBottom);
 
     bool showOnAllWorkspace() const;
     bool showOnWorkspace(int workspaceIndex) const;
@@ -438,7 +439,8 @@ private:
     void onWindowAnimationFinished();
     Q_SLOT void onShowAnimationFinished();
     Q_SLOT void onHideAnimationFinished();
-    void updateExplicitAlwaysOnTop();
+    void updateStackingLayer();
+    void updateXWaylandStackingState();
     void updateSizeCapabilities();
     void setModal(bool modal);
     void startMinimizeAnimation(const QRectF &iconGeometry, uint direction);
@@ -495,6 +497,7 @@ private:
                                          &SurfaceWrapper::surfaceStateChanged)
     int m_workspaceId = -1;
     int m_explicitAlwaysOnTop = 0;
+    bool m_explicitAlwaysOnBottom = false;
     qreal m_radius = 0.0;
     QRect m_iconGeometry;
     ActiveControlStates m_hasActiveCapability =
@@ -510,6 +513,7 @@ private:
     uint m_noTitleBar : 1;
     uint m_noCornerRadius : 1;
     uint m_alwaysOnTop : 1;
+    uint m_alwaysOnBottom : 1;
     uint m_skipSwitcher : 1;
     uint m_skipDockPreView : 1;
     uint m_skipMutiTaskView : 1;

--- a/waylib/src/server/protocols/wxwaylandsurface.cpp
+++ b/waylib/src/server/protocols/wxwaylandsurface.cpp
@@ -105,6 +105,12 @@ void WXWaylandSurfacePrivate::init()
                      [this, q] (wlr_xwayland_resize_event *event) {
         Q_EMIT q->requestResize(xwayland->seat(), WTools::toQtEdge(event->edges), 0);
     });
+    q->listeners()->add(&m_handle->events.request_above, this, [this, q] (void *) {
+        Q_EMIT q->aboveChanged(handle()->above);
+    });
+    q->listeners()->add(&m_handle->events.request_below, this, [this, q] (void *) {
+        Q_EMIT q->belowChanged(handle()->below);
+    });
     q->listeners()->add(&m_handle->events.set_override_redirect, q, &WXWaylandSurface::bypassManagerChanged);
     q->listeners()->add(&m_handle->events.set_geometry, q, &WXWaylandSurface::geometryChanged);
     q->listeners()->add(&m_handle->events.set_size_hints, this, &WXWaylandSurfacePrivate::updateSizeHints);
@@ -499,6 +505,18 @@ bool WXWaylandSurface::isBypassManager() const
 {
     W_DC(WXWaylandSurface);
     return d->handle()->override_redirect;
+}
+
+bool WXWaylandSurface::isAbove() const
+{
+    W_DC(WXWaylandSurface);
+    return d->handle()->above;
+}
+
+bool WXWaylandSurface::isBelow() const
+{
+    W_DC(WXWaylandSurface);
+    return d->handle()->below;
 }
 
 bool WXWaylandSurface::isModal() const

--- a/waylib/src/server/protocols/wxwaylandsurface.h
+++ b/waylib/src/server/protocols/wxwaylandsurface.h
@@ -21,6 +21,8 @@ class WAYLIB_SERVER_EXPORT WXWaylandSurface : public WToplevelSurface
     Q_PROPERTY(bool isToplevel READ isToplevel NOTIFY isToplevelChanged)
     Q_PROPERTY(bool hasChild READ hasChild NOTIFY hasChildChanged)
     Q_PROPERTY(bool bypassManager READ isBypassManager NOTIFY bypassManagerChanged FINAL)
+    Q_PROPERTY(bool above READ isAbove NOTIFY aboveChanged FINAL)
+    Q_PROPERTY(bool below READ isBelow NOTIFY belowChanged FINAL)
     Q_PROPERTY(QRect geometry READ geometry NOTIFY geometryChanged FINAL)
     Q_PROPERTY(WindowTypes windowTypes READ windowTypes NOTIFY windowTypesChanged FINAL)
     Q_PROPERTY(DecorationsFlags decorationsFlags READ decorationsFlags NOTIFY decorationsFlagsChanged FINAL)
@@ -109,6 +111,8 @@ public:
     ConfigureFlags requestConfigureFlags() const;
 
     bool isBypassManager() const;
+    bool isAbove() const;
+    bool isBelow() const;
     bool isModal() const;
     WindowTypes windowTypes() const;
     DecorationsFlags decorationsFlags() const;
@@ -135,6 +139,8 @@ Q_SIGNALS:
     void isToplevelChanged();
     void hasChildChanged();
     void bypassManagerChanged();
+    void aboveChanged(bool above);
+    void belowChanged(bool below);
     void geometryChanged();
     void windowTypesChanged();
     void decorationsFlagsChanged();

--- a/waylib/tests/unit_tests/test_native_handles/main.cpp
+++ b/waylib/tests/unit_tests/test_native_handles/main.cpp
@@ -163,6 +163,8 @@ class NativeHandlesTest : public QObject
                  &surface->events.request_minimize,
                  &surface->events.request_move,
                  &surface->events.request_resize,
+                 &surface->events.request_above,
+                 &surface->events.request_below,
                  &surface->events.set_override_redirect,
                  &surface->events.set_geometry,
                  &surface->events.set_size_hints,
@@ -373,6 +375,31 @@ private Q_SLOTS:
         }
         QVERIFY(!WXWaylandSurface::fromHandle(&nativeSurface));
         wl_signal_emit_mutable(&nativeSurface.events.destroy, &nativeSurface);
+    }
+
+    void xwaylandSurfaceTracksStackingState()
+    {
+        wlr_xwayland_surface nativeSurface {};
+        initXWaylandSurface(&nativeSurface);
+        WXWaylandSurface surface(&nativeSurface, nullptr);
+        QSignalSpy aboveChanged(&surface, &WXWaylandSurface::aboveChanged);
+        QSignalSpy belowChanged(&surface, &WXWaylandSurface::belowChanged);
+
+        QVERIFY(!surface.isAbove());
+        QVERIFY(!surface.isBelow());
+        nativeSurface.above = true;
+        wl_signal_emit_mutable(&nativeSurface.events.request_above, nullptr);
+
+        QVERIFY(surface.isAbove());
+        QCOMPARE(aboveChanged.count(), 1);
+        QVERIFY(aboveChanged.takeFirst().at(0).toBool());
+
+        nativeSurface.below = true;
+        wl_signal_emit_mutable(&nativeSurface.events.request_below, nullptr);
+
+        QVERIFY(surface.isBelow());
+        QCOMPARE(belowChanged.count(), 1);
+        QVERIFY(belowChanged.takeFirst().at(0).toBool());
     }
 
     void inputDeviceTracksNativeLifetime()


### PR DESCRIPTION
Propagate the XWayland _NET_WM_STATE_ABOVE and _NET_WM_STATE_BELOW states to Treeland's workspace stacking layers.

Place ABOVE windows at the top of the current workspace and BELOW windows at the bottom, while restoring windows without either state to the normal layer. Handle both initial state and runtime changes, with ABOVE taking precedence if both states are set. Transient children inherit their parent's effective stacking layer.

Log: fix XWayland above and below window stacking
PMS: BUG-376267
Influence: XWayland workspace window stacking

## Summary by Sourcery

Honor XWayland above and below states when positioning windows within workspace stacking layers.

New Features:
- Expose XWayland ABOVE and BELOW window states and propagate them to workspace stacking behavior.
- Place XWayland windows and their transient children in the top, bottom, or normal stacking layer, with ABOVE taking precedence over BELOW.

Bug Fixes:
- Honor initial and runtime XWayland _NET_WM_STATE_ABOVE and _NET_WM_STATE_BELOW changes when stacking windows.

Tests:
- Add coverage verifying XWayland stacking-state accessors and change notifications.