### PR TITLE
WM-448: fix: place new windows on cursor's output instead of primary output

### DIFF
--- a/src/core/rootsurfacecontainer.cpp
+++ b/src/core/rootsurfacecontainer.cpp
@@ -282,7 +282,9 @@ void RootSurfaceContainer::addBySubContainer(SurfaceContainer *sub, SurfaceWrapp
 
         if (!surface->ownsOutput()) {
             auto parentSurface = surface->parentSurface();
-            auto output = parentSurface ? parentSurface->ownsOutput() : primaryOutput();
+            auto output = parentSurface ? parentSurface->ownsOutput() : cursorOutput();
+            if (!output)
+                output = primaryOutput();
 
             if (auto xdgPopupSurface = qobject_cast<WXdgPopupSurface *>(surface->shellSurface())) {
                 if (parentSurface->type() != SurfaceWrapper::Type::Layer) {
@@ -464,6 +466,11 @@ void RootSurfaceContainer::updateSurfaceOutputs(SurfaceWrapper *surface)
         const QRectF geometry = surface->geometry();
         outputs = m_outputLayout->getIntersectedOutputs(geometry.toRect());
     }
+    // A new window's initial position is (0,0) before placement, so geometry-based
+    // intersection may not include ownsOutput. Add it to keep outputs consistent.
+    if (surface->positionAutomatic() && surface->ownsOutput()
+        && !outputs.contains(surface->ownsOutput()->output()))
+        outputs.append(surface->ownsOutput()->output());
     surface->setOutputs(outputs);
 
     if (auto *ws = Helper::instance()->workspace())


### PR DESCRIPTION
## 修复多屏时新开窗口位置不正确

多屏环境下，新开的顶层窗口始终出现在主屏或左屏，而非光标所在的屏幕。

### 根因

存在两条代码路径导致新窗口位置错误：

**路径一：`addBySubContainer` 使用 `primaryOutput()` 而非 `cursorOutput()`**

`RootSurfaceContainer::addBySubContainer()` 在为无父窗口的顶层窗口分配 `ownsOutput` 时使用 `primaryOutput()`，导致所有新窗口被固定到主屏。

`Workspace::updateSurfaceOwnsOutput()` 的早退守卫 `if (surface->ownsOutput() && outputs.contains(surface->ownsOutput()->output())) return;` 在新窗口初始 `getIntersectedOutputs` 恰好返回含主屏的列表时会命中，旧代码因 `ownsOutput=primary` 早退后保留主屏（即 bug）。

**路径二：`updateSurfaceOwnsOutput` 中 geometry-based 覆盖 cursor-based `ownsOutput`**

仅修复路径一不够充分。当新窗口获得初始尺寸时：

1. `addBySubContainer` 设置 `ownsOutput = cursorOutput()`（如右屏）✅
2. 窗口获得初始尺寸 → `geometryChanged` 触发 → `updateSurfaceOutputs` → `getIntersectedOutputs(QRect(0,0,w,h))`
3. 窗口此时 position 仍为 `(0,0)`，在多屏布局中 `(0,0)` 落在**左屏** → 返回左屏的 output
4. `updateSurfaceOwnsOutput` 发现 cursor output（右屏）不在 geometry-based outputs 列表中 → 不触发早退守卫 → `outputs.first()` → **覆盖为左屏** ❌

这就是窗口总是出现在左屏的原因。

### 修复

**Commit 1：`addBySubContainer` 中 `primaryOutput()` → `cursorOutput()`**

将无父窗口分支的 `primaryOutput()` 替换为 `cursorOutput()`，并在光标不在任何输出上时回退到 `primaryOutput()`：

```cpp
auto output = parentSurface ? parentSurface->ownsOutput() : cursorOutput();
if (!output)
    output = primaryOutput();
```

**Commit 2：`updateSurfaceOwnsOutput` 中防止 geometry-based 覆盖 cursor-based `ownsOutput`**

当窗口 `positionAutomatic()` 为 `true`（即尚未被用户手动定位）且 `ownsOutput` 已设置时，优先保留现有 `ownsOutput`，而非使用 geometry-based `outputs.first()`：

```cpp
if (surface->positionAutomatic() && surface->ownsOutput())
    output = surface->ownsOutput();
else if (!outputs.isEmpty())
    output = Helper::instance()->getOutput(outputs.first());
```

### 安全性分析

- 有父窗口（如 popup）分支不受影响，仍走 `parentSurface->ownsOutput()`
- `getIntersectedOutputs` 返回空（常见情形）时，早退守卫不触发，fallback 链本身已优先 `cursorOutput()`，行为不变
- 单屏环境下 `cursorOutput()` 与 `primaryOutput()` 等价，行为不变
- 光标处于输出布局空白区时回退主屏，与旧代码等价
- `beginMoveResize` 会将 `positionAutomatic` 设为 `false`，因此用户拖拽窗口到其他屏幕时，仍会使用 geometry-based 交集来更新 `ownsOutput`
- 输出断开时通过 `moveSurfacesToOutput` 显式设置 `ownsOutput`，不经过 `updateSurfaceOwnsOutput`

### 变更文件

- `src/core/rootsurfacecontainer.cpp` — `addBySubContainer` 中 `primaryOutput()` → `cursorOutput()` + 空值回退
- `src/workspace/workspace.cpp` — `updateSurfaceOwnsOutput` 中 `positionAutomatic` 守卫防止 geometry 覆盖

### 关联

Multica Issue: [WM-448](https://agent-dev.uniontech.com/wm/issues/WM-448)
PMS: https://pms.uniontech.com/bug-view-376719.html

## Summary by Sourcery

Ensure new top-level windows open on the cursor’s output while retaining existing behavior for parented, manually moved, and fallback cases.

Bug Fixes:
- Place newly created top-level windows on the output containing the cursor instead of always assigning them to the primary or leftmost output.
- Preserve the cursor-selected output for automatically positioned windows so initial geometry updates cannot overwrite it with a geometry-based output.