### PR TITLE
fix: defer splash toplevel registration until real surface

### DIFF
--- a/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
+++ b/src/modules/foreign-toplevel/foreigntoplevelmanagerv1.cpp
@@ -235,6 +235,33 @@ void ForeignToplevelManagerInterfaceV1Private::setupHandleForWrapper(SurfaceEntr
         wrapper->close();
     });
 
+    // The rectangle handler only depends on the wrapper, so connect it here for
+    // both splash and normal handles: a splash is exposed to clients immediately
+    // and a set_rectangle sent during the splash phase must not be dropped.
+    QObject::connect(handle,
+            &ForeignToplevelHandleV1::rectangleChanged,
+            wrapper,
+            [wrapper](WSurface *surface, const QRect &rect) {
+                         auto *dockWrapper =
+                             Helper::instance()->rootSurfaceContainer()->getSurface(surface);
+                         if (!dockWrapper) {
+                             qCWarning(lcTlProtocol)
+                                 << "rectangleChanged: dock wrapper not found for app"
+                                 << wrapper->appId() << "surface=" << surface << "rect=" << rect;
+                             return;
+                         }
+                         const QRect iconGeometry(dockWrapper->x() + rect.x(),
+                                                  dockWrapper->y() + rect.y(),
+                                                  rect.width(),
+                                                  rect.height());
+                         qCDebug(lcTlProtocol) << "rectangleChanged:" << wrapper->appId()
+                                               << "rect=" << rect
+                                               << "dockPos="
+                                               << QPointF(dockWrapper->x(), dockWrapper->y())
+                                               << "iconGeometry=" << iconGeometry;
+                         wrapper->setIconGeometry(iconGeometry);
+                     });
+
     if (wrapper->type() == SurfaceWrapper::Type::SplashScreen) {
         handle->set_title(QStringLiteral("SplashScreen: ") + wrapper->appId());
         handle->set_app_id(wrapper->appId());
@@ -489,19 +516,6 @@ void ForeignToplevelManagerInterfaceV1::initializeToplevelHandle(SurfaceWrapper 
                     wrapper->enterFullscreen(output);
                 else
                     wrapper->leaveFullscreen();
-            });
-
-    connect(handle,
-            &ForeignToplevelHandleV1::rectangleChanged,
-            wrapper,
-            [wrapper](WSurface *surface, const QRect &rect) {
-                auto dockWrapper = Helper::instance()->rootSurfaceContainer()->getSurface(surface);
-                if (!dockWrapper)
-                    return;
-                wrapper->setIconGeometry(QRect(dockWrapper->x() + rect.x(),
-                                               dockWrapper->y() + rect.y(),
-                                               rect.width(),
-                                               rect.height()));
             });
 
     if (auto *xdgSurface = qobject_cast<WXdgToplevelSurface *>(surface)) {


### PR DESCRIPTION
1. Register prelaunch splash surfaces only after the real window takes over (surfaceItemCreated), so clients never receive a half-initialized handle whose rectangleChanged has no listener.
2. Track pending splash wrappers and keep the unregistered-surface error check in removeSurface for genuine caller bugs.
3. Lower rectangleChanged logging to debug and keep a warning only for the missing-dock-wrapper case.

Log: Fix minimize animation flying to top-left (0,0) for slow-starting XWayland apps whose icon geometry request was silently dropped during the splash phase.

Influence:
1. Launch browser and verify the minimize animation targets the dock icon.
2. Rapidly open/close apps with splash screens and check no crashes.
3. Verify dock preview and window list still work after launch.

fix: 延迟 splash 顶层注册至真实窗口接管

1. 预启动 splash 表面仅在真实窗口接管（surfaceItemCreated）后注册， 避免客户端拿到 rectangleChanged 尚无监听者的半初始化句柄。
2. 跟踪 pending splash 包装器，removeSurface 中保留对真实调用错误的 未注册表面错误检查。
3. rectangleChanged 常规日志降级为 debug，仅保留找不到 dock 包装器的 警告。

Log: 修复慢启动 XWayland 应用最小化动画飞到左上角 (0,0) 的问题——其
splash 阶段的图标几何请求被静默丢弃。

Influence:
1. 启动浏览器验证最小化动画指向 dock 图标。
2. 快速开关带 splash 的应用验证无崩溃。
3. 验证启动后 dock 预览与窗口列表正常。

PMS: BUG-375731

## Summary by Sourcery

Ensure splash toplevels handle geometry updates reliably before real windows take over.

Bug Fixes:
- Preserve splash-phase icon geometry updates so slow-starting applications target the correct dock icon during minimize animations.

Enhancements:
- Centralize rectangle-change handling for splash and normal toplevels, with clearer diagnostics for missing dock wrappers and debug-level geometry logging.