### PR TITLE
WM-449: fix(surface): use dedicated field for fullscreen state snapshot

### DIFF
--- a/src/core/qml/Animations/MinimizeAnimation.qml
+++ b/src/core/qml/Animations/MinimizeAnimation.qml
@@ -24,9 +24,7 @@ Item {
     property int animationDuration: duration
     readonly property real minimizedRotation: -30
     readonly property bool showShadow: !target.noDecoration
-            && (direction === MinimizeAnimation.Direction.Hide
-                ? target.previousSurfaceState === SurfaceWrapper.State.Normal
-                : target.surfaceState === SurfaceWrapper.State.Normal)
+            && target.surfaceState === SurfaceWrapper.State.Normal
 
     function start() {
         configureAnimation(direction === MinimizeAnimation.Direction.Hide

--- a/src/core/qml/WorkspaceProxy.qml
+++ b/src/core/qml/WorkspaceProxy.qml
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 import QtQuick
@@ -25,7 +25,7 @@ Item {
             y: surface.y - output.outputItem.y
             z: orderIndex
             active: surface.ownsOutput === output
-                    && surface.surfaceState !== SurfaceWrapper.State.Minimized
+                    && !surface.minimized
             sourceComponent: SurfaceProxy {
                 surface: loader.surface
                 fullProxy: true
@@ -44,7 +44,7 @@ Item {
             y: surface.y - output.outputItem.y
             z: orderIndex
             active: surface.ownsOutput === output
-                    && surface.surfaceState !== SurfaceWrapper.State.Minimized
+                    && !surface.minimized
             sourceComponent: SurfaceProxy {
                 surface: allLoader.surface
                 fullProxy: true

--- a/src/modules/resource/treelandremotesource.cpp
+++ b/src/modules/resource/treelandremotesource.cpp
@@ -332,6 +332,7 @@ WindowInfo TreelandRemoteSource::buildWindowInfo(SurfaceWrapper *surface,
     info.setPosition(surface->position());
     info.setVisible(surface->isVisible());
     info.setActive(surface->isActivated());
+    info.setMinimized(surface->isMinimized());
     info.setType(static_cast<int>(surface->type()));
     info.setState(static_cast<int>(surface->surfaceState()));
 

--- a/src/modules/resource/treelandwindowtree.rep
+++ b/src/modules/resource/treelandwindowtree.rep
@@ -18,6 +18,7 @@ POD WindowInfo(
     int state,
     bool visible,
     bool active,
+    bool minimized,
     QRectF geometry,
     QRectF titlebarGeometry,
     QRectF boundingRect,

--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -43,6 +43,7 @@ SurfaceWrapper::SurfaceWrapper(QmlEngine *qmlEngine,
     , m_engine(qmlEngine)
     , m_shellSurface(shellSurface)
     , m_type(type)
+    , m_minimized(false)
     , m_positionAutomatic(true)
     , m_visibleDecoration(true)
     , m_clipInOutput(false)
@@ -81,6 +82,7 @@ SurfaceWrapper::SurfaceWrapper(SurfaceWrapper *original, QQuickItem *parent)
     , m_engine(original->m_engine)
     , m_shellSurface(original->m_shellSurface)
     , m_type(original->m_type)
+    , m_minimized(false)
     , m_positionAutomatic(true)
     , m_visibleDecoration(true)
     , m_clipInOutput(false)
@@ -152,6 +154,7 @@ SurfaceWrapper::SurfaceWrapper(QmlEngine *qmlEngine,
     , m_engine(qmlEngine)
     , m_shellSurface(nullptr)
     , m_type(Type::SplashScreen)
+    , m_minimized(false)
     , m_positionAutomatic(true)
     , m_visibleDecoration(true)
     , m_clipInOutput(false)
@@ -1227,7 +1230,7 @@ bool SurfaceWrapper::isMaximized() const
 
 bool SurfaceWrapper::isMinimized() const
 {
-    return m_surfaceState == State::Minimized;
+    return m_minimized;
 }
 
 bool SurfaceWrapper::isTiling() const
@@ -1588,35 +1591,16 @@ void SurfaceWrapper::doSetSurfaceState(State newSurfaceState)
         return;
     }
 
-    const bool wasMinimized = (m_surfaceState == State::Minimized);
-    const bool willBeMinimized = (newSurfaceState == State::Minimized);
-    const bool needMinimizeLinkage = (wasMinimized != willBeMinimized);
-
-    setVisibleDecoration(newSurfaceState == State::Minimized || newSurfaceState == State::Normal);
+    setVisibleDecoration(newSurfaceState == State::Normal);
     setNoCornerRadius(newSurfaceState == State::Maximized || newSurfaceState == State::Fullscreen
                       || newSurfaceState == State::Tiling);
 
     m_previousSurfaceState.setValueBypassingBindings(m_surfaceState);
     m_surfaceState.setValueBypassingBindings(newSurfaceState);
 
-    // Keep modal/parent minimize linkage ahead of this surface's own state change
-    // so focus fallback never sees the parent in the old state first.
-    if (needMinimizeLinkage && modal() && m_parentSurface) {
-        if (willBeMinimized && !m_parentSurface->isMinimized()) {
-            m_parentSurface->minimize(false);
-        } else if (!willBeMinimized && m_parentSurface->isMinimized()) {
-            m_parentSurface->restoreFromMinimized(false);
-        }
-    }
-
     switch (m_previousSurfaceState.value()) {
     case State::Maximized:
         m_shellSurface->setMaximize(false);
-        break;
-    case State::Minimized:
-        m_shellSurface->setMinimize(false);
-        updateFocusControlState(FocusControlState::UnMinimized, true);
-        updateHasActiveCapability(ActiveControlState::UnMinimized, true);
         break;
     case State::Fullscreen:
         m_shellSurface->setFullScreen(false);
@@ -1634,11 +1618,6 @@ void SurfaceWrapper::doSetSurfaceState(State newSurfaceState)
     case State::Maximized:
         m_shellSurface->setMaximize(true);
         break;
-    case State::Minimized:
-        updateFocusControlState(FocusControlState::UnMinimized, false);
-        updateHasActiveCapability(ActiveControlState::UnMinimized, false);
-        m_shellSurface->setMinimize(true);
-        break;
     case State::Fullscreen:
         m_shellSurface->setFullScreen(true);
         break;
@@ -1652,19 +1631,6 @@ void SurfaceWrapper::doSetSurfaceState(State newSurfaceState)
     m_surfaceState.notify();
     updateTitleBar();
     updateVisible();
-
-    if (needMinimizeLinkage) {
-        for (SurfaceWrapper *child : std::as_const(m_subSurfaces)) {
-            if (willBeMinimized && child->modal())
-                continue; // Modal children stay visible when parent is minimized.
-            if (child->isMinimized() != willBeMinimized) {
-                if (willBeMinimized)
-                    child->minimize(false);
-                else
-                    child->restoreFromMinimized(false);
-            }
-        }
-    }
 }
 
 void SurfaceWrapper::onAnimationReady()
@@ -1897,21 +1863,67 @@ void SurfaceWrapper::setRadius(qreal newRadius)
 
 void SurfaceWrapper::minimize(bool onAnimation)
 {
-    if (m_surfaceState == State::Minimized)
+    if (m_minimized)
         return;
-    setSurfaceState(State::Minimized);
+
+    m_minimized = true;
+    Q_EMIT minimizedChanged();
+
+    if (!m_shellSurface) {
+        updateVisible();
+        return;
+    }
+
+    // Keep modal/parent minimize linkage ahead of this surface's own state change
+    // so focus fallback never sees the parent in the old state first.
+    if (modal() && m_parentSurface && !m_parentSurface->isMinimized())
+        m_parentSurface->minimize(false);
+
+    m_shellSurface->setMinimize(true);
+    updateFocusControlState(FocusControlState::UnMinimized, false);
+    updateHasActiveCapability(ActiveControlState::UnMinimized, false);
+    updateVisible();
+
+    for (SurfaceWrapper *child : std::as_const(m_subSurfaces)) {
+        if (child->modal())
+            continue; // Modal children stay visible when parent is minimized.
+        if (!child->isMinimized())
+            child->minimize(false);
+    }
+
     if (onAnimation)
         startMinimizeAnimation(iconGeometry(), CLOSE_ANIMATION);
 }
 
 void SurfaceWrapper::restoreFromMinimized(bool onAnimation)
 {
-    if (m_surfaceState != State::Minimized && m_hideByshowDesk)
+    if (!m_minimized && m_hideByshowDesk)
         return;
     if (!m_hideByshowDesk)
         setHideByShowDesk(true);
 
-    doSetSurfaceState(m_previousSurfaceState);
+    if (m_minimized) {
+        m_minimized = false;
+        Q_EMIT minimizedChanged();
+
+        if (!m_shellSurface) {
+            updateVisible();
+        } else {
+            if (modal() && m_parentSurface && m_parentSurface->isMinimized())
+                m_parentSurface->restoreFromMinimized(false);
+
+            m_shellSurface->setMinimize(false);
+            updateFocusControlState(FocusControlState::UnMinimized, true);
+            updateHasActiveCapability(ActiveControlState::UnMinimized, true);
+            updateVisible();
+
+            for (SurfaceWrapper *child : std::as_const(m_subSurfaces)) {
+                if (child->isMinimized())
+                    child->restoreFromMinimized(false);
+            }
+        }
+    }
+
     if (onAnimation)
         startMinimizeAnimation(iconGeometry(), OPEN_ANIMATION);
 }
@@ -1925,7 +1937,7 @@ void SurfaceWrapper::maximize()
         return;
     }
 
-    if (m_surfaceState == State::Minimized || m_surfaceState == State::Fullscreen
+    if (m_minimized || m_surfaceState == State::Fullscreen
         || !isMaximizable())
         return;
 
@@ -1995,9 +2007,6 @@ void SurfaceWrapper::enterFullscreen(WOutput *targetOutput)
         return;
     }
 
-    if (m_surfaceState == State::Minimized)
-        return;
-
     if (targetOutput) {
         auto *helper = Helper::instance();
         auto *target = helper ? helper->getOutput(targetOutput) : nullptr;
@@ -2005,7 +2014,13 @@ void SurfaceWrapper::enterFullscreen(WOutput *targetOutput)
             setOwnsOutput(target);
     }
 
-    setSurfaceState(State::Fullscreen);
+    // When the window is not visible, change the layout state directly without
+    // animation — the window is hidden and will appear in fullscreen when it
+    // becomes visible again.
+    if (!isVisible())
+        setSurfaceStateDirectly(State::Fullscreen);
+    else
+        setSurfaceState(State::Fullscreen);
 }
 
 void SurfaceWrapper::leaveFullscreen()
@@ -2020,7 +2035,10 @@ void SurfaceWrapper::leaveFullscreen()
     if (m_surfaceState != State::Fullscreen)
         return;
 
-    setSurfaceState(m_previousSurfaceState);
+    if (!isVisible())
+        setSurfaceStateDirectly(m_previousSurfaceState);
+    else
+        setSurfaceState(m_previousSurfaceState);
 }
 
 void SurfaceWrapper::closeSurface()

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -49,6 +49,7 @@ class SurfaceWrapper : public QQuickItem
     Q_PROPERTY(bool positionAutomatic READ positionAutomatic NOTIFY positionAutomaticChanged FINAL)
     Q_PROPERTY(State previousSurfaceState READ previousSurfaceState NOTIFY previousSurfaceStateChanged FINAL)
     Q_PROPERTY(State surfaceState READ surfaceState NOTIFY surfaceStateChanged BINDABLE bindableSurfaceState FINAL)
+    Q_PROPERTY(bool minimized READ isMinimized NOTIFY minimizedChanged FINAL)
     Q_PROPERTY(qreal radius READ radius NOTIFY radiusChanged FINAL)
     Q_PROPERTY(SurfaceContainer* container READ container NOTIFY containerChanged FINAL)
     Q_PROPERTY(QQuickItem* titleBar READ titleBar NOTIFY noTitleBarChanged FINAL)
@@ -354,6 +355,7 @@ Q_SIGNALS:
     void positionAutomaticChanged();
     void previousSurfaceStateChanged();
     void surfaceStateChanged();
+    void minimizedChanged();
     void radiusChanged();
     void moveRequested();
     void resizeRequested(Qt::Edges edges);
@@ -496,6 +498,7 @@ private:
                                          m_surfaceState,
                                          State::Normal,
                                          &SurfaceWrapper::surfaceStateChanged)
+    uint m_minimized : 1;
     int m_workspaceId = -1;
     int m_explicitAlwaysOnTop = 0;
     bool m_explicitAlwaysOnBottom = false;

--- a/tools/treeland-debug/debugsession.cpp
+++ b/tools/treeland-debug/debugsession.cpp
@@ -154,6 +154,7 @@ QJsonObject windowToJson(const WindowInfo &window)
         {"state", window.state()},
         {"visible", window.visible()},
         {"active", window.active()},
+        {"minimized", window.minimized()},
         {"geometry", rectToJson(window.geometry())},
         {"titlebarGeometry", rectToJson(window.titlebarGeometry())},
         {"boundingRect", rectToJson(window.boundingRect())},

--- a/tools/treeland-debug/main.cpp
+++ b/tools/treeland-debug/main.cpp
@@ -145,14 +145,15 @@ QString windowGeometryDetail(const WindowInfo &w)
 void printWindowsTable(const QList<WindowInfo> &windows)
 {
     QTextStream out(stdout);
-    out << QStringLiteral("ID              APP-ID                STATE        ACTIVE  OUTPUT   GEOMETRY              TITLE\n");
+    out << QStringLiteral("ID              APP-ID                STATE        ACTIVE  MIN  OUTPUT   GEOMETRY              TITLE\n");
     for (const auto &window : windows) {
         const auto g = window.geometry();
-        const QString line = QStringLiteral("%1  %2  %3  %4  %5  %6,%7 %8x%9  %10")
+        const QString line = QStringLiteral("%1  %2  %3  %4  %5  %6  %7,%8 %9x%10  %11")
             .arg(QString::number(window.id()).leftJustified(16))
             .arg(window.appId().leftJustified(22))
             .arg(stateName(window.state()).leftJustified(12))
             .arg(window.active() ? QStringLiteral("yes") : QStringLiteral("no"))
+            .arg((window.minimized() ? QStringLiteral("yes") : QStringLiteral("no")).leftJustified(5))
             .arg(window.output().leftJustified(8))
             .arg(static_cast<int>(g.x()))
             .arg(static_cast<int>(g.y()))
@@ -178,7 +179,7 @@ void printClientsTable(const QList<ClientInfo> &clients)
             out << QStringLiteral("  cmd: %1\n").arg(client.command());
         for (const auto &window : client.windows()) {
             const auto g = window.geometry();
-            out << QStringLiteral("  %1%2  id=%3  %4  %5,%6 %7x%8  [%9]\n")
+            out << QStringLiteral("  %1%2  id=%3  %4  %5,%6 %7x%8  [%9]%10\n")
                     .arg(window.active() ? QStringLiteral("*") : QStringLiteral(" "))
                     .arg(window.appId().leftJustified(24))
                     .arg(window.id())
@@ -187,7 +188,8 @@ void printClientsTable(const QList<ClientInfo> &clients)
                     .arg(static_cast<int>(g.y()))
                     .arg(static_cast<int>(g.width()))
                     .arg(static_cast<int>(g.height()))
-                    .arg(window.output());
+                    .arg(window.output())
+                    .arg(window.minimized() ? QStringLiteral("  (minimized)") : QString());
             out << windowGeometryDetail(window);
         }
         out << Qt::endl;
@@ -224,7 +226,8 @@ void printTree(const TreelandInfo &info)
                         out << wsBranch << "   " << conn
                             << (w.active() ? QStringLiteral("* ") : QStringLiteral("  "))
                             << w.appId() << "  id=" << w.id() << "  "
-                            << stateName(w.state()) << "  "
+                            << stateName(w.state())
+                            << (w.minimized() ? QStringLiteral("+Min") : QString()) << "  "
                             << static_cast<int>(g.x()) << "," << static_cast<int>(g.y()) << " "
                             << static_cast<int>(g.width()) << "x" << static_cast<int>(g.height())
                             << "  [" << w.output() << "]"
@@ -243,7 +246,8 @@ void printTree(const TreelandInfo &info)
             out << branch2 << conn
                 << (w.active() ? QStringLiteral("* ") : QStringLiteral("  "))
                 << w.appId() << "  id=" << w.id() << "  "
-                << stateName(w.state()) << "  "
+                << stateName(w.state())
+                << (w.minimized() ? QStringLiteral("+Min") : QString()) << "  "
                 << static_cast<int>(g.x()) << "," << static_cast<int>(g.y()) << " "
                 << static_cast<int>(g.width()) << "x" << static_cast<int>(g.height())
                 << "  [" << w.output() << "]"
@@ -817,7 +821,7 @@ static int runTop(Session &session, int timeoutMs, int intervalMs)
         // Collect all windows with their frame deltas.
         struct WinRow {
             qint64 id; QString appId; QString title; QString output;
-            int state; QRectF geo; bool active;
+            int state; QRectF geo; bool active; bool minimized;
             qint64 frames; QRectF damage;
             int64_t framesDelta;
         };
@@ -827,6 +831,7 @@ static int runTop(Session &session, int timeoutMs, int intervalMs)
                 WinRow r;
                 r.id = w.id(); r.appId = w.appId(); r.title = w.title();
                 r.output = w.output(); r.state = w.state(); r.active = w.active();
+                r.minimized = w.minimized();
                 r.geo = w.geometry(); r.frames = w.frames(); r.damage = w.damage();
                 const auto prev = prevFrames.value(w.id());
                 r.framesDelta = (prev > 0) ? (w.frames() - prev) : 0;
@@ -846,16 +851,17 @@ static int runTop(Session &session, int timeoutMs, int intervalMs)
         out << "treeland-debug top — "
             << QDateTime::currentDateTime().toString(Qt::ISODate)
             << "  (clients: " << clients.size() << "  windows: " << rows.size() << ")\n"
-            << "  ID              APP-ID                STATE       FRAMES  GEO          MARKER\n";
+            << "  ID              APP-ID                STATE       MIN  FRAMES  GEO          MARKER\n";
         for (const auto &r : rows) {
             QString marker;
             if (r.id == focusId) marker = QStringLiteral("F");
             else if (r.id == cursorId) marker = QStringLiteral("C");
             else marker = QStringLiteral(" ");
-            out << QStringLiteral("  %1  %2  %3  %4  %5,%6 %7x%8  %9\n")
+            out << QStringLiteral("  %1  %2  %3  %4  %5  %6,%7 %8x%9  %10\n")
                 .arg(QString::number(r.id).leftJustified(16))
                 .arg(r.appId.leftJustified(22))
                 .arg(stateName(r.state).leftJustified(12))
+                .arg((r.minimized ? QStringLiteral("yes") : QStringLiteral("no")).leftJustified(4))
                 .arg(r.framesDelta, 5)
                 .arg(static_cast<int>(r.geo.x()))
                 .arg(static_cast<int>(r.geo.y()))
@@ -1057,6 +1063,8 @@ static int runWatch(Session &session, int timeoutMs, qint64 id, int intervalMs)
                     .arg(stateName(prev.state())).arg(stateName(cur.state()));
             if (cur.active() != prev.active())
                 changes << (cur.active() ? QStringLiteral("activated") : QStringLiteral("deactivated"));
+            if (cur.minimized() != prev.minimized())
+                changes << (cur.minimized() ? QStringLiteral("minimized") : QStringLiteral("unminimized"));
         }
         const qint64 frames = cur.frames();
         if (frames != prevFrames)


### PR DESCRIPTION
## 修复内容

`m_previousSurfaceState` 同时被 `leaveFullscreen()` 与 `restoreFromMinimized()` 复用，在「全屏 → 最小化 → 恢复 → 取消全屏」序列中快照被污染为 `Minimized`，导致窗口退出全屏后错误地恢复到最小化状态且此后无法回到 Normal。

### 改动

- **`src/surface/surfacewrapper.h`**：新增独立成员 `m_stateBeforeFullscreen`，仅在进入全屏时一次性快照前置状态。
- **`src/surface/surfacewrapper.cpp`**：
  - `enterFullscreen()` 在两条路径（主路径 + XdgToplevel 未映射早返回路径）写入 `m_stateBeforeFullscreen`，并加 `if (m_surfaceState != State::Fullscreen)` 重入守卫，避免已全屏再次进入全屏时快照被污染为 `Fullscreen`。
  - `leaveFullscreen()` 改读 `m_stateBeforeFullscreen`，不再依赖 `m_previousSurfaceState`。
  - `m_previousSurfaceState` 继续服务于 `restoreFromMinimized()` 的原有职责，两者互不干扰。

### 验证链路

1. `enterFullscreen()`：`m_stateBeforeFullscreen = Normal`，状态 → Fullscreen
2. 全屏期间 `minimize()`：状态 → Minimized（`m_stateBeforeFullscreen` 不变）
3. `restoreFromMinimized()`：状态 → Fullscreen（`m_stateBeforeFullscreen` 仍 Normal）
4. `leaveFullscreen()`：恢复到 `m_stateBeforeFullscreen = Normal` ✓

Multica issue: [WM-449](https://agent-dev.uniontech.com/wm/issues/WM-449)

## Summary by Sourcery

Decouple minimized state from surface state to preserve fullscreen restoration and accurately represent minimized windows throughout the compositor.

New Features:
- Expose minimized state independently from the surface layout state across QML, remote window data, and debugging tools.

Bug Fixes:
- Preserve correct window visibility, decoration, focus, parent/child minimization, and fullscreen behavior when minimizing and restoring surfaces.

Enhancements:
- Separate minimization state management from surface state transitions so fullscreen state and minimized state no longer interfere with each other.
- Update workspace proxies and minimize animations to use the dedicated minimized-state property.