### PR TITLE
fix(surface): restore correct window state after minimize/restore cycle

### DIFF
--- a/src/surface/surfacewrapper.cpp
+++ b/src/surface/surfacewrapper.cpp
@@ -1596,7 +1596,17 @@ void SurfaceWrapper::doSetSurfaceState(State newSurfaceState)
     setNoCornerRadius(newSurfaceState == State::Maximized || newSurfaceState == State::Fullscreen
                       || newSurfaceState == State::Tiling);
 
-    m_previousSurfaceState.setValueBypassingBindings(m_surfaceState);
+    // Preserve the original previousSurfaceState across a Minimized interruption.
+    // Save BEFORE overwriting m_previousSurfaceState so we capture the value
+    // from before this minimize (e.g. Normal), not the current surface state.
+    const State oldState = m_surfaceState.value();
+    if (willBeMinimized && !wasMinimized)
+        m_preMinimizePreviousState = m_previousSurfaceState.value();
+
+    if (wasMinimized && !willBeMinimized)
+        m_previousSurfaceState.setValueBypassingBindings(m_preMinimizePreviousState);
+    else
+        m_previousSurfaceState.setValueBypassingBindings(m_surfaceState);
     m_surfaceState.setValueBypassingBindings(newSurfaceState);
 
     // Keep modal/parent minimize linkage ahead of this surface's own state change
@@ -1609,7 +1619,7 @@ void SurfaceWrapper::doSetSurfaceState(State newSurfaceState)
         }
     }
 
-    switch (m_previousSurfaceState.value()) {
+    switch (oldState) {
     case State::Maximized:
         m_shellSurface->setMaximize(false);
         break;

--- a/src/surface/surfacewrapper.h
+++ b/src/surface/surfacewrapper.h
@@ -496,6 +496,11 @@ private:
                                          m_surfaceState,
                                          State::Normal,
                                          &SurfaceWrapper::surfaceStateChanged)
+    // Snapshot of m_previousSurfaceState captured when entering Minimized and
+    // restored when leaving Minimized, so that leaveFullscreen() and
+    // restoreFromMinimized() return to the correct pre-minimize state instead
+    // of Minimized after a minimize/restore cycle.
+    SurfaceWrapper::State m_preMinimizePreviousState = State::Normal;
     int m_workspaceId = -1;
     int m_explicitAlwaysOnTop = 0;
     bool m_explicitAlwaysOnBottom = false;


### PR DESCRIPTION
## Problem

F11 退出全屏后，窗口未还原到原始大小，而是变为最小化状态。

**复现路径：**

| 步骤 | 操作 | m_surfaceState | m_previousSurfaceState |
|------|------|----------------|----------------------|
| 1 | 打开浏览器 | Normal | Normal |
| 2 | F11 全屏 | Fullscreen | Normal |
| 3 | 任务栏点击最小化 | Minimized | Fullscreen |
| 4 | 任务栏点击恢复 | Fullscreen | **Minimized** ← 原始的 Normal 丢失 |
| 5 | F11 退出全屏 → `leaveFullscreen()` 调用 `setSurfaceState(m_previousSurfaceState)` → **Minimized** → 窗口最小化 |

## Root Cause

`m_previousSurfaceState` 同时服务于 `restoreFromMinimized()` 和 `leaveFullscreen()`。在步骤 4 中，`restoreFromMinimized()` 调用 `doSetSurfaceState(Fullscreen)`，此时代码执行 `m_previousSurfaceState = m_surfaceState`（即 Minimized），覆盖了步骤 2 保存的 Normal，导致步骤 5 `leaveFullscreen()` 恢复到 Minimized 而非 Normal。

## Fix

- **`src/surface/surfacewrapper.h`**：新增成员变量 `m_preMinimizePreviousState`，在进入 Minimized 时保存当前 `m_previousSurfaceState`，在离开 Minimized 时恢复它。
- **`src/surface/surfacewrapper.cpp`** `doSetSurfaceState()`：
  - 进入 Minimized（`willBeMinimized && !wasMinimized`）：保存 `m_preMinimizePreviousState = m_previousSurfaceState`
  - 离开 Minimized（`wasMinimized && !willBeMinimized`）：恢复 `m_previousSurfaceState = m_preMinimizePreviousState`
  - 引入局部变量 `oldState` 替代 switch 块中的 `m_previousSurfaceState.value()`，确保离开 Minimized 时仍正确执行 `setMinimize(false)` 等旧状态清理逻辑

修复后步骤 4 恢复 `m_previousSurfaceState = Normal`，步骤 5 `leaveFullscreen()` 正确还原到 Normal 状态。

## Issue

- WM-461
- PMS: https://pms.uniontech.com/bug-view-376727.html

## Summary by Sourcery

Restore the original window state when exiting fullscreen after minimizing and restoring the window.

Bug Fixes:
- Restore the correct pre-minimize window state after a minimize/restore cycle interrupted fullscreen mode, preventing F11 exit from leaving the window minimized.

Enhancements:
- Preserve the previous surface state across minimize transitions while retaining correct cleanup of the prior window state.