### PR TITLE
fix(surface): keep modal window animation above parent

### DIFF
--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -1522,9 +1522,7 @@ void SurfaceWrapper::createNewOrClose(uint direction)
     }
 
     if (m_windowAnimation) {
-        if (m_windowAnimation->parentItem() == parentItem()) {
-            m_windowAnimation->stackAfter(this);
-        }
+        restackWindowAnimationAbove();
         if (Helper::instance()->noAnimation()) {
             if (direction == OPEN_ANIMATION) {
                 onShowAnimationFinished();
@@ -2084,6 +2082,7 @@ bool SurfaceWrapper::stackBefore(QQuickItem *item)
     } while (false);
 
     updateSubSurfaceStacking();
+    restackWindowAnimationAbove();
     return true;
 }
 
@@ -2129,6 +2128,7 @@ bool SurfaceWrapper::stackAfter(QQuickItem *item)
     } while (false);
 
     updateSubSurfaceStacking();
+    restackWindowAnimationAbove();
     return true;
 }
 
@@ -2158,6 +2158,12 @@ void SurfaceWrapper::stackToFirst()
         auto first = parentItem()->childItems().first();
         stackBefore(first);
     }
+}
+
+void SurfaceWrapper::restackWindowAnimationAbove()
+{
+    if (m_windowAnimation && parentItem() && m_windowAnimation->parentItem() == parentItem())
+        m_windowAnimation->stackAfter(this);
 }
 
 void SurfaceWrapper::addSubSurface(SurfaceWrapper *surface)
@@ -2394,6 +2400,8 @@ SurfaceWrapper *SurfaceWrapper::findModal() const
         return nullptr;
     for (auto *child : std::as_const(m_subSurfaces)) {
         if (child->m_wrapperAboutToRemove)
+            continue;
+        if (!child->surface() || !child->surface()->mapped())
             continue;
         if (child->modal()) {
             if (SurfaceWrapper *deepModal = child->findModal())

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -417,6 +417,7 @@ private:
     void updateBoundingRect();
     void updateVisible();
     void updateSubSurfaceStacking();
+    void restackWindowAnimationAbove();
     void ensureAboveParent();
     void updateClipRect();
     void geometryChange(const QRectF &newGeo, const QRectF &oldGeometry) override;


### PR DESCRIPTION
Skip unmapped children in findModal() and restack the window animation above its target after stacking operations.

findModal() 跳过未映射的子窗口，并在叠放操作后把窗口动画
重新叠放到目标窗口之上。

Log: 修复模态窗口开关动画被主窗盖住的问题
PMS: BUG-296659
Influence: 模态对话框打开和关闭动画始终显示在主窗口之上，不再被遮挡。

## Summary by Sourcery

Ensure modal window animations remain visible above their parent throughout stacking and modal-surface lookup.

Bug Fixes:
- Keep modal window open and close animations above their target windows so they are not obscured.
- Ignore unmapped child surfaces when locating modal descendants.

Enhancements:
- Centralize window-animation restacking and apply it after stacking operations.