### PR TITLE
fix(lockscreen): restore white window text color in login view

### DIFF
--- a/src/plugins/lockscreen/qml/LoginView.qml
+++ b/src/plugins/lockscreen/qml/LoginView.qml
@@ -12,6 +12,8 @@ import LockScreen
 FocusScope {
     id: root
 
+    palette.windowText: Qt.rgba(1.0, 1.0, 1.0, 1.0)
+
     signal animationPlayed
     signal animationPlayFinished
 


### PR DESCRIPTION
Restore palette.windowText to pure white on the LoginView root, matching the color previously inherited from Greeter.

恢复锁屏启动期间跟随Greeter时的白色前景色，在LoginView根节点显式设置windowText为纯白。

Log: 恢复锁屏登录界面白色文字颜色

PMS: BUG-371115

Influence: 锁屏登录界面文字颜色恢复为登录前跟随Greeter时的白色。

## Summary by Sourcery

Bug Fixes:
- Restore pure white text rendering in the lock-screen login view.